### PR TITLE
Remove flyteadmin config options which now have defaults

### DIFF
--- a/deployment/eks/flyte_generated.yaml
+++ b/deployment/eks/flyte_generated.yaml
@@ -8142,13 +8142,6 @@ data:
     logger:
       show-source: true
       level: 2
-  remote_data.yaml: |
-    remoteData:
-      # TODO change this to match the region of the s3 bucket
-      region: "us-west-2"
-      scheme: aws
-      signedUrls:
-        durationMinutes: 3
   server.yaml: |
     server:
       httpPort: 8088
@@ -8164,14 +8157,6 @@ data:
           - "Content-Type"
     flyteadmin:
       roleNameKey: "iam.amazonaws.com/role"
-      profilerPort: 10254
-      metricsScope: "flyte:"
-      metadataStoragePrefix:
-        - "metadata"
-        - "admin"
-      eventVersion: 1
-      testing:
-        host: http://flyteadmin
   storage.yaml: |
     storage:
       type: stow
@@ -8203,7 +8188,7 @@ data:
         gpu: 1
 kind: ConfigMap
 metadata:
-  name: flyte-admin-config-4ft85ftt4m
+  name: flyte-admin-config-ddg9df67hb
   namespace: flyte
 ---
 apiVersion: v1
@@ -8701,7 +8686,7 @@ spec:
       labels:
         app: flyteadmin
         app.kubernetes.io/name: flyteadmin
-        app.kubernetes.io/version: 0.3.38
+        app.kubernetes.io/version: 0.4.13
     spec:
       containers:
       - command:
