### PR TITLE
add flytekit docs link to top navbar

### DIFF
--- a/rsts/conf.py
+++ b/rsts/conf.py
@@ -124,11 +124,16 @@ html_theme_options = {
     "master_doc": False,
     # custom nav in breadcrumb bar
     "nav_links": [
-        {"href": "index", "internal": True, "title": "Flyte Docs"},
+        {"href": "index", "internal": True, "title": "Flyte"},
         {
             "href": "https://flytecookbook.readthedocs.io",
             "internal": False,
             "title": "Flytekit Tutorials",
+        },
+        {
+            "href": "https://flytekit.readthedocs.io",
+            "internal": False,
+            "title": "Flytekit Python Reference"
         },
     ],
 }


### PR DESCRIPTION
Signed-off-by: cosmicBboy <niels.bantilan@gmail.com>

This diff makes the top nav consistent so that users can toggle between the main docs.flyte.org docs, the cookbook tutorials, and flytekit reference docs.