### PR TITLE
Added kustomize support in docker sandbox

### DIFF
--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -78,7 +78,7 @@ COPY --from=base_ /flyteorg/ /flyteorg/
 COPY docker/sandbox/flyte-entrypoint-dind.sh /flyteorg/bin/flyte-entrypoint.sh
 
 # Copy kustomization template 
-COPY docker/sandbox/kustomization.yaml.tmpl /opt/flyteorg/share/deployment/kustomization.yaml
+COPY docker/sandbox/kustomization.yaml  /flyteorg/share/kustomization.yaml
 
 # Update PATH variable
 ENV PATH "/flyteorg/bin:${PATH}"

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -22,13 +22,6 @@ ARG K3S_VERSION="v1.21.1%2Bk3s1"
 RUN wget -q -O /flyteorg/bin/k3s https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION}/k3s \
     && chmod +x /flyteorg/bin/k3s
 
-# Install kustomize
-ARG KUSTOMIZE_VERSION="v4.0.5"
-RUN wget -q -O /tmp/kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz \
-    && tar -xf /tmp/kustomize.tar.gz -C /flyteorg/bin \
-    && chmod +x /flyteorg/bin/kustomize \
-    && rm /tmp/kustomize.tar.gz
-
 # Install flytectl
 RUN wget -q -O - https://raw.githubusercontent.com/flyteorg/flytectl/master/install.sh | BINDIR=/flyteorg/bin sh -s
 

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -22,6 +22,13 @@ ARG K3S_VERSION="v1.21.1%2Bk3s1"
 RUN wget -q -O /flyteorg/bin/k3s https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION}/k3s \
     && chmod +x /flyteorg/bin/k3s
 
+# Install kustomize
+ARG KUSTOMIZE_VERSION="v4.0.5"
+RUN wget -q -O /tmp/kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz \
+    && tar -xf /tmp/kustomize.tar.gz -C /flyteorg/bin \
+    && chmod +x /flyteorg/bin/kustomize \
+    && rm /tmp/kustomize.tar.gz
+
 # Install flytectl
 RUN wget -q -O - https://raw.githubusercontent.com/flyteorg/flytectl/master/install.sh | BINDIR=/flyteorg/bin sh -s
 
@@ -69,6 +76,9 @@ COPY --from=base_ /flyteorg/ /flyteorg/
 
 # Copy entrypoints
 COPY docker/sandbox/flyte-entrypoint-dind.sh /flyteorg/bin/flyte-entrypoint.sh
+
+# Copy kustomization template 
+COPY docker/sandbox/kustomization.yaml.tmpl /opt/flyteorg/share/deployment/kustomization.yaml
 
 # Update PATH variable
 ENV PATH "/flyteorg/bin:${PATH}"

--- a/docker/sandbox/flyte-entrypoint-default.sh
+++ b/docker/sandbox/flyte-entrypoint-default.sh
@@ -15,6 +15,11 @@ K3S_PID=$!
 timeout 600 sh -c "until k3s kubectl explain deployment &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for the Kubernetes cluster to start"; exit 1 )
 echo "Done."
 
+# Build flyte
+echo "Build Flyte..."
+cp /flyteorg/share/flyte_generated.yaml /opt/flyteorg/share/deployment
+kustomize build /opt/flyteorg/share/deployment | tee /flyteorg/share/flyte_generated.yaml
+
 # Deploy flyte
 echo "Deploying Flyte..."
 k3s kubectl apply -f /flyteorg/share/flyte_generated.yaml

--- a/docker/sandbox/flyte-entrypoint-default.sh
+++ b/docker/sandbox/flyte-entrypoint-default.sh
@@ -15,14 +15,9 @@ K3S_PID=$!
 timeout 600 sh -c "until k3s kubectl explain deployment &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for the Kubernetes cluster to start"; exit 1 )
 echo "Done."
 
-# Build flyte
-echo "Build Flyte..."
-cp /flyteorg/share/flyte_generated.yaml /opt/flyteorg/share/deployment
-kustomize build /opt/flyteorg/share/deployment | tee /flyteorg/share/flyte_generated.yaml
-
 # Deploy flyte
 echo "Deploying Flyte..."
-k3s kubectl apply -f /flyteorg/share/flyte_generated.yaml
+k3s kubectl apply -k /flyteorg/share
 wait-for-flyte.sh
 
 wait ${K3S_PID}

--- a/docker/sandbox/flyte-entrypoint-dind.sh
+++ b/docker/sandbox/flyte-entrypoint-dind.sh
@@ -32,6 +32,11 @@ K3S_PID=$!
 timeout 600 sh -c "until k3s kubectl explain deployment &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for the Kubernetes cluster to start"; exit 1 )
 echo "Done."
 
+# Build flyte
+echo "Build Flyte..."
+cp /flyteorg/share/flyte_generated.yaml /opt/flyteorg/share/deployment
+kustomize build /opt/flyteorg/share/deployment | tee /flyteorg/share/flyte_generated.yaml
+
 # Deploy flyte
 echo "Deploying Flyte..."
 k3s kubectl apply -f /flyteorg/share/flyte_generated.yaml

--- a/docker/sandbox/flyte-entrypoint-dind.sh
+++ b/docker/sandbox/flyte-entrypoint-dind.sh
@@ -32,14 +32,9 @@ K3S_PID=$!
 timeout 600 sh -c "until k3s kubectl explain deployment &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for the Kubernetes cluster to start"; exit 1 )
 echo "Done."
 
-# Build flyte
-echo "Build Flyte..."
-cp /flyteorg/share/flyte_generated.yaml /opt/flyteorg/share/deployment
-kustomize build /opt/flyteorg/share/deployment | tee /flyteorg/share/flyte_generated.yaml
-
 # Deploy flyte
 echo "Deploying Flyte..."
-k3s kubectl apply -f /flyteorg/share/flyte_generated.yaml
+k3s kubectl apply -k /flyteorg/share
 wait-for-flyte.sh
 
 # Monitor running processes. Exit when the first process exits.

--- a/docker/sandbox/kustomization.yaml
+++ b/docker/sandbox/kustomization.yaml
@@ -4,6 +4,3 @@ kind: Kustomization
 
 bases:
   - flyte_generated.yaml
-
-# Image overrides
-images: []

--- a/docker/sandbox/kustomization.yaml.tmpl
+++ b/docker/sandbox/kustomization.yaml.tmpl
@@ -1,0 +1,9 @@
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - flyte_generated.yaml
+
+# Image overrides
+images: []


### PR DESCRIPTION
Context : In flytectl sandbox, I am introducing a new flag i.e. `--kustomize`, But for that container should build manifest before deployment in the entry point.`. Currently, Pytest-flyte maintains the logic for kustomize build-in entry point (https://github.com/flyteorg/pytest-flyte/tree/main/src/pytest_flyte/docker). 


- I used the same implementation that pytest has but after these changes flytectl and pytest can share the same dependency. 

