### PR TITLE
Generate config docs only when running release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ helm_upgrade: ## Upgrade helm charts
 
 .PHONY: docs
 docs:
-	script/generate_config_docs.sh
 	make -C rsts clean html SPHINXOPTS=-W
 
 .PHONY: help


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

Nit: Generate config docs only when running release workflow