### PR TITLE
WIP: [infra]: Add config-connector for GCP

### DIFF
--- a/kustomize/overlays/gcp/configconnector/cloudsql/kustomization.yaml
+++ b/kustomize/overlays/gcp/configconnector/cloudsql/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ./sqldb.yaml
+  - ./sqlinstance.yaml
+  - ./sqluser.yaml

--- a/kustomize/overlays/gcp/configconnector/cloudsql/sqldb.yaml
+++ b/kustomize/overlays/gcp/configconnector/cloudsql/sqldb.yaml
@@ -1,0 +1,25 @@
+apiVersion: sql.cnrm.cloud.google.com/v1beta1
+kind: SQLDatabase
+metadata:
+  name: flytedb
+  labels:
+    app.kubernetes.io/name: flytedb
+    app.kubernetes.io/component: postgresql
+spec:
+  charset: utf8mb4
+  collation: utf8mb4_bin
+  instanceRef:
+    name: flyte-instance
+---
+apiVersion: sql.cnrm.cloud.google.com/v1beta1
+kind: SQLDatabase
+metadata:
+  name: datacatalog
+  labels:
+    app.kubernetes.io/name: flytedb
+    app.kubernetes.io/component: postgresql
+spec:
+  charset: utf8mb4
+  collation: utf8mb4_bin
+  instanceRef:
+    name: flyte-instance

--- a/kustomize/overlays/gcp/configconnector/cloudsql/sqlinstance.yaml
+++ b/kustomize/overlays/gcp/configconnector/cloudsql/sqlinstance.yaml
@@ -1,0 +1,12 @@
+apiVersion: sql.cnrm.cloud.google.com/v1beta1
+kind: SQLInstance
+metadata:
+  name: flyte-instance
+  labels:
+    app.kubernetes.io/name: flytedb
+    app.kubernetes.io/component: postgresql
+spec:
+  region: us-central1
+  databaseVersion: POSTGRES_13
+  settings:
+    tier: db-custom-4-13312

--- a/kustomize/overlays/gcp/configconnector/cloudsql/sqluser.yaml
+++ b/kustomize/overlays/gcp/configconnector/cloudsql/sqluser.yaml
@@ -1,0 +1,15 @@
+apiVersion: sql.cnrm.cloud.google.com/v1beta1
+kind: SQLUser
+metadata:
+  name: flyte-user
+  labels:
+    app.kubernetes.io/name: flytedb
+    app.kubernetes.io/component: postgresql
+spec:
+  instanceRef:
+    name: flyte-instance
+  password:
+    valueFrom:
+      secretKeyRef:
+        name: db-user-pass
+        key: password

--- a/kustomize/overlays/gcp/configconnector/gcs.yaml
+++ b/kustomize/overlays/gcp/configconnector/gcs.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  annotations:
+    cnrm.cloud.google.com/force-destroy: "false"
+  name: flyte-test-bucket
+spec:
+  bucketPolicyOnly: true
+  versioning:
+    enabled: false

--- a/kustomize/overlays/gcp/configconnector/kustomization.yaml
+++ b/kustomize/overlays/gcp/configconnector/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: REPLACE_ME_GCP_PROJECT
+
+resources:
+  - ./gcs.yaml
+  - ./cloudsql
+
+secretGenerator:
+- name: db-user-pass
+  literals:
+  - username=fyltedb
+  - password=yourpassword #TODO: autogenerate password

--- a/kustomize/overlays/gcp/flyte/admin/deployment.yaml
+++ b/kustomize/overlays/gcp/flyte/admin/deployment.yaml
@@ -7,6 +7,15 @@ spec:
   template:
     spec:
       containers:
