### PR TITLE
Configure user and group in security context

### DIFF
--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -83,11 +83,13 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             [
-                "flyteadmin --config={{ .Values.flyteadmin.configPath }} secrets init --localPath /etc/secrets/auth && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --name flyte-admin-secrets --fromPath /etc/secrets/auth",
+                "flyteadmin --config={{ .Values.flyteadmin.configPath }} secrets init --localPath /etc/scratch/secrets && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --name flyte-admin-secrets --fromPath /etc/scratch/secrets",
             ]
           volumeMounts:
             - name: config-volume
               mountPath: /etc/flyte/config
+            - name: scratch
+              mountPath: /etc/scratch
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -145,6 +147,8 @@ spec:
       volumes: {{- include "databaseSecret.volume" . | nindent 8 }}
         - emptyDir: {}
           name: shared-data
+        - emptyDir: {}
+          name: scratch
         - configMap:
             name: flyte-admin-config
           name: config-volume

--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -18,13 +18,15 @@ spec:
       labels: {{ include "flyteadmin.labels" . | nindent 8 }}
     spec:
       securityContext:
-        fsGroup: 1001
+        fsGroup: 65534
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       initContainers:
         {{- if .Values.db.checks }}
         - name: check-db-ready
           image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
+          securityContext:
+             runAsUser: 0
           command:
           - sh
           - -c

