### PR TITLE
Add catalog config for demo cluster

### DIFF
--- a/flyte.yaml
+++ b/flyte.yaml
@@ -96,3 +96,7 @@ task_resources:
     cpu: 500m
     memory: 500Mi
     storage: 500Mi
+catalog-cache:
+  endpoint: localhost:8081
+  insecure: true
+  type: datacatalog

--- a/flyte_local.yaml
+++ b/flyte_local.yaml
@@ -97,3 +97,7 @@ task_resources:
     cpu: 500m
     memory: 500Mi
     storage: 500Mi
+catalog-cache:
+  endpoint: localhost:8081
+  insecure: true
+  type: datacatalog

--- a/flyte_local_k3d.yaml
+++ b/flyte_local_k3d.yaml
@@ -90,3 +90,7 @@ flyte:
   admin:
     disableClusterResourceManager: true
     disableScheduler: true
+catalog-cache:
+  endpoint: localhost:8081
+  insecure: true
+  type: datacatalog


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

Related to https://flyte-org.slack.com/archives/CNMKCU6FR/p1653977629229469

The catalog doesn’t work because the default catalog type is noop
https://github.com/flyteorg/flytepropeller/blob/f6f4934e80469e0c2e22b2a87691235b83004c2d/pkg/controller/nodes/task/catalog/config.go#L18-L21

Add catalog config for demo cluster.

<img width="1117" alt="image" src="https://user-images.githubusercontent.com/37936015/171215172-96ebb62b-21b3-40a1-82d2-69f90c1f95ae.png">
