### PR TITLE
Added user setting in opta, 

### DIFF
--- a/opta/aws/flyte.yaml
+++ b/opta/aws/flyte.yaml
@@ -50,14 +50,6 @@ modules:
     values_file: "../../charts/flyte-core/values-eks.yaml" # NOTE: relative path to values yaml
     # Additional overrides to the values provided by the chart. Opta enables piping through produced outputs from prior modules/steps.
     values:
-      userSettings:
-        rdsHost: "${{module.postgres.db_host}}"
-        accountRegion: "{vars.region}"
-        bucketName: "{parent_name}-{layer_name}"
-        logGroup: /eks/opta-staging/cluster
-        dbUser: "${{module.postgres.db_user}}"
-        dbname: "${{module.postgres.db_name}}"
-        dbPassword: "${{module.postgres.db_password}}"
       db:
         datacatalog:
           database:
@@ -148,6 +140,9 @@ modules:
           plugins:
             logs:
               cloudwatch-region: "{vars.region}"
+        core:
+          propeller:
+            rawoutput-prefix: "s3://{parent_name}-{layer_name}"
       cluster_resource_manager:
         enabled: true
         config:

--- a/opta/aws/flyte.yaml
+++ b/opta/aws/flyte.yaml
@@ -50,8 +50,15 @@ modules:
     values_file: "../../charts/flyte-core/values-eks.yaml" # NOTE: relative path to values yaml
     # Additional overrides to the values provided by the chart. Opta enables piping through produced outputs from prior modules/steps.
     values:
-      postgres:
-        enabled: false
+      userSettings:
+        rdsHost: "${{module.postgres.db_host}}"
+        accountRegion: "{vars.region}"
+        # TODO: Use a hard-coded bucket
+        bucketName: "{parent_name}-{layer_name}"
+        logGroup: /eks/opta-staging/cluster
+        dbUser: "${{module.postgres.db_user}}"
+        dbname: "${{module.postgres.db_name}}"
+        dbPassword: "${{module.postgres.db_password}}"
       db:
         datacatalog:
           database:

--- a/opta/aws/flyte.yaml
+++ b/opta/aws/flyte.yaml
@@ -53,7 +53,6 @@ modules:
       userSettings:
         rdsHost: "${{module.postgres.db_host}}"
         accountRegion: "{vars.region}"
-        # TODO: Use a hard-coded bucket
         bucketName: "{parent_name}-{layer_name}"
         logGroup: /eks/opta-staging/cluster
         dbUser: "${{module.postgres.db_user}}"

--- a/opta/gcp/flyte.yaml
+++ b/opta/gcp/flyte.yaml
@@ -74,6 +74,13 @@ modules:
     values_file: "../../charts/flyte-core/values-gcp.yaml" # NOTE: relative path to values yaml
     # Additional overrides to the values provided by the chart. Opta enables piping through produced outputs from prior modules/steps.
     values:
+      userSettings:
+        bucketName: "${{module.gcs.bucket_name}}"
+        hostName: "{parent.domain}"
+        dbHost: "${{module.postgres.db_host}}"
+        dbUser: "${{module.postgres.db_user}}"
+        dbname: "${{module.postgres.db_name}}"
+        dbPassword: "${{module.postgres.db_password}}"
       postgres:
         enabled: false
       db:

--- a/opta/gcp/flyte.yaml
+++ b/opta/gcp/flyte.yaml
@@ -74,13 +74,6 @@ modules:
     values_file: "../../charts/flyte-core/values-gcp.yaml" # NOTE: relative path to values yaml
     # Additional overrides to the values provided by the chart. Opta enables piping through produced outputs from prior modules/steps.
     values:
-      userSettings:
-        bucketName: "${{module.gcs.bucket_name}}"
-        hostName: "{parent.domain}"
-        dbHost: "${{module.postgres.db_host}}"
-        dbUser: "${{module.postgres.db_user}}"
-        dbname: "${{module.postgres.db_name}}"
-        dbPassword: "${{module.postgres.db_password}}"
       postgres:
         enabled: false
       db:


### PR DESCRIPTION
Currently in aws opta setup, We are not overriding the propeller config for bucket name, That's why execution is failing in cluster, 

To avoid the conflict, I added the user setting in opta so if we missed something then `values-eks.yaml` will override it 



Fix: https://github.com/flyteorg/flyte/issues/1827