### PR TITLE
Added helm registry in sandbox

### DIFF
--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -13,6 +13,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: "0"
+      - name: Set flyte version to release
+        id: set_version
+        run: |
+          if [ ${{ github.event_name}} = "release" ]; then
+            echo ::set-output name=flyte_version::$(echo ${{ github.event.release.tag_name }})
+          else
+            echo ::set-output name=flyte_version::latest)
+          fi
       - name: Prepare sandbox Image Names
         id: sandbox-names
         uses: docker/metadata-action@v3
@@ -59,6 +67,7 @@ jobs:
           platforms: linux/arm64, linux/amd64
           push: ${{ github.event_name == 'release' }}
           target: default
+          build-args: "FLYTE_VERSION=${{ steps.set_version.outputs.flyte_version }}"
           tags: ${{ steps.sandbox-names.outputs.tags }}
           file: docker/sandbox/Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -71,6 +80,7 @@ jobs:
           push: ${{ github.event_name == 'release' }}
           target: dind
           tags: ${{ steps.dind-names.outputs.tags }}
+          build-args: "FLYTE_VERSION=${{ steps.set_version.outputs.flyte_version }}"
           file: docker/sandbox/Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -19,7 +19,7 @@ jobs:
           if [ ${{ github.event_name}} = "release" ]; then
             echo ::set-output name=flyte_version::$(echo ${{ github.event.release.tag_name }})
           else
-            echo ::set-output name=flyte_version::latest)
+            echo ::set-output name=flyte_version::latest
           fi
       - name: Prepare sandbox Image Names
         id: sandbox-names

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -65,6 +65,9 @@ RUN apk add --no-cache bash git make tini curl jq
 COPY docker/sandbox/flyte-entrypoint-default.sh /flyteorg/bin/flyte-entrypoint.sh
 COPY docker/sandbox/bashrc /root/.bashrc
 
+ARG FLYTE_VERSION="latest"
+ENV FLYTE_VERSION "${FLYTE_VERSION}"
+
 # Update PATH variable
 ENV PATH "/flyteorg/bin:${PATH}"
 
@@ -90,6 +93,9 @@ COPY --from=base_ /flyteorg/ /flyteorg/
 
 # Copy entrypoints
 COPY docker/sandbox/flyte-entrypoint-dind.sh /flyteorg/bin/flyte-entrypoint.sh
+
+ARG FLYTE_VERSION="latest"
+ENV FLYTE_VERSION "${FLYTE_VERSION}"
 
 # Update PATH variable
 ENV PATH "/flyteorg/bin:${PATH}"

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -59,7 +59,7 @@ COPY docker/sandbox/kubectl docker/sandbox/cgroup-v2-hack.sh docker/sandbox/wait
 FROM base_ AS default
 
 # Install dependencies
-RUN apk add --no-cache bash git make tini
+RUN apk add --no-cache bash git make tini curl jq
 
 # Copy entrypoints
 COPY docker/sandbox/flyte-entrypoint-default.sh /flyteorg/bin/flyte-entrypoint.sh
@@ -83,7 +83,7 @@ ENTRYPOINT ["tini", "flyte-entrypoint.sh"]
 FROM docker:20.10.8-dind AS dind
 
 # Install dependencies
-RUN apk add --no-cache bash git make tini
+RUN apk add --no-cache bash git make tini curl jq
 
 # Copy artifacts from base
 COPY --from=base_ /flyteorg/ /flyteorg/

--- a/docker/sandbox/flyte-entrypoint-default.sh
+++ b/docker/sandbox/flyte-entrypoint-default.sh
@@ -15,7 +15,6 @@ K3S_PID=$!
 timeout 600 sh -c "until k3s kubectl explain deployment &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for the Kubernetes cluster to start"; exit 1 )
 echo "Done."
 
-
 FLYTE_VERSION=${FLYTE_VERSION:-latest}
 if [[ $FLYTE_VERSION = "latest" ]]
 then

--- a/docker/sandbox/flyte-entrypoint-dind.sh
+++ b/docker/sandbox/flyte-entrypoint-dind.sh
@@ -32,10 +32,18 @@ K3S_PID=$!
 timeout 600 sh -c "until k3s kubectl explain deployment &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for the Kubernetes cluster to start"; exit 1 )
 echo "Done."
 
+FLYTE_VERSION=${FLYTE_VERSION:-latest}
+if [[ $FLYTE_VERSION = "latest" ]]
+then
+  FLYTE_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flyte/releases/latest" | jq -r .tag_name)
+fi
+
 # Deploy flyte
 echo "Deploying Flyte..."
-helm dep update /flyteorg/share/flyte/
-helm upgrade -n flyte -f /flyteorg/share/flyte/values-sandbox.yaml --create-namespace flyte /flyteorg/share/flyte --kubeconfig /etc/rancher/k3s/k3s.yaml --install
+helm repo add flyteorg https://flyteorg.github.io/flyte
+helm repo update
+helm fetch flyteorg/flyte --version=$FLYTE_VERSION
+helm upgrade -n flyte -f /flyteorg/share/flyte/values-sandbox.yaml --create-namespace flyte flyteorg/flyte --kubeconfig /etc/rancher/k3s/k3s.yaml --install --version $FLYTE_VERSION
 
 wait-for-flyte.sh
 


### PR DESCRIPTION
Currently for local testing if user wants to upgrade the sandbox then they need clone the flyte repo because of chart but with new changes user can use registry name for installing/upgrading the sandbox. 

For new release user can use `flyteorg/flyte` for installing/upgrading helm in sandbox, For older version user need to clone flyte repo for installing/upgrading flyte helm