### PR TITLE
Make initial projects customizable

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -125,6 +125,7 @@ helm upgrade -f values-sandbox.yaml flyte .
 | flyteadmin.image.pullPolicy | string | `"IfNotPresent"` |  |
 | flyteadmin.image.repository | string | `"cr.flyte.org/flyteorg/flyteadmin"` | Docker image for Flyteadmin deployment |
 | flyteadmin.image.tag | string | `"v0.6.0"` |  |
+| flyteadmin.initialProjects | list | `["flytesnacks","flytetester","flyteexamples"]` | Initial projects to create |
 | flyteadmin.nodeSelector | object | `{}` | nodeSelector for Flyteadmin deployment |
 | flyteadmin.podAnnotations | object | `{}` | Annotations for Flyteadmin pods |
 | flyteadmin.replicaCount | int | `1` | Replicas count for Flyteadmin deployment |

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -189,7 +189,7 @@ storage:
     auth-type: accesskey
     secret-key: miniostorage
     disable-ssl: true
-    endpoint: http://minio.flyte.svc.cluster.local:9000
+    endpoint: http://minio.{{ .Release.Namespace }}.svc.cluster.local:9000
     region: us-east-1
 {{- else if eq .Values.storage.type "custom" }}
 {{- with .Values.storage.custom -}}

--- a/helm/templates/admin/deployment.yaml
+++ b/helm/templates/admin/deployment.yaml
@@ -38,21 +38,23 @@ spec:
           volumeMounts: {{- include "databaseSecret.volumeMount" . | nindent 10 }}
           - mountPath: /etc/flyte/config
             name: config-volume
+        {{- if .Values.flyteadmin.initialProjects }}
         - command:
           - flyteadmin
           - --config
           - {{ .Values.flyteadmin.configPath }}
           - migrate
           - seed-projects
-          - flytesnacks
-          - flytetester
-          - flyteexamples
+          {{- range .Values.flyteadmin.initialProjects }}
+          - {{ . }}
+          {{- end }}
           image: "{{ .Values.flyteadmin.image.repository }}:{{ .Values.flyteadmin.image.tag }}"
           imagePullPolicy: "{{ .Values.flyteadmin.image.pullPolicy }}"
           name: seed-projects
           volumeMounts: {{- include "databaseSecret.volumeMount" . | nindent 10 }}
           - mountPath: /etc/flyte/config
             name: config-volume
+        {{- end }}
         {{- if .Values.cluster_resource_manager.enabled }}
         - command:
           - flyteadmin

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -29,6 +29,11 @@ flyteadmin:
       memory: 50Mi
   # -- Default regex string for searching configuration files
   configPath: /etc/flyte/config/*.yaml
+  # -- Initial projects to create
+  initialProjects:
+    - flytesnacks
+    - flytetester
+    - flyteexamples
   # -- Service settings for Flyteadmin
   service:
     annotations:


### PR DESCRIPTION
This change allows customizing the projects created on helm install. Defaults to the previously hardcoded list of ["flytesnacks","flytetester","flyteexamples"].