### PR TITLE
fix sandbox restart

### DIFF
--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -13,7 +13,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: "0"
-      - uses: unionai/flytectl-setup-action@v0.0.1
       - name: Prepare sandbox Image Names
         id: sandbox-names
         uses: docker/metadata-action@v3
@@ -24,6 +23,16 @@ jobs:
           tags: |
             latest
             type=sha,format=long
+      - name: Prepare DIND Image Names
+        id: dind-names
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository_owner }}/flyte-sandbox
+          tags: |
+            dind
+            type=sha,format=long, prefix=dind-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -54,54 +63,6 @@ jobs:
           file: docker/sandbox/Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-      - name: Run Sandbox
-        run: |
-           flytectl sandbox start --image ghcr.io/${{ github.repository_owner }}/flyte-sandbox:latest
-           flytectl register example -p flytesnacks -d development
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-  sandbox-dind-build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: "0"
-      - uses: unionai/flytectl-setup-action@v0.0.1
-      - name: Prepare DIND Image Names
-        id: dind-names
-        uses: docker/metadata-action@v3
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            ghcr.io/${{ github.repository_owner }}/flyte-sandbox
-          tags: |
-            dind
-            type=sha,format=long, prefix=dind-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-single-buildx
-      - name: Login to GitHub Container Registry
-        if: ${{ github.event_name == 'release' }}
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: "${{ secrets.FLYTE_BOT_USERNAME }}"
-          password: "${{ secrets.FLYTE_BOT_PAT }}"
       - name: Build and push DIND Image
         uses: docker/build-push-action@v2
         with:
@@ -113,10 +74,6 @@ jobs:
           file: docker/sandbox/Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-      - name: Run Sandbox
-        run: |
-          flytectl sandbox start --image ghcr.io/${{ github.repository_owner }}/flyte-sandbox:dind
-          flytectl register example -p flytesnacks -d development
       - # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: "0"
+      - uses: unionai/flytectl-setup-action@v0.0.1
       - name: Prepare sandbox Image Names
         id: sandbox-names
         uses: docker/metadata-action@v3
@@ -23,16 +24,6 @@ jobs:
           tags: |
             latest
             type=sha,format=long
-      - name: Prepare DIND Image Names
-        id: dind-names
-        uses: docker/metadata-action@v3
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            ghcr.io/${{ github.repository_owner }}/flyte-sandbox
-          tags: |
-            dind
-            type=sha,format=long, prefix=dind-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -63,6 +54,54 @@ jobs:
           file: docker/sandbox/Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+      - name: Run Sandbox
+        run: |
+           flytectl sandbox start --image ghcr.io/${{ github.repository_owner }}/flyte-sandbox:latest
+           flytectl register example -p flytesnacks -d development
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+  sandbox-dind-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - uses: unionai/flytectl-setup-action@v0.0.1
+      - name: Prepare DIND Image Names
+        id: dind-names
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository_owner }}/flyte-sandbox
+          tags: |
+            dind
+            type=sha,format=long, prefix=dind-
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-single-buildx
+      - name: Login to GitHub Container Registry
+        if: ${{ github.event_name == 'release' }}
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: "${{ secrets.FLYTE_BOT_USERNAME }}"
+          password: "${{ secrets.FLYTE_BOT_PAT }}"
       - name: Build and push DIND Image
         uses: docker/build-push-action@v2
         with:
@@ -74,6 +113,10 @@ jobs:
           file: docker/sandbox/Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+      - name: Run Sandbox
+        run: |
+          flytectl sandbox start --image ghcr.io/${{ github.repository_owner }}/flyte-sandbox:dind
+          flytectl register example -p flytesnacks -d development
       - # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896

--- a/docker/sandbox/flyte-entrypoint-default.sh
+++ b/docker/sandbox/flyte-entrypoint-default.sh
@@ -18,7 +18,7 @@ echo "Done."
 # Deploy flyte
 echo "Deploying Flyte..."
 helm dep update /flyteorg/share/flyte/
-helm install -n flyte -f /flyteorg/share/flyte/values-sandbox.yaml --create-namespace flyte /flyteorg/share/flyte --kubeconfig /etc/rancher/k3s/k3s.yaml
+helm upgrade -n flyte -f /flyteorg/share/flyte/values-sandbox.yaml --create-namespace flyte /flyteorg/share/flyte --kubeconfig /etc/rancher/k3s/k3s.yaml --install
 
 wait-for-flyte.sh
 

--- a/docker/sandbox/flyte-entrypoint-dind.sh
+++ b/docker/sandbox/flyte-entrypoint-dind.sh
@@ -35,7 +35,7 @@ echo "Done."
 # Deploy flyte
 echo "Deploying Flyte..."
 helm dep update /flyteorg/share/flyte/
-helm install -n flyte -f /flyteorg/share/flyte/values-sandbox.yaml --create-namespace flyte /flyteorg/share/flyte --kubeconfig /etc/rancher/k3s/k3s.yaml
+helm upgrade -n flyte -f /flyteorg/share/flyte/values-sandbox.yaml --create-namespace flyte /flyteorg/share/flyte --kubeconfig /etc/rancher/k3s/k3s.yaml --install
 
 wait-for-flyte.sh
 


### PR DESCRIPTION
- Added fix for sandbox restart

Problem: Currently k3s bring all the resource during restart, Ideally in this case we don't need `helm install` but our entrypoint script has `helm install` steps  that's why it through error 
```
Deploying Flyte...
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://googlecloudplatform.github.io/spark-on-k8s-operator" chart repository
...Successfully got an update from the "https://kubernetes.github.io/dashboard/" chart repository
...Successfully got an update from the "https://charts.bitnami.com/bitnami" chart repository
Saving 3 charts
Downloading contour from repo https://charts.bitnami.com/bitnami
Downloading spark-operator from repo https://googlecloudplatform.github.io/spark-on-k8s-operator
Downloading kubernetes-dashboard from repo https://kubernetes.github.io/dashboard/
Deleting outdated charts
Error: cannot re-use a name that is still in use
```

Solution: In entry point script change `helm install` to `helm upgrade --install`. It will upgrade chart if available or else it will install the chart

Fix: https://github.com/flyteorg/flyte/issues/1432