### PR TITLE
Update the Getting started docs to use `pyflyte init`

### DIFF
--- a/rsts/getting_started.rst
+++ b/rsts/getting_started.rst
@@ -44,7 +44,7 @@ Make sure you have `Git <https://git-scm.com/>`__, and `Python <https://www.pyth
 
 Start a new project / repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Install Flyte's Python SDK — `Flytekit <https://pypi.org/project/flytekit/>`__ (recommended using a  `virtual environment <https://docs.python.org/3/library/venv.html>`__), run a command to initialize your project, that command will prompt you for the name of directory where your example workflows are going to live. The ``init`` command comes with a help menu that can be shown by running ``pyflyte init --help``. For this guide we're going to use ``myflyteapp`` in the initial invocation.
+Install Flyte's Python SDK — `Flytekit <https://pypi.org/project/flytekit/>`__ (recommended using a  `virtual environment <https://docs.python.org/3/library/venv.html>`__), run ``pyflyte init {project_name}``, where ``{project_name}`` is the directory that will be created containing the scaffolding for a flyte-ready project. Feel free to use any name as your project name, however for this guide we're going to use ``myflyteapp`` in the  invocation:
 
 .. prompt:: bash (venv)$
 

--- a/rsts/getting_started.rst
+++ b/rsts/getting_started.rst
@@ -44,15 +44,15 @@ Make sure you have `Git <https://git-scm.com/>`__, and `Python <https://www.pyth
 
 Start a new project / repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Install Flyte's Python SDK — `Flytekit <https://pypi.org/project/flytekit/>`__ (recommended using a  `virtual environment <https://docs.python.org/3/library/venv.html>`__) and clone the `flytekit-python-template <https://github.com/flyteorg/flytekit-python-template>`__ repo.
+Install Flyte's Python SDK — `Flytekit <https://pypi.org/project/flytekit/>`__ (recommended using a  `virtual environment <https://docs.python.org/3/library/venv.html>`__), run a command to initialize your project, that command will prompt you for the name of directory where your example workflows are going to live. The ``init`` command comes with a help menu that can be shown by running ``pyflyte init --help``. For this guide we're going to use ``myflyteapp`` in the initial invocation.
 
 .. prompt:: bash (venv)$
 
     pip3 install flytekit --upgrade
-    git clone https://github.com/flyteorg/flytekit-python-template.git myflyteapp
+    pyflyte init myflyteapp
     cd myflyteapp
 
-The repo comes with a sample workflow, which can be found under ``myapp/workflows/example.py``. The structure below shows the most important files and how a typical Flyte app should be laid out.
+The ``myflyteapp`` directory comes with a sample workflow, which can be found under ``myapp/workflows/example.py``. The structure below shows the most important files and how a typical Flyte app should be laid out.
 
 .. dropdown:: A typical Flyte app should have these files
 
@@ -77,7 +77,7 @@ The repo comes with a sample workflow, which can be found under ``myapp/workflow
 
 Run the Workflow Locally
 ^^^^^^^^^^^^^^^^^^^^^^^^
-The workflow can be run locally, simply by running it as a Python script; note the ``__main__`` entry point at the `bottom of the file <https://github.com/flyteorg/flytekit-python-template/blob/main/myapp/workflows/example.py#L58>`__.
+The workflow can be run locally, simply by running it as a Python script; note the ``__main__`` entry point at the bottom of ``myapp/workflows/example.py``.
 
 .. prompt:: bash (venv)$
 

--- a/rsts/getting_started.rst
+++ b/rsts/getting_started.rst
@@ -52,7 +52,7 @@ Install Flyte's Python SDK — `Flytekit <https://pypi.org/project/flytekit/>`__
     pyflyte init myflyteapp
     cd myflyteapp
 
-The ``myflyteapp`` directory comes with a sample workflow, which can be found under ``myapp/workflows/example.py``. The structure below shows the most important files and how a typical Flyte app should be laid out.
+The ``myflyteapp`` directory comes with a sample workflow, which can be found under ``flyte/workflows/example.py``. The structure below shows the most important files and how a typical Flyte app should be laid out.
 
 .. dropdown:: A typical Flyte app should have these files
 
@@ -61,7 +61,7 @@ The ``myflyteapp`` directory comes with a sample workflow, which can be found un
        .
        ├── Dockerfile
        ├── docker_build_and_tag.sh
-       ├── myapp
+       ├── flyte
        │         ├── __init__.py
        │         └── workflows
        │             ├── __init__.py
@@ -77,11 +77,11 @@ The ``myflyteapp`` directory comes with a sample workflow, which can be found un
 
 Run the Workflow Locally
 ^^^^^^^^^^^^^^^^^^^^^^^^
-The workflow can be run locally, simply by running it as a Python script; note the ``__main__`` entry point at the bottom of ``myapp/workflows/example.py``.
+The workflow can be run locally, simply by running it as a Python script; note the ``__main__`` entry point at the bottom of ``flyte/workflows/example.py``.
 
 .. prompt:: bash (venv)$
 
