### PR TITLE
Kustomize update

### DIFF
--- a/kustomize/base/adminserviceaccount/adminserviceaccount.yaml
+++ b/kustomize/base/adminserviceaccount/adminserviceaccount.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: flyte
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flyteadmin-binding

--- a/kustomize/base/propeller/rbac.yaml
+++ b/kustomize/base/propeller/rbac.yaml
@@ -75,7 +75,7 @@ metadata:
 ---
 # Create a binding from Role -> ServiceAccount
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flytepropeller
   namespace: flyte

--- a/kustomize/base/wf_crd/wf_crd.yaml
+++ b/kustomize/base/wf_crd/wf_crd.yaml
@@ -8,22 +8,13 @@ spec:
   group: flyte.lyft.com
   # version name to use for REST API: /apis/<group>/<version>
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                cronSpec:
-                  type: string
-                image:
-                  type: string
-                replicas:
-                  type: integer
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'FlyteWorkflow: represents one Execution Workflow object'
+        type: object
+    served: true
+    storage: true
   # either Namespaced or Cluster
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>

--- a/kustomize/base/wf_crd/wf_crd.yaml
+++ b/kustomize/base/wf_crd/wf_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
@@ -7,7 +7,23 @@ spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: flyte.lyft.com
   # version name to use for REST API: /apis/<group>/<version>
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
   # either Namespaced or Cluster
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>


### PR DESCRIPTION
the current yaml files use some beta version API, which are not supported any more by K8S, in turn, this causes failures when we run Kustomize to install flyte on customized server.

To fix the above issue, we update the apiVersion in the  following three yaml files according to https://kubernetes.io/docs/reference/using-api/deprecation-guide/, and successfully deployed to our server.