### PR TITLE
Bugfix - Added kustomize file in non dind image 

### DIFF
--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -44,6 +44,9 @@ RUN apk add --no-cache bash git make tini
 COPY docker/sandbox/flyte-entrypoint-default.sh /flyteorg/bin/flyte-entrypoint.sh
 COPY docker/sandbox/bashrc /root/.bashrc
 
+# Copy kustomization template
+COPY docker/sandbox/kustomization.yaml  /flyteorg/share/kustomization.yaml
+
 # Update PATH variable
 ENV PATH "/flyteorg/bin:${PATH}"
 


### PR DESCRIPTION
- Added kustomize file in docker for non dind image 

Currently non did image is failing because of  kustomize file. 

```bash
$ docker run --rm --privileged -p 30081:30081 -p 30084:30084 cr.flyte.org/flyteorg/flyte-sandbox
Starting k3s cluster...
Done.
Deploying Flyte...
error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/flyteorg/sh
```

Fix : #1321 