-   python myapp/workflows/example.py
+   python flyte/workflows/example.py
 
 .. dropdown:: Expected output
 

--- a/rsts/getting_started.rst
+++ b/rsts/getting_started.rst
@@ -58,7 +58,7 @@ The ``myflyteapp`` directory comes with a sample workflow, which can be found un
 
    .. code-block:: text
 
-       .
+       myflyteapp
        ├── Dockerfile
        ├── docker_build_and_tag.sh
        ├── flyte

--- a/rsts/getting_started_iterate.rst
+++ b/rsts/getting_started_iterate.rst
@@ -41,9 +41,9 @@ Modify Code and Test Locally
 
    .. code-block::
 
-       myapp/workflows/example.py
+       flyte/workflows/example.py
 
-   .. dropdown:: myapp/workflows/example.py
+   .. dropdown:: flyte/workflows/example.py
 
       .. rli:: https://raw.githubusercontent.com/flyteorg/flytekit-python-template/simplify-template/myapp/workflows/example.py
          :language: python
@@ -73,7 +73,7 @@ Modify Code and Test Locally
 
    .. prompt:: bash (venv)$
 
-     python myapp/workflows/example.py
+     python flyte/workflows/example.py
 
 
    .. dropdown:: Expected output
@@ -91,7 +91,7 @@ Modify Code and Test Locally
 
    .. prompt:: bash (venv)$
 
-       pyflyte --pkgs myapp.workflows package --image myapp:v1 --fast --force
+       pyflyte --pkgs flyte.workflows package --image myapp:v1 --fast --force
 
    .. note::
 
@@ -174,7 +174,7 @@ Modify Code and Test Locally
 
             For other supported storage backends like Oracle, Azure, etc., refer to the configuration structure `here <https://pkg.go.dev/github.com/flyteorg/flytestdlib/storage#Config>`__.
 
-#. Finally, visit `the sandbox console <http://localhost:30081/console/projects/flytesnacks/domains/development/workflows/myapp.workflows.example.my_wf>`__, click launch, and give your name as the input.
+#. Finally, visit `the sandbox console <http://localhost:30081/console/projects/flytesnacks/domains/development/workflows/flyte.workflows.example.my_wf>`__, click launch, and give your name as the input.
 
    .. image:: https://raw.githubusercontent.com/flyteorg/flyte/static-resources/img/flytesnacks/tutorial/getting_started_fastreg.gif
       :alt: A quick visual tour for launching a workflow and checking the outputs when they're done.
@@ -185,7 +185,7 @@ Modify Code and Test Locally
 
       .. prompt:: bash $
 
-       flytectl get launchplan --project flytesnacks --domain development myapp.workflows.example.my_wf --latest --execFile exec_spec.yaml
+       flytectl get launchplan --project flytesnacks --domain development flyte.workflows.example.my_wf --latest --execFile exec_spec.yaml
 
    #. Modify the execution spec file and update the input params and save the file. Notice that the version would be changed to your latest one.
 

--- a/rsts/getting_started_scale.rst
+++ b/rsts/getting_started_scale.rst
@@ -139,7 +139,7 @@ Build & Deploy Your Application to the Cluster
 
    .. prompt:: bash (venv)$
 
-      pyflyte --pkgs myapp.workflows package --image <registry/repo:version>
+      pyflyte --pkgs flyte.workflows package --image <registry/repo:version>
 
 #. Upload this package to the Flyte backend. We refer to this as ``registration``. The version here ``v1`` does not have to match the version
    used in the commands above. It's generally recommended to match the versions to make it easier to track.
@@ -157,7 +157,7 @@ Build & Deploy Your Application to the Cluster
 
    .. prompt:: bash $
 
-      flytectl get workflows --project flytesnacks --domain development myapp.workflows.example.my_wf --version v1 -o doturl
+      flytectl get workflows --project flytesnacks --domain development flyte.workflows.example.my_wf --version v1 -o doturl
 
 
 .. _getting-started-execute:
@@ -178,7 +178,7 @@ More details can be found `here <https://docs.flyte.org/projects/flytectl/en/sta
 
    .. prompt:: bash $
 
-      flytectl get launchplan --project flytesnacks --domain development myapp.workflows.example.my_wf --latest --execFile exec_spec.yaml
+      flytectl get launchplan --project flytesnacks --domain development flyte.workflows.example.my_wf --latest --execFile exec_spec.yaml
 
 #. Create an execution using the exec spec file.
 


### PR DESCRIPTION
This is the corresponding changes to the Getting Started docs in order to reflect the introduction of[ cookiecutter templates in flytekit](https://github.com/flyteorg/flytekit/pull/738). 

This should only be merged after we cut the new `flytekit` release.

The Getting started docs now look like: https://flyte--1801.org.readthedocs.build/en/1801/getting_started.html

Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>