### PR TITLE
Use the same pod annotation formatting in syncresources cronjob

### DIFF
--- a/charts/flyte-core/templates/clusterresourcesync/cronjob.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/cronjob.yaml
@@ -10,10 +10,11 @@ spec:
   jobTemplate:
     spec:
       template:
-        {{- with .Values.flyteadmin.podAnnotations }}
         metadata:
-          annotations: {{ tpl (toYaml .) $ | nindent 12 }}
-        {{- end }}
+          annotations:
+            {{- with .Values.flyteadmin.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           containers:
           - command:

--- a/charts/flyte-core/templates/clusterresourcesync/cronjob.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/cronjob.yaml
@@ -11,10 +11,10 @@ spec:
     spec:
       template:
         metadata:
+          {{- with .Values.flyteadmin.podAnnotations }}
           annotations:
-            {{- with .Values.flyteadmin.podAnnotations }}
             {{- toYaml . | nindent 12 }}
-            {{- end }}
+          {{- end }}
         spec:
           containers:
           - command:

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -1304,6 +1304,8 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
         spec:
           containers:
           - command:

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -1305,7 +1305,6 @@ spec:
     spec:
       template:
         metadata:
-          annotations:
         spec:
           containers:
           - command:

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -935,7 +935,6 @@ spec:
     spec:
       template:
         metadata:
-          annotations:
         spec:
           containers:
           - command:

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -934,6 +934,8 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
         spec:
           containers:
           - command:

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -1424,7 +1424,6 @@ spec:
     spec:
       template:
         metadata:
-          annotations:
         spec:
           containers:
           - command:

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -1423,6 +1423,8 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
         spec:
           containers:
           - command:

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -942,7 +942,6 @@ spec:
     spec:
       template:
         metadata:
-          annotations:
         spec:
           containers:
           - command:

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -941,6 +941,8 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
         spec:
           containers:
           - command:

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -1438,7 +1438,6 @@ spec:
     spec:
       template:
         metadata:
-          annotations:
         spec:
           containers:
           - command:

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -1437,6 +1437,8 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
         spec:
           containers:
           - command:

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -5227,7 +5227,6 @@ spec:
     spec:
       template:
         metadata:
-          annotations:
         spec:
           containers:
           - command:

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -5226,6 +5226,8 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
         spec:
           containers:
           - command:


### PR DESCRIPTION
The pod annotations for `flyteadmin` and `clusterresourcesync` are inconsistent in the `flyte-core` helm chart. 

Flyteadmin:
```yaml
  template:
    metadata:
      annotations:
        configChecksum: {{ include (print .Template.BasePath "/admin/configmap.yaml") . | sha256sum | trunc 63 | quote }}
        {{- with .Values.flyteadmin.podAnnotations }}
        {{- toYaml . | nindent 8 }}
        {{- end }}
```

Clusterresourcesync: 
```yaml
      template:
        {{- with .Values.flyteadmin.podAnnotations }}
        metadata:
          annotations: {{ tpl (toYaml .) $ | nindent 12 }}
        {{- end }}
```

Note that one will try to complete the template, whereas the other will not. 
So with annotations defined as: 
```yaml
  flyteadmin:
    podAnnotations:
      vault.hashicorp.com/agent-inject-template-flyte-admin-database: |
        {{- with secret "secret/flyte/admin/database" -}}
          {{- .Data.data.PASSWORD }}
        {{- end }}
```

The outcome would be different on the two pods.


This PR would align the formatting to be the same in both (just "print" the values as is)