### PR TITLE
Support test workflow runs on other branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,5 @@
 name: tests
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 jobs:
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Support test workflow runs on other branches, so we could check whether tests are failed before creating a PR.