### PR TITLE
Access GRPC services using projectcontour

### DIFF
--- a/deployment/eks/flyte_generated.yaml
+++ b/deployment/eks/flyte_generated.yaml
@@ -8365,8 +8365,8 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    contour.heptio.com/upstream-protocol.h2c: grpc
     external-dns.alpha.kubernetes.io/hostname: flyteadmin.subdomain.mydomain.com
+    projectcontour.io/upstream-protocol.h2c: grpc
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "600"
     service.beta.kubernetes.io/aws-load-balancer-extra-security-groups: sg-...,sg-...,sg-...
   name: flyteadmin

--- a/deployment/gcp/flyte_generated.yaml
+++ b/deployment/gcp/flyte_generated.yaml
@@ -8382,7 +8382,7 @@ kind: Service
 metadata:
   annotations:
     cloud.google.com/load-balancer-type: Internal
-    contour.heptio.com/upstream-protocol.h2c: grpc
+    projectcontour.io/upstream-protocol.h2c: grpc
   name: flyteadmin
   namespace: flyte
 spec:

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -9863,6 +9863,7 @@ spec:
   externalTrafficPolicy: Local
   ports:
   - name: http
+    nodePort: 30081
     port: 80
     protocol: TCP
   - name: https
@@ -9876,7 +9877,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    contour.heptio.com/upstream-protocol.h2c: grpc
+    projectcontour.io/upstream-protocol.h2c: grpc
   name: flyteadmin
   namespace: flyte
 spec:

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -677,7 +677,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    contour.heptio.com/upstream-protocol.h2c: grpc
+    projectcontour.io/upstream-protocol.h2c: grpc
   name: flyteadmin
   namespace: flyte
 spec:

--- a/kustomize/base/admindeployment/service.yaml
+++ b/kustomize/base/admindeployment/service.yaml
@@ -9,7 +9,8 @@ metadata:
     # with the name 'grpc' under spec/ports.
     # For more information, refer to
     # https://github.com/heptio/contour/blob/master/docs/annotations.md#contour-specific-service-annotations
-    contour.heptio.com/upstream-protocol.h2c: "grpc"
+    # # Following this issue - the annotation was updated https://github.com/projectcontour/contour/issues/2092
+    projectcontour.io/upstream-protocol.h2c: "grpc"
 spec:
   selector:
     app: flyteadmin

--- a/kustomize/overlays/sandbox/dependencies/contour_ingress_controller/contour.yaml
+++ b/kustomize/overlays/sandbox/dependencies/contour_ingress_controller/contour.yaml
@@ -1631,6 +1631,7 @@ spec:
   - port: 80
     name: http
     protocol: TCP
+    nodePort: 30081
   - port: 443
     name: https
     protocol: TCP

--- a/kustomize/overlays/sandbox/dependencies/contour_ingress_controller/service.yaml
+++ b/kustomize/overlays/sandbox/dependencies/contour_ingress_controller/service.yaml
@@ -1,0 +1,16 @@
+# Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: contour
+  labels:
+    app: contour
+spec:
+  # use NodePort to make sure the service is accessible
+  type: NodePort
+  selector:
+    app: contour
+  ports:
+  - protocol: TCP
+    port: 80
+    nodePort: 30081


### PR DESCRIPTION
Between previous versions and later version the annotation to access a grpc service was change. Also during the previous change localhost:30084 was accidently removed. This change keeps the nodeport but also allows grpc to seamlessly work on port 80.

Thus to use the new sandbox config with flyte-cli use the following cli

```bash
$ flyte-cli -h localhost:80  -i list-projects
```
`Note the :80` this is required. Also assuming you are using docker for mac or running k8s locally`
here localhost can be replaced with envoy external IP

for flytectl use the following config
```yaml
admin:
  # For GRPC endpoints you might want to use dns:///flyte.myexample.com
  endpoint: localhost:80
  insecure: true
```


