### PR TITLE
Update Kind to 0.11.1 to fix CNI issue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
       - master
   pull_request:
 jobs:
-
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +31,7 @@ jobs:
         run: DELTA_CHECK=true make helm
       - uses: engineerd/setup-kind@v0.5.0
         with:
-          version: "v0.10.0"
+          version: "v0.11.1"
       - name: End2End
         env:
           DOCKER_USERNAME: ${{ github.actor }}


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Kind started failing to bring up CNI plugin and causing E2E tests to fail across all repos. We're not sure what caused this but something in the Github environment is probably to blame.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin
