### PR TITLE
Update auth_setup.rst

### DIFF
--- a/rsts/deployment/cluster_config/auth_setup.rst
+++ b/rsts/deployment/cluster_config/auth_setup.rst
@@ -217,8 +217,8 @@ Apply Configuration
                     # 3. Replace with a new Native Client ID provisioned in the custom authorization server
                     clientId: flytectl
 
-                    # This should not change
-                    redirectUri: https://localhost:53593/callback
+                    # Do not change to other callback. Switch to https when using TLS (secure: true)
+                    redirectUri: http://localhost:53593/callback
 
                     # 4. "all" is a required scope and must be configured in the custom authorization server
                     scopes:
@@ -282,6 +282,7 @@ If your organization does any automated registration, then you'll need to authen
    Flytectl's `config.yaml <https://docs.flyte.org/projects/flytectl/en/stable/#configure>`_ can be
    configured to use either PKCE (`Proof key for code exchange <https://datatracker.ietf.org/doc/html/rfc7636>`_)
    or Client Credentials (`Client Credentials <https://datatracker.ietf.org/doc/html/rfc6749#section-4.4>`_) flows.
+   If you are using the internal auth server, you can obtain the client credential by ... (This is what we are trying to figure out)
 
    Update ``config.yaml`` as follows:
 


### PR DESCRIPTION
Update draft based on discussion on Flyte Slack where changing to "http://localhost..." was suggested as a fix. It works for us. Unsure if the comment on using https in case of secure: true is correct. 
Added unfinished explanation for obtaining to ClientSecret, since this is what we're looking for. We tried both internal auth server and external (Google). In the latter case obtaining the ClientSecret was obvious however Google does not support the `grant_type=client_credentials`. It would be good to know if the ClientSecret flow is at all possible with the internal auth server and which external providers acutally support it.