### PR TITLE
Support setting priorityClassName for flyte pods

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -108,7 +108,7 @@ helm install gateway bitnami/contour -n flyte
 | datacatalog.image.tag | string | `"v0.3.23"` | Docker image tag |
 | datacatalog.nodeSelector | object | `{}` | nodeSelector for Datacatalog deployment |
 | datacatalog.podAnnotations | object | `{}` | Annotations for Datacatalog pods |
-| datacatalog.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
+| datacatalog.priorityClassName | string | `""` | Sets priorityClassName for datacatalog pod(s). |
 | datacatalog.replicaCount | int | `1` | Replicas count for Datacatalog deployment |
 | datacatalog.resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Datacatalog deployment |
 | datacatalog.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"type":"NodePort"}` | Service settings for Datacatalog |
@@ -140,7 +140,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.initialProjects | list | `["flytesnacks","flytetester","flyteexamples"]` | Initial projects to create |
 | flyteadmin.nodeSelector | object | `{}` | nodeSelector for Flyteadmin deployment |
 | flyteadmin.podAnnotations | object | `{}` | Annotations for Flyteadmin pods |
-| flyteadmin.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
+| flyteadmin.priorityClassName | string | `""` | Sets priorityClassName for flyteadmin pod(s). |
 | flyteadmin.replicaCount | int | `1` | Replicas count for Flyteadmin deployment |
 | flyteadmin.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flyteadmin deployment |
 | flyteadmin.secrets | object | `{}` |  |
@@ -160,7 +160,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteconsole.image.tag | string | `"v0.43.0"` |  |
 | flyteconsole.nodeSelector | object | `{}` | nodeSelector for Flyteconsole deployment |
 | flyteconsole.podAnnotations | object | `{}` | Annotations for Flyteconsole pods |
-| flyteconsole.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
+| flyteconsole.priorityClassName | string | `""` | Sets priorityClassName for flyte console pod(s). |
 | flyteconsole.replicaCount | int | `1` | Replicas count for Flyteconsole deployment |
 | flyteconsole.resources | object | `{"limits":{"cpu":"500m","memory":"250Mi"},"requests":{"cpu":"10m","memory":"50Mi"}}` | Default resources requests and limits for Flyteconsole deployment |
 | flyteconsole.service | object | `{"annotations":{},"type":"ClusterIP"}` | Service settings for Flyteconsole |
@@ -192,7 +192,7 @@ helm install gateway bitnami/contour -n flyte
 | flytescheduler.image.tag | string | `"v0.6.104"` | Docker image tag |
 | flytescheduler.nodeSelector | object | `{}` | nodeSelector for Flytescheduler deployment |
 | flytescheduler.podAnnotations | object | `{}` | Annotations for Flytescheduler pods |
-| flytescheduler.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
+| flytescheduler.priorityClassName | string | `""` | Sets priorityClassName for flyte scheduler pod(s). |
 | flytescheduler.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flytescheduler deployment |
 | flytescheduler.secrets | object | `{}` |  |
 | flytescheduler.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":{}}` | Configuration for service accounts for Flytescheduler |

--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -108,6 +108,7 @@ helm install gateway bitnami/contour -n flyte
 | datacatalog.image.tag | string | `"v0.3.23"` | Docker image tag |
 | datacatalog.nodeSelector | object | `{}` | nodeSelector for Datacatalog deployment |
 | datacatalog.podAnnotations | object | `{}` | Annotations for Datacatalog pods |
