### PR TITLE
Revert variablemapentry change in task.rst

### DIFF
--- a/rsts/concepts/tasks.rst
+++ b/rsts/concepts/tasks.rst
@@ -18,7 +18,7 @@ In general, a Flyte task is characterized by:
 
    In order for tasks to exchange data with each other, a task can define a signature (much like a function/method
    signature in programming languages). A task interface defines the input and output variables —
-   :std:ref:`variable map entry <flyteidl:protos/docs/core/core:variablemapentry>`
+   :std:ref:`variablesentry <flyteidl:protos/docs/core/core:variablemap.variablesentry>`
    and their types, :std:ref:`literaltype <flyteidl:protos/docs/core/core:literaltype>`.
 
 Can "X" Be a Flyte Task?


### PR DESCRIPTION
The recent [flyteidl](https://github.com/flyteorg/flyteidl/pull/220) reverted the variable map entry change. This PR partially reverts https://github.com/flyteorg/flyte/pull/1400/files which added variable map entry.
![Screen Shot 2021-09-10 at 12 56 30](https://user-images.githubusercontent.com/6239450/132910843-426210a9-329a-4b1f-8a79-d9b7e438dca1.png)
The link now points to
https://docs.flyte.org/projects/flyteidl/en/latest/protos/docs/core/core.html#variablemap-variablesentry
Signed-off-by: Sean Lin <sean@union.ai>