### PR TITLE
Sandbox support for arm64

### DIFF
--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -6,42 +6,77 @@ on:
     types: [published]
 
 jobs:
-  push-sandbox-image:
-    name: Push sandbox image to GHCR
+  sandbox-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           fetch-depth: "0"
-      - name: Push Sandbox Docker Image to Github Registry
-        uses: whoan/docker-build-with-cache-action@v5
+      - name: Prepare sandbox Image Names
+        id: sandbox-names
+        uses: docker/metadata-action@v3
         with:
-          # https://docs.github.com/en/packages/learn-github-packages/publishing-a-package
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository_owner }}/flyte-sandbox
+          tags: |
+            latest
+            type=sha,format=long
+      - name: Prepare DIND Image Names
+        id: dind-names
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository_owner }}/flyte-sandbox
+          tags: |
+            dind
+            type=sha,format=long, prefix=dind-
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-single-buildx
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
           username: "${{ secrets.FLYTE_BOT_USERNAME }}"
           password: "${{ secrets.FLYTE_BOT_PAT }}"
-          image_name: ${{ github.repository_owner }}/flyte-sandbox
-          image_tag: latest,${{ github.sha }},${{ github.event.ref }}
-          registry: ghcr.io
-          build_extra_args: "--target=default --compress=true"
-          context: ./
-          dockerfile: docker/sandbox/Dockerfile
-          push_image_and_stages: ${{ github.event_name == 'release' }}
-  push-sandbox-dind-image:
-    name: Push sandbox DinD image to GHCR
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      - name: Build and push Sandbox image
+        uses: docker/build-push-action@v2
         with:
-          fetch-depth: "0"
-      - name: Push Sandbox DinD Docker Image to Github Registry
-        uses: whoan/docker-build-with-cache-action@v5
+          context: .
+          platforms: linux/arm64, linux/amd64
+          push: ${{ github.event_name == 'release' }}
+          target: default
+          tags: ${{ steps.sandbox-names.outputs.tags }}
+          file: docker/sandbox/Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+      - name: Build and push DIND Image
+        uses: docker/build-push-action@v2
         with:
-          username: "${{ secrets.FLYTE_BOT_USERNAME }}"
-          password: "${{ secrets.FLYTE_BOT_PAT }}"
-          image_name: ${{ github.repository_owner }}/flyte-sandbox
-          image_tag: dind,dind-${{ github.sha }},dind-${{ github.event.ref }}
-          registry: ghcr.io
-          build_extra_args: "--target=dind --compress=true"
-          context: ./
-          dockerfile: docker/sandbox/Dockerfile
-          push_image_and_stages: ${{ github.event_name == 'release' }}
+          context: .
+          platforms: linux/arm64, linux/amd64
+          push: ${{ github.event_name == 'release' }}
+          target: dind
+          tags: ${{ steps.dind-names.outputs.tags }}
+          file: docker/sandbox/Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -46,7 +46,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-single-buildx
       - name: Login to GitHub Container Registry
-        if: ${{ github.event_name != 'release' }}
+        if: ${{ github.event_name == 'release' }}
         uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -46,6 +46,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-single-buildx
       - name: Login to GitHub Container Registry
+        if: ${{ github.event_name != 'release' }}
         uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -44,7 +44,7 @@ RUN wget -q -O /flyteorg/bin/get_helm.sh https://raw.githubusercontent.com/helm/
 
 
 # Install flytectl
-RUN wget -q -O - https://raw.githubusercontent.com/avan-sh/flytectl/test/arm-support/install.sh | BINDIR=/flyteorg/bin sh -s
+RUN wget -q -O - https://raw.githubusercontent.com/flyteorg/flytectl/master/install.sh | BINDIR=/flyteorg/bin sh -s
 
 # Install buildkit-cli-for-kubectl
 COPY --from=go_builder_ /install/linux/ /flyteorg/bin/

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -14,24 +14,37 @@ RUN git clone -b ${BUILDKIT_CLI_FOR_KUBECTL_VERSION} --single-branch --depth 1 h
 
 FROM alpine:3.13.5 AS base_
 
+# Install dependencies
+RUN apk add --no-cache openssl
+
 # Make directory to store artifacts
 RUN mkdir -p /flyteorg/bin /flyteorg/share
 
 # Install k3s
 ARG K3S_VERSION="v1.21.1%2Bk3s1"
-RUN wget -q -O /flyteorg/bin/k3s https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION}/k3s \
+ARG TARGETARCH
+
+RUN case $TARGETARCH in \
+    amd64) export SUFFIX=;; \
+    arm64) export SUFFIX=-arm64;; \
+    aarch64)  export SUFFIX=-arm64;; \
+    # TODO: Check if we need to add case fail
+    esac; \
+    wget -q -O /flyteorg/bin/k3s https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION}/k3s${SUFFIX} \
     && chmod +x /flyteorg/bin/k3s
 
 # Install Helm
-ENV HELM_URL="https://get.helm.sh"
 ARG HELM_VERSION="v3.6.3"
-RUN wget ${HELM_URL}/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xz && \
-    mv linux-amd64/helm /flyteorg/bin/helm && \
-    chmod +x /flyteorg/bin/helm && \
-    rm -rf linux-amd64
+
+RUN wget -q -O /flyteorg/bin/get_helm.sh https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get-helm-3 && \
+    chmod 700 /flyteorg/bin/get_helm.sh && \
+    sh /flyteorg/bin/get_helm.sh --version ${HELM_VERSION} && \
+    mv /usr/local/bin/helm /flyteorg/bin/helm && \
+    rm /flyteorg/bin/get_helm.sh 
+
 
 # Install flytectl
-RUN wget -q -O - https://raw.githubusercontent.com/flyteorg/flytectl/master/install.sh | BINDIR=/flyteorg/bin sh -s
+RUN wget -q -O - https://raw.githubusercontent.com/avan-sh/flytectl/test/arm-support/install.sh | BINDIR=/flyteorg/bin sh -s
 
 # Install buildkit-cli-for-kubectl
 COPY --from=go_builder_ /install/linux/ /flyteorg/bin/


### PR DESCRIPTION
Updated Dockerfile for helm and k3s installations to be platform agnostic
Modified sandbox build pipeline to build linux/amd64 and linux/arm64 versions
Uses docker/build-push-action@v2 to build docker images as docker-build-with-cache-action doesn't support multi-platform builds
Fix: #1248

Depends on https://github.com/flyteorg/flytectl/pull/209 to add arm entries to `install.sh`