+      - name: cloudsql-proxy
+        image: gcr.io/cloudsql-docker/gce-proxy:1.16
+        imagePullPolicy: IfNotPresent
+        # TODO: replace <project-id> with the GCP project ID and <region> with the region where
+        # Cloud SQL runs
+        command: ["/cloud_sql_proxy", "-instances=data-infra-flyte:us-central1:flyte-instance=tcp:0.0.0.0:5432"]
+        ports:
+          - containerPort: 5432
+
       - name: flyteadmin
         resources:
           limits:

--- a/kustomize/overlays/gcp/flyte/config/admin/db.yaml
+++ b/kustomize/overlays/gcp/flyte/config/admin/db.yaml
@@ -1,6 +1,6 @@
 database:
   port: 5432
-  username: flyte
+  username: flyte-user
   host: cloudsqlproxy
-  dbname: flyte
+  dbname: flytedb
   passwordPath: /etc/db/pass.txt

--- a/kustomize/overlays/gcp/flyte/config/common/storage.yaml
+++ b/kustomize/overlays/gcp/flyte/config/common/storage.yaml
@@ -5,10 +5,10 @@ storage:
     config:
       json: ""
       # TODO: replace <project-id> with the GCP project ID
-      project_id: <project-id>
+      project_id: data-infra-flyte
       scopes: https://www.googleapis.com/auth/devstorage.read_write
   # TODO replace with the container (bucket) in GCS used by Flyte as intermediate store
-  container: "flyte"
+  container: "data-infra-flyte-test-bucket"
   # NOTE this cache configuration is purely for propeller. But since we are having a common storage
   # config, we are configuring this value. In production create a separate storage config for
   # propeller and increase the cache size

--- a/kustomize/overlays/gcp/flyte/config/datacatalog/db.yaml
+++ b/kustomize/overlays/gcp/flyte/config/datacatalog/db.yaml
@@ -1,7 +1,7 @@
 database:
   port: 5432
-  username: flyte
-  host: cloudsqlproxy
+  username: flyte-user
+  host: localhost
   dbname: datacatalog
   options: "sslmode=disable"
   passwordPath: /etc/db/pass.txt

--- a/kustomize/overlays/gcp/flyte/config/propeller/plugins/task_logs.yaml
+++ b/kustomize/overlays/gcp/flyte/config/propeller/plugins/task_logs.yaml
@@ -6,5 +6,5 @@ plugins:
     # #2 GCP stackdriver
     stackdriver-enabled: true
     # TODO: replace <project-id> with the GCP project ID
-    gcp-project: <project-id>
+    gcp-project: data-infra-flyte
     stackdriver-logresourcename: k8s_container

--- a/kustomize/overlays/gcp/flyte/datacatalog/deployment.yaml
+++ b/kustomize/overlays/gcp/flyte/datacatalog/deployment.yaml
@@ -7,6 +7,15 @@ spec:
   template:
     spec:
       containers:
+      - name: cloudsql-proxy
+        image: gcr.io/cloudsql-docker/gce-proxy:1.16
+        imagePullPolicy: IfNotPresent
+        # TODO: replace <project-id> with the GCP project ID and <region> with the region where
+        # Cloud SQL runs
+        command: ["/cloud_sql_proxy", "-instances=data-infra-flyte:us-central1:flyte-instance=tcp:0.0.0.0:5432"]
+        ports:
+          - containerPort: 5432
+
       - name: datacatalog
         resources:
           limits:

--- a/kustomize/overlays/gcp/flyte/kustomization.yaml
+++ b/kustomize/overlays/gcp/flyte/kustomization.yaml
@@ -57,4 +57,4 @@ secretGenerator:
 - name: db-pass
   behavior: merge
   literals:
-  - pass.txt="yourpassword"
+  - pass.txt="be1J4IG5EAUkkmI6A6BhUEW22g9PvhAN"


### PR DESCRIPTION
TODO:
- [ ] create GKE cluster with config-connector
- [ ] Configure URL with the generated CloudSQL instance
- [ ] Use cloudsql_proxy as a sidecar in manifest for `flyteadmin` and `datacatalog`
- [ ] documentation