@@ -8709,7 +8694,7 @@ spec:
         - --config
         - /etc/flyte/config/*.yaml
         - serve
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: flyteadmin
         ports:
@@ -8754,7 +8739,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - migrate
         - run
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -8771,7 +8756,7 @@ spec:
         - flytesnacks
         - flytetester
         - flyteexamples
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: seed-projects
         volumeMounts:
@@ -8785,7 +8770,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - clusterresource
         - sync
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: sync-cluster-resources
         volumeMounts:
@@ -8800,7 +8785,7 @@ spec:
       - emptyDir: {}
         name: shared-data
       - configMap:
-          name: flyte-admin-config-4ft85ftt4m
+          name: flyte-admin-config-ddg9df67hb
         name: config-volume
       - configMap:
           name: clusterresource-template-tkdkkt4cb5
@@ -9063,7 +9048,7 @@ spec:
             - /etc/flyte/config/*.yaml
             - clusterresource
             - sync
-            image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+            image: ghcr.io/flyteorg/flyteadmin:v0.4.13
             imagePullPolicy: IfNotPresent
             name: sync-cluster-resources
             volumeMounts:
@@ -9080,7 +9065,7 @@ spec:
               name: clusterresource-template-tkdkkt4cb5
             name: resource-templates
           - configMap:
-              name: flyte-admin-config-4ft85ftt4m
+              name: flyte-admin-config-ddg9df67hb
             name: config-volume
           - name: db-pass
             secret:

--- a/deployment/gcp/flyte_generated.yaml
+++ b/deployment/gcp/flyte_generated.yaml
@@ -8139,9 +8139,6 @@ data:
     logger:
       show-source: true
       level: 2
-  remote_data.yaml: |
-    remoteData:
-      scheme: "gcp"
   server.yaml: |
     server:
       httpPort: 8088
@@ -8157,14 +8154,6 @@ data:
           - "Content-Type"
     flyteadmin:
       roleNameKey: "iam.amazonaws.com/role"
-      profilerPort: 10254
-      metricsScope: "flyte:"
-      metadataStoragePrefix:
-        - "metadata"
-        - "admin"
-      eventVersion: 1
-      testing:
-        host: http://flyteadmin
   storage.yaml: |
     storage:
       type: stow
@@ -8198,7 +8187,7 @@ data:
         gpu: 1
 kind: ConfigMap
 metadata:
-  name: flyte-admin-config-7k2dmcb4tg
+  name: flyte-admin-config-mhdft5gck2
   namespace: flyte
 ---
 apiVersion: v1
@@ -8739,7 +8728,7 @@ spec:
       labels:
         app: flyteadmin
         app.kubernetes.io/name: flyteadmin
-        app.kubernetes.io/version: 0.3.38
+        app.kubernetes.io/version: 0.4.13
     spec:
       containers:
       - command:
@@ -8747,7 +8736,7 @@ spec:
         - --config
         - /etc/flyte/config/*.yaml
         - serve
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: flyteadmin
         ports:
@@ -8792,7 +8781,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - migrate
         - run
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -8809,7 +8798,7 @@ spec:
         - flytesnacks
         - flytetester
         - flyteexamples
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: seed-projects
         volumeMounts:
@@ -8823,7 +8812,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - clusterresource
         - sync
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: sync-cluster-resources
         volumeMounts:
@@ -8838,7 +8827,7 @@ spec:
       - emptyDir: {}
         name: shared-data
       - configMap:
-          name: flyte-admin-config-7k2dmcb4tg
+          name: flyte-admin-config-mhdft5gck2
         name: config-volume
       - configMap:
           name: clusterresource-template-tkdkkt4cb5
@@ -9101,7 +9090,7 @@ spec:
             - /etc/flyte/config/*.yaml
             - clusterresource
             - sync
-            image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+            image: ghcr.io/flyteorg/flyteadmin:v0.4.13
             imagePullPolicy: IfNotPresent
             name: sync-cluster-resources
             volumeMounts:
@@ -9118,7 +9107,7 @@ spec:
               name: clusterresource-template-tkdkkt4cb5
             name: resource-templates
           - configMap:
-              name: flyte-admin-config-7k2dmcb4tg
+              name: flyte-admin-config-mhdft5gck2
             name: config-volume
           - name: db-pass
             secret:

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -2152,12 +2152,6 @@ data:
     logger:
       show-source: true
       level: 2
-  remote_data.yaml: |
-    remoteData:
-      region: "us-east-1"
-      scheme: "local"
-      signedUrls:
-        durationMinutes: 3
   server.yaml: |
     server:
       httpPort: 8088
@@ -2173,14 +2167,6 @@ data:
           - "Content-Type"
     flyteadmin:
       roleNameKey: "iam.amazonaws.com/role"
-      profilerPort: 10254
-      metricsScope: "flyte:"
-      metadataStoragePrefix:
-        - "metadata"
-        - "admin"
-      eventVersion: 1
-      testing:
-        host: http://flyteadmin
   storage.yaml: |+
     storage:
       type: minio
@@ -2206,7 +2192,7 @@ data:
         gpu: 1
 kind: ConfigMap
 metadata:
-  name: flyte-admin-config-5b5g7785h8
+  name: flyte-admin-config-8kt2hhhb92
   namespace: flyte
 ---
 apiVersion: v1
@@ -2843,7 +2829,7 @@ spec:
       labels:
         app: flyteadmin
         app.kubernetes.io/name: flyteadmin
-        app.kubernetes.io/version: 0.3.38
+        app.kubernetes.io/version: 0.4.13
     spec:
       containers:
       - command:
@@ -2851,7 +2837,7 @@ spec:
         - --config
         - /etc/flyte/config/*.yaml
         - serve
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: flyteadmin
         ports:
@@ -2902,7 +2888,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - migrate
         - run
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -2918,7 +2904,7 @@ spec:
         - seed-projects
         - flytesnacks
         - flyteexamples
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: seed-projects
         volumeMounts:
@@ -2932,7 +2918,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - clusterresource
         - sync
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: sync-cluster-resources
         volumeMounts:
@@ -2950,7 +2936,7 @@ spec:
       - emptyDir: {}
         name: shared-data
       - configMap:
-          name: flyte-admin-config-5b5g7785h8
+          name: flyte-admin-config-8kt2hhhb92
         name: config-volume
       - name: db-pass
         secret:
@@ -3337,7 +3323,7 @@ spec:
             - /etc/flyte/config/*.yaml
             - clusterresource
             - sync
-            image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+            image: ghcr.io/flyteorg/flyteadmin:v0.4.13
             imagePullPolicy: IfNotPresent
             name: sync-cluster-resources
             volumeMounts:
@@ -3354,7 +3340,7 @@ spec:
               name: clusterresource-template-dtg8ff28mt
             name: resource-templates
           - configMap:
-              name: flyte-admin-config-5b5g7785h8
+              name: flyte-admin-config-8kt2hhhb92
             name: config-volume
           - name: db-pass
             secret:

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -300,12 +300,6 @@ data:
     logger:
       show-source: true
       level: 2
-  remote_data.yaml: |
-    remoteData:
-      region: "us-east-1"
-      scheme: "local"
-      signedUrls:
-        durationMinutes: 3
   server.yaml: |
     server:
       httpPort: 8088
@@ -321,14 +315,6 @@ data:
           - "Content-Type"
     flyteadmin:
       roleNameKey: "iam.amazonaws.com/role"
-      profilerPort: 10254
-      metricsScope: "flyte:"
-      metadataStoragePrefix:
-        - "metadata"
-        - "admin"
-      eventVersion: 1
-      testing:
-        host: http://flyteadmin
   storage.yaml: |+
     storage:
       type: minio
@@ -354,7 +340,7 @@ data:
         gpu: 1
 kind: ConfigMap
 metadata:
-  name: flyte-admin-config-k7f4k7g76c
+  name: flyte-admin-config-2mg752ch75
   namespace: flyte
 ---
 apiVersion: v1
@@ -697,7 +683,7 @@ spec:
       labels:
         app: flyteadmin
         app.kubernetes.io/name: flyteadmin
-        app.kubernetes.io/version: 0.3.38
+        app.kubernetes.io/version: 0.4.13
     spec:
       containers:
       - command:
@@ -705,7 +691,7 @@ spec:
         - --config
         - /etc/flyte/config/*.yaml
         - serve
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: flyteadmin
         ports:
@@ -756,7 +742,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - migrate
         - run
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -772,7 +758,7 @@ spec:
         - seed-projects
         - flytetester
         - flytesnacks
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: seed-projects
         volumeMounts:
@@ -786,7 +772,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - clusterresource
         - sync
-        image: ghcr.io/flyteorg/flyteadmin:v0.4.7
+        image: ghcr.io/flyteorg/flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         name: sync-cluster-resources
         volumeMounts:
@@ -804,7 +790,7 @@ spec:
       - emptyDir: {}
         name: shared-data
       - configMap:
-          name: flyte-admin-config-k7f4k7g76c
+          name: flyte-admin-config-2mg752ch75
         name: config-volume
       - name: db-pass
         secret:

--- a/kustomize/base/admindeployment/clustersync/cron.yaml
+++ b/kustomize/base/admindeployment/clustersync/cron.yaml
@@ -12,7 +12,7 @@ spec:
           serviceAccountName: flyteadmin
           containers:
           - name: sync-cluster-resources
-            image: flyteadmin:v0.3.29
+            image: flyteadmin:v0.4.13
             imagePullPolicy: IfNotPresent
             command: ["flyteadmin", "--config", "/etc/flyte/config/*.yaml", "clusterresource", "sync"]
             volumeMounts:

--- a/kustomize/base/admindeployment/deployment.yaml
+++ b/kustomize/base/admindeployment/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app: flyteadmin
         app.kubernetes.io/name: flyteadmin
-        app.kubernetes.io/version: 0.3.38
+        app.kubernetes.io/version: 0.4.13
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "10254"
@@ -37,7 +37,7 @@ spec:
           secretName: db-pass
       initContainers:
       - name: run-migrations
-        image: flyteadmin:v0.4.0
+        image: flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--config", "/etc/flyte/config/*.yaml", "migrate", "run"]
         volumeMounts:
@@ -47,7 +47,7 @@ spec:
           mountPath: /etc/db
       # Optional, These just seed the project - TODO move them to only
       - name: seed-projects
-        image: flyteadmin:v0.4.0
+        image: flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--config", "/etc/flyte/config/*.yaml",
                   "migrate", "seed-projects", "flytesnacks", "flytetester", "flyteexamples"]
@@ -57,7 +57,7 @@ spec:
         - name: db-pass
           mountPath: /etc/db
       - name: sync-cluster-resources
-        image: flyteadmin:v0.4.0
+        image: flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--config", "/etc/flyte/config/*.yaml", "clusterresource", "sync"]
         volumeMounts:
@@ -69,7 +69,7 @@ spec:
           mountPath: /etc/db
       containers:
       - name: flyteadmin
-        image: flyteadmin:v0.4.0
+        image: flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--config", "/etc/flyte/config/*.yaml", "serve"]
         ports:

--- a/kustomize/base/single_cluster/headless/config/admin/remote_data.yaml
+++ b/kustomize/base/single_cluster/headless/config/admin/remote_data.yaml
@@ -1,5 +1,0 @@
-remoteData:
-  region: "us-east-1"
-  scheme: "local"
-  signedUrls:
-    durationMinutes: 3

--- a/kustomize/base/single_cluster/headless/config/admin/server.yaml
+++ b/kustomize/base/single_cluster/headless/config/admin/server.yaml
@@ -12,11 +12,3 @@ server:
       - "Content-Type"
 flyteadmin:
   roleNameKey: "iam.amazonaws.com/role"
-  profilerPort: 10254
-  metricsScope: "flyte:"
-  metadataStoragePrefix:
-    - "metadata"
-    - "admin"
-  eventVersion: 1
-  testing:
-    host: http://flyteadmin

--- a/kustomize/base/single_cluster/headless/kustomization.yaml
+++ b/kustomize/base/single_cluster/headless/kustomization.yaml
@@ -19,7 +19,6 @@ configMapGenerator:
       - ./config/admin/domain.yaml
       - ./config/admin/db.yaml
       - ./config/admin/cluster_resources.yaml
-      - ./config/admin/remote_data.yaml
       - ./config/admin/task_resource_defaults.yaml
       - ./config/common/storage.yaml
       - ./config/common/logger.yaml

--- a/kustomize/overlays/eks/flyte/config/admin/remote_data.yaml
+++ b/kustomize/overlays/eks/flyte/config/admin/remote_data.yaml
@@ -1,6 +1,0 @@
-remoteData:
-  # TODO change this to match the region of the s3 bucket
-  region: "us-west-2"
-  scheme: aws
-  signedUrls:
-    durationMinutes: 3

--- a/kustomize/overlays/eks/flyte/kustomization.yaml
+++ b/kustomize/overlays/eks/flyte/kustomization.yaml
@@ -27,7 +27,6 @@ configMapGenerator:
   - behavior: merge
     files:
       - ./config/admin/db.yaml
-      - ./config/admin/remote_data.yaml
       - ./config/admin/task_resource_defaults.yaml
       - ./config/common/storage.yaml
     name: flyte-admin-config

--- a/kustomize/overlays/eks/kustomization.yaml
+++ b/kustomize/overlays/eks/kustomization.yaml
@@ -21,7 +21,7 @@ bases:
 images:
   # FlyteAdmin
   - name: flyteadmin # match images with this name
-    newTag: v0.4.7 # FLYTEADMIN_TAG override the tag
+    newTag: v0.4.13 # FLYTEADMIN_TAG override the tag
     newName: ghcr.io/flyteorg/flyteadmin # override the name
   # FlyteConsole
   - name: flyteconsole # match images with this name

--- a/kustomize/overlays/gcp/flyte/config/admin/remote_data.yaml
+++ b/kustomize/overlays/gcp/flyte/config/admin/remote_data.yaml
@@ -1,2 +1,0 @@
-remoteData:
-  scheme: "gcp"

--- a/kustomize/overlays/gcp/flyte/kustomization.yaml
+++ b/kustomize/overlays/gcp/flyte/kustomization.yaml
@@ -24,7 +24,6 @@ configMapGenerator:
 - behavior: merge
   files:
   - ./config/admin/db.yaml
-  - ./config/admin/remote_data.yaml
   - ./config/admin/task_resource_defaults.yaml
   - ./config/common/storage.yaml
   name: flyte-admin-config

--- a/kustomize/overlays/gcp/kustomization.yaml
+++ b/kustomize/overlays/gcp/kustomization.yaml
@@ -23,7 +23,7 @@ bases:
 images:
   # FlyteAdmin
   - name: flyteadmin # match images with this name
-    newTag: v0.4.7 # FLYTEADMIN_TAG override the tag
+    newTag: v0.4.13 # FLYTEADMIN_TAG override the tag
     newName: ghcr.io/flyteorg/flyteadmin # override the name
   # FlyteConsole
   - name: flyteconsole # match images with this name

--- a/kustomize/overlays/sandbox/flyte/admin/deployment.yaml
+++ b/kustomize/overlays/sandbox/flyte/admin/deployment.yaml
@@ -20,7 +20,7 @@ spec:
               do echo waiting for database; sleep 2; done;",
             ]
         - name: run-migrations
-          image: flyteadmin:v0.4.0
+          image: flyteadmin:v0.4.13
           imagePullPolicy: IfNotPresent
           command:
             [
@@ -34,7 +34,7 @@ spec:
             - name: config-volume
               mountPath: /etc/flyte/config
         - name: seed-projects
-          image: flyteadmin:v0.4.0
+          image: flyteadmin:v0.4.13
           imagePullPolicy: IfNotPresent
           command:
             [
@@ -50,7 +50,7 @@ spec:
             - name: config-volume
               mountPath: /etc/flyte/config
         - name: sync-cluster-resources
-          image: flyteadmin:v0.4.0
+          image: flyteadmin:v0.4.13
           imagePullPolicy: IfNotPresent
           command:
             [

--- a/kustomize/overlays/sandbox/kustomization.yaml
+++ b/kustomize/overlays/sandbox/kustomization.yaml
@@ -25,7 +25,7 @@ resources:
 images:
   # FlyteAdmin
   - name: flyteadmin # match images with this name
-    newTag: v0.4.7 # FLYTEADMIN_TAG override the tag
+    newTag: v0.4.13 # FLYTEADMIN_TAG override the tag
     newName: ghcr.io/flyteorg/flyteadmin # override the name
   # FlyteConsole
   - name: flyteconsole # match images with this name

--- a/kustomize/overlays/test/flyte/admin/deployment.yaml
+++ b/kustomize/overlays/test/flyte/admin/deployment.yaml
@@ -17,7 +17,7 @@ spec:
           'until pg_isready -h postgres -p 5432;
           do echo waiting for database; sleep 2; done;']
       - name: run-migrations
-        image: flyteadmin:v0.3.5
+        image: flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--config", "/etc/flyte/config/*.yaml",
                   "migrate", "run"]
@@ -25,7 +25,7 @@ spec:
         - name: config-volume
           mountPath: /etc/flyte/config
       - name: seed-projects
-        image: flyteadmin:v0.3.5
+        image: flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--config", "/etc/flyte/config/*.yaml",
                   "migrate", "seed-projects", "flytetester", "flytesnacks"]
@@ -33,7 +33,7 @@ spec:
         - name: config-volume
           mountPath: /etc/flyte/config
       - name: sync-cluster-resources
-        image: flyteadmin:v0.3.5
+        image: flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--config", "/etc/flyte/config/*.yaml", "clusterresource", "sync"]
         volumeMounts:

--- a/kustomize/overlays/test/kustomization.yaml
+++ b/kustomize/overlays/test/kustomization.yaml
@@ -19,7 +19,7 @@ bases:
 images:
   # FlyteAdmin
   - name: flyteadmin # match images with this name
-    newTag: v0.4.7 # FLYTEADMIN_TAG override the tag
+    newTag: v0.4.13 # FLYTEADMIN_TAG override the tag
     newName: ghcr.io/flyteorg/flyteadmin # override the name
   # FlyteConsole
   - name: flyteconsole # match images with this name


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

We can also remove the domains and the db options if we really want to, but I think it's instructive to leave those in since I imagine they're more frequently configured per-deployment and having a base to work off of is helpful.

On the flipside, would it be useful to include task resource request & limit defaults in flyteadmin too?