### PR TITLE
Wait for deployments to be created using rollout before checking for availability

### DIFF
--- a/docker/sandbox/wait-for-flyte.sh
+++ b/docker/sandbox/wait-for-flyte.sh
@@ -12,6 +12,12 @@ until k3s kubectl explain deployment &> /dev/null; do sleep 1; done
 # Wait for Flyte namespace to be created. This is necessary for the next step.
 timeout 600 sh -c "until k3s kubectl get namespace flyte &> /dev/null; do sleep 1; done"  || ( echo >&2 "Timed out while waiting for the Flyte namespace to be created"; exit 1 )
 
+# Wait for Flyte deployment to be created. This is necessary for the next step.
+timeout 600 sh -c "until k3s kubectl rollout status deployment datacatalog -n flyte  &> /dev/null; do sleep 1; done"  || ( echo >&2 "Timed out while waiting for the datacatalog rollout to be created"; exit 1 )
+timeout 600 sh -c "until k3s kubectl rollout status deployment flyteadmin -n flyte  &> /dev/null; do sleep 1; done"  || ( echo >&2 "Timed out while waiting for the flyteadmin rollout to be created"; exit 1 )
+timeout 600 sh -c "until k3s kubectl rollout status deployment flyteconsole -n flyte  &> /dev/null; do sleep 1; done"  || ( echo >&2 "Timed out while waiting for the flyteconsole rollout to be created"; exit 1 )
+timeout 600 sh -c "until k3s kubectl rollout status deployment flytepropeller -n flyte  &> /dev/null; do sleep 1; done"  || ( echo >&2 "Timed out while waiting for the flytepropeller rollout to be created"; exit 1 )
+
 # Wait for flyte deployment
 k3s kubectl wait --for=condition=available deployment/datacatalog deployment/flyteadmin deployment/flyteconsole deployment/flytepropeller -n flyte --timeout=10m || ( echo >&2 "Timed out while waiting for the Flyte deployment to start"; exit 1 )
 


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

`k3s kubectl apply -f /flyteorg/share/flyte_generated.yaml` is an async command and doesn't wait for the deployments to be created.
Hence when on the next line we call wait-for-flyte.sh it fails in rare cases where the deployment hasn't yet been created and we call into `k3s kubectl wait --for=condition=available`
Following is the error that thrown
```
Error from server (NotFound): deployments.apps "datacatalog" not found
Error from server (NotFound): deployments.apps "flyteadmin" not found
Error from server (NotFound): deployments.apps "flyteconsole" not found
Error from server (NotFound): deployments.apps "flytepropeller" not found
Timed out while waiting for the Flyte deployment to start
```

Would be ideal for kubectl wait to also do this but that isn't the case.
Hence adding an explicit check with rollout status command 


Tested by doing `make start` and running the above commands in another prompt which completed successfully

