### PR TITLE
fix: added prefix in sandbox-lite image tag

### DIFF
--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -98,7 +98,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/flyte-sandbox-lite
           tags: |
             ${{ steps.set_version.outputs.flyte_version }}
-            type=sha,format=long
+            type=sha,format=long, prefix=dind-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx


### PR DESCRIPTION
Currently sandbox-lite doesn't add `dind-` prefix in image tag, That's why `flytectl demo start` is failing. 

Added prefix in sandbox lite image tag 