### PR TITLE
single binary: Add env POD_NAMESPACE to dockerfile

### DIFF
--- a/docker/sandbox-lite/Dockerfile
+++ b/docker/sandbox-lite/Dockerfile
@@ -83,6 +83,7 @@ RUN addgroup -S docker
 
 # Update PATH variable
 ENV PATH "/flyteorg/bin:${PATH}"
+ENV POD_NAMESPACE "flyte"
 
 # Declare volumes for k3s
 VOLUME /var/lib/kubelet

--- a/flyte.yaml
+++ b/flyte.yaml
@@ -10,7 +10,8 @@ webhook:
   certDir: /tmp/k8s-webhook-server/serving-certs
   serviceName: flyte-pod-webhook
   localCert: true
-  servicePort: 9443
+  servicePort: 30090
+  ListenPort: 30090
 tasks:
   task-plugins:
     enabled-plugins:


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

Related to https://unionai.slack.com/archives/C01H0FN1NJX/p1652311344484609

1. we will expose the webhook service(30090) in flytectl so that the k8s API server can connect to it. 
2. Add env POD_NAMESPACE=flyte to [dockerfile](https://github.com/flyteorg/flyte/blob/81044f8b1d620b123318db3fb9fe8d38fe74f565/docker/sandbox-lite/Dockerfile#L86), just like we did in [webhook deployment](https://github.com/flyteorg/flyte/blob/0f4ccfc58ad0d3656a37baf483a4cec073dae960/charts/flyte-core/templates/propeller/webhook.yaml#L57-L60)