### PR TITLE
Fix broken links

### DIFF
--- a/rsts/concepts/admin.rst
+++ b/rsts/concepts/admin.rst
@@ -18,7 +18,7 @@ RPC
 FlyteAdmin uses the `grpc-gateway <https://github.com/grpc-ecosystem/grpc-gateway>`__ library to serve
 incoming gRPC and HTTP requests with identical handlers. For a more detailed overview of the API,
 including request and response entities, see the admin
-service :std:ref:`definition <protos/docs/service/index:rest/and/grpc/interface/for/the/flyte/admin/service>`. The
+service :std:ref:`definition <protos/docs/service/index>`. The
 RPC handlers are a thin shim that enforce some request structure validation and call out to appropriate :ref:`manager <divedeep-admin-manager>`.
 methods to process requests.
 
@@ -145,7 +145,7 @@ FlyteAdmin Service Background
 Entities
 ---------
 
-The  :std:ref:`admin service definition <protos/docs/service/index:rest/and/grpc/interface/for/the/flyte/admin/service>` defines REST operations for the entities
+The  :std:ref:`admin service definition <protos/docs/service/index>` defines REST operations for the entities
 flyteadmin administers.
 
 As a refresher, the primary :ref:`entities <divedeep>` across Flyte map similarly to FlyteAdmin entities.

--- a/rsts/concepts/admin.rst
+++ b/rsts/concepts/admin.rst
@@ -18,7 +18,7 @@ RPC
 FlyteAdmin uses the `grpc-gateway <https://github.com/grpc-ecosystem/grpc-gateway>`__ library to serve
 incoming gRPC and HTTP requests with identical handlers. For a more detailed overview of the API,
 including request and response entities, see the admin
-service :std:ref:`definition <protos/docs/service/service:flyteidl/service/admin.proto>`. The
+service :std:ref:`definition <protos/docs/service/index:rest/and/grpc/interface/for/the/flyte/admin/service>`. The
 RPC handlers are a thin shim that enforce some request structure validation and call out to appropriate :ref:`manager <divedeep-admin-manager>`.
 methods to process requests.
 
@@ -145,7 +145,7 @@ FlyteAdmin Service Background
 Entities
 ---------
 
-The  :std:ref:`admin service definition <protos/docs/service/service:flyteidl/service/admin.proto>` defines REST operations for the entities
+The  :std:ref:`admin service definition <protos/docs/service/index:rest/and/grpc/interface/for/the/flyte/admin/service>` defines REST operations for the entities
 flyteadmin administers.
 
 As a refresher, the primary :ref:`entities <divedeep>` across Flyte map similarly to FlyteAdmin entities.

--- a/rsts/concepts/architecture.rst
+++ b/rsts/concepts/architecture.rst
@@ -11,7 +11,7 @@ FlyteIDL
 
 In Flyte, entities like "Workflows", "Tasks", "Launch Plans", and "Schedules" are recognized by multiple system components. In order for components to communicate effectively, they need a shared understanding about the structure of these entities.
 
-The Flyte IDL (Interface Definition Language) is where shared Flyte entities are defined. This IDL also defines the RPC service definition for the :std:ref:`core Flyte API <protos/docs/service/index:rest/and/grpc/interface/for/the/flyte/admin/service>`.
+The Flyte IDL (Interface Definition Language) is where shared Flyte entities are defined. This IDL also defines the RPC service definition for the :std:ref:`core Flyte API <protos/docs/service/index>`.
 
 FlyteIDL uses the `protobuf <https://developers.google.com/protocol-buffers/>`_ schema to describe entities. Clients are generated for Python, Golang, and JavaScript and imported by Flyte components.
 

--- a/rsts/concepts/architecture.rst
+++ b/rsts/concepts/architecture.rst
@@ -11,7 +11,7 @@ FlyteIDL
 
 In Flyte, entities like "Workflows", "Tasks", "Launch Plans", and "Schedules" are recognized by multiple system components. In order for components to communicate effectively, they need a shared understanding about the structure of these entities.
 
-The Flyte IDL (Interface Definition Language) is where shared Flyte entities are defined. This IDL also defines the RPC service definition for the :std:ref:`core Flyte API <protos/docs/service/service:flyteidl/service/admin.proto>`.
+The Flyte IDL (Interface Definition Language) is where shared Flyte entities are defined. This IDL also defines the RPC service definition for the :std:ref:`core Flyte API <protos/docs/service/index:rest/and/grpc/interface/for/the/flyte/admin/service>`.
 
 FlyteIDL uses the `protobuf <https://developers.google.com/protocol-buffers/>`_ schema to describe entities. Clients are generated for Python, Golang, and JavaScript and imported by Flyte components.
 


### PR DESCRIPTION
Fix broken link in https://docs.flyte.org/en/stable/concepts/admin.html
Error message: https://github.com/flyteorg/flyte/pull/1334/checks?check_run_id=3319088096
```
Warning, treated as error:
/home/runner/work/flyte/flyte/rsts/concepts/admin.rst:18:undefined label: protos/docs/service/service:flyteidl/service/admin.proto
make[1]: *** [Makefile:20: html] Error 2
make[1]: Leaving directory '/home/runner/work/flyte/flyte/rsts'
make: *** [Makefile:71: docs] Error 2
Error: Process completed with exit code 2.
```

This link should point to https://docs.flyte.org/projects/flyteidl/en/latest/protos/docs/service/index.html#rest-and-grpc-interface-for-the-flyte-admin-service