### PR TITLE
Speed up building process of sandbox-lite image

### DIFF
--- a/docker/sandbox-lite/Dockerfile
+++ b/docker/sandbox-lite/Dockerfile
@@ -4,15 +4,7 @@ FROM ghcr.io/flyteorg/flyteconsole:${FLYTECONSOLE_VERSION} AS flyteconsole
 FROM golang:1.18.0-alpine3.15 AS go_builder
 
 # Install dependencies
-RUN apk add --no-cache build-base git make
-
-# Create directory to store built artifacts
-ARG INSTALL_DIR="/install"
-RUN mkdir -p ${INSTALL_DIR}
-
-ARG BUILDKIT_CLI_FOR_KUBECTL_VERSION="v0.1.2"
-RUN git clone -b ${BUILDKIT_CLI_FOR_KUBECTL_VERSION} --single-branch --depth 1 https://github.com/vmware-tanzu/buildkit-cli-for-kubectl.git ${GOPATH}/src/github.com/vmware-tanzu/buildkit-cli-for-kubectl \
-    && make -C ${GOPATH}/src/github.com/vmware-tanzu/buildkit-cli-for-kubectl ${INSTALL_DIR}/linux/kubectl-build BIN_DIR=${INSTALL_DIR} VERSION=${BUILDKIT_CLI_FOR_KUBECTL_VERSION}
+RUN apk add --no-cache build-base
 
 COPY --from=flyteconsole /app/dist /app/flyte/cmd/single/dist
 COPY go.mod go.sum /app/flyte/
@@ -57,7 +49,7 @@ RUN wget -q -O /flyteorg/bin/get_helm.sh https://raw.githubusercontent.com/helm/
 RUN wget -q -O - https://raw.githubusercontent.com/flyteorg/flytectl/master/install.sh | BINDIR=/flyteorg/bin sh -s
 
 # Install buildkit-cli-for-kubectl
-COPY --from=go_builder /install/linux/ /flyte /flyteorg/bin/
+COPY --from=go_builder /flyte /flyteorg/bin/
 
 # Copy flyte chart
 COPY charts/flyte-deps/ /flyteorg/share/flyte-deps
@@ -98,7 +90,6 @@ VOLUME /var/lib/kubelet
 VOLUME /var/lib/rancher/k3s
 VOLUME /var/lib/cni
 VOLUME /var/log
-COPY --from=flyteconsole /app/dist /app/flyte/cmd/single/dist
 
 # Expose Flyte ports
 # 30080 for console, 30081 for gRPC, 30082 for k8s dashboard, 30084 for minio api, 30088 for minio console


### PR DESCRIPTION
- Remove `kubectl`, we can use `k3s kubectl` instead 

The main reason why the sandbox lite dnd image takes an hour to build is that it's our first time building the image, and we don't even cache any image layers.

I built the image in my fork repo a second time, it only took 3 mins
https://github.com/pingsutw/flyte/actions/runs/2163267735