### PR TITLE
Re-order clusterresourcesync annotations

### DIFF
--- a/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
@@ -11,11 +11,11 @@ spec:
     matchLabels: {{ include "flyteclusterresourcesync.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.cluster_resource_manager.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
         configChecksum: {{ include (print .Template.BasePath "/clusterresourcesync/configmap.yaml") . | sha256sum | trunc 63 | quote }}
-      {{- end }}
+        {{- with .Values.cluster_resource_manager.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels: {{ include "flyteclusterresourcesync.labels" . | nindent 8 }}
     spec:
       containers:

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -999,6 +999,8 @@ spec:
       app.kubernetes.io/instance: flyte
   template:
     metadata:
+      annotations:
+        configChecksum: "96ecbccfd19ea2e8268104eae476320f13d53bfa83ddae7ac29d072b3fbc238"
       labels: 
         app.kubernetes.io/name: flyteclusterresourcesync
         app.kubernetes.io/instance: flyte

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -706,6 +706,8 @@ spec:
       app.kubernetes.io/instance: flyte
   template:
     metadata:
+      annotations:
+        configChecksum: "96ecbccfd19ea2e8268104eae476320f13d53bfa83ddae7ac29d072b3fbc238"
       labels: 
         app.kubernetes.io/name: flyteclusterresourcesync
         app.kubernetes.io/instance: flyte

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -1030,6 +1030,8 @@ spec:
       app.kubernetes.io/instance: flyte
   template:
     metadata:
+      annotations:
+        configChecksum: "96ecbccfd19ea2e8268104eae476320f13d53bfa83ddae7ac29d072b3fbc238"
       labels: 
         app.kubernetes.io/name: flyteclusterresourcesync
         app.kubernetes.io/instance: flyte

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -713,6 +713,8 @@ spec:
       app.kubernetes.io/instance: flyte
   template:
     metadata:
+      annotations:
+        configChecksum: "2a1e5e5cff9966c9658d2b665fc4787ef644d6eb43b0954a3eb59df94c0c678"
       labels: 
         app.kubernetes.io/name: flyteclusterresourcesync
         app.kubernetes.io/instance: flyte

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -1045,6 +1045,8 @@ spec:
       app.kubernetes.io/instance: flyte
   template:
     metadata:
+      annotations:
+        configChecksum: "2a1e5e5cff9966c9658d2b665fc4787ef644d6eb43b0954a3eb59df94c0c678"
       labels: 
         app.kubernetes.io/name: flyteclusterresourcesync
         app.kubernetes.io/instance: flyte

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -4607,6 +4607,8 @@ spec:
       app.kubernetes.io/instance: flyte
   template:
     metadata:
+      annotations:
+        configChecksum: "c9c09c6c4db7eb63d15b3c38ac229d0df28647bb980aaf23a0be22a37f33d94"
       labels: 
         app.kubernetes.io/name: flyteclusterresourcesync
         app.kubernetes.io/instance: flyte


### PR DESCRIPTION
This is done as otherwise we would get a ` <.Template.BasePath>: nil pointer evaluating interface {}.BasePath` error when setting e.g.:

```yaml
cluster_resource_manager:
  podAnnotations:
    foo: bar
```


Signed-off-by: Bernhard Stadlbauer <11799671+bstadlbauer@users.noreply.github.com>