### PR TITLE
Use cr.flyte.org to fetch flyte containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ producer-consumer order create a workflow.
 With [docker installed](https://docs.docker.com/get-docker/), run the following command:
 
 ```bash
-  docker run --rm --privileged -p 30081:30081 -p 30084:30084 ghcr.io/flyteorg/flyte-sandbox
+  docker run --rm --privileged -p 30081:30081 -p 30084:30084 cr.flyte.org/flyteorg/flyte-sandbox
 ```
 
 This creates a local Flyte sandbox. Once the sandbox is ready, you should see the following message: `Flyte is ready! Flyte UI is available at http://localhost:30081/console`.

--- a/deployment/eks/flyte_generated.yaml
+++ b/deployment/eks/flyte_generated.yaml
@@ -8251,7 +8251,7 @@ data:
       k8s:
         co-pilot:
           name: "flyte-copilot-"
-          image: "ghcr.io/flyteorg/flytecopilot:v0.5.28"
+          image: "cr.flyte.org/flyteorg/flytecopilot:v0.5.28"
           start-timeout: "30s"
   core.yaml: |
     propeller:
@@ -8388,7 +8388,7 @@ data:
         cloudwatch-log-group: <log-group>
 kind: ConfigMap
 metadata:
-  name: flyte-propeller-config-8fdc62895h
+  name: flyte-propeller-config-79b62khbc5
   namespace: flyte
 ---
 apiVersion: v1
@@ -8612,7 +8612,7 @@ spec:
         - --config
         - /etc/datacatalog/config/*.yaml
         - serve
-        image: ghcr.io/flyteorg/datacatalog:v0.3.4
+        image: cr.flyte.org/flyteorg/datacatalog:v0.3.4
         imagePullPolicy: IfNotPresent
         name: datacatalog
         ports:
@@ -8635,7 +8635,7 @@ spec:
         - /etc/datacatalog/config/*.yaml
         - migrate
         - run
-        image: ghcr.io/flyteorg/datacatalog:v0.3.4
+        image: cr.flyte.org/flyteorg/datacatalog:v0.3.4
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -8692,7 +8692,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/flyteorg/flytepropeller:v0.11.0
+        image: cr.flyte.org/flyteorg/flytepropeller:v0.11.0
         imagePullPolicy: IfNotPresent
         name: webhook
         volumeMounts:
@@ -8705,7 +8705,7 @@ spec:
       serviceAccountName: flyte-pod-webhook
       volumes:
       - configMap:
-          name: flyte-propeller-config-8fdc62895h
+          name: flyte-propeller-config-79b62khbc5
         name: config-volume
       - name: webhook-certs
         secret:
@@ -8740,7 +8740,7 @@ spec:
         - --config
         - /etc/flyte/config/*.yaml
         - serve
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: flyteadmin
         ports:
@@ -8787,7 +8787,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - migrate
         - run
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -8804,7 +8804,7 @@ spec:
         - flytesnacks
         - flytetester
         - flyteexamples
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: seed-projects
         volumeMounts:
@@ -8818,7 +8818,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - clusterresource
         - sync
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: sync-cluster-resources
         volumeMounts:
@@ -8838,7 +8838,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: generate-secrets
         volumeMounts:
@@ -8884,7 +8884,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: flyte-console-config
-        image: ghcr.io/flyteorg/flyteconsole:v0.20.1
+        image: cr.flyte.org/flyteorg/flyteconsole:v0.20.1
         name: flyteconsole
         ports:
         - containerPort: 8080
@@ -8928,7 +8928,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: ghcr.io/flyteorg/flytepropeller:v0.11.0
+        image: cr.flyte.org/flyteorg/flytepropeller:v0.11.0
         imagePullPolicy: IfNotPresent
         name: flytepropeller
         ports:
@@ -8946,7 +8946,7 @@ spec:
       serviceAccountName: flytepropeller
       volumes:
       - configMap:
-          name: flyte-propeller-config-8fdc62895h
+          name: flyte-propeller-config-79b62khbc5
         name: config-volume
       - name: auth
         secret:
@@ -9120,7 +9120,7 @@ spec:
             - /etc/flyte/config/*.yaml
             - clusterresource
             - sync
-            image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+            image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
             imagePullPolicy: IfNotPresent
             name: sync-cluster-resources
             volumeMounts:
@@ -9170,7 +9170,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/flyteorg/flytepropeller:v0.11.0
+        image: cr.flyte.org/flyteorg/flytepropeller:v0.11.0
         imagePullPolicy: IfNotPresent
         name: webhook
         volumeMounts:
@@ -9180,7 +9180,7 @@ spec:
       serviceAccountName: flyte-pod-webhook
       volumes:
       - configMap:
-          name: flyte-propeller-config-8fdc62895h
+          name: flyte-propeller-config-79b62khbc5
         name: config-volume
   ttlSecondsAfterFinished: 0
 ---

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -408,7 +408,7 @@ data:
     plugins:
       k8s:
         co-pilot:
-          image: ghcr.io/lyft/flyteplugins/flytecopilot:dc4bdbd61cac88a39a5ff43e40f026bdbc2c78a2
+          image: cr.flyte.org/lyft/flyteplugins/flytecopilot:dc4bdbd61cac88a39a5ff43e40f026bdbc2c78a2
           name: flyte-copilot-
           start-timeout: 30s
   core.yaml: | 
@@ -1299,7 +1299,7 @@ spec:
           - /etc/flyte/config/*.yaml
           - migrate
           - run
-          image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+          image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
           imagePullPolicy: "IfNotPresent"
           name: run-migrations
           volumeMounts:
@@ -1316,7 +1316,7 @@ spec:
           - flytesnacks
           - flytetester
           - flyteexamples
-          image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+          image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
           imagePullPolicy: "IfNotPresent"
           name: seed-projects
           volumeMounts:
@@ -1330,7 +1330,7 @@ spec:
           - /etc/flyte/config/*.yaml
           - clusterresource
           - sync
-          image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+          image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           volumeMounts:
@@ -1341,7 +1341,7 @@ spec:
           - mountPath: /etc/flyte/config
             name: config-volume
         - name: generate-secrets
-          image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+          image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
           imagePullPolicy: "IfNotPresent"
           command: ["/bin/sh", "-c"]
           args:
@@ -1362,7 +1362,7 @@ spec:
         - --config
         - /etc/flyte/config/*.yaml
         - serve
-        image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+        image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
         imagePullPolicy: "IfNotPresent"
         name: flyteadmin
         ports:
@@ -1458,7 +1458,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       containers:
-      - image: "ghcr.io/flyteorg/flyteconsole:v0.20.1"
+      - image: "cr.flyte.org/flyteorg/flyteconsole:v0.20.1"
         imagePullPolicy: "IfNotPresent"
         name: flyteconsole
         envFrom:
@@ -1521,7 +1521,7 @@ spec:
         - /etc/datacatalog/config/*.yaml
         - migrate
         - run
-        image: "ghcr.io/flyteorg/datacatalog:v0.3.4"
+        image: "cr.flyte.org/flyteorg/datacatalog:v0.3.4"
         imagePullPolicy: "IfNotPresent"
         name: run-migrations
         volumeMounts:
@@ -1535,7 +1535,7 @@ spec:
         - --config
         - /etc/datacatalog/config/*.yaml
         - serve
-        image: "ghcr.io/flyteorg/datacatalog:v0.3.4"
+        image: "cr.flyte.org/flyteorg/datacatalog:v0.3.4"
         imagePullPolicy: "IfNotPresent"
         name: datacatalog
         ports:
@@ -1593,7 +1593,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d9a27caae10c6c11604b66b9eb45b87068a28048ad0c6293ee44a366c9cbf63"
+        configChecksum: "d852e0a0c08a227673b22bee493dfb7b341d494442afb8300d4e12971fbe34e"
       labels: 
         app.kubernetes.io/name: flytepropeller
         app.kubernetes.io/instance: flyte
@@ -1610,7 +1610,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: "ghcr.io/flyteorg/flytepropeller:v0.11.0"
+        image: "cr.flyte.org/flyteorg/flytepropeller:v0.11.0"
         imagePullPolicy: "IfNotPresent"
         name: flytepropeller
         ports:
@@ -1665,12 +1665,12 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v0.11.0
       annotations:
-        configChecksum: "d9a27caae10c6c11604b66b9eb45b87068a28048ad0c6293ee44a366c9cbf63"
+        configChecksum: "d852e0a0c08a227673b22bee493dfb7b341d494442afb8300d4e12971fbe34e"
     spec:
       serviceAccountName: flyte-pod-webhook
       initContainers:
       - name: generate-secrets
-        image: "ghcr.io/flyteorg/flytepropeller:v0.11.0"
+        image: "cr.flyte.org/flyteorg/flytepropeller:v0.11.0"
         imagePullPolicy: "IfNotPresent"
         command:
           - flytepropeller
@@ -1693,7 +1693,7 @@ spec:
             mountPath: /etc/flyte/config
       containers:
         - name: webhook
-          image: "ghcr.io/flyteorg/flytepropeller:v0.11.0"
+          image: "cr.flyte.org/flyteorg/flytepropeller:v0.11.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -1875,7 +1875,7 @@ spec:
             - /etc/flyte/config/*.yaml
             - clusterresource
             - sync
-            image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+            image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
             imagePullPolicy: "IfNotPresent"
             name: sync-cluster-resources
             volumeMounts:

--- a/deployment/gcp/flyte_generated.yaml
+++ b/deployment/gcp/flyte_generated.yaml
@@ -8250,7 +8250,7 @@ data:
       k8s:
         co-pilot:
           name: "flyte-copilot-"
-          image: "ghcr.io/flyteorg/flytecopilot:v0.5.28"
+          image: "cr.flyte.org/flyteorg/flytecopilot:v0.5.28"
           start-timeout: "30s"
   core.yaml: |
     propeller:
@@ -8385,7 +8385,7 @@ data:
         stackdriver-logresourcename: k8s_container
 kind: ConfigMap
 metadata:
-  name: flyte-propeller-config-k8km2mmdgf
+  name: flyte-propeller-config-dtk4mh9k2d
   namespace: flyte
 ---
 apiVersion: v1
@@ -8654,7 +8654,7 @@ spec:
         - --config
         - /etc/datacatalog/config/*.yaml
         - serve
-        image: ghcr.io/flyteorg/datacatalog:v0.3.4
+        image: cr.flyte.org/flyteorg/datacatalog:v0.3.4
         imagePullPolicy: IfNotPresent
         name: datacatalog
         ports:
@@ -8677,7 +8677,7 @@ spec:
         - /etc/datacatalog/config/*.yaml
         - migrate
         - run
-        image: ghcr.io/flyteorg/datacatalog:v0.3.4
+        image: cr.flyte.org/flyteorg/datacatalog:v0.3.4
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -8734,7 +8734,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/flyteorg/flytepropeller:v0.11.0
+        image: cr.flyte.org/flyteorg/flytepropeller:v0.11.0
         imagePullPolicy: IfNotPresent
         name: webhook
         volumeMounts:
@@ -8747,7 +8747,7 @@ spec:
       serviceAccountName: flyte-pod-webhook
       volumes:
       - configMap:
-          name: flyte-propeller-config-k8km2mmdgf
+          name: flyte-propeller-config-dtk4mh9k2d
         name: config-volume
       - name: webhook-certs
         secret:
@@ -8782,7 +8782,7 @@ spec:
         - --config
         - /etc/flyte/config/*.yaml
         - serve
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: flyteadmin
         ports:
@@ -8829,7 +8829,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - migrate
         - run
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -8846,7 +8846,7 @@ spec:
         - flytesnacks
         - flytetester
         - flyteexamples
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: seed-projects
         volumeMounts:
@@ -8860,7 +8860,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - clusterresource
         - sync
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: sync-cluster-resources
         volumeMounts:
@@ -8880,7 +8880,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: generate-secrets
         volumeMounts:
@@ -8926,7 +8926,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: flyte-console-config
-        image: ghcr.io/flyteorg/flyteconsole:v0.20.1
+        image: cr.flyte.org/flyteorg/flyteconsole:v0.20.1
         name: flyteconsole
         ports:
         - containerPort: 8080
@@ -8970,7 +8970,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: ghcr.io/flyteorg/flytepropeller:v0.11.0
+        image: cr.flyte.org/flyteorg/flytepropeller:v0.11.0
         imagePullPolicy: IfNotPresent
         name: flytepropeller
         ports:
@@ -8988,7 +8988,7 @@ spec:
       serviceAccountName: flytepropeller
       volumes:
       - configMap:
-          name: flyte-propeller-config-k8km2mmdgf
+          name: flyte-propeller-config-dtk4mh9k2d
         name: config-volume
       - name: auth
         secret:
@@ -9162,7 +9162,7 @@ spec:
             - /etc/flyte/config/*.yaml
             - clusterresource
             - sync
-            image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+            image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
             imagePullPolicy: IfNotPresent
             name: sync-cluster-resources
             volumeMounts:
@@ -9212,7 +9212,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/flyteorg/flytepropeller:v0.11.0
+        image: cr.flyte.org/flyteorg/flytepropeller:v0.11.0
         imagePullPolicy: IfNotPresent
         name: webhook
         volumeMounts:
@@ -9222,7 +9222,7 @@ spec:
       serviceAccountName: flyte-pod-webhook
       volumes:
       - configMap:
-          name: flyte-propeller-config-k8km2mmdgf
+          name: flyte-propeller-config-dtk4mh9k2d
         name: config-volume
   ttlSecondsAfterFinished: 0
 ---

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -423,7 +423,7 @@ data:
     plugins:
       k8s:
         co-pilot:
-          image: ghcr.io/lyft/flyteplugins/flytecopilot:dc4bdbd61cac88a39a5ff43e40f026bdbc2c78a2
+          image: cr.flyte.org/lyft/flyteplugins/flytecopilot:dc4bdbd61cac88a39a5ff43e40f026bdbc2c78a2
           name: flyte-copilot-
           start-timeout: 30s
   core.yaml: | 
@@ -3143,7 +3143,7 @@ spec:
           - /etc/flyte/config/*.yaml
           - migrate
           - run
-          image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+          image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
           imagePullPolicy: "IfNotPresent"
           name: run-migrations
           volumeMounts:
@@ -3159,7 +3159,7 @@ spec:
           - flytesnacks
           - flytetester
           - flyteexamples
-          image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+          image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
           imagePullPolicy: "IfNotPresent"
           name: seed-projects
           volumeMounts:
@@ -3172,7 +3172,7 @@ spec:
           - /etc/flyte/config/*.yaml
           - clusterresource
           - sync
-          image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+          image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           volumeMounts:
@@ -3182,7 +3182,7 @@ spec:
           - mountPath: /etc/flyte/config
             name: config-volume
         - name: generate-secrets
-          image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+          image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
           imagePullPolicy: "IfNotPresent"
           command: ["/bin/sh", "-c"]
           args:
@@ -3203,7 +3203,7 @@ spec:
         - --config
         - /etc/flyte/config/*.yaml
         - serve
-        image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+        image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
         imagePullPolicy: "IfNotPresent"
         name: flyteadmin
         ports:
@@ -3289,7 +3289,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       containers:
-      - image: "ghcr.io/flyteorg/flyteconsole:v0.20.1"
+      - image: "cr.flyte.org/flyteorg/flyteconsole:v0.20.1"
         imagePullPolicy: "IfNotPresent"
         name: flyteconsole
         envFrom:
@@ -3345,7 +3345,7 @@ spec:
         - /etc/datacatalog/config/*.yaml
         - migrate
         - run
-        image: "ghcr.io/flyteorg/datacatalog:v0.3.4"
+        image: "cr.flyte.org/flyteorg/datacatalog:v0.3.4"
         imagePullPolicy: "IfNotPresent"
         name: run-migrations
         volumeMounts:
@@ -3358,7 +3358,7 @@ spec:
         - --config
         - /etc/datacatalog/config/*.yaml
         - serve
-        image: "ghcr.io/flyteorg/datacatalog:v0.3.4"
+        image: "cr.flyte.org/flyteorg/datacatalog:v0.3.4"
         imagePullPolicy: "IfNotPresent"
         name: datacatalog
         ports:
@@ -3509,7 +3509,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "22dc283ed085f4307daa1f80e9256258efc08bbc8604800ce9aee224017e01c"
+        configChecksum: "8aefd61e6cf16442584f2e1980cee5db78fbc48e55b9e68d61299d7083fb389"
       labels: 
         app.kubernetes.io/name: flytepropeller
         app.kubernetes.io/instance: flyte
@@ -3526,7 +3526,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: "ghcr.io/flyteorg/flytepropeller:v0.11.0"
+        image: "cr.flyte.org/flyteorg/flytepropeller:v0.11.0"
         imagePullPolicy: "IfNotPresent"
         name: flytepropeller
         ports:
@@ -3574,12 +3574,12 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v0.11.0
       annotations:
-        configChecksum: "22dc283ed085f4307daa1f80e9256258efc08bbc8604800ce9aee224017e01c"
+        configChecksum: "8aefd61e6cf16442584f2e1980cee5db78fbc48e55b9e68d61299d7083fb389"
     spec:
       serviceAccountName: flyte-pod-webhook
       initContainers:
       - name: generate-secrets
-        image: "ghcr.io/flyteorg/flytepropeller:v0.11.0"
+        image: "cr.flyte.org/flyteorg/flytepropeller:v0.11.0"
         imagePullPolicy: "IfNotPresent"
         command:
           - flytepropeller
@@ -3602,7 +3602,7 @@ spec:
             mountPath: /etc/flyte/config
       containers:
         - name: webhook
-          image: "ghcr.io/flyteorg/flytepropeller:v0.11.0"
+          image: "cr.flyte.org/flyteorg/flytepropeller:v0.11.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -3784,7 +3784,7 @@ spec:
             - /etc/flyte/config/*.yaml
             - clusterresource
             - sync
-            image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+            image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
             imagePullPolicy: "IfNotPresent"
             name: sync-cluster-resources
             volumeMounts:

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -2254,7 +2254,7 @@ data:
       k8s:
         co-pilot:
           name: "flyte-copilot-"
-          image: "ghcr.io/flyteorg/flytecopilot:v0.5.28"
+          image: "cr.flyte.org/flyteorg/flytecopilot:v0.5.28"
           start-timeout: "30s"
   core.yaml: |
     propeller:
@@ -2340,7 +2340,7 @@ data:
         kubernetes-template-uri: "http://localhost:30082/#/log/{{ .namespace }}/{{ .podName }}/pod?namespace={{ .namespace }}"
 kind: ConfigMap
 metadata:
-  name: flyte-propeller-config-6gd7cgkkdt
+  name: flyte-propeller-config-d9bhkt4m5d
   namespace: flyte
 ---
 apiVersion: v1
@@ -2754,7 +2754,7 @@ spec:
         - --config
         - /etc/datacatalog/config/*.yaml
         - serve
-        image: ghcr.io/flyteorg/datacatalog:v0.3.4
+        image: cr.flyte.org/flyteorg/datacatalog:v0.3.4
         imagePullPolicy: IfNotPresent
         name: datacatalog
         ports:
@@ -2772,7 +2772,7 @@ spec:
         - /etc/datacatalog/config/*.yaml
         - migrate
         - run
-        image: ghcr.io/flyteorg/datacatalog:v0.3.4
+        image: cr.flyte.org/flyteorg/datacatalog:v0.3.4
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -2829,7 +2829,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/flyteorg/flytepropeller:v0.11.0
+        image: cr.flyte.org/flyteorg/flytepropeller:v0.11.0
         imagePullPolicy: IfNotPresent
         name: webhook
         volumeMounts:
@@ -2848,7 +2848,7 @@ spec:
         secret:
           secretName: user-info
       - configMap:
-          name: flyte-propeller-config-6gd7cgkkdt
+          name: flyte-propeller-config-d9bhkt4m5d
         name: config-volume
       - name: webhook-certs
         secret:
@@ -2883,7 +2883,7 @@ spec:
         - --config
         - /etc/flyte/config/*.yaml
         - serve
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: flyteadmin
         ports:
@@ -2936,7 +2936,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - migrate
         - run
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -2952,7 +2952,7 @@ spec:
         - seed-projects
         - flytesnacks
         - flyteexamples
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: seed-projects
         volumeMounts:
@@ -2966,7 +2966,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - clusterresource
         - sync
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: sync-cluster-resources
         volumeMounts:
@@ -2986,7 +2986,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: generate-secrets
         volumeMounts:
@@ -3032,7 +3032,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: flyte-console-config
-        image: ghcr.io/flyteorg/flyteconsole:v0.20.1
+        image: cr.flyte.org/flyteorg/flyteconsole:v0.20.1
         name: flyteconsole
         ports:
         - containerPort: 8080
@@ -3076,7 +3076,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: ghcr.io/flyteorg/flytepropeller:v0.11.0
+        image: cr.flyte.org/flyteorg/flytepropeller:v0.11.0
         imagePullPolicy: IfNotPresent
         name: flytepropeller
         ports:
@@ -3089,7 +3089,7 @@ spec:
       serviceAccountName: flytepropeller
       volumes:
       - configMap:
-          name: flyte-propeller-config-6gd7cgkkdt
+          name: flyte-propeller-config-d9bhkt4m5d
         name: config-volume
       - name: auth
         secret:
@@ -3395,7 +3395,7 @@ spec:
             - /etc/flyte/config/*.yaml
             - clusterresource
             - sync
-            image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+            image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
             imagePullPolicy: IfNotPresent
             name: sync-cluster-resources
             volumeMounts:
@@ -3579,7 +3579,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/flyteorg/flytepropeller:v0.11.0
+        image: cr.flyte.org/flyteorg/flytepropeller:v0.11.0
         imagePullPolicy: IfNotPresent
         name: webhook
         volumeMounts:
@@ -3589,7 +3589,7 @@ spec:
       serviceAccountName: flyte-pod-webhook
       volumes:
       - configMap:
-          name: flyte-propeller-config-6gd7cgkkdt
+          name: flyte-propeller-config-d9bhkt4m5d
         name: config-volume
   ttlSecondsAfterFinished: 0
 ---

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -525,7 +525,7 @@ data:
     plugins:
       k8s:
         co-pilot:
-          image: ghcr.io/lyft/flyteplugins/flytecopilot:dc4bdbd61cac88a39a5ff43e40f026bdbc2c78a2
+          image: cr.flyte.org/lyft/flyteplugins/flytecopilot:dc4bdbd61cac88a39a5ff43e40f026bdbc2c78a2
           name: flyte-copilot-
           start-timeout: 30s
   core.yaml: | 
@@ -3308,7 +3308,7 @@ spec:
           - /etc/flyte/config/*.yaml
           - migrate
           - run
-          image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+          image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
           imagePullPolicy: "IfNotPresent"
           name: run-migrations
           volumeMounts:
@@ -3324,7 +3324,7 @@ spec:
           - flytesnacks
           - flytetester
           - flyteexamples
-          image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+          image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
           imagePullPolicy: "IfNotPresent"
           name: seed-projects
           volumeMounts:
@@ -3337,7 +3337,7 @@ spec:
           - /etc/flyte/config/*.yaml
           - clusterresource
           - sync
-          image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+          image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           volumeMounts:
@@ -3347,7 +3347,7 @@ spec:
           - mountPath: /etc/flyte/config
             name: config-volume
         - name: generate-secrets
-          image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+          image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
           imagePullPolicy: "IfNotPresent"
           command: ["/bin/sh", "-c"]
           args:
@@ -3368,7 +3368,7 @@ spec:
         - --config
         - /etc/flyte/config/*.yaml
         - serve
-        image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+        image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
         imagePullPolicy: "IfNotPresent"
         name: flyteadmin
         ports:
@@ -3454,7 +3454,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       containers:
-      - image: "ghcr.io/flyteorg/flyteconsole:v0.20.1"
+      - image: "cr.flyte.org/flyteorg/flyteconsole:v0.20.1"
         imagePullPolicy: "IfNotPresent"
         name: flyteconsole
         envFrom:
@@ -3510,7 +3510,7 @@ spec:
         - /etc/datacatalog/config/*.yaml
         - migrate
         - run
-        image: "ghcr.io/flyteorg/datacatalog:v0.3.4"
+        image: "cr.flyte.org/flyteorg/datacatalog:v0.3.4"
         imagePullPolicy: "IfNotPresent"
         name: run-migrations
         volumeMounts:
@@ -3523,7 +3523,7 @@ spec:
         - --config
         - /etc/datacatalog/config/*.yaml
         - serve
-        image: "ghcr.io/flyteorg/datacatalog:v0.3.4"
+        image: "cr.flyte.org/flyteorg/datacatalog:v0.3.4"
         imagePullPolicy: "IfNotPresent"
         name: datacatalog
         ports:
@@ -3674,7 +3674,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "39b1bbbb470253315bf89bc2ef85d67d4aced1b6db49127bd40077117742ac1"
+        configChecksum: "e058717a2d188a9fa4f917de689533fdb2c07c6978169c5b15a2ec765900b3b"
       labels: 
         app.kubernetes.io/name: flytepropeller
         app.kubernetes.io/instance: flyte
@@ -3691,7 +3691,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: "ghcr.io/flyteorg/flytepropeller:v0.11.0"
+        image: "cr.flyte.org/flyteorg/flytepropeller:v0.11.0"
         imagePullPolicy: "IfNotPresent"
         name: flytepropeller
         ports:
@@ -3739,12 +3739,12 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v0.11.0
       annotations:
-        configChecksum: "39b1bbbb470253315bf89bc2ef85d67d4aced1b6db49127bd40077117742ac1"
+        configChecksum: "e058717a2d188a9fa4f917de689533fdb2c07c6978169c5b15a2ec765900b3b"
     spec:
       serviceAccountName: flyte-pod-webhook
       initContainers:
       - name: generate-secrets
-        image: "ghcr.io/flyteorg/flytepropeller:v0.11.0"
+        image: "cr.flyte.org/flyteorg/flytepropeller:v0.11.0"
         imagePullPolicy: "IfNotPresent"
         command:
           - flytepropeller
@@ -3767,7 +3767,7 @@ spec:
             mountPath: /etc/flyte/config
       containers:
         - name: webhook
-          image: "ghcr.io/flyteorg/flytepropeller:v0.11.0"
+          image: "cr.flyte.org/flyteorg/flytepropeller:v0.11.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -3823,7 +3823,7 @@ spec:
             - /etc/flyte/config/*.yaml
             - clusterresource
             - sync
-            image: "ghcr.io/flyteorg/flyteadmin:v0.6.0"
+            image: "cr.flyte.org/flyteorg/flyteadmin:v0.6.0"
             imagePullPolicy: "IfNotPresent"
             name: sync-cluster-resources
             volumeMounts:

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -393,7 +393,7 @@ data:
       k8s:
         co-pilot:
           name: "flyte-copilot-"
-          image: "ghcr.io/flyteorg/flytecopilot:v0.5.28"
+          image: "cr.flyte.org/flyteorg/flytecopilot:v0.5.28"
           start-timeout: "30s"
   core.yaml: |
     propeller:
@@ -474,7 +474,7 @@ data:
 
 kind: ConfigMap
 metadata:
-  name: flyte-propeller-config-dtdt5gbgg2
+  name: flyte-propeller-config-d9cm925f8m
   namespace: flyte
 ---
 apiVersion: v1
@@ -614,7 +614,7 @@ spec:
         - --config
         - /etc/datacatalog/config/*.yaml
         - serve
-        image: ghcr.io/flyteorg/datacatalog:v0.3.4
+        image: cr.flyte.org/flyteorg/datacatalog:v0.3.4
         imagePullPolicy: IfNotPresent
         name: datacatalog
         ports:
@@ -632,7 +632,7 @@ spec:
         - /etc/datacatalog/config/*.yaml
         - migrate
         - run
-        image: ghcr.io/flyteorg/datacatalog:v0.3.4
+        image: cr.flyte.org/flyteorg/datacatalog:v0.3.4
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -689,7 +689,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/flyteorg/flytepropeller:v0.11.0
+        image: cr.flyte.org/flyteorg/flytepropeller:v0.11.0
         imagePullPolicy: IfNotPresent
         name: webhook
         volumeMounts:
@@ -702,7 +702,7 @@ spec:
       serviceAccountName: flyte-pod-webhook
       volumes:
       - configMap:
-          name: flyte-propeller-config-dtdt5gbgg2
+          name: flyte-propeller-config-d9cm925f8m
         name: config-volume
       - name: webhook-certs
         secret:
@@ -737,7 +737,7 @@ spec:
         - --config
         - /etc/flyte/config/*.yaml
         - serve
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: flyteadmin
         ports:
@@ -790,7 +790,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - migrate
         - run
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -806,7 +806,7 @@ spec:
         - seed-projects
         - flytetester
         - flytesnacks
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: seed-projects
         volumeMounts:
@@ -820,7 +820,7 @@ spec:
         - /etc/flyte/config/*.yaml
         - clusterresource
         - sync
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: sync-cluster-resources
         volumeMounts:
@@ -840,7 +840,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/flyteorg/flyteadmin:v0.6.0
+        image: cr.flyte.org/flyteorg/flyteadmin:v0.6.0
         imagePullPolicy: IfNotPresent
         name: generate-secrets
         volumeMounts:
@@ -896,7 +896,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: ghcr.io/flyteorg/flytepropeller:v0.11.0
+        image: cr.flyte.org/flyteorg/flytepropeller:v0.11.0
         imagePullPolicy: IfNotPresent
         name: flytepropeller
         ports:
@@ -909,7 +909,7 @@ spec:
       serviceAccountName: flytepropeller
       volumes:
       - configMap:
-          name: flyte-propeller-config-dtdt5gbgg2
+          name: flyte-propeller-config-d9cm925f8m
         name: config-volume
       - name: auth
         secret:
@@ -1015,7 +1015,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/flyteorg/flytepropeller:v0.11.0
+        image: cr.flyte.org/flyteorg/flytepropeller:v0.11.0
         imagePullPolicy: IfNotPresent
         name: webhook
         volumeMounts:
@@ -1025,7 +1025,7 @@ spec:
       serviceAccountName: flyte-pod-webhook
       volumes:
       - configMap:
-          name: flyte-propeller-config-dtdt5gbgg2
+          name: flyte-propeller-config-d9cm925f8m
         name: config-volume
   ttlSecondsAfterFinished: 0
 ---

--- a/end2end/tests/endtoend.yaml
+++ b/end2end/tests/endtoend.yaml
@@ -11,7 +11,7 @@ spec:
     command:
     - bash
     - -c
-    image: ghcr.io/flyteorg/flytetools:7701a15fbdd3f2debfb51b250e5744791e406249
+    image: cr.flyte.org/flyteorg/flytetools:7701a15fbdd3f2debfb51b250e5744791e406249
     imagePullPolicy: IfNotPresent
     name: flytetester
     resources:

--- a/helm/README.md
+++ b/helm/README.md
@@ -74,8 +74,8 @@ helm upgrade -f values-sandbox.yaml flyte .
 | configmap.adminServer.server.security.useAuth | bool | `false` | Controls whether to enforce authentication. Follow the guide in https://docs.flyte.org/ on how to setup authentication. |
 | configmap.catalog | object | `{"catalog-cache":{"endpoint":"datacatalog:89","insecure":true,"type":"datacatalog"}}` | Catalog Client configuration [structure](https://pkg.go.dev/github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/catalog#Config) Additional advanced Catalog configuration [here](https://pkg.go.dev/github.com/lyft/flyteplugins/go/tasks/pluginmachinery/catalog#Config) |
 | configmap.console | object | `{"BASE_URL":"/console","CONFIG_DIR":"/etc/flyte/config","DISABLE_AUTH":"1"}` | Configuration for Flyte console UI |
-| configmap.copilot | object | `{"plugins":{"k8s":{"co-pilot":{"image":"ghcr.io/lyft/flyteplugins/flytecopilot:dc4bdbd61cac88a39a5ff43e40f026bdbc2c78a2","name":"flyte-copilot-","start-timeout":"30s"}}}}` | Copilot configuration |
-| configmap.copilot.plugins.k8s.co-pilot | object | `{"image":"ghcr.io/lyft/flyteplugins/flytecopilot:dc4bdbd61cac88a39a5ff43e40f026bdbc2c78a2","name":"flyte-copilot-","start-timeout":"30s"}` | Structure documented [here](https://pkg.go.dev/github.com/lyft/flyteplugins@v0.5.28/go/tasks/pluginmachinery/flytek8s/config#FlyteCoPilotConfig) |
+| configmap.copilot | object | `{"plugins":{"k8s":{"co-pilot":{"image":"cr.flyte.org/lyft/flyteplugins/flytecopilot:dc4bdbd61cac88a39a5ff43e40f026bdbc2c78a2","name":"flyte-copilot-","start-timeout":"30s"}}}}` | Copilot configuration |
+| configmap.copilot.plugins.k8s.co-pilot | object | `{"image":"cr.flyte.org/lyft/flyteplugins/flytecopilot:dc4bdbd61cac88a39a5ff43e40f026bdbc2c78a2","name":"flyte-copilot-","start-timeout":"30s"}` | Structure documented [here](https://pkg.go.dev/github.com/lyft/flyteplugins@v0.5.28/go/tasks/pluginmachinery/flytek8s/config#FlyteCoPilotConfig) |
 | configmap.core | object | `{"propeller":{"downstream-eval-duration":"30s","enable-admin-launcher":true,"leader-election":{"enabled":true,"lease-duration":"15s","lock-config-map":{"name":"propeller-leader","namespace":"flyte"},"renew-deadline":"10s","retry-period":"2s"},"limit-namespace":"all","max-workflow-retries":30,"metadata-prefix":"metadata/propeller","metrics-prefix":"flyte","prof-port":10254,"queue":{"batch-size":-1,"batching-interval":"2s","queue":{"base-delay":"5s","capacity":1000,"max-delay":"120s","rate":100,"type":"maxof"},"sub-queue":{"capacity":100,"rate":10,"type":"bucket"},"type":"batch"},"rawoutput-prefix":"s3://my-s3-bucket/","workers":4,"workflow-reeval-duration":"30s"},"webhook":{"certDir":"/etc/webhook/certs","serviceName":"flyte-pod-webhook"}}` | Core propeller configuration |
 | configmap.core.propeller | object | `{"downstream-eval-duration":"30s","enable-admin-launcher":true,"leader-election":{"enabled":true,"lease-duration":"15s","lock-config-map":{"name":"propeller-leader","namespace":"flyte"},"renew-deadline":"10s","retry-period":"2s"},"limit-namespace":"all","max-workflow-retries":30,"metadata-prefix":"metadata/propeller","metrics-prefix":"flyte","prof-port":10254,"queue":{"batch-size":-1,"batching-interval":"2s","queue":{"base-delay":"5s","capacity":1000,"max-delay":"120s","rate":100,"type":"maxof"},"sub-queue":{"capacity":100,"rate":10,"type":"bucket"},"type":"batch"},"rawoutput-prefix":"s3://my-s3-bucket/","workers":4,"workflow-reeval-duration":"30s"}` | follows the structure specified [here](https://pkg.go.dev/github.com/flyteorg/flytepropeller/pkg/controller/config). |
 | configmap.datacatalogServer | object | `{"application":{"grpcPort":8089,"grpcServerReflection":true,"httpPort":8080},"datacatalog":{"metrics-scope":"datacatalog","profiler-port":10254,"storage-prefix":"metadata/datacatalog"}}` | Datacatalog server config |
@@ -107,7 +107,7 @@ helm upgrade -f values-sandbox.yaml flyte .
 | datacatalog.affinity | object | `{}` | affinity for Datacatalog deployment |
 | datacatalog.configPath | string | `"/etc/datacatalog/config/*.yaml"` | Default regex string for searching configuration files |
 | datacatalog.image.pullPolicy | string | `"IfNotPresent"` |  |
-| datacatalog.image.repository | string | `"ghcr.io/flyteorg/datacatalog"` | Docker image for Datacatalog deployment |
+| datacatalog.image.repository | string | `"cr.flyte.org/flyteorg/datacatalog"` | Docker image for Datacatalog deployment |
 | datacatalog.image.tag | string | `"v0.3.4"` |  |
 | datacatalog.nodeSelector | object | `{}` | nodeSelector for Datacatalog deployment |
 | datacatalog.podAnnotations | object | `{}` | Annotations for Datacatalog pods |
@@ -123,7 +123,7 @@ helm upgrade -f values-sandbox.yaml flyte .
 | flyteadmin.affinity | object | `{}` | affinity for Flyteadmin deployment |
 | flyteadmin.configPath | string | `"/etc/flyte/config/*.yaml"` | Default regex string for searching configuration files |
 | flyteadmin.image.pullPolicy | string | `"IfNotPresent"` |  |
-| flyteadmin.image.repository | string | `"ghcr.io/flyteorg/flyteadmin"` | Docker image for Flyteadmin deployment |
+| flyteadmin.image.repository | string | `"cr.flyte.org/flyteorg/flyteadmin"` | Docker image for Flyteadmin deployment |
 | flyteadmin.image.tag | string | `"v0.6.0"` |  |
 | flyteadmin.nodeSelector | object | `{}` | nodeSelector for Flyteadmin deployment |
 | flyteadmin.podAnnotations | object | `{}` | Annotations for Flyteadmin pods |
@@ -137,7 +137,7 @@ helm upgrade -f values-sandbox.yaml flyte .
 | flyteadmin.tolerations | list | `[]` | tolerations for Flyteadmin deployment |
 | flyteconsole.affinity | object | `{}` | affinity for Flyteconsole deployment |
 | flyteconsole.image.pullPolicy | string | `"IfNotPresent"` |  |
-| flyteconsole.image.repository | string | `"ghcr.io/flyteorg/flyteconsole"` | Docker image for Flyteconsole deployment |
+| flyteconsole.image.repository | string | `"cr.flyte.org/flyteorg/flyteconsole"` | Docker image for Flyteconsole deployment |
 | flyteconsole.image.tag | string | `"v0.20.1"` |  |
 | flyteconsole.nodeSelector | object | `{}` | nodeSelector for Flyteconsole deployment |
 | flyteconsole.podAnnotations | object | `{}` | Annotations for Flyteconsole pods |
@@ -149,7 +149,7 @@ helm upgrade -f values-sandbox.yaml flyte .
 | flytepropeller.cacheSizeMbs | int | `0` |  |
 | flytepropeller.configPath | string | `"/etc/flyte/config/*.yaml"` | Default regex string for searching configuration files |
 | flytepropeller.image.pullPolicy | string | `"IfNotPresent"` |  |
-| flytepropeller.image.repository | string | `"ghcr.io/flyteorg/flytepropeller"` | Docker image for Flytepropeller deployment |
+| flytepropeller.image.repository | string | `"cr.flyte.org/flyteorg/flytepropeller"` | Docker image for Flytepropeller deployment |
 | flytepropeller.image.tag | string | `"v0.11.0"` |  |
 | flytepropeller.nodeSelector | object | `{}` | nodeSelector for Flytepropeller deployment |
 | flytepropeller.podAnnotations | object | `{}` | Annotations for Flytepropeller pods |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -14,7 +14,7 @@ flyteadmin:
   replicaCount: 1
   image:
     # -- Docker image for Flyteadmin deployment
-    repository: ghcr.io/flyteorg/flyteadmin
+    repository: cr.flyte.org/flyteorg/flyteadmin
     tag: v0.6.0 # FLYTEADMIN_TAG
     pullPolicy: IfNotPresent
   # -- Default resources requests and limits for Flyteadmin deployment
@@ -61,7 +61,7 @@ datacatalog:
   replicaCount: 1
   image:
     # -- Docker image for Datacatalog deployment
-    repository: ghcr.io/flyteorg/datacatalog
+    repository: cr.flyte.org/flyteorg/datacatalog
     tag: v0.3.4 # DATACATALOG_TAG
     pullPolicy: IfNotPresent
   # -- Default resources requests and limits for Datacatalog deployment
@@ -107,7 +107,7 @@ flytepropeller:
   replicaCount: 1
   image:
     # -- Docker image for Flytepropeller deployment
-    repository: ghcr.io/flyteorg/flytepropeller
+    repository: cr.flyte.org/flyteorg/flytepropeller
     tag: v0.11.0 # FLYTEPROPELLER_TAG
     pullPolicy: IfNotPresent
   # -- Default resources requests and limits for Flytepropeller deployment
@@ -150,7 +150,7 @@ flyteconsole:
   replicaCount: 1
   image:
     # -- Docker image for Flyteconsole deployment
-    repository: ghcr.io/flyteorg/flyteconsole
+    repository: cr.flyte.org/flyteorg/flyteconsole
     tag: v0.20.1 # FLYTECONSOLE_TAG
     pullPolicy: IfNotPresent
   # -- Default resources requests and limits for Flyteconsole deployment
@@ -554,7 +554,7 @@ configmap:
         # -- Structure documented [here](https://pkg.go.dev/github.com/lyft/flyteplugins@v0.5.28/go/tasks/pluginmachinery/flytek8s/config#FlyteCoPilotConfig)
         co-pilot:
           name: flyte-copilot-
-          image: ghcr.io/lyft/flyteplugins/flytecopilot:dc4bdbd61cac88a39a5ff43e40f026bdbc2c78a2
+          image: cr.flyte.org/lyft/flyteplugins/flytecopilot:dc4bdbd61cac88a39a5ff43e40f026bdbc2c78a2
           start-timeout: 30s
 
   # -- Core propeller configuration

--- a/kustomize/base/single_cluster/headless/config/propeller/plugins/copilot.yaml
+++ b/kustomize/base/single_cluster/headless/config/propeller/plugins/copilot.yaml
@@ -2,5 +2,5 @@ plugins:
   k8s:
     co-pilot:
       name: "flyte-copilot-"
-      image: "ghcr.io/flyteorg/flytecopilot:v0.5.28"
+      image: "cr.flyte.org/flyteorg/flytecopilot:v0.5.28"
       start-timeout: "30s"

--- a/kustomize/overlays/eks/kustomization.yaml
+++ b/kustomize/overlays/eks/kustomization.yaml
@@ -22,20 +22,20 @@ images:
   # FlyteAdmin
   - name: flyteadmin # match images with this name
     newTag: v0.6.0 # FLYTEADMIN_TAG override the tag
-    newName: ghcr.io/flyteorg/flyteadmin # override the name
+    newName: cr.flyte.org/flyteorg/flyteadmin # override the name
   # FlyteConsole
   - name: flyteconsole # match images with this name
     newTag: v0.20.1 # FLYTECONSOLE_TAG  the tag
-    newName: ghcr.io/flyteorg/flyteconsole # override the namep
+    newName: cr.flyte.org/flyteorg/flyteconsole # override the namep
   # Flyte DataCatalog
   - name: datacatalog # match images with this name
     newTag: v0.3.4 # DATACATALOG_TAG override the tag
-    newName: ghcr.io/flyteorg/datacatalog # override the name
+    newName: cr.flyte.org/flyteorg/datacatalog # override the name
   # FlytePropeller
   - name: flytepropeller # match images with this name
     newTag: v0.11.0 # FLYTEPROPELLER_TAG override the tag
-    newName: ghcr.io/flyteorg/flytepropeller # override the name
+    newName: cr.flyte.org/flyteorg/flytepropeller # override the name
   # Webhook
   - name: webhook # match images with this name
     newTag: v0.11.0 # FLYTEPROPELLER_TAG override the tag
-    newName: ghcr.io/flyteorg/flytepropeller # override the name
+    newName: cr.flyte.org/flyteorg/flytepropeller # override the name

--- a/kustomize/overlays/gcp/kustomization.yaml
+++ b/kustomize/overlays/gcp/kustomization.yaml
@@ -24,20 +24,20 @@ images:
   # FlyteAdmin
   - name: flyteadmin # match images with this name
     newTag: v0.6.0 # FLYTEADMIN_TAG override the tag
-    newName: ghcr.io/flyteorg/flyteadmin # override the name
+    newName: cr.flyte.org/flyteorg/flyteadmin # override the name
   # FlyteConsole
   - name: flyteconsole # match images with this name
     newTag: v0.20.1 # FLYTECONSOLE_TAG  the tag
-    newName: ghcr.io/flyteorg/flyteconsole # override the namep
+    newName: cr.flyte.org/flyteorg/flyteconsole # override the namep
   # Flyte DataCatalog
   - name: datacatalog # match images with this name
     newTag: v0.3.4 # DATACATALOG_TAG override the tag
-    newName: ghcr.io/flyteorg/datacatalog # override the name
+    newName: cr.flyte.org/flyteorg/datacatalog # override the name
   # FlytePropeller
   - name: flytepropeller # match images with this name
     newTag: v0.11.0 # FLYTEPROPELLER_TAG override the tag
-    newName: ghcr.io/flyteorg/flytepropeller # override the name
+    newName: cr.flyte.org/flyteorg/flytepropeller # override the name
   # Webhook
   - name: webhook # match images with this name
     newTag: v0.11.0 # FLYTEPROPELLER_TAG override the tag
-    newName: ghcr.io/flyteorg/flytepropeller # override the name
+    newName: cr.flyte.org/flyteorg/flytepropeller # override the name

--- a/kustomize/overlays/sandbox/kustomization.yaml
+++ b/kustomize/overlays/sandbox/kustomization.yaml
@@ -26,23 +26,23 @@ images:
   # FlyteAdmin
   - name: flyteadmin # match images with this name
     newTag: v0.6.0 # FLYTEADMIN_TAG override the tag
-    newName: ghcr.io/flyteorg/flyteadmin # override the name
+    newName: cr.flyte.org/flyteorg/flyteadmin # override the name
   # FlyteConsole
   - name: flyteconsole # match images with this name
     newTag: v0.20.1 # FLYTECONSOLE_TAG  the tag
-    newName: ghcr.io/flyteorg/flyteconsole # override the namep
+    newName: cr.flyte.org/flyteorg/flyteconsole # override the namep
   # Flyte DataCatalog
   - name: datacatalog # match images with this name
     newTag: v0.3.4 # DATACATALOG_TAG override the tag
-    newName: ghcr.io/flyteorg/datacatalog # override the name
+    newName: cr.flyte.org/flyteorg/datacatalog # override the name
   # FlytePropeller
   - name: flytepropeller # match images with this name
     newTag: v0.11.0 # FLYTEPROPELLER_TAG override the tag
-    newName: ghcr.io/flyteorg/flytepropeller # override the name
+    newName: cr.flyte.org/flyteorg/flytepropeller # override the name
   # Webhook
   - name: webhook # match images with this name
     newTag: v0.11.0 # FLYTEPROPELLER_TAG override the tag
-    newName: ghcr.io/flyteorg/flytepropeller # override the name
+    newName: cr.flyte.org/flyteorg/flytepropeller # override the name
   # Override postgres image to use alpine based (rather smaller) docker image
   - name: postgres
     newTag: 10.16-alpine

--- a/kustomize/overlays/test/kustomization.yaml
+++ b/kustomize/overlays/test/kustomization.yaml
@@ -20,23 +20,23 @@ images:
   # FlyteAdmin
   - name: flyteadmin # match images with this name
     newTag: v0.6.0 # FLYTEADMIN_TAG override the tag
-    newName: ghcr.io/flyteorg/flyteadmin # override the name
+    newName: cr.flyte.org/flyteorg/flyteadmin # override the name
   # FlyteConsole
   - name: flyteconsole # match images with this name
     newTag: v0.20.1 # FLYTECONSOLE_TAG  the tag
-    newName: ghcr.io/flyteorg/flyteconsole # override the namep
+    newName: cr.flyte.org/flyteorg/flyteconsole # override the namep
   # Flyte DataCatalog
   - name: datacatalog # match images with this name
     newTag: v0.3.4 # DATACATALOG_TAG override the tag
-    newName: ghcr.io/flyteorg/datacatalog # override the name
+    newName: cr.flyte.org/flyteorg/datacatalog # override the name
   # FlytePropeller
   - name: flytepropeller # match images with this name
     newTag: v0.11.0 # FLYTEPROPELLER_TAG override the tag
-    newName: ghcr.io/flyteorg/flytepropeller # override the name
+    newName: cr.flyte.org/flyteorg/flytepropeller # override the name
   # Webhook
   - name: webhook # match images with this name
     newTag: v0.11.0 # FLYTEPROPELLER_TAG override the tag
-    newName: ghcr.io/flyteorg/flytepropeller # override the name
+    newName: cr.flyte.org/flyteorg/flytepropeller # override the name
   # Override postgres image to use alpine based (rather smaller) docker image
   - name: postgres
     newTag: 10.16-alpine

--- a/rsts/getting_started.rst
+++ b/rsts/getting_started.rst
@@ -81,7 +81,7 @@ Steps
 
 .. prompt:: bash
 
-  REGISTRY=ghcr.io/flyteorg make fast_register
+  REGISTRY=cr.flyte.org/flyteorg make fast_register
 
 .. note::
    If the images are to be re-built, run ``make register`` command.

--- a/script/generate_helm.sh
+++ b/script/generate_helm.sh
@@ -21,7 +21,7 @@ then
     GO111MODULE=on go get github.com/norwoodj/helm-docs/cmd/helm-docs
 fi
 
-~/go/bin/helm-docs -t ${DIR}/../helm/README.md.gotmpl ${DIR}/../helm/
+${GOPATH}/bin/helm-docs -t ${DIR}/../helm/README.md.gotmpl ${DIR}/../helm/
 
 # This section is used by GitHub workflow to ensure that the generation step was run
 if [ -n "$DELTA_CHECK" ]; then

--- a/script/generate_helm.sh
+++ b/script/generate_helm.sh
@@ -21,7 +21,7 @@ then
     GO111MODULE=on go get github.com/norwoodj/helm-docs/cmd/helm-docs
 fi
 
-${GOPATH}/bin/helm-docs -t ${DIR}/../helm/README.md.gotmpl ${DIR}/../helm/
+${GOPATH:-~/go}/bin/helm-docs -t ${DIR}/../helm/README.md.gotmpl ${DIR}/../helm/
 
 # This section is used by GitHub workflow to ensure that the generation step was run
 if [ -n "$DELTA_CHECK" ]; then


### PR DESCRIPTION
This change updates ghcr.io container references to instead use flyte's new cr.flyte.org domain. All generated yaml files have been updated as well. Please let me know if I missed anything, changed something that shouldn't be, etc. Thanks!