### PR TITLE
Add `runPrecheck` option to `flytescheduler`

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -199,6 +199,7 @@ helm install gateway bitnami/contour -n flyte
 | flytescheduler.podAnnotations | object | `{}` | Annotations for Flytescheduler pods |
 | flytescheduler.priorityClassName | string | `""` | Sets priorityClassName for flyte scheduler pod(s). |
 | flytescheduler.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flytescheduler deployment |
+| flytescheduler.runPrecheck | bool | `true` | Whether to inject an init container which waits on flyteadmin |
 | flytescheduler.secrets | object | `{}` |  |
 | flytescheduler.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for Flytescheduler |
 | flytescheduler.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Flytescheduler pods |

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       {{- if .Values.flytescheduler.priorityClassName }}
       priorityClassName: {{ .Values.flytescheduler.priorityClassName }}
       {{- end }}
+      {{- if .Values.flytescheduler.runPrecheck }}
       initContainers:
       - command:
         - flytescheduler
@@ -40,6 +41,7 @@ spec:
             name: config-volume
           - name: auth
             mountPath: /etc/secrets/
+      {{- end }}
       containers:
       - command:
         - flytescheduler

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -87,6 +87,8 @@ flyteadmin:
 #
 
 flytescheduler:
+  # -- Whether to inject an init container which waits on flyteadmin
+  runPrecheck: true
   image:
     # -- Docker image for Flytescheduler deployment
     repository: cr.flyte.org/flyteorg/flytescheduler # FLYTESCHEDULER_IMAGE


### PR DESCRIPTION
This PR adds a configuration option to make the `precheck` init-container optional for `flytescheduler`. This is useful, as it enables the use of the scheduler together with Istio (see #2562 for more information).

Happy to rename/reorder the configuration option, just let me know :-) 

Also @pmahindrakar-oss, I've tried runnning `make helm`, but it seems like `helm` can't resolve the  `bitnami/contour` chart in version `5.0.0` (dependency of the `flyte` chart), seems like that might have been yanked? 

Closes #2562 

Signed-off-by: Bernhard Stadlbauer <11799671+bstadlbauer@users.noreply.github.com>