### PR TITLE
Add Statsd prometheus exporter to sandbox deployment

### DIFF
--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -644,9 +644,10 @@ data:
           - FLYTE_AWS_ENDPOINT: "http://minio.flyte:9000"
           - FLYTE_AWS_ACCESS_KEY_ID: minio
           - FLYTE_AWS_SECRET_ACCESS_KEY: miniostorage
+          - FLYTE_STATSD_HOST: stats.statsagent
 kind: ConfigMap
 metadata:
-  name: flyte-plugin-config-b525btf774
+  name: flyte-plugin-config-h7t6tbcf22
   namespace: flyte
 ---
 apiVersion: v1
@@ -1194,7 +1195,7 @@ spec:
           name: flyte-propeller-config-55gc695955
         name: config-volume
       - configMap:
-          name: flyte-plugin-config-b525btf774
+          name: flyte-plugin-config-h7t6tbcf22
         name: plugin-config-volume
 ---
 apiVersion: apps/v1

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -18,6 +18,16 @@ kind: Namespace
 metadata:
   name: sparkoperator
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: statsagent
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -861,6 +871,21 @@ spec:
     app: contour
   type: NodePort
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stats
+  namespace: statsagent
+spec:
+  clusterIP: None
+  ports:
+  - name: udp
+    port: 8125
+    protocol: UDP
+    targetPort: 9125
+  selector:
+    app: stats
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1456,6 +1481,51 @@ spec:
               name: flyte-admin-config-4k466cfctf
             name: config-volume
   schedule: '*/1 * * * *'
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: stats
+  name: stats
+  namespace: statsagent
+spec:
+  selector:
+    matchLabels:
+      app: stats
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9102"
+        prometheus.io/scrape: "true"
+      labels:
+        app: stats
+        app.kubernetes.io/name: statsdagent
+        app.kubernetes.io/version: latest
+    spec:
+      containers:
+      - image: docker.io/prom/statsd-exporter:latest
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sleep
+              - "300"
+        name: exporter
+        ports:
+        - containerPort: 9125
+        - containerPort: 9102
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: 200m
+            memory: 500Mi
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/kustomize/base/statsd-exporter/daemonset.yaml
+++ b/kustomize/base/statsd-exporter/daemonset.yaml
@@ -43,6 +43,12 @@ spec:
     metadata:
       labels:
         app: stats
+        app.kubernetes.io/name: statsdagent
+        app.kubernetes.io/version: latest
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9102"
+        prometheus.io/path: "/metrics"
     spec:
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
@@ -51,7 +57,6 @@ spec:
         image: docker.io/prom/statsd-exporter:latest
         imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 8125
         - containerPort: 9125
         - containerPort: 9102
         lifecycle:

--- a/kustomize/base/statsd-exporter/daemonset.yaml
+++ b/kustomize/base/statsd-exporter/daemonset.yaml
@@ -1,0 +1,69 @@
+# Namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: statsagent
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+---
+# Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: stats
+  namespace: statsagent
+spec:
+  clusterIP: None
+  ports:
+    - name: udp
+      protocol: UDP
+      port: 8125
+      targetPort: 9125
+  selector:
+    app: stats
+---
+
+# Create a deamonSet so that a pod is created on every node that joins the cluster and garbage colleter
+# from nodes that leave the cluster
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: stats
+  namespace: statsagent
+  labels:
+    app: stats
+spec:
+  selector:
+    matchLabels:
+      app: stats
+  template:
+    metadata:
+      labels:
+        app: stats
+    spec:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: exporter
+        image: docker.io/prom/statsd-exporter:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8125
+        - containerPort: 9125
+        - containerPort: 9102
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sleep
+              - "300"
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: "200m"
+            memory: 500Mi

--- a/kustomize/base/statsd-exporter/kustomization.yaml
+++ b/kustomize/base/statsd-exporter/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- daemonset.yaml

--- a/kustomize/overlays/sandbox/flyte/kustomization.yaml
+++ b/kustomize/overlays/sandbox/flyte/kustomization.yaml
@@ -1,6 +1,7 @@
 bases:
 # global resources
 - ../../../base/namespace
+- ../../../base/statsd-exporter
 - ../../../dependencies/database
 - ../../../dependencies/storage
 

--- a/kustomize/overlays/sandbox/propeller/plugins/config.yaml
+++ b/kustomize/overlays/sandbox/propeller/plugins/config.yaml
@@ -7,3 +7,4 @@ plugins:
       - FLYTE_AWS_ENDPOINT: "http://minio.flyte:9000"
       - FLYTE_AWS_ACCESS_KEY_ID: minio
       - FLYTE_AWS_SECRET_ACCESS_KEY: miniostorage
+      - FLYTE_STATSD_HOST: stats.statsagent


### PR DESCRIPTION
This change adds a new daemonSet that uses https://github.com/prometheus/statsd_exporter to receive statsd metrics from user pods, aggregate and expose them as a scrape-able prometheus endpoint.

Flyte uses 2 different pipelines/SDKs to emit metrics; 

- System components (Propeller, Admin... etc.) expose prometheus metrics directly. These components are long lived and are suited for the prometheus pull model.
- User tasks (Python Tasks, Spark Tasks... etc.) use StatsD metrics to push metrics out. These tasks have un-defined runtime (from seconds to days) hence why they are more suited for StatsD push model.

Work in this PR:
- [X] Add DaemonSet deployment
- [X] Configure Plugin's default environment variables to point to the statsd endpoint.