### PR TITLE
update github links

### DIFF
--- a/rsts/conf.py
+++ b/rsts/conf.py
@@ -122,10 +122,10 @@ html_theme_options = {
         "color-brand-content": "#9D68E4",
     },
     # custom flyteorg furo theme options
-    "github_repo": "flytesnacks",
+    "github_repo": "flyte",
     "github_username": "flyteorg",
     "github_commit": "master",
-    "docs_path": "cookbook/docs",  # path to documentation source
+    "docs_path": "rsts",  # path to documentation source
     "sphinx_gallery_src_dir": "cookbook",  # path to directory of sphinx gallery source files relative to repo root
     "sphinx_gallery_dest_dir": "auto",  # path to root directory containing auto-generated sphinx gallery examples
 }


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

This PR fixes an issue where the "Edit on Github" button wasn't working for pages hosted on the `flyte` repo