### PR TITLE
Add note about python 3.10 on Mac M1's

### DIFF
--- a/rsts/getting_started/index.rst
+++ b/rsts/getting_started/index.rst
@@ -18,15 +18,17 @@ Install `Flytekit <https://pypi.org/project/flytekit/>`__, Flyte's python SDK.
   pip install flytekit
 
 
-.. note::
+.. dropdown:: :fa:`info-circle` Please read on if you're running python 3.10 on a Mac M1
+    :title: text-muted
+    :animate: fade-in-slide-down
 
-   If you're running python 3.10 on a Mac M1, before proceeding, please install ``grpcio`` by building it locally via:
+    Before proceeding, install ``grpcio`` by building it locally via:
 
-   .. prompt:: bash
+    .. prompt:: bash
 
-     pip install --no-binary :all: grpcio --ignore-installed
+        pip install --no-binary :all: grpcio --ignore-installed
 
-   Visit https://github.com/flyteorg/flyte/issues/2486 for more details.
+    Visit https://github.com/flyteorg/flyte/issues/2486 for more details.
 
 
 Example: Computing Descriptive Statistics

--- a/rsts/getting_started/index.rst
+++ b/rsts/getting_started/index.rst
@@ -18,6 +18,17 @@ Install `Flytekit <https://pypi.org/project/flytekit/>`__, Flyte's python SDK.
   pip install flytekit
 
 
+.. note::
+
+   If you're running python 3.10 on a Mac M1, before proceeding, please install ``grpcio`` by building it locally via:
+
+   .. prompt:: bash
+
+     pip install --no-binary :all: grpcio --ignore-installed
+
+   Visit https://github.com/flyteorg/flyte/issues/2486 for more details.
+
+
 Example: Computing Descriptive Statistics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

`grpcio` python 3.10 wheel [is mislabeled as universal](https://github.com/flyteorg/flyte/issues/2486), which makes it so that all uses cases in flytekit that require a connection to admin are going to fail.

Here's how it renders:

![image](https://user-images.githubusercontent.com/653394/168190091-0c594571-8c73-4b0d-8c68-dc16175538b3.png)


The next step is to figure out a way of doing this automatically in flytekit itself, but just to unblock M1 users, let's add a note in the docs.