### PR TITLE
Reduced the defaults on gcp

### DIFF
--- a/charts/flyte-core/values-gcp.yaml
+++ b/charts/flyte-core/values-gcp.yaml
@@ -234,9 +234,9 @@ configmap:
   task_resource_defaults:
     task_resources:
       defaults:
-        cpu: 1000m
-        memory: 1000Mi
-        storage: 1000Mi
+        cpu: 100m
+        memory: 200Mi
+        storage: 500Mi
       limits:
         storage: 2000Mi
 

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -234,9 +234,9 @@ data:
   task_resource_defaults.yaml: | 
     task_resources:
       defaults:
-        cpu: 1000m
-        memory: 1000Mi
-        storage: 1000Mi
+        cpu: 100m
+        memory: 200Mi
+        storage: 500Mi
       limits:
         cpu: 2
         gpu: 1
@@ -818,7 +818,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8198ec011a4d51f4ac71e64b61e9a2bacebf476da569aa6fb369fd388d7744e"
+        configChecksum: "8460843e0e0cc6562fc821514ca4cc35d04c0f1571df8099527580aa845ee20"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -1137,7 +1137,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8198ec011a4d51f4ac71e64b61e9a2bacebf476da569aa6fb369fd388d7744e"
+        configChecksum: "8460843e0e0cc6562fc821514ca4cc35d04c0f1571df8099527580aa845ee20"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

With trial GCP account , the e3-medium machines 940 mCPU allocatable per node.
Reducing the default for task resources.

Tested this on GCP by running the basic greet worflow from flytesnack

<img width="1614" alt="Screenshot 2021-12-02 at 6 11 46 PM" src="https://user-images.githubusercontent.com/77798312/144424009-2f191f0c-f101-4217-8b0c-296a2f5941ae.png">
s
