### PR TITLE
explicitly grant replicasets finalizer permissions to flyte-pod-webhook

### DIFF
--- a/charts/flyte-core/templates/propeller/webhook.yaml
+++ b/charts/flyte-core/templates/propeller/webhook.yaml
@@ -128,6 +128,7 @@ rules:
       - mutatingwebhookconfigurations
       - secrets
       - pods
+      - replicasets/finalizers
     verbs:
       - get
       - create

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -653,6 +653,7 @@ rules:
       - mutatingwebhookconfigurations
       - secrets
       - pods
+      - replicasets/finalizers
     verbs:
       - get
       - create

--- a/deployment/eks/flyte_generated.yaml
+++ b/deployment/eks/flyte_generated.yaml
@@ -7657,6 +7657,7 @@ rules:
   - mutatingwebhookconfigurations
   - secrets
   - pods
+  - replicasets/finalizers
   verbs:
   - get
   - create

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -688,6 +688,7 @@ rules:
       - mutatingwebhookconfigurations
       - secrets
       - pods
+      - replicasets/finalizers
     verbs:
       - get
       - create

--- a/deployment/gcp/flyte_generated.yaml
+++ b/deployment/gcp/flyte_generated.yaml
@@ -7653,6 +7653,7 @@ rules:
   - mutatingwebhookconfigurations
   - secrets
   - pods
+  - replicasets/finalizers
   verbs:
   - get
   - create

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -711,6 +711,7 @@ rules:
       - mutatingwebhookconfigurations
       - secrets
       - pods
+      - replicasets/finalizers
     verbs:
       - get
       - create

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -1707,6 +1707,7 @@ rules:
   - mutatingwebhookconfigurations
   - secrets
   - pods
+  - replicasets/finalizers
   verbs:
   - get
   - create

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -3408,6 +3408,7 @@ rules:
       - mutatingwebhookconfigurations
       - secrets
       - pods
+      - replicasets/finalizers
     verbs:
       - get
       - create

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -54,6 +54,7 @@ rules:
   - mutatingwebhookconfigurations
   - secrets
   - pods
+  - replicasets/finalizers
   verbs:
   - get
   - create

--- a/kustomize/base/pod_webhook/rbac.yaml
+++ b/kustomize/base/pod_webhook/rbac.yaml
@@ -12,6 +12,7 @@ rules:
       - mutatingwebhookconfigurations
       - secrets
       - pods
+      - replicasets/finalizers
     verbs:
       - get
       - create


### PR DESCRIPTION
without granting this permission, installation of the mutatingwebhookconfiguration fails with the following error:
```
Error: mutatingwebhookconfigurations.admissionregistration.k8s.io "flyte-pod-webhook" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```