### PR TITLE
Update apis to allow for compatibility with k8s 1.22

### DIFF
--- a/charts/flyte-core/templates/admin/rbac.yaml
+++ b/charts/flyte-core/templates/admin/rbac.yaml
@@ -43,7 +43,7 @@ rules:
   - '*'
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "flyteadmin.name" . }}-binding

--- a/charts/flyte-core/templates/common/ingress.yaml
+++ b/charts/flyte-core/templates/common/ingress.yaml
@@ -3,46 +3,62 @@
 - path: /flyteidl.service.AdminService
   pathType: ImplementationSpecific
   backend:
-    serviceName: flyteadmin
-    servicePort: 81
+    service:
+      name: flyteadmin
+      port:
+        number: 81
 - path: /flyteidl.service.AdminService/*
   pathType: ImplementationSpecific
   backend:
-    serviceName: flyteadmin
-    servicePort: 81
+    service:
+      name: flyteadmin
+      port:
+        number: 81
 - path: /flyteidl.service.AuthMetadataService
   pathType: ImplementationSpecific
   backend:
-    serviceName: flyteadmin
-    servicePort: 81
+    service:
+      name: flyteadmin
+      port:
+        number: 81
 - path: /flyteidl.service.AuthMetadataService/*
   pathType: ImplementationSpecific
   backend:
-    serviceName: flyteadmin
-    servicePort: 81
+    service:
+      name: flyteadmin
+      port:
+        number: 81
 - path: /flyteidl.service.IdentityService
   pathType: ImplementationSpecific
   backend:
-    serviceName: flyteadmin
-    servicePort: 81
+    service:
+      name: flyteadmin
+      port:
+        number: 81
 - path: /flyteidl.service.IdentityService/*
   pathType: ImplementationSpecific
   backend:
-    serviceName: flyteadmin
-    servicePort: 81
+    service:
+      name: flyteadmin
+      port:
+        number: 81
 - path: /grpc.health.v1.Health
   pathType: ImplementationSpecific
   backend:
-    serviceName: flyteadmin
-    servicePort: 81
+    service:
+      name: flyteadmin
+      port:
+        number: 81
 - path: /grpc.health.v1.Health/*
   pathType: ImplementationSpecific
   backend:
-    serviceName: flyteadmin
-    servicePort: 81
+    service:
+      name: flyteadmin
+      port:
+        number: 81
   {{- end }}
   {{- if .Values.common.ingress.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "flyte.name" . }}
@@ -58,125 +74,171 @@ spec:
           - path: /*
             pathType: ImplementationSpecific
             backend:
-              serviceName: ssl-redirect
-              servicePort: use-annotation
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
           {{- end }}
           # This is useful only for frontend development
           {{- if .Values.common.ingress.webpackHMR }}
           - path: /__webpack_hmr
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteconsole
-              servicePort: 80
+              service:
+                name: flyteconsole
+                port:
+                  number: 80
           {{- end }}
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 87
+              service:
+                name: flyteadmin
+                port:
+                  number: 87
           # NOTE: If you change this, you must update the BASE_URL value in flyteconsole.yaml
           - path: /console
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteconsole
-              servicePort: 80
+              service:
+                name: flyteconsole
+                port:
+                  number: 80
           - path: /console/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteconsole
-              servicePort: 80
+              service:
+                name: flyteconsole
+                port:
+                  number: 80
           - path: /api
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /api/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /healthcheck
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /v1/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 87
+              service:
+                name: flyteadmin
+                port:
+                  number: 87
           - path: /.well-known
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /.well-known/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /login
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /login/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /logout
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /logout/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /callback
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /callback/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /me
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /config
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /config/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /oauth2
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /oauth2/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           {{- if not .Values.common.ingress.separateGrpcIngress }}
           {{- include "grpcRoutes" . | nindent 10 -}}
           {{- end }}
@@ -193,7 +255,7 @@ spec:
 # Certain ingress controllers like nginx cannot serve HTTP 1 and GRPC with a single ingress because GRPC can only
 # enabled on the ingress object, not on backend services (GRPC annotation is set on the ingress, not on the services).
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "flyte.name" . }}-grpc

--- a/charts/flyte-core/templates/propeller/crds/flyteworkflow.yaml
+++ b/charts/flyte-core/templates/propeller/crds/flyteworkflow.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.flytepropeller.enabled }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: flyteworkflows.flyte.lyft.com
@@ -12,5 +12,13 @@ spec:
     - fly
     singular: flyteworkflow
   scope: Namespaced
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          
 {{- end }}

--- a/charts/flyte-core/templates/propeller/crds/flyteworkflow.yaml
+++ b/charts/flyte-core/templates/propeller/crds/flyteworkflow.yaml
@@ -9,16 +9,16 @@ spec:
     kind: FlyteWorkflow
     plural: flyteworkflows
     shortNames:
-    - fly
+      - fly
     singular: flyteworkflow
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+          properties:
 {{- end }}

--- a/charts/flyte-core/templates/propeller/rbac.yaml
+++ b/charts/flyte-core/templates/propeller/rbac.yaml
@@ -83,7 +83,7 @@ rules:
   - deletecollection
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "flytepropeller.name" . }}

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -460,17 +460,18 @@ spec:
     kind: FlyteWorkflow
     plural: flyteworkflows
     shortNames:
-    - fly
+      - fly
     singular: flyteworkflow
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+          properties:
 ---
 # Source: flyte-core/templates/admin/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -450,7 +450,7 @@ data:
         kubernetes-enabled: false
 ---
 # Source: flyte-core/templates/propeller/crds/flyteworkflow.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: flyteworkflows.flyte.lyft.com
@@ -463,7 +463,14 @@ spec:
     - fly
     singular: flyteworkflow
   scope: Namespaced
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
 ---
 # Source: flyte-core/templates/admin/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -589,7 +596,7 @@ rules:
       - patch
 ---
 # Source: flyte-core/templates/admin/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flyteadmin-binding
@@ -608,7 +615,7 @@ subjects:
   namespace: flyte
 ---
 # Source: flyte-core/templates/propeller/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flytepropeller
@@ -1269,7 +1276,7 @@ spec:
             name: config-volume
 ---
 # Source: flyte-core/templates/common/ingress.yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flyte-core
@@ -1291,123 +1298,167 @@ spec:
           - path: /*
             pathType: ImplementationSpecific
             backend:
-              serviceName: ssl-redirect
-              servicePort: use-annotation
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
           # This is useful only for frontend development
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 87
+              service:
+                name: flyteadmin
+                port:
+                  number: 87
           # NOTE: If you change this, you must update the BASE_URL value in flyteconsole.yaml
           - path: /console
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteconsole
-              servicePort: 80
+              service:
+                name: flyteconsole
+                port:
+                  number: 80
           - path: /console/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteconsole
-              servicePort: 80
+              service:
+                name: flyteconsole
+                port:
+                  number: 80
           - path: /api
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /api/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /healthcheck
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /v1/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 87
+              service:
+                name: flyteadmin
+                port:
+                  number: 87
           - path: /.well-known
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /.well-known/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /login
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /login/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /logout
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /logout/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /callback
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /callback/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /me
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /config
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /config/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /oauth2
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /oauth2/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
       host: null
 # Certain ingress controllers like nginx cannot serve HTTP 1 and GRPC with a single ingress because GRPC can only
 # enabled on the ingress object, not on backend services (GRPC annotation is set on the ingress, not on the services).
 ---
 # Source: flyte-core/templates/common/ingress.yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flyte-core-grpc
@@ -1440,40 +1491,56 @@ spec:
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.AuthMetadataService
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.AuthMetadataService/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.IdentityService
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.IdentityService/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /grpc.health.v1.Health
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /grpc.health.v1.Health/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -485,7 +485,7 @@ data:
         kubernetes-enabled: false
 ---
 # Source: flyte-core/templates/propeller/crds/flyteworkflow.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: flyteworkflows.flyte.lyft.com
@@ -498,7 +498,14 @@ spec:
     - fly
     singular: flyteworkflow
   scope: Namespaced
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
 ---
 # Source: flyte-core/templates/admin/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -624,7 +631,7 @@ rules:
       - patch
 ---
 # Source: flyte-core/templates/admin/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flyteadmin-binding
@@ -643,7 +650,7 @@ subjects:
   namespace: flyte
 ---
 # Source: flyte-core/templates/propeller/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flytepropeller
@@ -1392,7 +1399,7 @@ spec:
             name: config-volume
 ---
 # Source: flyte-core/templates/common/ingress.yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flyte-core
@@ -1414,123 +1421,167 @@ spec:
           - path: /*
             pathType: ImplementationSpecific
             backend:
-              serviceName: ssl-redirect
-              servicePort: use-annotation
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
           # This is useful only for frontend development
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 87
+              service:
+                name: flyteadmin
+                port:
+                  number: 87
           # NOTE: If you change this, you must update the BASE_URL value in flyteconsole.yaml
           - path: /console
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteconsole
-              servicePort: 80
+              service:
+                name: flyteconsole
+                port:
+                  number: 80
           - path: /console/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteconsole
-              servicePort: 80
+              service:
+                name: flyteconsole
+                port:
+                  number: 80
           - path: /api
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /api/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /healthcheck
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /v1/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 87
+              service:
+                name: flyteadmin
+                port:
+                  number: 87
           - path: /.well-known
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /.well-known/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /login
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /login/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /logout
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /logout/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /callback
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /callback/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /me
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /config
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /config/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /oauth2
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /oauth2/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
       host: null
 # Certain ingress controllers like nginx cannot serve HTTP 1 and GRPC with a single ingress because GRPC can only
 # enabled on the ingress object, not on backend services (GRPC annotation is set on the ingress, not on the services).
 ---
 # Source: flyte-core/templates/common/ingress.yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flyte-core-grpc
@@ -1563,40 +1614,56 @@ spec:
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.AuthMetadataService
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.AuthMetadataService/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.IdentityService
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.IdentityService/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /grpc.health.v1.Health
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /grpc.health.v1.Health/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -495,17 +495,18 @@ spec:
     kind: FlyteWorkflow
     plural: flyteworkflows
     shortNames:
-    - fly
+      - fly
     singular: flyteworkflow
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+          properties:
 ---
 # Source: flyte-core/templates/admin/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -502,7 +502,7 @@ data:
         stackdriver-logresourcename: k8s_container
 ---
 # Source: flyte-core/templates/propeller/crds/flyteworkflow.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: flyteworkflows.flyte.lyft.com
@@ -515,7 +515,14 @@ spec:
     - fly
     singular: flyteworkflow
   scope: Namespaced
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
 ---
 # Source: flyte-core/templates/admin/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -641,7 +648,7 @@ rules:
       - patch
 ---
 # Source: flyte-core/templates/admin/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flyteadmin-binding
@@ -660,7 +667,7 @@ subjects:
   namespace: flyte
 ---
 # Source: flyte-core/templates/propeller/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flytepropeller
@@ -1419,7 +1426,7 @@ spec:
             name: config-volume
 ---
 # Source: flyte-core/templates/common/ingress.yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flyte-core
@@ -1438,110 +1445,152 @@ spec:
           - path: /openapi
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 87
+              service:
+                name: flyteadmin
+                port:
+                  number: 87
           # NOTE: If you change this, you must update the BASE_URL value in flyteconsole.yaml
           - path: /console
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteconsole
-              servicePort: 80
+              service:
+                name: flyteconsole
+                port:
+                  number: 80
           - path: /console/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteconsole
-              servicePort: 80
+              service:
+                name: flyteconsole
+                port:
+                  number: 80
           - path: /api
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /api/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /healthcheck
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /v1/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 87
+              service:
+                name: flyteadmin
+                port:
+                  number: 87
           - path: /.well-known
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /.well-known/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /login
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /login/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /logout
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /logout/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /callback
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /callback/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /me
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /config
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /config/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /oauth2
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /oauth2/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
       host: '<HOSTNAME>'
   tls:
     - secretName: flyte-flyte-tls
@@ -1552,7 +1601,7 @@ spec:
 # enabled on the ingress object, not on backend services (GRPC annotation is set on the ingress, not on the services).
 ---
 # Source: flyte-core/templates/common/ingress.yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flyte-core-grpc
@@ -1573,43 +1622,59 @@ spec:
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.AuthMetadataService
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.AuthMetadataService/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.IdentityService
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.IdentityService/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /grpc.health.v1.Health
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /grpc.health.v1.Health/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
   tls:
     - secretName: flyte-flyte-tls
       hosts:

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -512,17 +512,18 @@ spec:
     kind: FlyteWorkflow
     plural: flyteworkflows
     shortNames:
-    - fly
+      - fly
     singular: flyteworkflow
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+          properties:
 ---
 # Source: flyte-core/templates/admin/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -1915,17 +1915,18 @@ spec:
     kind: FlyteWorkflow
     plural: flyteworkflows
     shortNames:
-    - fly
+      - fly
     singular: flyteworkflow
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+          properties:
 ---
 # Source: flyte/charts/contour/templates/contour/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -1905,7 +1905,7 @@ status:
   storedVersions: []
 ---
 # Source: flyte/charts/flyte/templates/propeller/crds/flyteworkflow.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: flyteworkflows.flyte.lyft.com
@@ -1918,7 +1918,14 @@ spec:
     - fly
     singular: flyteworkflow
   scope: Namespaced
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
 ---
 # Source: flyte/charts/contour/templates/contour/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2354,7 +2361,7 @@ subjects:
     namespace: flyte
 ---
 # Source: flyte/charts/flyte/templates/admin/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flyteadmin-binding
@@ -2373,7 +2380,7 @@ subjects:
   namespace: flyte
 ---
 # Source: flyte/charts/flyte/templates/propeller/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flytepropeller
@@ -3929,7 +3936,7 @@ spec:
             name: config-volume
 ---
 # Source: flyte/charts/flyte/templates/common/ingress.yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flyte
@@ -3944,157 +3951,217 @@ spec:
           - path: /__webpack_hmr
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteconsole
-              servicePort: 80
+              service:
+                name: flyteconsole
+                port:
+                  number: 80
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 87
+              service:
+                name: flyteadmin
+                port:
+                  number: 87
           # NOTE: If you change this, you must update the BASE_URL value in flyteconsole.yaml
           - path: /console
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteconsole
-              servicePort: 80
+              service:
+                name: flyteconsole
+                port:
+                  number: 80
           - path: /console/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteconsole
-              servicePort: 80
+              service:
+                name: flyteconsole
+                port:
+                  number: 80
           - path: /api
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /api/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /healthcheck
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /v1/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 87
+              service:
+                name: flyteadmin
+                port:
+                  number: 87
           - path: /.well-known
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /.well-known/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /login
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /login/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /logout
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /logout/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /callback
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /callback/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /me
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /config
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /config/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /oauth2
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           - path: /oauth2/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 80
+              service:
+                name: flyteadmin
+                port:
+                  number: 80
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.AuthMetadataService
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.AuthMetadataService/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.IdentityService
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.IdentityService/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /grpc.health.v1.Health
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /grpc.health.v1.Health/*
             pathType: ImplementationSpecific
             backend:
-              serviceName: flyteadmin
-              servicePort: 81
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
       host: ""
 ---
 # Source: flyte/charts/kubernetes-dashboard/templates/ingress.yaml


### PR DESCRIPTION
The CRD for the flyteworkflows is incomplete, atm. A schema should be
added in the near future.

See #1273