### PR TITLE
add fontawesome icon to main nav toc, add edit on github link

### DIFF
--- a/doc-requirements.in
+++ b/doc-requirements.in
@@ -8,3 +8,4 @@ sphinx-copybutton
 sphinx-tabs
 sphinxext-remoteliteralinclude
 sphinx-issues
+sphinx_fontawesome

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -36,7 +36,7 @@ markupsafe==1.1.1
     # via jinja2
 packaging==20.9
     # via sphinx
-pygments==2.8.1
+pygments==2.9.0
     # via
     #   sphinx
     #   sphinx-prompt
@@ -51,7 +51,7 @@ readthedocs-sphinx-search==0.1.0
     # via -r doc-requirements.in
 requests==2.25.1
     # via sphinx
-six==1.15.0
+six==1.16.0
     # via
     #   sphinx-code-include
     #   sphinxext-remoteliteralinclude
@@ -64,6 +64,8 @@ sphinx-autoapi==1.8.1
 sphinx-code-include==1.1.1
     # via -r doc-requirements.in
 sphinx-copybutton==0.3.1
+    # via -r doc-requirements.in
+sphinx-fontawesome==0.0.6
     # via -r doc-requirements.in
 sphinx-issues==1.2.0
     # via -r doc-requirements.in
@@ -78,6 +80,7 @@ sphinx==3.5.4
     #   sphinx-autoapi
     #   sphinx-code-include
     #   sphinx-copybutton
+    #   sphinx-fontawesome
     #   sphinx-issues
     #   sphinx-prompt
     #   sphinx-tabs

--- a/rsts/conf.py
+++ b/rsts/conf.py
@@ -18,6 +18,7 @@
 
 import sphinx.application
 import sphinx.errors
+import sphinx_fontawesome
 sphinx.application.ExtensionError = sphinx.errors.ExtensionError
 
 # -- Project information -----------------------------------------------------
@@ -60,6 +61,7 @@ extensions = [
     "sphinxext.remoteliteralinclude",
     "sphinx_issues",
     "sphinx_search.extension",
+    "sphinx_fontawesome",
 ]
 
 extlinks = {
@@ -120,6 +122,13 @@ html_theme_options = {
         "color-brand-primary": "#9D68E4",
         "color-brand-content": "#9D68E4",
     },
+    # custom flyteorg furo theme options
+    "github_repo": "flytesnacks",
+    "github_username": "flyteorg",
+    "github_commit": "master",
+    "docs_path": "cookbook/docs",  # path to documentation source
+    "sphinx_gallery_src_dir": "cookbook",  # path to directory of sphinx gallery source files relative to repo root
+    "sphinx_gallery_dest_dir": "auto",  # path to root directory containing auto-generated sphinx gallery examples
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/rsts/index.rst
+++ b/rsts/index.rst
@@ -6,12 +6,12 @@
    :titlesonly:
    :hidden:
 
-   getting_started
-   User Guide <https://docs.flyte.org/projects/cookbook/en/latest/user_guide.html>
-   Tutorials <https://docs.flyte.org/projects/cookbook/en/latest/tutorials.html>
-   Concepts <concepts/basics>
-   API Reference <reference/index>
-   community/index
+   |plane| Getting Started <getting_started>
+   |book-reader| User Guide <https://docs.flyte.org/projects/cookbook/en/latest/user_guide.html>
+   |chalkboard| Tutorials <https://docs.flyte.org/projects/cookbook/en/latest/tutorials.html>
+   |project-diagram| Concepts <concepts/basics>
+   |book| API Reference <reference/index>
+   |hands-helping| community/index
 
 .. toctree::
    :caption: Concepts


### PR DESCRIPTION
This PR adds the edit on github link to the bottom of the page and icons to the main nav items to make it appear more distinct from the bottom nav:
![image](https://user-images.githubusercontent.com/2816689/119201028-14950480-ba5c-11eb-9299-9d930901fa5b.png)


Signed-off-by: cosmicBboy <niels.bantilan@gmail.com>