### PR TITLE
Added conditional annotation for grpc to use HTTP2 as target group

### DIFF
--- a/helm/manifest.yaml
+++ b/helm/manifest.yaml
@@ -1945,8 +1945,7 @@ metadata:
   name: flyte
   namespace: flyte
   annotations: 
-    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig":
-      { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:832573439839:certificate/a7db79d4-4f8c-4c7b-a4f4-109bf2fb5efa
     alb.ingress.kubernetes.io/group.name: flyte
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
@@ -2071,14 +2070,14 @@ metadata:
   name: flyte-grpc
   namespace: flyte
   annotations:
-    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig":
-      { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:832573439839:certificate/a7db79d4-4f8c-4c7b-a4f4-109bf2fb5efa
     alb.ingress.kubernetes.io/group.name: flyte
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/tags: service_instance=production
     kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/backend-protocol-version: HTTP2
     nginx.ingress.kubernetes.io/backend-protocol: GRPC
 spec:
   rules:

--- a/helm/manifest.yaml
+++ b/helm/manifest.yaml
@@ -1945,8 +1945,11 @@ metadata:
   name: flyte
   namespace: flyte
   annotations: 
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig":
+      { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:832573439839:certificate/a7db79d4-4f8c-4c7b-a4f4-109bf2fb5efa
     alb.ingress.kubernetes.io/group.name: flyte
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/tags: service_instance=production
     kubernetes.io/ingress.class: alb
@@ -1954,6 +1957,11 @@ spec:
   rules:
     - http:
         paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              serviceName: ssl-redirect
+              servicePort: use-annotation
           # This is useful only for frontend development
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi
@@ -2063,8 +2071,11 @@ metadata:
   name: flyte-grpc
   namespace: flyte
   annotations:
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig":
+      { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:832573439839:certificate/a7db79d4-4f8c-4c7b-a4f4-109bf2fb5efa
     alb.ingress.kubernetes.io/group.name: flyte
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/tags: service_instance=production
     kubernetes.io/ingress.class: alb
@@ -2073,6 +2084,12 @@ spec:
   rules:
     - http:
         paths:
+          #
+          # - backend:
+          #     serviceName: ssl-redirect
+          #     servicePort: use-annotation
+          #   path: /*
+          #   pathType: ImplementationSpecific
           #
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
           - path: /flyteidl.service.AdminService

--- a/helm/values-eks.yaml
+++ b/helm/values-eks.yaml
@@ -164,7 +164,7 @@ contour:
 
 common:
   ingress:
-    albSSLRedirect: false
+    albSSLRedirect: true
     separateGrpcIngress: true
     annotations:
       # -- aws-load-balancer-controller v2.1 or higher is required - https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/
@@ -172,9 +172,9 @@ common:
       kubernetes.io/ingress.class: alb
       alb.ingress.kubernetes.io/tags: service_instance=production
       alb.ingress.kubernetes.io/scheme: internet-facing
-#      alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:832573439839:certificate/a7db79d4-4f8c-4c7b-a4f4-109bf2fb5efa
-      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
-#      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+      alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:832573439839:certificate/a7db79d4-4f8c-4c7b-a4f4-109bf2fb5efa
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
       # -- Instruct ALB Controller to not create multiple load balancers (and hence maintain a single endpoint for both GRPC and Http)
       alb.ingress.kubernetes.io/group.name: flyte
   databaseSecret:

--- a/helm/values-eks.yaml
+++ b/helm/values-eks.yaml
@@ -172,6 +172,7 @@ common:
       kubernetes.io/ingress.class: alb
       alb.ingress.kubernetes.io/tags: service_instance=production
       alb.ingress.kubernetes.io/scheme: internet-facing
+      # -- This is the certificate arn of the cert imported in AWS certificate manager. 
       alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:832573439839:certificate/a7db79d4-4f8c-4c7b-a4f4-109bf2fb5efa
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
       alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'

--- a/helm/values-eks.yaml
+++ b/helm/values-eks.yaml
@@ -177,6 +177,8 @@ common:
       alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
       # -- Instruct ALB Controller to not create multiple load balancers (and hence maintain a single endpoint for both GRPC and Http)
       alb.ingress.kubernetes.io/group.name: flyte
+    separateGrpcIngressAnnotations:
+      alb.ingress.kubernetes.io/backend-protocol-version: HTTP2
   databaseSecret:
     name: db-pass
     secretManifest:


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

This arn points to self signed cert generated for flyte.example.org
arn:aws:acm:us-east-2:832573439839:certificate/577f9991-a6cf-4d1c-b56d-447b24077f46

User can directly hit the ingress https endpoint to browse UI console and also hit grpc to query through flytectl

User has to ignore the warning when browsing the UI console which is expected and new flag in flytectl has been added to do the same skip. This won't be the case in production flyte deployment where a CA verified cert will be used.
