### PR TITLE
fix github security issue in requirments

### DIFF
--- a/doc-requirements.in
+++ b/doc-requirements.in
@@ -1,4 +1,4 @@
-git+git://github.com/flyteorg/furo@main
+git+https://github.com/flyteorg/furo@main
 sphinx
 sphinx-prompt
 sphinx-code-include

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -23,7 +23,7 @@ docutils==0.16
     #   sphinx
     #   sphinx-panels
     #   sphinx-tabs
-furo @ git+git://github.com/flyteorg/furo@main
+furo @ git+https://github.com/flyteorg/furo@main
     # via -r doc-requirements.in
 idna==3.3
     # via requests


### PR DESCRIPTION
Issue started because of github changes https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

pip install stop working because of deprecated protocol, Change it from git:// to https://
