### PR TITLE
Hotfix for release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ stats:
 
 .PHONY: prepare_artifacts
 prepare_artifacts:
+	mkdir release
 	bash script/prepare_artifacts.sh
 
 .PHONY: helm_install


### PR DESCRIPTION
- Added mkdir before running make `preprare_artifacts`