### PR TITLE
Docs: Add missing permissions in GCP Manual Deployment and update missing values

### DIFF
--- a/rsts/deployment/gcp/manual.rst
+++ b/rsts/deployment/gcp/manual.rst
@@ -418,7 +418,7 @@ Installing Flyte
 
 .. code-block:: bash
 
-   curl https://raw.githubusercontent.com/flyteorg/flyte/master/charts/flyte/values-gcp.yaml >values-gcp.yaml
+   curl https://raw.githubusercontent.com/flyteorg/flyte/master/charts/flyte-core/values-gcp.yaml >values-gcp.yaml
 
 #. Update values
 

--- a/rsts/deployment/gcp/manual.rst
+++ b/rsts/deployment/gcp/manual.rst
@@ -128,6 +128,8 @@ Development
    * storage.buckets.get
    * storage.objects.create
    * storage.objects.delete
+   * storage.objects.update
+   * storage.objects.get
 * Create a new role FlyteAdminRole with following permissions
    * storage.buckets.get
    * storage.objects.create


### PR DESCRIPTION
The `values-gcp.yaml` is no more under the flyte charts folder. I updated the link to the version under flyte-core.
Also missing two permissions are added to `DataCatalog` role to make caching available.
Tracking issue: https://github.com/flyteorg/flyte/issues/1950