### PR TITLE
Update sandbox.rst

### DIFF
--- a/rsts/deployment/sandbox.rst
+++ b/rsts/deployment/sandbox.rst
@@ -187,6 +187,6 @@ Flyte configuration on your remote cluster.
 
 #. You can now port-forward (or if you have load-balancer enabled then get an LB) to connect to remote FlyteConsole, as follows::
 
-    kubectl port-forward svc/envoy 30081:80 -n projectcontour
+    kubectl port-forward --address 0.0.0.0 svc/envoy 30081:80 -n projectcontour
 
 #. Open console http://localhost:30081/console.


### PR DESCRIPTION
1. Expose the port to other machines, so we could connect it from other machines.
2. `svc/envoy` is in the namespace `projectcontour`, so specify the namespace in the `kubectl` command.

btw, I use `kubectl create -f https://raw.githubusercontent.com/flyteorg/flyte/master/deployment/sandbox/flyte_generated.yaml
` to install Flyte in minikube
```
(flyte) ➜  myflyteapp git:(main) k get svc -A
NAMESPACE              NAME                        TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE
default                kubernetes                  ClusterIP   10.96.0.1        <none>        443/TCP                      48m
flyte                  datacatalog                 ClusterIP   10.99.212.57     <none>        88/TCP,89/TCP                47m
flyte                  flyte-pod-webhook           ClusterIP   10.100.47.71     <none>        443/TCP                      47m
flyte                  flyteadmin                  ClusterIP   10.105.248.122   <none>        87/TCP,80/TCP,81/TCP         47m
flyte                  flyteconsole                ClusterIP   10.111.130.233   <none>        80/TCP                       47m
flyte                  minio                       ClusterIP   10.103.98.214    <none>        9000/TCP                     47m
flyte                  minio-direct                NodePort    10.104.230.107   <none>        9000:30084/TCP               47m
flyte                  postgres                    ClusterIP   10.108.25.36     <none>        5432/TCP                     47m
flyte                  postgres-direct             NodePort    10.106.186.71    <none>        5432:30083/TCP               47m
kube-system            kube-dns                    ClusterIP   10.96.0.10       <none>        53/UDP,53/TCP,9153/TCP       48m
kubernetes-dashboard   dashboard-metrics-scraper   ClusterIP   10.101.158.228   <none>        8000/TCP                     47m
kubernetes-dashboard   kubernetes-dashboard        NodePort    10.96.115.222    <none>        80:30082/TCP                 47m
projectcontour         contour                     ClusterIP   10.105.125.55    <none>        8001/TCP                     47m
projectcontour         envoy                       NodePort    10.107.129.249   <none>        80:30081/TCP,443:31954/TCP   47m

```