--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{- end }}
       labels: {{ include "flyteadmin.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
         {{- if .Values.db.checks }}
         - name: check-db-ready

--- a/charts/flyte-core/templates/console/deployment.yaml
+++ b/charts/flyte-core/templates/console/deployment.yaml
@@ -17,6 +17,9 @@ spec:
         {{- end }}
       labels: {{ include "flyteconsole.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - image: "{{ .Values.flyteconsole.image.repository }}:{{ .Values.flyteconsole.image.tag }}"
         imagePullPolicy: "{{ .Values.flyteconsole.image.pullPolicy }}"

--- a/charts/flyte-core/templates/datacatalog/deployment.yaml
+++ b/charts/flyte-core/templates/datacatalog/deployment.yaml
@@ -25,6 +25,8 @@ spec:
       {{- if .Values.db.checks }}
       - name: check-db-ready
         image: postgres:10.16-alpine
+        securityContext:
+          runAsUser: 0
         command:
           - sh
           - -c

--- a/charts/flyte-core/templates/datacatalog/deployment.yaml
+++ b/charts/flyte-core/templates/datacatalog/deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{- end }}
       labels: {{ include "datacatalog.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
       {{- if .Values.db.checks }}
       - name: check-db-ready

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -20,9 +20,9 @@ spec:
       labels: {{ include "flytescheduler.labels" . | nindent 8 }}
     spec:
       securityContext:
-        fsGroup: 1001
+        fsGroup: 65534
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       initContainers:
       - command:
         - flytescheduler

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         {{- end }}
       labels: {{ include "flytescheduler.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
       - command:
         - flytescheduler

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -18,9 +18,9 @@ spec:
       labels: {{ include "flytepropeller.labels" . | nindent 8 }}
     spec:
       securityContext:
-        fsGroup: 1001
+        fsGroup: 65534
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       containers:
       - command:
         - flytepropeller

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{- end }}
       labels: {{ include "flytepropeller.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - command:
         - flytepropeller

--- a/charts/flyte-core/templates/propeller/webhook.yaml
+++ b/charts/flyte-core/templates/propeller/webhook.yaml
@@ -31,6 +31,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       serviceAccountName: {{ template "flyte-pod-webhook.name" . }}
 {{- if .Values.webhook.enabled }}
       initContainers:

--- a/charts/flyte-core/templates/propeller/webhook.yaml
+++ b/charts/flyte-core/templates/propeller/webhook.yaml
@@ -32,9 +32,9 @@ spec:
         {{- end }}
     spec:
       securityContext:
-        fsGroup: 1001
+        fsGroup: 65534
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       serviceAccountName: {{ template "flyte-pod-webhook.name" . }}
 {{- if .Values.webhook.enabled }}
       initContainers:

--- a/charts/flyte/templates/console/deployment.yaml
+++ b/charts/flyte/templates/console/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       securityContext:
         runAsUser: 1000
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       containers:
       - image: "{{ .Values.flyteconsole.image.repository }}:{{ .Values.flyteconsole.image.tag }}"
         imagePullPolicy: "{{ .Values.flyteconsole.image.pullPolicy }}"

--- a/charts/flyte/templates/console/deployment.yaml
+++ b/charts/flyte/templates/console/deployment.yaml
@@ -17,6 +17,9 @@ spec:
         {{- end }}
       labels: {{ include "flyteconsole.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - image: "{{ .Values.flyteconsole.image.repository }}:{{ .Values.flyteconsole.image.tag }}"
         imagePullPolicy: "{{ .Values.flyteconsole.image.pullPolicy }}"

--- a/charts/flyte/templates/datacatalog/deployment.yaml
+++ b/charts/flyte/templates/datacatalog/deployment.yaml
@@ -18,13 +18,15 @@ spec:
       labels: {{ include "datacatalog.labels" . | nindent 8 }}
     spec:
       securityContext:
-        fsGroup: 1001
+        fsGroup: 65534
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       initContainers:
         {{- if .Values.db.checks }}
         - name: check-db-ready
           image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
+          securityContext:
+             runAsUser: 0
           command:
             - sh
             - -c

--- a/charts/flyte/templates/datacatalog/deployment.yaml
+++ b/charts/flyte/templates/datacatalog/deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{- end }}
       labels: {{ include "datacatalog.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
         {{- if .Values.db.checks }}
         - name: check-db-ready

--- a/charts/flyte/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte/templates/flytescheduler/deployment.yaml
@@ -20,9 +20,9 @@ spec:
       labels: {{ include "flytescheduler.labels" . | nindent 8 }}
     spec:
       securityContext:
-        fsGroup: 1001
+        fsGroup: 65534
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       initContainers:
       - command:
         - flytescheduler

--- a/charts/flyte/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte/templates/flytescheduler/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         {{- end }}
       labels: {{ include "flytescheduler.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
       - command:
         - flytescheduler

--- a/charts/flyte/templates/propeller/deployment.yaml
+++ b/charts/flyte/templates/propeller/deployment.yaml
@@ -18,9 +18,9 @@ spec:
       labels: {{ include "flytepropeller.labels" . | nindent 8 }}
     spec:
       securityContext:
-        fsGroup: 1001
+        fsGroup: 65534
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       containers:
       - command:
         - flytepropeller

--- a/charts/flyte/templates/propeller/deployment.yaml
+++ b/charts/flyte/templates/propeller/deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{- end }}
       labels: {{ include "flytepropeller.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - command:
         - flytepropeller

--- a/charts/flyte/templates/propeller/webhook.yaml
+++ b/charts/flyte/templates/propeller/webhook.yaml
@@ -31,6 +31,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       serviceAccountName: {{ template "flyte-pod-webhook.name" . }}
 {{- if .Values.webhook.enabled }}
       initContainers:

--- a/charts/flyte/templates/propeller/webhook.yaml
+++ b/charts/flyte/templates/propeller/webhook.yaml
@@ -32,9 +32,9 @@ spec:
         {{- end }}
     spec:
       securityContext:
-        fsGroup: 1001
+        fsGroup: 65534
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       serviceAccountName: {{ template "flyte-pod-webhook.name" . }}
 {{- if .Values.webhook.enabled }}
       initContainers:

--- a/deployment/eks/flyte_core_helm_generated.yaml
+++ b/deployment/eks/flyte_core_helm_generated.yaml
@@ -830,11 +830,13 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             [
-                "flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/secrets/auth && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --name flyte-admin-secrets --fromPath /etc/secrets/auth",
+                "flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/scratch/secrets && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --name flyte-admin-secrets --fromPath /etc/scratch/secrets",
             ]
           volumeMounts:
             - name: config-volume
               mountPath: /etc/flyte/config
+            - name: scratch
+              mountPath: /etc/scratch
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -877,6 +879,8 @@ spec:
             secretName: db-pass
         - emptyDir: {}
           name: shared-data
+        - emptyDir: {}
+          name: scratch
         - configMap:
             name: flyte-admin-config
           name: config-volume

--- a/deployment/eks/flyte_core_helm_generated.yaml
+++ b/deployment/eks/flyte_core_helm_generated.yaml
@@ -772,6 +772,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       initContainers:
         - command:
           - flyteadmin
@@ -917,6 +921,9 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - image: "cr.flyte.org/flyteorg/flyteconsole:v0.29.0"
         imagePullPolicy: "IfNotPresent"
@@ -974,6 +981,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
       - command:
         - datacatalog
@@ -1060,6 +1071,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       containers:
       - command:
         - flytepropeller
@@ -1127,6 +1142,10 @@ spec:
       annotations:
         configChecksum: "e7425fcb5931f5a1ccfc272ff07af80519fc001d873e6f3d360f56e1ff940a9"
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       serviceAccountName: flyte-pod-webhook
       initContainers:
       - name: generate-secrets

--- a/deployment/eks/flyte_generated.yaml
+++ b/deployment/eks/flyte_generated.yaml
@@ -8663,6 +8663,10 @@ spec:
           name: config-volume
         - mountPath: /etc/db
           name: db-pass
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: datacatalog
       volumes:
       - emptyDir: {}
@@ -8745,6 +8749,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: flyte-pod-webhook
       volumes:
       - configMap:
@@ -8887,6 +8895,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: flyteadmin
       volumes:
       - emptyDir: {}
@@ -8934,6 +8946,9 @@ spec:
         volumeMounts:
         - mountPath: /srv/flyte
           name: shared-data
+      securityContext:
+        fsGroupChangePolicy: Always
+        runAsUser: 1000
       volumes:
       - emptyDir: {}
         name: shared-data
@@ -8986,6 +9001,10 @@ spec:
           name: config-volume
         - mountPath: /etc/secrets/
           name: auth
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: flytepropeller
       volumes:
       - configMap:

--- a/deployment/eks/flyte_generated.yaml
+++ b/deployment/eks/flyte_generated.yaml
@@ -8880,7 +8880,7 @@ spec:
         - mountPath: /etc/db
           name: db-pass
       - args:
-        - flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/secrets/auth && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --fromPath /etc/secrets/auth
+        - flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/scratch/secrets && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --fromPath /etc/scratch/secrets
         command:
         - /bin/sh
         - -c
@@ -8895,6 +8895,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+        - mountPath: /etc/scratch
+          name: scratch
       securityContext:
         fsGroup: 65534
         fsGroupChangePolicy: Always
@@ -8903,6 +8905,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: shared-data
+      - emptyDir: {}
+        name: scratch
       - configMap:
           name: flyte-admin-config-29g4dtt8tc
         name: config-volume

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -1471,6 +1471,9 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroupChangePolicy: "Always"
       containers:
       - image: "cr.flyte.org/flyteorg/flyteconsole:v0.29.0"
         imagePullPolicy: "IfNotPresent"
@@ -1528,6 +1531,10 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       initContainers:
         - command:
             - datacatalog
@@ -1614,6 +1621,10 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       containers:
       - command:
         - flytepropeller
@@ -1681,6 +1692,10 @@ spec:
       annotations:
         configChecksum: "f0f56517059d2ab9e6397a7c55ccb4bfbfaa54bf5662902582c768494539b44"
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       serviceAccountName: flyte-pod-webhook
       initContainers:
       - name: generate-secrets

--- a/deployment/gcp/flyte_core_helm_generated.yaml
+++ b/deployment/gcp/flyte_core_helm_generated.yaml
@@ -827,11 +827,13 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             [
-                "flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/secrets/auth && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --name flyte-admin-secrets --fromPath /etc/secrets/auth",
+                "flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/scratch/secrets && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --name flyte-admin-secrets --fromPath /etc/scratch/secrets",
             ]
           volumeMounts:
             - name: config-volume
               mountPath: /etc/flyte/config
+            - name: scratch
+              mountPath: /etc/scratch
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -871,6 +873,8 @@ spec:
         
         - emptyDir: {}
           name: shared-data
+        - emptyDir: {}
+          name: scratch
         - configMap:
             name: flyte-admin-config
           name: config-volume

--- a/deployment/gcp/flyte_core_helm_generated.yaml
+++ b/deployment/gcp/flyte_core_helm_generated.yaml
@@ -764,9 +764,15 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       initContainers:
         - name: check-db-ready
           image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
+          securityContext:
+             runAsUser: 0
           command:
           - sh
           - -c
@@ -902,6 +908,9 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - image: "cr.flyte.org/flyteorg/flyteconsole:v0.29.0"
         imagePullPolicy: "IfNotPresent"
@@ -952,6 +961,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
       - name: check-db-ready
         image: postgres:10.16-alpine
@@ -1033,6 +1046,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       initContainers:
       - command:
         - flytescheduler
@@ -1104,6 +1121,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       containers:
       - command:
         - flytepropeller
@@ -1164,6 +1185,10 @@ spec:
       annotations:
         configChecksum: "06fa4b4fb82a374700c8dcc5c2911b763e25eeef535488cb6166e201c0d8a1a"
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       serviceAccountName: flyte-pod-webhook
       initContainers:
       - name: generate-secrets

--- a/deployment/gcp/flyte_core_helm_generated.yaml
+++ b/deployment/gcp/flyte_core_helm_generated.yaml
@@ -968,6 +968,8 @@ spec:
       initContainers:
       - name: check-db-ready
         image: postgres:10.16-alpine
+        securityContext:
+          runAsUser: 0
         command:
           - sh
           - -c

--- a/deployment/gcp/flyte_generated.yaml
+++ b/deployment/gcp/flyte_generated.yaml
@@ -8705,6 +8705,10 @@ spec:
           name: config-volume
         - mountPath: /etc/db
           name: db-pass
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: datacatalog
       volumes:
       - emptyDir: {}
@@ -8787,6 +8791,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: flyte-pod-webhook
       volumes:
       - configMap:
@@ -8929,6 +8937,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: flyteadmin
       volumes:
       - emptyDir: {}
@@ -8976,6 +8988,9 @@ spec:
         volumeMounts:
         - mountPath: /srv/flyte
           name: shared-data
+      securityContext:
+        fsGroupChangePolicy: Always
+        runAsUser: 1000
       volumes:
       - emptyDir: {}
         name: shared-data
@@ -9028,6 +9043,10 @@ spec:
           name: config-volume
         - mountPath: /etc/secrets/
           name: auth
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: flytepropeller
       volumes:
       - configMap:

--- a/deployment/gcp/flyte_generated.yaml
+++ b/deployment/gcp/flyte_generated.yaml
@@ -8922,7 +8922,7 @@ spec:
         - mountPath: /etc/db
           name: db-pass
       - args:
-        - flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/secrets/auth && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --fromPath /etc/secrets/auth
+        - flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/scratch/secrets && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --fromPath /etc/scratch/secrets
         command:
         - /bin/sh
         - -c
@@ -8937,6 +8937,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+        - mountPath: /etc/scratch
+          name: scratch
       securityContext:
         fsGroup: 65534
         fsGroupChangePolicy: Always
@@ -8945,6 +8947,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: shared-data
+      - emptyDir: {}
+        name: scratch
       - configMap:
           name: flyte-admin-config-7g6ctk6762
         name: config-volume

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -1055,6 +1055,9 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroupChangePolicy: "Always"
       containers:
       - image: "cr.flyte.org/flyteorg/flyteconsole:v0.29.0"
         imagePullPolicy: "IfNotPresent"
@@ -1112,9 +1115,15 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       initContainers:
         - name: check-db-ready
           image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
+          securityContext:
+             runAsUser: 0
           command:
             - sh
             - -c
@@ -1204,6 +1213,10 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       initContainers:
       - command:
         - flytescheduler
@@ -1286,6 +1299,10 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       containers:
       - command:
         - flytepropeller
@@ -1353,6 +1370,10 @@ spec:
       annotations:
         configChecksum: "e6061ecfb96415f4871fd08abec51204dec69e23cb6d8f5d89583676657de08"
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       serviceAccountName: flyte-pod-webhook
       initContainers:
       - name: generate-secrets

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -3047,7 +3047,7 @@ spec:
         - mountPath: /etc/db
           name: db-pass
       - args:
-        - flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/secrets/auth && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --fromPath /etc/secrets/auth
+        - flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/scratch/secrets && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --fromPath /etc/scratch/secrets
         command:
         - /bin/sh
         - -c
@@ -3062,6 +3062,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+        - mountPath: /etc/scratch
+          name: scratch
       securityContext:
         fsGroup: 65534
         fsGroupChangePolicy: Always
@@ -3073,6 +3075,8 @@ spec:
         name: resource-templates
       - emptyDir: {}
         name: shared-data
+      - emptyDir: {}
+        name: scratch
       - configMap:
           name: flyte-admin-config-dbg8dt2dgb
         name: config-volume

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -2999,7 +2999,8 @@ spec:
         image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
         name: check-db-ready
         securityContext:
-          runAsUser: 0
+          fsGroup: 999
+          runAsUser: 999
       - command:
         - flyteadmin
         - --config

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -2998,6 +2998,8 @@ spec:
         - until pg_isready -h postgres -p 5432; do echo waiting for database; sleep 2; done;
         image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
         name: check-db-ready
+        securityContext:
+          runAsUser: 0
       - command:
         - flyteadmin
         - --config

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -2999,7 +2999,6 @@ spec:
         image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
         name: check-db-ready
         securityContext:
-          fsGroup: 999
           runAsUser: 999
       - command:
         - flyteadmin

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -2803,6 +2803,10 @@ spec:
           name: config-volume
         - mountPath: /etc/db
           name: db-pass
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: datacatalog
       volumes:
       - emptyDir: {}
@@ -2888,6 +2892,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: flyte-pod-webhook
       volumes:
       - name: sample-secrets
@@ -3052,6 +3060,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: flyteadmin
       volumes:
       - configMap:
@@ -3099,6 +3111,9 @@ spec:
         volumeMounts:
         - mountPath: /srv/flyte
           name: shared-data
+      securityContext:
+        fsGroupChangePolicy: Always
+        runAsUser: 1000
       volumes:
       - emptyDir: {}
         name: shared-data
@@ -3146,6 +3161,10 @@ spec:
           name: config-volume
         - mountPath: /etc/secrets/
           name: auth
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: flytepropeller
       volumes:
       - configMap:

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -3400,6 +3400,9 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroupChangePolicy: "Always"
       containers:
       - image: "cr.flyte.org/flyteorg/flyteconsole:v0.29.0"
         imagePullPolicy: "IfNotPresent"
@@ -3450,9 +3453,15 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       initContainers:
         - name: check-db-ready
           image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
+          securityContext:
+             runAsUser: 0
           command:
             - sh
             - -c
@@ -3531,6 +3540,10 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       initContainers:
       - command:
         - flytescheduler
@@ -3715,6 +3728,10 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       containers:
       - command:
         - flytepropeller
@@ -3775,6 +3792,10 @@ spec:
       annotations:
         configChecksum: "75bc68f92c6e42261dbda75899da728751f494060a31ad9088def7aa8c96e53"
     spec:
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 1001
+        fsGroupChangePolicy: "Always"
       serviceAccountName: flyte-pod-webhook
       initContainers:
       - name: generate-secrets

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -838,6 +838,8 @@ spec:
         - until pg_isready -h postgres -p 5432; do echo waiting for database; sleep 2; done;
         image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
         name: check-db-ready
+        securityContext:
+          runAsUser: 0
       - command:
         - flyteadmin
         - --config

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -839,7 +839,8 @@ spec:
         image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
         name: check-db-ready
         securityContext:
-          runAsUser: 0
+          fsGroup: 999
+          runAsUser: 999
       - command:
         - flyteadmin
         - --config

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -663,6 +663,10 @@ spec:
           name: config-volume
         - mountPath: /etc/db
           name: db-pass
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: datacatalog
       volumes:
       - emptyDir: {}
@@ -745,6 +749,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: flyte-pod-webhook
       volumes:
       - configMap:
@@ -892,6 +900,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: flyteadmin
       volumes:
       - configMap:
@@ -952,6 +964,10 @@ spec:
           name: config-volume
         - mountPath: /etc/secrets/
           name: auth
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsUser: 1001
       serviceAccountName: flytepropeller
       volumes:
       - configMap:

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -887,7 +887,7 @@ spec:
         - mountPath: /etc/db
           name: db-pass
       - args:
-        - flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/secrets/auth && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --fromPath /etc/secrets/auth
+        - flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/scratch/secrets && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --fromPath /etc/scratch/secrets
         command:
         - /bin/sh
         - -c
@@ -902,6 +902,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+        - mountPath: /etc/scratch
+          name: scratch
       securityContext:
         fsGroup: 65534
         fsGroupChangePolicy: Always
@@ -913,6 +915,8 @@ spec:
         name: resource-templates
       - emptyDir: {}
         name: shared-data
+      - emptyDir: {}
+        name: scratch
       - configMap:
           name: flyte-admin-config-hc64g2ct6h
         name: config-volume

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -839,7 +839,6 @@ spec:
         image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
         name: check-db-ready
         securityContext:
-          fsGroup: 999
           runAsUser: 999
       - command:
         - flyteadmin

--- a/kustomize/base/admindeployment/deployment.yaml
+++ b/kustomize/base/admindeployment/deployment.yaml
@@ -30,6 +30,8 @@ spec:
       volumes:
         - name: shared-data
           emptyDir: {}
+        - emptyDir: {}
+          name: scratch
         - name: config-volume
           configMap:
             name: flyte-admin-config
@@ -103,11 +105,13 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             [
-              "flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/secrets/auth && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --fromPath /etc/secrets/auth",
+              "flyteadmin --config=/etc/flyte/config/*.yaml secrets init --localPath /etc/scratch/secrets && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --fromPath /etc/scratch/secrets",
             ]
           volumeMounts:
             - name: config-volume
               mountPath: /etc/flyte/config
+            - name: scratch
+              mountPath: /etc/scratch
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/kustomize/base/admindeployment/deployment.yaml
+++ b/kustomize/base/admindeployment/deployment.yaml
@@ -22,6 +22,10 @@ spec:
         prometheus.io/port: "10254"
         prometheus.io/path: "/metrics"
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       serviceAccountName: flyteadmin
       volumes:
         - name: shared-data

--- a/kustomize/base/admindeployment/deployment.yaml
+++ b/kustomize/base/admindeployment/deployment.yaml
@@ -23,9 +23,9 @@ spec:
         prometheus.io/path: "/metrics"
     spec:
       securityContext:
-        fsGroup: 1001
+        fsGroup: 65534
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       serviceAccountName: flyteadmin
       volumes:
         - name: shared-data

--- a/kustomize/base/console/deployment.yaml
+++ b/kustomize/base/console/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       securityContext:
         runAsUser: 1000
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       volumes:
       - name: shared-data
         emptyDir: {}

--- a/kustomize/base/console/deployment.yaml
+++ b/kustomize/base/console/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app.kubernetes.io/name: flyteconsole
         app.kubernetes.io/version: 0.19.0
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
       volumes:
       - name: shared-data
         emptyDir: {}

--- a/kustomize/base/datacatalog/deployment.yaml
+++ b/kustomize/base/datacatalog/deployment.yaml
@@ -22,9 +22,9 @@ spec:
         prometheus.io/path: "/metrics"
     spec:
       securityContext:
-        fsGroup: 1001
+        fsGroup: 65534
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       serviceAccountName: datacatalog
       volumes:
       - name: shared-data

--- a/kustomize/base/datacatalog/deployment.yaml
+++ b/kustomize/base/datacatalog/deployment.yaml
@@ -21,6 +21,10 @@ spec:
         prometheus.io/port: "10254"
         prometheus.io/path: "/metrics"
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       serviceAccountName: datacatalog
       volumes:
       - name: shared-data

--- a/kustomize/base/pod_webhook/deployment.yaml
+++ b/kustomize/base/pod_webhook/deployment.yaml
@@ -21,9 +21,9 @@ spec:
         prometheus.io/path: "/metrics"
     spec:
       securityContext:
-        fsGroup: 1001
+        fsGroup: 65534
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       serviceAccountName: flyte-pod-webhook
       initContainers:
         - name: generate-secrets

--- a/kustomize/base/pod_webhook/deployment.yaml
+++ b/kustomize/base/pod_webhook/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         prometheus.io/port: "10254"
         prometheus.io/path: "/metrics"
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       serviceAccountName: flyte-pod-webhook
       initContainers:
         - name: generate-secrets

--- a/kustomize/base/propeller/deployment.yaml
+++ b/kustomize/base/propeller/deployment.yaml
@@ -21,6 +21,10 @@ spec:
         prometheus.io/port: "10254"
         prometheus.io/path: "/metrics"
     spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       serviceAccountName: flytepropeller
       volumes:
         - name: config-volume

--- a/kustomize/base/propeller/deployment.yaml
+++ b/kustomize/base/propeller/deployment.yaml
@@ -22,9 +22,9 @@ spec:
         prometheus.io/path: "/metrics"
     spec:
       securityContext:
-        fsGroup: 1001
+        fsGroup: 65534
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
+        fsGroupChangePolicy: "Always"
       serviceAccountName: flytepropeller
       volumes:
         - name: config-volume

--- a/kustomize/overlays/eks/README.md
+++ b/kustomize/overlays/eks/README.md
@@ -19,11 +19,11 @@ A few things are required for this overlay to function:
 
 ## Create S3 bucket
 1. Create a S3 bucket named as `flyte` (if other name replace it next)
-1. Replace in [config/common/storage.yaml](config/common/storage.yaml) if using a bucket other than Flyte then replace the bucket name too
+1. Replace in [config/common/storage.yaml](flyte/config/common/storage.yaml) if using a bucket other than Flyte then replace the bucket name too
 
 ## flyteadmin
 
-flyteadmin configuration is derived from the [single cluster](../../base/single_cluster) overlay, with only modification to [database configuration db.yaml](config/admin/db.yaml)
+flyteadmin configuration is derived from the [single cluster](../../base/single_cluster) overlay, with only modification to [database configuration db.yaml](flyte/config/admin/db.yaml)
 
 **Advanced / OPTIONAL**
 1. The default CORS setting in flyteAdmin allows cross origin requests. A more secure way would be to allow requests only from the expected domain. To do this, you will have to create a new *server.yaml*
@@ -40,7 +40,7 @@ flyteconsole is exposed as a service using [internal load balancer](https://clou
 ## flytepropeller
 
 flytepropeller configuration is derived from the [single cluster](../../base/single_cluster) overlay, with only modification to the config for performance tuning and logs
-For logs configuration Replace `<project-id>` in [config/propeller/plugins/task_logs.yaml](config/propeller/plugins/task_logs.yaml) to use CloudWatch
+For logs configuration Replace `<project-id>` in [config/propeller/plugins/task_logs.yaml](flyte/config/propeller/plugins/task_logs.yaml) to use CloudWatch
 
 Some important points
 
@@ -53,7 +53,7 @@ Some important points
 
 ## datacatalog
 
-datacatalog configuration is derived from the [single cluster](../../base/single_cluster) overlay, with only modification to [database configuration db.yaml](config/datacatalog/db.yaml)
+datacatalog configuration is derived from the [single cluster](../../base/single_cluster) overlay, with only modification to [database configuration db.yaml](flyte/config/datacatalog/db.yaml)
 
 
 ## How to build your overlay

--- a/kustomize/overlays/gcp/README.md
+++ b/kustomize/overlays/gcp/README.md
@@ -30,11 +30,11 @@ needs to replace `<project-id>` and `<region>` accordingly in
 
 ## Create GCS Storage
 1. Create a GCS bucket named as `flyte` in a GCP project.
-1. Replace `<project-id>` in [config/common/storage.yaml](config/common/storage.yaml) with the GCP project ID and if using a bucket other than Flyte then replace the bucket name too
+1. Replace `<project-id>` in [config/common/storage.yaml](flyte/config/common/storage.yaml) with the GCP project ID and if using a bucket other than Flyte then replace the bucket name too
 
 ## flyteadmin
 
-flyteadmin configuration is derived from the [single cluster](../../base/single_cluster) overlay, with only modification to [database configuration db.yaml](config/admin/db.yaml)
+flyteadmin configuration is derived from the [single cluster](../../base/single_cluster) overlay, with only modification to [database configuration db.yaml](flyte/config/admin/db.yaml)
 
 If one has followed [Cloud SQL](#cloud-sql) section, there is nothing to be done for database.
 
@@ -55,7 +55,7 @@ flyteconsole is exposed as a service using [internal load balancer](https://clou
 ## flytepropeller
 
 flytepropeller configuration is derived from the [single cluster](../../base/single_cluster) overlay, with only modification to the config for performance tuning and logs
-For logs configuration Replace `<project-id>` in [config/propeller/plugins/task_logs.yaml](config/propeller/plugins/task_logs.yaml) with the GCP project ID
+For logs configuration Replace `<project-id>` in [config/propeller/plugins/task_logs.yaml](flyte/config/propeller/plugins/task_logs.yaml) with the GCP project ID
 
 Some important points
 
@@ -70,7 +70,7 @@ Some important points
 
 ## datacatalog
 
-datacatalog configuration is derived from the [single cluster](../../base/single_cluster) overlay, with only modification to [database configuration db.yaml](config/datacatalog/db.yaml)
+datacatalog configuration is derived from the [single cluster](../../base/single_cluster) overlay, with only modification to [database configuration db.yaml](flyte/config/datacatalog/db.yaml)
 
 If one has followed [Cloud SQL](#cloud-sql) section, there is nothing to be done for database.
 

--- a/kustomize/overlays/sandbox/flyte/admin/deployment.yaml
+++ b/kustomize/overlays/sandbox/flyte/admin/deployment.yaml
@@ -20,7 +20,8 @@ spec:
               do echo waiting for database; sleep 2; done;",
             ]
           securityContext:
-            runAsUser: 0
+            runAsUser: 999
+            fsGroup: 999
         - name: run-migrations
           image: flyteadmin:v0.4.13
           imagePullPolicy: IfNotPresent

--- a/kustomize/overlays/sandbox/flyte/admin/deployment.yaml
+++ b/kustomize/overlays/sandbox/flyte/admin/deployment.yaml
@@ -21,7 +21,6 @@ spec:
             ]
           securityContext:
             runAsUser: 999
-            fsGroup: 999
         - name: run-migrations
           image: flyteadmin:v0.4.13
           imagePullPolicy: IfNotPresent

--- a/kustomize/overlays/sandbox/flyte/admin/deployment.yaml
+++ b/kustomize/overlays/sandbox/flyte/admin/deployment.yaml
@@ -19,6 +19,8 @@ spec:
               "until pg_isready -h postgres -p 5432;
               do echo waiting for database; sleep 2; done;",
             ]
+          securityContext:
+            runAsUser: 0
         - name: run-migrations
           image: flyteadmin:v0.4.13
           imagePullPolicy: IfNotPresent

--- a/kustomize/overlays/test/flyte/admin/deployment.yaml
+++ b/kustomize/overlays/test/flyte/admin/deployment.yaml
@@ -17,7 +17,8 @@ spec:
           'until pg_isready -h postgres -p 5432;
           do echo waiting for database; sleep 2; done;']
         securityContext:
-          runAsUser: 0
+          runAsUser: 999
+          fsGroup: 999
       - name: run-migrations
         image: flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent

--- a/kustomize/overlays/test/flyte/admin/deployment.yaml
+++ b/kustomize/overlays/test/flyte/admin/deployment.yaml
@@ -16,6 +16,8 @@ spec:
         command: ['sh', '-c',
           'until pg_isready -h postgres -p 5432;
           do echo waiting for database; sleep 2; done;']
+        securityContext:
+          runAsUser: 0
       - name: run-migrations
         image: flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent

--- a/kustomize/overlays/test/flyte/admin/deployment.yaml
+++ b/kustomize/overlays/test/flyte/admin/deployment.yaml
@@ -18,7 +18,6 @@ spec:
           do echo waiting for database; sleep 2; done;']
         securityContext:
           runAsUser: 999
-          fsGroup: 999
       - name: run-migrations
         image: flyteadmin:v0.4.13
         imagePullPolicy: IfNotPresent

--- a/rsts/deployment/cluster_config/auth_setup.rst
+++ b/rsts/deployment/cluster_config/auth_setup.rst
@@ -111,7 +111,7 @@ Apply Configuration
 
    .. prompt:: bash
 
-     kubectl edit secret -n flyte flyte-admin-auth
+     kubectl edit secret -n flyte flyte-admin-secrets
 
    Add a new key under `stringData`:
 

--- a/rsts/deployment/index.rst
+++ b/rsts/deployment/index.rst
@@ -78,3 +78,4 @@ solution). The following pages will help you effectively deploy and manage an en
     cluster_config/index
     sandbox
     plugin_setup/index
+    security/security

--- a/rsts/deployment/security/security.rst
+++ b/rsts/deployment/security/security.rst
@@ -1,0 +1,45 @@
+.. _security-overview:
+
+###################
+Security Overview
+###################
+
+Here we cover security aspects of running your flyte deployments. In the current state we will be covering the user
+which is used for running the flyte services and we will go through why we do this and not run them as root user
+
+#################
+Why non-root user
+#################
+Flyte uses docker for container packaging and by default its containers run as root. This gives full
+permissions on the system but may not be suitable for production deployments where a security breach could comprise your
+application deployments.
+It's considered to be a best practice for security because running in constrained permission environment will prevent any
+malicious code from utilizing the full permissions of the host `Ref <https://kubernetes.io/blog/2018/07/18/11-ways-not-to-get-hacked/#8-run-containers-as-a-non-root-user>`__
+Also in certain container platforms like `OpenShift <https://engineering.bitnami.com/articles/running-non-root-containers-on-openshift.html>`__ running non-root containers is mandatory.
+
+
+*******
+Changes
+*******
+New user group and user have been added to the Docker files for all the flyte components
+`Flyteadmin <https://github.com/flyteorg/flyteadmin/blob/master/Dockerfile>`__
+`Flytepropeller <https://github.com/flyteorg/flytepropeller/blob/master/Dockerfile>`__
+`Datacatalog <https://github.com/flyteorg/datacatalog/blob/master/Dockerfile>`__
+`Flyteconsole <https://github.com/flyteorg/flyteconsole/blob/master/Dockerfile>`__
+
+And Dockerfile uses `USER command <https://docs.docker.com/engine/reference/builder/#user>`__ which sets user
+and group which will be used for running the container.
+
+Additionally the k8s manifest files for the flyte components define the overridden security context with the created
+user and group to run them. Following shows the overriden security context added for flyteadmin
+`Flyteadmin <https://github.com/flyteorg/flyte/blob/master/charts/flyte/templates/admin/deployment.yaml>`__
+
+
+************
+Why override
+************
+There are certain init-containers that still require root permissions and hence we required to override the security
+context for these.
+For example: in case of `Flyteadmin <https://github.com/flyteorg/flyte/blob/master/charts/flyte/templates/admin/deployment.yaml>`__
+the init container of check-db-ready that runs postgres-provided docker image is not able to resolve the host for the checks and fails. This is mostly due to no read
+permissions on etc/hosts file. Only the check-db-ready container is run using the root user and which we will plan to fix as well.


### PR DESCRIPTION
We set the user and group id in the security context to match the user and group defined explicitly in the docker images.

Note, the `console` uses [user id 1000](https://github.com/flyteorg/flyteconsole/blob/a64e1385852125bec9efe7f37c1d3930c7e2a434/Dockerfile#L30), while the rest of the images use user id `1001` and group id `1001` (see PRs below)


Related PRs:
* https://github.com/flyteorg/flytepropeller/pull/356
* https://github.com/flyteorg/flyteadmin/pull/280
* https://github.com/flyteorg/datacatalog/pull/54

Related issue:
* https://github.com/flyteorg/flyte/issues/1606