### PR TITLE
Add app: flytepropeller to pod labels

### DIFF
--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -29,6 +29,7 @@ spec:
       labels: {{ include "flytepropeller-manager.labels" . | nindent 8 }}
       {{- else }}
       labels: {{ include "flytepropeller.labels" . | nindent 8 }}
+        app: flytepropeller
       {{- end }}
     spec:
       securityContext:

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -1158,6 +1158,7 @@ spec:
         app.kubernetes.io/instance: flyte
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
+        app: flytepropeller
     spec:
       securityContext:
         fsGroup: 65534

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -1281,6 +1281,7 @@ spec:
         app.kubernetes.io/instance: flyte
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
+        app: flytepropeller
     spec:
       securityContext:
         fsGroup: 65534

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -1314,6 +1314,7 @@ spec:
         app.kubernetes.io/instance: flyte
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
+        app: flytepropeller
     spec:
       securityContext:
         fsGroup: 65534

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -4820,6 +4820,7 @@ spec:
         app.kubernetes.io/instance: flyte
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
+        app: flytepropeller
     spec:
       securityContext:
         fsGroup: 65534


### PR DESCRIPTION
Together with this PR https://github.com/flyteorg/flytepropeller/pull/410, they try to use the same set of labels on the flytepropeller pods deployed by Helm or flytepropeller manager.