### PR TITLE
Update getting started guide to follow new style of pyflyte run

### DIFF
--- a/rsts/getting_started/index.rst
+++ b/rsts/getting_started/index.rst
@@ -88,14 +88,14 @@ Run your workflow locally using ``pyflyte``, the CLI that ships with ``flytekit`
 
 .. prompt:: bash $
 
-  pyflyte run example.py:wf --n 500 --mean 42 --sigma 2
+  pyflyte run example.py wf --n 500 --mean 42 --sigma 2
 
 .. dropdown:: :fa:`info-circle` Why use ``pyflyte run`` rather than ``python example.py``?
     :title: text-muted
     :animate: fade-in-slide-down
 
     ``pyflyte run`` enables you to execute a specific workflow in your python script using the syntax
-    ``pyflyte run <path/to/script.py>:<workflow_function_name>``.
+    ``pyflyte run <path/to/script.py> <workflow_function_name>``.
 
     Key-word arguments can be supplied to ``pyflyte run`` by passing in options in the format ``--kwarg value``, and in
     the case of ``snake_case_arg`` argument names, you can pass in options in the form of ``--snake-case-arg value``.
@@ -155,9 +155,6 @@ Start a Flyte demonstration environment on your local machine:
    .. code-block::
    
       👨‍💻 Flyte is ready! Flyte UI is available at http://localhost:30080/console 🚀 🚀 🎉
-      Add KUBECONFIG and FLYTECTL_CONFIG to your environment variable
-      export KUBECONFIG=$KUBECONFIG:/Users/<username>/.kube/config:/Users/<username>/.flyte/k3s/k3s.yaml
-      export FLYTECTL_CONFIG=/Users/<username>/.flyte/config-sandbox.yaml
 
 .. note::
 
@@ -183,7 +180,7 @@ Then run the same Workflow on the Flyte cluster:
 
 .. prompt:: bash $
 
-  pyflyte run --remote example.py:wf --n 500 --mean 42 --sigma 2
+  pyflyte run --remote example.py wf --n 500 --mean 42 --sigma 2
 
 .. div:: shadow p-3 mb-8 rounded
 


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

https://github.com/flyteorg/flytekit/pull/960 modified the `pyflyte run` interaction. 

We should only merge this after flytekit `1.0.0` is out. Also, it'd be good to mention that running `pyflyte run <workflow_file.py> <workflow_name> --help` actually produces a message containing the description of the workflow parameters, including their types.