### PR TITLE
update main section TOC card styles

### DIFF
--- a/rsts/concepts/architecture.rst
+++ b/rsts/concepts/architecture.rst
@@ -97,7 +97,7 @@ Component Code Architecture
 
 .. panels::
   :container: container-lg pb-4
-  :column: col-lg-4 col-md-4 col-sm-4 col-xs-12 p-2
+  :column: col-lg-12 p-2
   :body: text-center
 
   .. link-button:: flytepropeller-architecture
@@ -117,7 +117,7 @@ Component Code References
 
 .. panels::
   :container: container-lg pb-4
-  :column: col-lg-4 col-md-4 col-sm-4 col-xs-12 p-2
+  :column: col-lg-12 p-2
   :body: text-center
 
   .. link-button:: https://pkg.go.dev/mod/github.com/flyteorg/flyteadmin

--- a/rsts/concepts/basics.rst
+++ b/rsts/concepts/basics.rst
@@ -6,6 +6,7 @@ Core Concepts
 
 .. panels::
     :header: text-center
+    :column: col-lg-12 p-2
 
     .. link-button:: divedeep-tasks
        :type: ref
@@ -121,11 +122,11 @@ Core Concepts
     ---
 
     .. link-button:: divedeep-versioning
-         :type: ref
-         :text: Workflow & Task Versioning
-         :classes: btn-block stretched-link
-     ^^^^^^^^^^^^
-     A deeper dive into one of the Flyte's most important features: versioning of workflows and tasks.
+        :type: ref
+        :text: Workflow & Task Versioning
+        :classes: btn-block stretched-link
+    ^^^^^^^^^^^^
+    A deeper dive into one of the Flyte's most important features: versioning of workflows and tasks.
 
 The diagram below shows how inputs flow through tasks and workflows to produce outputs.
 

--- a/rsts/concepts/control_plane.rst
+++ b/rsts/concepts/control_plane.rst
@@ -6,6 +6,7 @@ Control Plane
 
 .. panels::
     :header: text-center
+    :column: col-lg-12 p-2
 
     .. link-button:: divedeep-projects
         :type: ref

--- a/rsts/deployment/index.rst
+++ b/rsts/deployment/index.rst
@@ -14,6 +14,7 @@ solution). The following pages will help you effectively deploy and manage an en
 
 .. panels::
     :header: text-center
+    :column: col-lg-12 p-2
 
     .. link-button:: deployment-overview
        :type: ref

--- a/rsts/reference/index.rst
+++ b/rsts/reference/index.rst
@@ -6,6 +6,7 @@ API Reference
 
 .. panels::
    :header: text-center
+   :column: col-lg-12 p-2
 
    .. link-button:: https://flytectl.readthedocs.io
       :type: url


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

fixes https://github.com/flyteorg/flyte/issues/2013

These three PRs together will update the main section TOC card styles

https://github.com/flyteorg/flyte/pull/2027
https://github.com/flyteorg/flytesnacks/pull/575
https://github.com/flyteorg/furo/pull/9

Once these changes are merged the TOC cards should look like:

![image](https://user-images.githubusercontent.com/2816689/148435495-d43b11e6-9a2a-4945-8178-8035b6512613.png)