+| datacatalog.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
 | datacatalog.replicaCount | int | `1` | Replicas count for Datacatalog deployment |
 | datacatalog.resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Datacatalog deployment |
 | datacatalog.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"type":"NodePort"}` | Service settings for Datacatalog |
@@ -139,6 +140,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.initialProjects | list | `["flytesnacks","flytetester","flyteexamples"]` | Initial projects to create |
 | flyteadmin.nodeSelector | object | `{}` | nodeSelector for Flyteadmin deployment |
 | flyteadmin.podAnnotations | object | `{}` | Annotations for Flyteadmin pods |
+| flyteadmin.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
 | flyteadmin.replicaCount | int | `1` | Replicas count for Flyteadmin deployment |
 | flyteadmin.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flyteadmin deployment |
 | flyteadmin.secrets | object | `{}` |  |
@@ -158,6 +160,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteconsole.image.tag | string | `"v0.43.0"` |  |
 | flyteconsole.nodeSelector | object | `{}` | nodeSelector for Flyteconsole deployment |
 | flyteconsole.podAnnotations | object | `{}` | Annotations for Flyteconsole pods |
+| flyteconsole.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
 | flyteconsole.replicaCount | int | `1` | Replicas count for Flyteconsole deployment |
 | flyteconsole.resources | object | `{"limits":{"cpu":"500m","memory":"250Mi"},"requests":{"cpu":"10m","memory":"50Mi"}}` | Default resources requests and limits for Flyteconsole deployment |
 | flyteconsole.service | object | `{"annotations":{},"type":"ClusterIP"}` | Service settings for Flyteconsole |
@@ -174,6 +177,7 @@ helm install gateway bitnami/contour -n flyte
 | flytepropeller.manager | bool | `false` |  |
 | flytepropeller.nodeSelector | object | `{}` | nodeSelector for Flytepropeller deployment |
 | flytepropeller.podAnnotations | object | `{}` | Annotations for Flytepropeller pods |
+| flytepropeller.priorityClassName | string | `"system-cluster-critical"` | Sets priorityClassName for propeller pod(s). |
 | flytepropeller.replicaCount | int | `1` | Replicas count for Flytepropeller deployment |
 | flytepropeller.resources | object | `{"limits":{"cpu":"200m","ephemeral-storage":"100Mi","memory":"200Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flytepropeller deployment |
 | flytepropeller.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":{}}` | Configuration for service accounts for FlytePropeller |
@@ -188,6 +192,7 @@ helm install gateway bitnami/contour -n flyte
 | flytescheduler.image.tag | string | `"v0.6.104"` | Docker image tag |
 | flytescheduler.nodeSelector | object | `{}` | nodeSelector for Flytescheduler deployment |
 | flytescheduler.podAnnotations | object | `{}` | Annotations for Flytescheduler pods |
+| flytescheduler.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
 | flytescheduler.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flytescheduler deployment |
 | flytescheduler.secrets | object | `{}` |  |
 | flytescheduler.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":{}}` | Configuration for service accounts for Flytescheduler |

--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         fsGroup: 65534
         runAsUser: 1001
         fsGroupChangePolicy: "Always"
+      {{- if .Values.flyteadmin.priorityClassName }}
+      priorityClassName: {{ .Values.flyteadmin.priorityClassName }}
+      {{- end }}
       initContainers:
         {{- if .Values.db.checks }}
         - name: check-db-ready

--- a/charts/flyte-core/templates/console/deployment.yaml
+++ b/charts/flyte-core/templates/console/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       securityContext:
         runAsUser: 1000
         fsGroupChangePolicy: "OnRootMismatch"
+      {{- if .Values.flyteconsole.priorityClassName }}
+      priorityClassName: {{ .Values.flyteconsole.priorityClassName }}
+      {{- end }}
       containers:
       - image: "{{ .Values.flyteconsole.image.repository }}:{{ .Values.flyteconsole.image.tag }}"
         imagePullPolicy: "{{ .Values.flyteconsole.image.pullPolicy }}"

--- a/charts/flyte-core/templates/datacatalog/deployment.yaml
+++ b/charts/flyte-core/templates/datacatalog/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         fsGroup: 1001
         runAsUser: 1001
         fsGroupChangePolicy: "OnRootMismatch"
+      {{- if .Values.datacatalog.priorityClassName }}
+      priorityClassName: {{ .Values.datacatalog.priorityClassName }}
+      {{- end }}
       initContainers:
       {{- if .Values.db.checks }}
       - name: check-db-ready

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         fsGroup: 65534
         runAsUser: 1001
         fsGroupChangePolicy: "Always"
+      {{- if .Values.flytescheduler.priorityClassName }}
+      priorityClassName: {{ .Values.flytescheduler.priorityClassName }}
+      {{- end }}
       initContainers:
       - command:
         - flytescheduler

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -35,6 +35,9 @@ spec:
         fsGroup: 65534
         runAsUser: 1001
         fsGroupChangePolicy: "Always"
+      {{- if .Values.flytepropeller.priorityClassName }}
+      priorityClassName: {{ .Values.flytepropeller.priorityClassName }}
+      {{- end }}
       containers:
       - command:
         {{- if .Values.flytepropeller.manager }}

--- a/charts/flyte-core/templates/propeller/manager.yaml
+++ b/charts/flyte-core/templates/propeller/manager.yaml
@@ -19,6 +19,9 @@ template:
       fsGroup: 65534
       runAsUser: 1001
       fsGroupChangePolicy: "Always"
+    {{- if .Values.flytepropeller.priorityClassName }}
+    priorityClassName: {{ .Values.flytepropeller.priorityClassName }}
+    {{- end }}
     containers:
     - command:
       - flytepropeller

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -66,6 +66,8 @@ flyteadmin:
   deployRedoc: true
   # -- Appends extra command line arguments to the serve command
   extraArgs: {}
+  # -- Sets priorityClassName for propeller pod(s).
+  priorityClassName: ""
 
 #
 # FLYTESCHEDULER SETTINGS
@@ -109,6 +111,8 @@ flytescheduler:
   # -- affinity for Flytescheduler deployment
   affinity: {}
   secrets: {}
+  # -- Sets priorityClassName for propeller pod(s).
+  priorityClassName: ""
 
 #
 # DATACATALOG SETTINGS
@@ -160,6 +164,8 @@ datacatalog:
   affinity: {}
   # -- Appends extra command line arguments to the main command
   extraArgs: {}
+  # -- Sets priorityClassName for propeller pod(s).
+  priorityClassName: ""
 
 #
 # FLYTEPROPELLER SETTINGS
@@ -209,6 +215,8 @@ flytepropeller:
   extraArgs: {}
   # -- Defines the cluster name used in events sent to Admin
   clusterName: ""
+  # -- Sets priorityClassName for propeller pod(s).
+  priorityClassName: "system-cluster-critical"
 
 #
 # FLYTECONSOLE SETTINGS
@@ -247,6 +255,8 @@ flyteconsole:
   ga:
     enabled: false
     tracking_id: "G-0QW4DJWJ20"
+  # -- Sets priorityClassName for propeller pod(s).
+  priorityClassName: ""
 
 #
 # Common secret auth for propeller & scheduler

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -66,7 +66,7 @@ flyteadmin:
   deployRedoc: true
   # -- Appends extra command line arguments to the serve command
   extraArgs: {}
-  # -- Sets priorityClassName for propeller pod(s).
+  # -- Sets priorityClassName for flyteadmin pod(s).
   priorityClassName: ""
 
 #
@@ -111,7 +111,7 @@ flytescheduler:
   # -- affinity for Flytescheduler deployment
   affinity: {}
   secrets: {}
-  # -- Sets priorityClassName for propeller pod(s).
+  # -- Sets priorityClassName for flyte scheduler pod(s).
   priorityClassName: ""
 
 #
@@ -164,7 +164,7 @@ datacatalog:
   affinity: {}
   # -- Appends extra command line arguments to the main command
   extraArgs: {}
-  # -- Sets priorityClassName for propeller pod(s).
+  # -- Sets priorityClassName for datacatalog pod(s).
   priorityClassName: ""
 
 #
@@ -255,7 +255,7 @@ flyteconsole:
   ga:
     enabled: false
     tracking_id: "G-0QW4DJWJ20"
-  # -- Sets priorityClassName for propeller pod(s).
+  # -- Sets priorityClassName for flyte console pod(s).
   priorityClassName: ""
 
 #

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -1163,6 +1163,7 @@ spec:
         fsGroup: 65534
         runAsUser: 1001
         fsGroupChangePolicy: "Always"
+      priorityClassName: system-cluster-critical
       containers:
       - command:
         - flytepropeller

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -1286,6 +1286,7 @@ spec:
         fsGroup: 65534
         runAsUser: 1001
         fsGroupChangePolicy: "Always"
+      priorityClassName: system-cluster-critical
       containers:
       - command:
         - flytepropeller

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -1313,6 +1313,7 @@ spec:
         fsGroup: 65534
         runAsUser: 1001
         fsGroupChangePolicy: "Always"
+      priorityClassName: system-cluster-critical
       containers:
       - command:
         - flytepropeller

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -4825,6 +4825,7 @@ spec:
         fsGroup: 65534
         runAsUser: 1001
         fsGroupChangePolicy: "Always"
+      priorityClassName: system-cluster-critical
       containers:
       - command:
         - flytepropeller

--- a/script/generate_helm.sh
+++ b/script/generate_helm.sh
@@ -12,14 +12,14 @@ HELM_CAPABILITIES="-a rbac.authorization.k8s.io/v1 -a networking.k8s.io/v1/Ingre
 
 helm dep update ${DIR}/../charts/flyte/
 
-helm template flyte -n flyte ${DIR}/../charts/flyte/ -f ${DIR}/../charts/flyte/values.yaml ${HELM_CAPABILITIES} > ${DIR}/../deployment/sandbox/flyte_helm_generated.yaml
+helm template flyte -n flyte ${DIR}/../charts/flyte/ -f ${DIR}/../charts/flyte/values.yaml ${HELM_CAPABILITIES} --debug > ${DIR}/../deployment/sandbox/flyte_helm_generated.yaml
 
 for deployment in ${DEPLOYMENT_CORE}; do
-    helm template flyte -n flyte ${DIR}/../charts/flyte-core/ -f ${DIR}/../charts/flyte-core/values.yaml -f ${DIR}/../charts/flyte-core/values-${deployment}.yaml ${HELM_CAPABILITIES} > ${DIR}/../deployment/${deployment}/flyte_helm_generated.yaml
+    helm template flyte -n flyte ${DIR}/../charts/flyte-core/ -f ${DIR}/../charts/flyte-core/values.yaml -f ${DIR}/../charts/flyte-core/values-${deployment}.yaml ${HELM_CAPABILITIES} --debug > ${DIR}/../deployment/${deployment}/flyte_helm_generated.yaml
 done
 
 # Generate manifest AWS Scheduler
-helm template flyte -n flyte ${DIR}/../charts/flyte-core/ -f ${DIR}/../charts/flyte-core/values.yaml -f ${DIR}/../charts/flyte-core/values-eks.yaml -f ${DIR}/../charts/flyte-core/values-eks-override.yaml ${HELM_CAPABILITIES} > ${DIR}/../deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+helm template flyte -n flyte ${DIR}/../charts/flyte-core/ -f ${DIR}/../charts/flyte-core/values.yaml -f ${DIR}/../charts/flyte-core/values-eks.yaml -f ${DIR}/../charts/flyte-core/values-eks-override.yaml ${HELM_CAPABILITIES} --debug > ${DIR}/../deployment/eks/flyte_aws_scheduler_helm_generated.yaml
 
 echo "Generating helm docs"
 if ! command -v helm-docs &> /dev/null


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

Under pressure, k8s starts evicting pods and all pods being equal, critical flyte pods can also get evicted and new ones get stuck in a pending state. [Setting priorityClassName](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/) can help prioritize these pods to ensure the flyte cluster is up and continues to be responsive.