### PR TITLE
rename chart for backword compatibility

### DIFF
--- a/charts/flyte/Chart.yaml
+++ b/charts/flyte/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: flyte-sandbox
+name: flyte
 description: A Helm chart for Flyte Sandbox
 type: application
 version: v0.1.10 # VERSION

--- a/charts/flyte/README.md
+++ b/charts/flyte/README.md
@@ -1,4 +1,4 @@
-# flyte-sandbox
+# flyte
 
 ![Version: v0.1.10](https://img.shields.io/badge/Version-v0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: flyte-sandbox/charts/contour/templates/contour/serviceaccount.yaml
+# Source: flyte/charts/contour/templates/contour/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: contour
 ---
-# Source: flyte-sandbox/charts/contour/templates/envoy/serviceaccount.yaml
+# Source: flyte/charts/contour/templates/envoy/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -25,7 +25,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: envoy
 ---
-# Source: flyte-sandbox/charts/flyte/templates/admin/rbac.yaml
+# Source: flyte/charts/flyte/templates/admin/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -37,7 +37,7 @@ metadata:
     helm.sh/chart: flyte-v0.1.10
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: flyte-sandbox/charts/flyte/templates/datacatalog/rbac.yaml
+# Source: flyte/charts/flyte/templates/datacatalog/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -49,7 +49,7 @@ metadata:
     helm.sh/chart: flyte-v0.1.10
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: flyte-sandbox/charts/flyte/templates/flytescheduler/sa.yaml
+# Source: flyte/charts/flyte/templates/flytescheduler/sa.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -61,7 +61,7 @@ metadata:
     helm.sh/chart: flyte-v0.1.10
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/rbac.yaml
+# Source: flyte/charts/flyte/templates/propeller/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -73,7 +73,7 @@ metadata:
     helm.sh/chart: flyte-v0.1.10
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/webhook.yaml
+# Source: flyte/charts/flyte/templates/propeller/webhook.yaml
 # Create a Service Account for webhook
 apiVersion: v1
 kind: ServiceAccount
@@ -81,7 +81,7 @@ metadata:
   name: flyte-pod-webhook
   namespace: flyte
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/serviceaccount.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/serviceaccount.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -107,7 +107,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   name: flyte-kubernetes-dashboard
 ---
-# Source: flyte-sandbox/charts/flyte/templates/admin/secret-auth.yaml
+# Source: flyte/charts/flyte/templates/admin/secret-auth.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -116,7 +116,7 @@ metadata:
 type: Opaque
 stringData:
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/secret-auth.yaml
+# Source: flyte/charts/flyte/templates/propeller/secret-auth.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -126,7 +126,7 @@ type: Opaque
 stringData:
   client_secret: foobar
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/webhook.yaml
+# Source: flyte/charts/flyte/templates/propeller/webhook.yaml
 # Create an empty secret that the first propeller pod will populate
 apiVersion: v1
 kind: Secret
@@ -135,7 +135,7 @@ metadata:
   namespace: flyte
 type: Opaque
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/secret.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/secret.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -163,7 +163,7 @@ metadata:
   name: flyte-kubernetes-dashboard-certs
 type: Opaque
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/secret.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/secret.yaml
 # kubernetes-dashboard-csrf
 apiVersion: v1
 kind: Secret
@@ -177,7 +177,7 @@ metadata:
   name: kubernetes-dashboard-csrf
 type: Opaque
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/secret.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/secret.yaml
 # kubernetes-dashboard-key-holder
 apiVersion: v1
 kind: Secret
@@ -191,7 +191,7 @@ metadata:
   name: kubernetes-dashboard-key-holder
 type: Opaque
 ---
-# Source: flyte-sandbox/charts/contour/templates/contour/configmap.yaml
+# Source: flyte/charts/contour/templates/contour/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -212,7 +212,7 @@ data:
       configmap-namespace: 'flyte'
     tls: {}
 ---
-# Source: flyte-sandbox/charts/flyte/templates/admin/cluster_resource_configmap.yaml
+# Source: flyte/charts/flyte/templates/admin/cluster_resource_configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -244,7 +244,7 @@ data:
         limits.cpu: {{ projectQuotaCpu }}
         limits.memory: {{ projectQuotaMemory }}
 ---
-# Source: flyte-sandbox/charts/flyte/templates/admin/configmap.yaml
+# Source: flyte/charts/flyte/templates/admin/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -369,7 +369,7 @@ data:
       refreshInterval: 5m
       templatePath: /etc/flyte/clusterresource/templates
 ---
-# Source: flyte-sandbox/charts/flyte/templates/console/configmap.yaml
+# Source: flyte/charts/flyte/templates/console/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -385,7 +385,7 @@ data:
   CONFIG_DIR: /etc/flyte/config
   DISABLE_AUTH: "1"
 ---
-# Source: flyte-sandbox/charts/flyte/templates/datacatalog/configmap.yaml
+# Source: flyte/charts/flyte/templates/datacatalog/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -430,7 +430,7 @@ data:
       limits:
         maxDownloadMBs: 10
 ---
-# Source: flyte-sandbox/charts/flyte/templates/flytescheduler/configmap.yaml
+# Source: flyte/charts/flyte/templates/flytescheduler/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -463,7 +463,7 @@ data:
       level: 4
       show-source: true
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/configmap.yaml
+# Source: flyte/charts/flyte/templates/propeller/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -586,7 +586,7 @@ data:
         kubernetes-enabled: true
         kubernetes-template-uri: http://localhost:30082/#/log/{{ .namespace }}/{{ .podName }}/pod?namespace={{ .namespace }}
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/configmap.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/configmap.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -613,7 +613,7 @@ metadata:
   name: kubernetes-dashboard-settings
 data:
 ---
-# Source: flyte-sandbox/charts/contour/templates/00-crds.yaml
+# Source: flyte/charts/contour/templates/00-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -851,7 +851,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: flyte-sandbox/charts/contour/templates/00-crds.yaml
+# Source: flyte/charts/contour/templates/00-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1710,7 +1710,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: flyte-sandbox/charts/contour/templates/00-crds.yaml
+# Source: flyte/charts/contour/templates/00-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1900,7 +1900,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/crds/flyteworkflow.yaml
+# Source: flyte/charts/flyte/templates/propeller/crds/flyteworkflow.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -1916,7 +1916,7 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
-# Source: flyte-sandbox/charts/contour/templates/contour/rbac.yaml
+# Source: flyte/charts/contour/templates/contour/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -2026,7 +2026,7 @@ rules:
       - get
       - update
 ---
-# Source: flyte-sandbox/charts/flyte/templates/admin/rbac.yaml
+# Source: flyte/charts/flyte/templates/admin/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -2056,7 +2056,7 @@ rules:
   verbs:
   - '*'
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/rbac.yaml
+# Source: flyte/charts/flyte/templates/propeller/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -2128,7 +2128,7 @@ rules:
   - post
   - deletecollection
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/webhook.yaml
+# Source: flyte/charts/flyte/templates/propeller/webhook.yaml
 # Create a ClusterRole for the webhook
 # https://kubernetes.io/docs/admin/authorization/rbac/
 kind: ClusterRole
@@ -2149,7 +2149,7 @@ rules:
       - update
       - patch
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/clusterrole-metrics.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/clusterrole-metrics.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -2180,7 +2180,7 @@ rules:
     resources: ["pods", "nodes"]
     verbs: ["get", "list", "watch"]
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/clusterrole-readonly.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/clusterrole-readonly.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -2330,7 +2330,7 @@ rules:
       - list
       - watch
 ---
-# Source: flyte-sandbox/charts/contour/templates/contour/rbac.yaml
+# Source: flyte/charts/contour/templates/contour/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -2349,7 +2349,7 @@ subjects:
     name: flyte-contour-contour
     namespace: flyte
 ---
-# Source: flyte-sandbox/charts/flyte/templates/admin/rbac.yaml
+# Source: flyte/charts/flyte/templates/admin/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -2368,7 +2368,7 @@ subjects:
   name: flyteadmin
   namespace: flyte
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/rbac.yaml
+# Source: flyte/charts/flyte/templates/propeller/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -2387,7 +2387,7 @@ subjects:
   name: flytepropeller
   namespace: flyte
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/webhook.yaml
+# Source: flyte/charts/flyte/templates/propeller/webhook.yaml
 # Create a binding from Role -> ServiceAccount
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2403,7 +2403,7 @@ subjects:
     name: flyte-pod-webhook
     namespace: flyte
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/clusterrolebinding-metrics.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/clusterrolebinding-metrics.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -2437,7 +2437,7 @@ subjects:
     name: flyte-kubernetes-dashboard
     namespace: flyte
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/clusterrolebinding-readonly.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/clusterrolebinding-readonly.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -2471,7 +2471,7 @@ subjects:
     name: flyte-kubernetes-dashboard
     namespace: flyte
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/role.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/role.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -2517,7 +2517,7 @@ rules:
     resourceNames: ["heapster", "http:heapster:", "https:heapster:", "dashboard-metrics-scraper", "http:dashboard-metrics-scraper"]
     verbs: ["get"]
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/rolebinding.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/rolebinding.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -2551,7 +2551,7 @@ subjects:
     name: flyte-kubernetes-dashboard
     namespace: flyte
 ---
-# Source: flyte-sandbox/charts/contour/templates/contour/service.yaml
+# Source: flyte/charts/contour/templates/contour/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -2575,7 +2575,7 @@ spec:
     app.kubernetes.io/component: contour
   type: ClusterIP
 ---
-# Source: flyte-sandbox/charts/contour/templates/envoy/service.yaml
+# Source: flyte/charts/contour/templates/envoy/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -2614,7 +2614,7 @@ spec:
     app.kubernetes.io/component: envoy
   type: NodePort
 ---
-# Source: flyte-sandbox/charts/flyte/templates/admin/service.yaml
+# Source: flyte/charts/flyte/templates/admin/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -2649,7 +2649,7 @@ spec:
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: flyte
 ---
-# Source: flyte-sandbox/charts/flyte/templates/console/service.yaml
+# Source: flyte/charts/flyte/templates/console/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -2670,7 +2670,7 @@ spec:
     app.kubernetes.io/name: flyteconsole
     app.kubernetes.io/instance: flyte
 ---
-# Source: flyte-sandbox/charts/flyte/templates/datacatalog/service.yaml
+# Source: flyte/charts/flyte/templates/datacatalog/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -2702,7 +2702,7 @@ spec:
     app.kubernetes.io/name: datacatalog
     app.kubernetes.io/instance: flyte
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/webhook.yaml
+# Source: flyte/charts/flyte/templates/propeller/webhook.yaml
 # Service
 apiVersion: v1
 kind: Service
@@ -2720,7 +2720,7 @@ spec:
       port: 443
       targetPort: 9443
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/service.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/service.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -2759,7 +2759,7 @@ spec:
     app.kubernetes.io/instance: flyte
     app.kubernetes.io/component: kubernetes-dashboard
 ---
-# Source: flyte-sandbox/templates/minio/service.yaml
+# Source: flyte/templates/minio/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -2768,7 +2768,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: minio
     app.kubernetes.io/instance: flyte
-    helm.sh/chart: flyte-sandbox-v0.1.10
+    helm.sh/chart: flyte-v0.1.10
     app.kubernetes.io/managed-by: Helm
 spec:
   type: NodePort
@@ -2787,7 +2787,7 @@ spec:
     app.kubernetes.io/name: minio
     app.kubernetes.io/instance: flyte
 ---
-# Source: flyte-sandbox/templates/postgres/service.yaml
+# Source: flyte/templates/postgres/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -2796,7 +2796,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: postgres
     app.kubernetes.io/instance: flyte
-    helm.sh/chart: flyte-sandbox-v0.1.10
+    helm.sh/chart: flyte-v0.1.10
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -2809,7 +2809,7 @@ spec:
     app.kubernetes.io/name: postgres
     app.kubernetes.io/instance: flyte
 ---
-# Source: flyte-sandbox/charts/contour/templates/envoy/daemonset.yaml
+# Source: flyte/charts/contour/templates/envoy/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -2991,7 +2991,7 @@ spec:
             secretName: envoycert
       restartPolicy: Always
 ---
-# Source: flyte-sandbox/charts/contour/templates/contour/deployment.yaml
+# Source: flyte/charts/contour/templates/contour/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -3130,7 +3130,7 @@ spec:
               - key: contour.yaml
                 path: contour.yaml
 ---
-# Source: flyte-sandbox/charts/flyte/templates/admin/deployment.yaml
+# Source: flyte/charts/flyte/templates/admin/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -3298,7 +3298,7 @@ spec:
           secret:
             secretName: flyte-admin-secrets
 ---
-# Source: flyte-sandbox/charts/flyte/templates/console/deployment.yaml
+# Source: flyte/charts/flyte/templates/console/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -3351,7 +3351,7 @@ spec:
       - emptyDir: {}
         name: shared-data
 ---
-# Source: flyte-sandbox/charts/flyte/templates/datacatalog/deployment.yaml
+# Source: flyte/charts/flyte/templates/datacatalog/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -3438,7 +3438,7 @@ spec:
           name: datacatalog-config
         name: config-volume
 ---
-# Source: flyte-sandbox/charts/flyte/templates/flytescheduler/deployment.yaml
+# Source: flyte/charts/flyte/templates/flytescheduler/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -3520,7 +3520,7 @@ spec:
           secret:
             secretName: flyte-propeller-auth
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/deployment.yaml
+# Source: flyte/charts/flyte/templates/propeller/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -3589,7 +3589,7 @@ spec:
         secret:
           secretName: flyte-propeller-auth
 ---
-# Source: flyte-sandbox/charts/flyte/templates/propeller/webhook.yaml
+# Source: flyte/charts/flyte/templates/propeller/webhook.yaml
 # Create the actual deployment
 apiVersion: apps/v1
 kind: Deployment
@@ -3673,7 +3673,7 @@ spec:
           secret:
             secretName: flyte-pod-webhook
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/deployment.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/deployment.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -3770,7 +3770,7 @@ spec:
       - name: tmp-volume
         emptyDir: {}
 ---
-# Source: flyte-sandbox/templates/minio/deployment.yaml
+# Source: flyte/templates/minio/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -3779,7 +3779,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: minio
     app.kubernetes.io/instance: flyte
-    helm.sh/chart: flyte-sandbox-v0.1.10
+    helm.sh/chart: flyte-v0.1.10
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -3792,7 +3792,7 @@ spec:
       labels: 
         app.kubernetes.io/name: minio
         app.kubernetes.io/instance: flyte
-        helm.sh/chart: flyte-sandbox-v0.1.10
+        helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
       containers:
@@ -3825,7 +3825,7 @@ spec:
       - name: minio-storage
         emptyDir: {}
 ---
-# Source: flyte-sandbox/templates/postgres/deployment.yaml
+# Source: flyte/templates/postgres/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -3834,7 +3834,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: postgres
     app.kubernetes.io/instance: flyte
-    helm.sh/chart: flyte-sandbox-v0.1.10
+    helm.sh/chart: flyte-v0.1.10
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -3847,7 +3847,7 @@ spec:
       labels: 
         app.kubernetes.io/name: postgres
         app.kubernetes.io/instance: flyte
-        helm.sh/chart: flyte-sandbox-v0.1.10
+        helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
       containers:
@@ -3876,7 +3876,7 @@ spec:
         - name: postgres-storage
           emptyDir: {}
 ---
-# Source: flyte-sandbox/charts/flyte/templates/admin/cronjob.yaml
+# Source: flyte/charts/flyte/templates/admin/cronjob.yaml
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -3920,7 +3920,7 @@ spec:
               name: flyte-admin-config
             name: config-volume
 ---
-# Source: flyte-sandbox/charts/flyte/templates/common/ingress.yaml
+# Source: flyte/charts/flyte/templates/common/ingress.yaml
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -4089,7 +4089,7 @@ spec:
               servicePort: 81
       host: ""
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/ingress.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/ingress.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -4104,7 +4104,7 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/networkpolicy.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/networkpolicy.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -4119,7 +4119,7 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/pdb.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/pdb.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -4134,7 +4134,7 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-# Source: flyte-sandbox/charts/kubernetes-dashboard/templates/psp.yaml
+# Source: flyte/charts/kubernetes-dashboard/templates/psp.yaml
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -4149,7 +4149,7 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-# Source: flyte-sandbox/charts/contour/templates/certgen/serviceaccount.yaml
+# Source: flyte/charts/contour/templates/certgen/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -4165,7 +4165,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: contour-certgen
 ---
-# Source: flyte-sandbox/charts/contour/templates/certgen/rbac.yaml
+# Source: flyte/charts/contour/templates/certgen/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -4189,7 +4189,7 @@ rules:
       - create
       - update
 ---
-# Source: flyte-sandbox/charts/contour/templates/certgen/rbac.yaml
+# Source: flyte/charts/contour/templates/certgen/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -4212,7 +4212,7 @@ subjects:
   - kind: ServiceAccount
     name: flyte-contour-contour-certgen
 ---
-# Source: flyte-sandbox/charts/contour/templates/certgen/job.yaml
+# Source: flyte/charts/contour/templates/certgen/job.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Currently if we used sandbox chart name `flyte-sandbox` then it will publish new chart and old chart will not work, In this way user just need to update values.yaml for helm chart migration. 

https://artifacthub.io/packages/search?ts_query_web=flyte&sort=relevance&page=1
