### PR TITLE
Fix readme links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ To dig deeper into Flyte, refer to the [Documentation](https://docs.flyte.org/en
 - Presto Queries
 - Distributed Pytorch (K8s Native) -- [Pytorch Operator](https://docs.flyte.org/projects/cookbook/en/latest/auto/integrations/kubernetes/kfpytorch/index.html)
 - Sagemaker ([builtin algorithms](https://docs.flyte.org/projects/cookbook/en/latest/auto/integrations/aws/sagemaker_training/sagemaker_builtin_algo_training.html) & [custom models](https://docs.flyte.org/projects/cookbook/en/latest/auto/integrations/aws/sagemaker_training/sagemaker_custom_training.html))
-- Distributed Tensorflow (K8s Native) -- [TFOperator](https://docs.flyte.org/projects/cookbook/en/latest/auto/integrations/kubernetes/kftensorflow/index.html)
+- Distributed Tensorflow (K8s Native)
 - Papermill notebook execution ([Python](https://docs.flyte.org/projects/cookbook/en/latest/auto/integrations/flytekit_plugins/papermilltasks/index.html) and Spark)
-- [Type safe and data checking for Pandas dataframe](https://docs.flyte.org/projects/cookbook/en/latest/auto/integrations/flytekit_plugins/pandera/index.html) using Pandera
+- [Type safe and data checking for Pandas dataframe](https://docs.flyte.org/projects/cookbook/en/latest/auto/integrations/flytekit_plugins/pandera_examples/index.html) using Pandera
 - Versioned datastores using DoltHub and Dolt
 - Use SQLAlchemy to query any relational database 
 - Build your own plugins that use library containers


### PR DESCRIPTION
- Update pandera link
- Drop tensorflow link, since the relevant page is disabled for now: https://github.com/flyteorg/flytesnacks/blob/master/cookbook/docs/conf.py#L267