### PR TITLE
[WIP] Added hotfix for sandbox

### DIFF
--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -2,8 +2,9 @@ name: Build & Push Sandbox Docker Image
 
 on:
   pull_request:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
 
 jobs:
   push-sandbox-image:
@@ -25,7 +26,7 @@ jobs:
           build_extra_args: "--target=default --compress=true"
           context: ./
           dockerfile: docker/sandbox/Dockerfile
-          push_image_and_stages: ${{ github.event_name == 'release' }}
+          push_image_and_stages: ${{ github.event_name != 'pull_request' }}
   push-sandbox-dind-image:
     name: Push sandbox DinD image to GHCR
     runs-on: ubuntu-latest
@@ -44,4 +45,4 @@ jobs:
           build_extra_args: "--target=dind --compress=true"
           context: ./
           dockerfile: docker/sandbox/Dockerfile
-          push_image_and_stages: ${{ github.event_name == 'release' }}
+          push_image_and_stages: ${{ github.event_name != 'pull_request' }}

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -37,7 +37,7 @@ RUN wget -q -O - https://raw.githubusercontent.com/flyteorg/flytectl/master/inst
 COPY --from=go_builder_ /install/linux/ /flyteorg/bin/
 
 # Copy flyte chart
-COPY charts/flyte/ /flyteorg/share/flyte
+COPY charts/flyte/values-sandbox.yaml /flyteorg/share/values-sandbox.yaml
 
 # Copy scripts
 COPY docker/sandbox/kubectl docker/sandbox/cgroup-v2-hack.sh docker/sandbox/wait-for-flyte.sh /flyteorg/bin/

--- a/docker/sandbox/flyte-entrypoint-default.sh
+++ b/docker/sandbox/flyte-entrypoint-default.sh
@@ -17,7 +17,8 @@ echo "Done."
 
 # Deploy flyte
 echo "Deploying Flyte..."
-helm install -n flyte -f /flyteorg/share/flyte/values-sandbox.yaml --create-namespace flyte /flyteorg/share/flyte --kubeconfig /etc/rancher/k3s/k3s.yaml
+helm repo add flyteorg https://flyteorg.github.io/flyte
+helm install -n flyte -f /flyteorg/share/values-sandbox.yaml --create-namespace flyte flyteorg/flyte --kubeconfig /etc/rancher/k3s/k3s.yaml
 
 wait-for-flyte.sh
 

--- a/docker/sandbox/flyte-entrypoint-dind.sh
+++ b/docker/sandbox/flyte-entrypoint-dind.sh
@@ -34,7 +34,8 @@ echo "Done."
 
 # Deploy flyte
 echo "Deploying Flyte..."
-helm install -n flyte -f /flyteorg/share/flyte/values-sandbox.yaml --create-namespace flyte /flyteorg/share/flyte --kubeconfig /etc/rancher/k3s/k3s.yaml
+helm repo add flyteorg https://flyteorg.github.io/flyte
+helm install -n flyte -f /flyteorg/share/values-sandbox.yaml --create-namespace flyte flyteorg/flyte --kubeconfig /etc/rancher/k3s/k3s.yaml
 
 wait-for-flyte.sh
 

--- a/docker/sandbox/wait-for-flyte.sh
+++ b/docker/sandbox/wait-for-flyte.sh
@@ -22,6 +22,6 @@ timeout 600 sh -c "until k3s kubectl rollout status deployment flytepropeller -n
 k3s kubectl wait --for=condition=available deployment/datacatalog deployment/flyteadmin deployment/flyteconsole deployment/flytepropeller -n flyte --timeout=10m || ( echo >&2 "Timed out while waiting for the Flyte deployment to start"; exit 1 )
 
 # Wait for envoy proxy to become ready
-timeout 600 sh -c 'until [[ $(k3s kubectl get daemonset envoy -n projectcontour -o jsonpath="{.status.numberReady}") -eq 1 ]]; do sleep 1; done' || ( echo >&2 "Timed out while waiting for the Flyte envoy proxy to start"; exit 1 )
+timeout 600 sh -c 'until [[ $(k3s kubectl get daemonset flyte-contour-envoy -n flyte -o jsonpath="{.status.numberReady}") -eq 1 ]]; do sleep 1; done' || ( echo >&2 "Timed out while waiting for the Flyte envoy proxy to start"; exit 1 )
 
 echo "Flyte is ready! Flyte UI is available at http://localhost:30081/console."


### PR DESCRIPTION
Bug Sandbox break after a new release. The issue was I didn't add `helm dep update` and it got passed in local testing because I have all the dependency when I build the image and it didn't through error

Fix:
- Made changes in GitHub workflow, Now we will publish sandbox image in each release
- At runtime in the entry point script, Sandbox will add helm registry and always install the latest release with `values-sandbox.yaml`....values-sandbox is always available in docker image but we can override it


Tested:  Tested for both images dind & nondind...Also able to excute basic workflow 
```
Starting Docker daemon...
Done.
Starting k3s cluster...
Done.
Deploying Flyte...
"flyteorg" has been added to your repositories
NAME: flyte
LAST DEPLOYED: Fri Sep 3 10:42:32 2021
NAMESPACE: flyte
STATUS: deployed
REVISION: 1
TEST SUITE: None

Waiting for Flyte to become ready...
W0903 10:42:28.423852 576 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0903 10:42:28.620954 576 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0903 10:42:29.846817 576 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0903 10:42:29.898518 576 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0903 10:42:31.950984 576 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0903 10:42:31.992426 576 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0903 10:42:33.972518 576 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0903 10:42:34.001818 576 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W0903 10:42:34.004957 576 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W0903 10:42:34.080678 576 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W0903 10:42:34.083960 576 warnings.go:70] networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
W0903 10:44:24.019827 576 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0903 10:44:24.068966 576 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W0903 10:44:24.070250 576 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W0903 10:44:24.196919 576 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W0903 10:44:24.226757 576 warnings.go:70] networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
deployment.apps/datacatalog condition met
deployment.apps/flyteadmin condition met
deployment.apps/flyteconsole condition met
deployment.apps/flytepropeller condition met
Flyte is ready! Flyte UI is available at http://localhost:30081/console.


```