### PR TITLE
Add "http" name to port 80 in console template (flyte-core helm chart)

### DIFF
--- a/charts/flyte-core/templates/console/service.yaml
+++ b/charts/flyte-core/templates/console/service.yaml
@@ -13,7 +13,8 @@ spec:
   type: {{ . }}
   {{- end }}
   ports:
-  - port: 80
+  - name: http
+    port: 80
     protocol: TCP
     targetPort: 8080
   selector: {{ include "flyteconsole.selectorLabels" . | nindent 4 }}

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -760,7 +760,8 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 80
+  - name: http
+    port: 80
     protocol: TCP
     targetPort: 8080
   selector: 

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -485,7 +485,8 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 80
+  - name: http
+    port: 80
     protocol: TCP
     targetPort: 8080
   selector: 

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -791,7 +791,8 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 80
+  - name: http
+    port: 80
     protocol: TCP
     targetPort: 8080
   selector: 

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -492,7 +492,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 80
+  - name: http
+    port: 80
     protocol: TCP
     targetPort: 8080
   selector: 

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -806,7 +806,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 80
+  - name: http
+    port: 80
     protocol: TCP
     targetPort: 8080
   selector: 

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -3947,7 +3947,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 80
+  - name: http
+    port: 80
     protocol: TCP
     targetPort: 8080
   selector: 


### PR DESCRIPTION
Port naming is required for some tools to function correctly 

Istio requires the following naming convention: https://istio.io/v1.0/docs/setup/kubernetes/spec-requirements/

Ports in the `admin` template are already named using this convention: 
https://github.com/flyteorg/flyte/blob/6c3d3abe55eda0199a866f77cfd09da4707f5960/charts/flyte-core/templates/admin/service.yaml#L20