### PR TITLE
Removed db check container from sandbox

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -123,7 +123,6 @@ helm install gateway bitnami/contour -n flyte
 | db.admin.database.host | string | `"postgres"` |  |
 | db.admin.database.port | int | `5432` |  |
 | db.admin.database.username | string | `"postgres"` |  |
-| db.checks | bool | `true` |  |
 | db.datacatalog.database.dbname | string | `"datacatalog"` |  |
 | db.datacatalog.database.host | string | `"postgres"` |  |
 | db.datacatalog.database.port | int | `5432` |  |

--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -26,16 +26,6 @@ spec:
       priorityClassName: {{ .Values.flyteadmin.priorityClassName }}
       {{- end }}
       initContainers:
-        {{- if .Values.db.checks }}
-        - name: check-db-ready
-          image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
-          securityContext:
-             runAsUser: 0
-          command:
-          - sh
-          - -c
-          - until pg_isready -h {{ tpl .Values.db.admin.database.host $ }} -p {{ .Values.db.admin.database.port }}; do echo waiting for database; sleep 2; done;
-        {{- end }}
         - command:
           - flyteadmin
           - --config

--- a/charts/flyte-core/templates/datacatalog/deployment.yaml
+++ b/charts/flyte-core/templates/datacatalog/deployment.yaml
@@ -26,16 +26,6 @@ spec:
       priorityClassName: {{ .Values.datacatalog.priorityClassName }}
       {{- end }}
       initContainers:
-      {{- if .Values.db.checks }}
-      - name: check-db-ready
-        image: postgres:10.16-alpine
-        securityContext:
-          runAsUser: 0
-        command:
-          - sh
-          - -c
-          - until pg_isready -h {{ tpl .Values.db.datacatalog.database.host $ }} -p {{ .Values.db.datacatalog.database.port }}; do echo waiting for database; sleep 2; done;
-      {{- end }}
       - command:
         - datacatalog
         - --config

--- a/charts/flyte-core/values-eks.yaml
+++ b/charts/flyte-core/values-eks.yaml
@@ -202,7 +202,6 @@ storage:
     region: "{{ .Values.userSettings.accountRegion }}"
 
 db:
-  checks: false
   datacatalog:
     database:
       port: 5432

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -368,7 +368,6 @@ storage:
 
 # Database configuration
 db:
-  checks: true
   datacatalog:
     database:
       port: 5432

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -577,14 +577,6 @@ spec:
         runAsUser: 1001
         fsGroupChangePolicy: "Always"
       initContainers:
-        - name: check-db-ready
-          image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
-          securityContext:
-             runAsUser: 0
-          command:
-          - sh
-          - -c
-          - until pg_isready -h <CLOUD-SQL-IP> -p 5432; do echo waiting for database; sleep 2; done;
         - command:
           - flyteadmin
           - --config
@@ -799,14 +791,6 @@ spec:
         runAsUser: 1001
         fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
-      - name: check-db-ready
-        image: postgres:10.16-alpine
-        securityContext:
-          runAsUser: 0
-        command:
-          - sh
-          - -c
-          - until pg_isready -h <CLOUD-SQL-IP> -p 5432; do echo waiting for database; sleep 2; done;
       - command:
         - datacatalog
         - --config

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -914,14 +914,6 @@ spec:
         runAsUser: 1001
         fsGroupChangePolicy: "Always"
       initContainers:
-        - name: check-db-ready
-          image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
-          securityContext:
-             runAsUser: 0
-          command:
-          - sh
-          - -c
-          - until pg_isready -h <CLOUD-SQL-IP> -p 5432; do echo waiting for database; sleep 2; done;
         - command:
           - flyteadmin
           - --config
@@ -1136,14 +1128,6 @@ spec:
         runAsUser: 1001
         fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
-      - name: check-db-ready
-        image: postgres:10.16-alpine
-        securityContext:
-          runAsUser: 0
-        command:
-          - sh
-          - -c
-          - until pg_isready -h <CLOUD-SQL-IP> -p 5432; do echo waiting for database; sleep 2; done;
       - command:
         - datacatalog
         - --config

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -4430,14 +4430,6 @@ spec:
         runAsUser: 1001
         fsGroupChangePolicy: "Always"
       initContainers:
-        - name: check-db-ready
-          image: ecr.flyte.org/ubuntu/postgres:13-21.04_beta
-          securityContext:
-             runAsUser: 0
-          command:
-          - sh
-          - -c
-          - until pg_isready -h postgres -p 5432; do echo waiting for database; sleep 2; done;
         - command:
           - flyteadmin
           - --config
@@ -4657,14 +4649,6 @@ spec:
         runAsUser: 1001
         fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
-      - name: check-db-ready
-        image: postgres:10.16-alpine
-        securityContext:
-          runAsUser: 0
-        command:
-          - sh
-          - -c
-          - until pg_isready -h postgres -p 5432; do echo waiting for database; sleep 2; done;
       - command:
         - datacatalog
         - --config

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13.5 AS base_
+FROM alpine:3.13.5 AS base
 
 # Install dependencies
 RUN apk add --no-cache openssl
@@ -45,7 +45,7 @@ FROM docker:20.10.11-dind AS dind
 RUN apk add --no-cache bash git make tini curl jq
 
 # Copy artifacts from base
-COPY --from=base_ /flyteorg/ /flyteorg/
+COPY --from=base /flyteorg/ /flyteorg/
 
 # Copy entrypoints
 COPY docker/sandbox/flyte-entrypoint-default.sh /flyteorg/bin/flyte-entrypoint.sh


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

Flyteadmin and datacatalog use check-db-ready init containers before running the migrations.
This is to avoid the following error during the migrations

```
kubectl logs -f -n flyte flyteadmin-c787fff7b-vhk2q  run-migrations
time="2022-03-14T06:05:10Z" level=info msg="Using config file: [/etc/flyte/config/cluster_resources.yaml /etc/flyte/config/db.yaml /etc/flyte/config/domain.yaml /etc/flyte/config/logger.yaml /etc/flyte/config/remoteData.yaml /etc/flyte/config/server.yaml /etc/flyte/config/storage.yaml /etc/flyte/config/task_resource_defaults.yaml]"

2022/03/14 06:06:25 /go/src/github.com/flyteorg/flyteadmin/pkg/repositories/database.go:102
[error] failed to initialize database, got error failed to connect to `host=postgres user=postgres database=flyteadmin`: dial error (dial tcp 10.102.122.224:5432: connect: connection refused)
{"json":{"src":"migrate.go:33"},"level":"fatal","msg":"failed to connect to `host=postgres user=postgres database=flyteadmin`: dial error (dial tcp 10.102.122.224:5432: connect: connection refused)","ts":"2022-03-14T06:06:25Z"}
```

This causes the pod restart backoff to kick in and restart the init-container which succeeds once the postgres container is up.

Hence instead of relying on the explicit init container of check-db-ready which uses a postgres image with multiple security vulenrabilities, we use the kubernetes restart policy on the pods to take care of resolving this issue.


Removed the check flag and also the template of init-container for check-db-ready

https://github.com/flyteorg/flyte/issues/1920