### PR TITLE
Use beta version of ingress

### DIFF
--- a/helm/templates/common/ingress.yaml
+++ b/helm/templates/common/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.common.ingress.enabled }}
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "flyte.name" . }}
@@ -15,166 +15,122 @@ spec:
           - path: /*
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: ssl-redirect
-                port:
-                  name: use-annotation
+              serviceName: ssl-redirect
+              servicePort: use-annotation
           {{- end }}
           # This is useful only for frontend development
           {{- if .Values.common.ingress.webpackHMR }}
           - path: /__webpack_hmr
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteconsole
-                port:
-                  number: 80
+              serviceName: flyteconsole
+              servicePort: 80
           {{- end }}
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 87
+              serviceName: flyteadmin
+              servicePort: 87
           # NOTE: If you change this, you must update the BASE_URL value in flyteconsole.yaml
           - path: /console
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteconsole
-                port:
-                  number: 80
+              serviceName: flyteconsole
+              servicePort: 80
           - path: /console/*
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteconsole
-                port:
-                  number: 80
+              serviceName: flyteconsole
+              servicePort: 80
           - path: /api
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /api/*
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /healthcheck
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /v1/*
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi/*
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /.well-known/*
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /login
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /login/*
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /logout
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /logout/*
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /callback
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /callback/*
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /me
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /config
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           - path: /config/*
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 80
+              serviceName: flyteadmin
+              servicePort: 80
           {{- if not .Values.common.ingress.separateGrpcIngress }}
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
+              serviceName: flyteadmin
+              servicePort: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
+              serviceName: flyteadmin
+              servicePort: 81
           {{- end }}
       {{- with .Values.common.ingress.host }}
       host: {{ . }}
@@ -191,7 +147,7 @@ spec:
 # Certain ingress controllers like nginx cannot serve HTTP 1 and GRPC with a single ingress because GRPC can only
 # enabled on the ingress object, not on backend services (GRPC annotation is set on the ingress, not on the services).
 ---
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "flyte.name" . }}-grpc
@@ -209,10 +165,8 @@ spec:
         paths:
           {{- if .Values.common.ingress.albSSLRedirect }}
           - backend:
-              service:
-                name: ssl-redirect
-                port:
-                  name: use-annotation
+              serviceName: ssl-redirect
+              servicePort: use-annotation
             path: /*
             pathType: ImplementationSpecific
           {{- end }}
@@ -220,17 +174,13 @@ spec:
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
+              serviceName: flyteadmin
+              servicePort: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
+              serviceName: flyteadmin
+              servicePort: 81
       {{- with .Values.common.ingress.host }}
       host: {{ . }}
       {{- end }}


### PR DESCRIPTION
"Hey so, I noticed that you are using the Ingress class out of beta, which is kind of an issue-- the Ingress class was moved out of beta in the 1.19 release, which happened in late august. If flyte is run in clusters older than this (e.g. 1.18), then this will fail. EKS only started offering 1.19 a couple of months ago, and the GKE regular channel defaults to 1.18, so this really won't work for most of your users. Do you guys mind if I file a pr to move back to the beta ingress version? I don't see you guys using anyhting required from the GA version, and beta has been serving everyone well for the past 6 years"
