### PR TITLE
Enabling Event version 1 by default

### DIFF
--- a/deployment/eks/flyte_generated.yaml
+++ b/deployment/eks/flyte_generated.yaml
@@ -8123,6 +8123,7 @@ data:
       metadataStoragePrefix:
         - "metadata"
         - "admin"
+      eventVersion: 1
       testing:
         host: http://flyteadmin
   storage.yaml: |
@@ -8157,7 +8158,7 @@ data:
         storage: 2000Mi
 kind: ConfigMap
 metadata:
-  name: flyte-admin-config-g79597h75m
+  name: flyte-admin-config-m8c8m77fgd
   namespace: flyte
 ---
 apiVersion: v1
@@ -8657,7 +8658,7 @@ spec:
       - emptyDir: {}
         name: shared-data
       - configMap:
-          name: flyte-admin-config-g79597h75m
+          name: flyte-admin-config-m8c8m77fgd
         name: config-volume
       - configMap:
           name: clusterresource-template-tkdkkt4cb5
@@ -8938,7 +8939,7 @@ spec:
               name: clusterresource-template-tkdkkt4cb5
             name: resource-templates
           - configMap:
-              name: flyte-admin-config-g79597h75m
+              name: flyte-admin-config-m8c8m77fgd
             name: config-volume
           - name: db-pass
             secret:

--- a/deployment/gcp/flyte_generated.yaml
+++ b/deployment/gcp/flyte_generated.yaml
@@ -8114,6 +8114,7 @@ data:
       metadataStoragePrefix:
         - "metadata"
         - "admin"
+      eventVersion: 1
       testing:
         host: http://flyteadmin
   storage.yaml: |
@@ -8148,7 +8149,7 @@ data:
         storage: 2000Mi
 kind: ConfigMap
 metadata:
-  name: flyte-admin-config-678t259tk4
+  name: flyte-admin-config-dd52bb74bf
   namespace: flyte
 ---
 apiVersion: v1
@@ -8721,7 +8722,7 @@ spec:
       - emptyDir: {}
         name: shared-data
       - configMap:
-          name: flyte-admin-config-678t259tk4
+          name: flyte-admin-config-dd52bb74bf
         name: config-volume
       - configMap:
           name: clusterresource-template-tkdkkt4cb5
@@ -9002,7 +9003,7 @@ spec:
               name: clusterresource-template-tkdkkt4cb5
             name: resource-templates
           - configMap:
-              name: flyte-admin-config-678t259tk4
+              name: flyte-admin-config-dd52bb74bf
             name: config-volume
           - name: db-pass
             secret:

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -9637,6 +9637,7 @@ data:
       metadataStoragePrefix:
         - "metadata"
         - "admin"
+      eventVersion: 1
       testing:
         host: http://flyteadmin
   storage.yaml: |+
@@ -9663,7 +9664,7 @@ data:
         storage: 20Mi
 kind: ConfigMap
 metadata:
-  name: flyte-admin-config-c96tt5m6b7
+  name: flyte-admin-config-c4gcfmb2k7
   namespace: flyte
 ---
 apiVersion: v1
@@ -10323,7 +10324,7 @@ spec:
       - emptyDir: {}
         name: shared-data
       - configMap:
-          name: flyte-admin-config-c96tt5m6b7
+          name: flyte-admin-config-c4gcfmb2k7
         name: config-volume
       - name: db-pass
         secret:
@@ -10658,7 +10659,7 @@ spec:
               name: clusterresource-template-tkdkkt4cb5
             name: resource-templates
           - configMap:
-              name: flyte-admin-config-c96tt5m6b7
+              name: flyte-admin-config-c4gcfmb2k7
             name: config-volume
           - name: db-pass
             secret:

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -492,6 +492,7 @@ data:
       metadataStoragePrefix:
         - "metadata"
         - "admin"
+      eventVersion: 1
       testing:
         host: http://flyteadmin
   storage.yaml: |+
@@ -518,7 +519,7 @@ data:
         storage: 20Mi
 kind: ConfigMap
 metadata:
-  name: flyte-admin-config-c96tt5m6b7
+  name: flyte-admin-config-c4gcfmb2k7
   namespace: flyte
 ---
 apiVersion: v1
@@ -1020,7 +1021,7 @@ spec:
       - emptyDir: {}
         name: shared-data
       - configMap:
-          name: flyte-admin-config-c96tt5m6b7
+          name: flyte-admin-config-c4gcfmb2k7
         name: config-volume
       - name: db-pass
         secret:

--- a/kustomize/base/single_cluster/headless/config/admin/server.yaml
+++ b/kustomize/base/single_cluster/headless/config/admin/server.yaml
@@ -17,5 +17,6 @@ flyteadmin:
   metadataStoragePrefix:
     - "metadata"
     - "admin"
+  eventVersion: 1
   testing:
     host: http://flyteadmin


### PR DESCRIPTION
- This change enables event version 1.0 by default. This is useful in
  complex node to node relationships