### PR TITLE
remove .cache .helm .kube root files in sandbox

### DIFF
--- a/docker/sandbox/flyte-entrypoint-default.sh
+++ b/docker/sandbox/flyte-entrypoint-default.sh
@@ -44,7 +44,4 @@ helm upgrade -n flyte --create-namespace flyte $charts --kubeconfig /etc/rancher
 
 wait-for-flyte.sh
 
-# With flytectl sandbox --source flag, we mount the root volume to user source dir that will create helm & k8s specific directory. It cause issue while doing fast register 
-rm -rf /root/.cache /root/.kube /root/.config
-
 wait ${K3S_PID}

--- a/docker/sandbox/flyte-entrypoint-default.sh
+++ b/docker/sandbox/flyte-entrypoint-default.sh
@@ -44,4 +44,7 @@ helm upgrade -n flyte --create-namespace flyte $charts --kubeconfig /etc/rancher
 
 wait-for-flyte.sh
 
+# With flytectl sandbox --source flag, we mount the root volume to user source dir that will create helm & k8s specific directory. It cause issue while doing fast register 
+rm -rf /root/.cache /root/.kube /root/.config
+
 wait ${K3S_PID}

--- a/docker/sandbox/flyte-entrypoint-dind.sh
+++ b/docker/sandbox/flyte-entrypoint-dind.sh
@@ -22,7 +22,7 @@ echo "Starting Docker daemon..."
 # Remove docker PID if exist, Used for restart
 if [ -f "/var/run/docker.pid" ]
 then
-    rm /var/log/dockerd.log
+  rm /var/run/docker.pid
 fi
 
 dockerd &> /var/log/dockerd.log &
@@ -66,7 +66,9 @@ helm upgrade -n flyte --create-namespace flyte $charts --kubeconfig /etc/rancher
 
 wait-for-flyte.sh
 
-# With flytectl sandbox --source flag, we mount the root volume to user source dir that will create helm & k8s specific directory. It cause issue while doing fast register 
+# With flytectl sandbox --source flag, we mount the root volume to user source dir that will create helm & k8s cache specific directory.
+# In Linux, These file belongs to root user that is different then current user
+# In this case during fast serialization, Pyflyte will through error because of permission denied
 rm -rf /root/.cache /root/.kube /root/.config
 
 # Monitor running processes. Exit when the first process exits.

--- a/docker/sandbox/flyte-entrypoint-dind.sh
+++ b/docker/sandbox/flyte-entrypoint-dind.sh
@@ -19,6 +19,12 @@ monitor() {
 
 # Start docker daemon
 echo "Starting Docker daemon..."
+# Remove docker PID if exist, Used for restart
+if [ -f "/var/run/docker.pid" ]
+then
+    rm /var/log/dockerd.log
+fi
+
 dockerd &> /var/log/dockerd.log &
 DOCKERD_PID=$!
 timeout 600 sh -c "until docker info &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for dockerd to start"; exit 1 )

--- a/docker/sandbox/flyte-entrypoint-dind.sh
+++ b/docker/sandbox/flyte-entrypoint-dind.sh
@@ -19,12 +19,6 @@ monitor() {
 
 # Start docker daemon
 echo "Starting Docker daemon..."
-# Remove docker PID if exist, Used for restart
-if [ -f "/var/run/docker.pid" ]
-then
-  rm /var/run/docker.pid
-fi
-
 dockerd &> /var/log/dockerd.log &
 DOCKERD_PID=$!
 timeout 600 sh -c "until docker info &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for dockerd to start"; exit 1 )

--- a/docker/sandbox/flyte-entrypoint-dind.sh
+++ b/docker/sandbox/flyte-entrypoint-dind.sh
@@ -60,5 +60,8 @@ helm upgrade -n flyte --create-namespace flyte $charts --kubeconfig /etc/rancher
 
 wait-for-flyte.sh
 
+# With flytectl sandbox --source flag, we mount the root volume to user source dir that will create helm & k8s specific directory. It cause issue while doing fast register 
+rm -rf /root/.cache /root/.kube /root/.config
+
 # Monitor running processes. Exit when the first process exits.
 monitor ${DOCKERD_PID} ${K3S_PID}


### PR DESCRIPTION
- Removed files in sandbox after successful deployment 
- 
Fix: https://github.com/flyteorg/flyte/issues/1989 

Testing
```
Starting Docker daemon...

Done.


Starting k3s cluster...

Done.

Deploying Flyte...

"flyteorg" has been added to your repositories

Release "flyte" does not exist. Installing it now.

NAME: flyte

LAST DEPLOYED: Tue Dec 28 09:34:09 2021

NAMESPACE: flyte


W1228 09:34:03.314490 710 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition

W1228 09:34:03.606660 710 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition

W1228 09:34:03.829549 710 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition

W1228 09:34:05.926564 710 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition

W1228 09:34:06.010689 710 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition

W1228 09:34:07.918059 710 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition

W1228 09:34:07.993209 710 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition

W1228 09:34:16.700005 710 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition

W1228 09:34:16.744164 710 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding

W1228 09:34:16.752684 710 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding

W1228 09:34:16.886153 710 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob

W1228 09:34:16.894216 710 warnings.go:70] networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress

W1228 09:34:51.155495 710 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition

W1228 09:34:51.253139 710 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding

W1228 09:34:51.271765 710 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding

W1228 09:34:51.580977 710 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob

W1228 09:34:51.640420 710 warnings.go:70] networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress


STATUS: deployed

REVISION: 1

TEST SUITE: None

Waiting for Flyte to become ready...
```

```
Starting Docker daemon...

Done.

Starting k3s cluster...


Done.


Deploying Flyte...


"flyteorg" has been added to your repositories


W1228 09:37:50.239050 1628 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition


W1228 09:37:50.247197 1628 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition


W1228 09:37:50.311734 1628 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition

W1228 09:37:50.514300 1628 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding

W1228 09:37:50.522606 1628 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding


W1228 09:37:50.536522 1628 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding

W1228 09:37:50.548028 1628 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding

W1228 09:37:50.567582 1628 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding

W1228 09:37:50.577496 1628 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding


W1228 09:37:51.361805 1628 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob

W1228 09:37:51.373156 1628 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob


W1228 09:37:51.385997 1628 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob

W1228 09:37:51.393984 1628 warnings.go:70] networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress


W1228 09:37:51.403520 1628 warnings.go:70] networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress


W1228 09:37:51.433698 1628 warnings.go:70] networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress


Release "flyte" has been upgraded. Happy Helming!


NAME: flyte

LAST DEPLOYED: Tue Dec 28 09:37:05 2021

NAMESPACE: flyte

STATUS: deployed

REVISION: 2

TEST SUITE: None

Waiting for Flyte to become ready...

Starting Docker daemon...
```