### PR TITLE
explicitly grant flyteworkflow finalizer permissions to flytepropeller

### DIFF
--- a/deployment/eks/flyte_generated.yaml
+++ b/deployment/eks/flyte_generated.yaml
@@ -7737,6 +7737,7 @@ rules:
   - flyte.lyft.com
   resources:
   - flyteworkflows
+  - flyteworkflows/finalizers
   verbs:
   - get
   - list

--- a/deployment/gcp/flyte_generated.yaml
+++ b/deployment/gcp/flyte_generated.yaml
@@ -7733,6 +7733,7 @@ rules:
   - flyte.lyft.com
   resources:
   - flyteworkflows
+  - flyteworkflows/finalizers
   verbs:
   - get
   - list

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -1900,6 +1900,7 @@ rules:
   - flyte.lyft.com
   resources:
   - flyteworkflows
+  - flyteworkflows/finalizers
   verbs:
   - get
   - list

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -134,6 +134,7 @@ rules:
   - flyte.lyft.com
   resources:
   - flyteworkflows
+  - flyteworkflows/finalizers
   verbs:
   - get
   - list

--- a/kustomize/base/propeller/rbac.yaml
+++ b/kustomize/base/propeller/rbac.yaml
@@ -54,6 +54,7 @@ rules:
    - flyte.lyft.com
    resources:
    - flyteworkflows
+   - flyteworkflows/finalizers
    verbs:
    - get
    - list


### PR DESCRIPTION
By explicitly granting flyteworkflow finalizer permissions to flytepropeller, it is clearer which specific permissions are necessary for flyte to work.