### PR TITLE
Specify how resource is cleaned up

### DIFF
--- a/rsts/deployment/cluster_config/flytepropeller_config.rst
+++ b/rsts/deployment/cluster_config/flytepropeller_config.rst
@@ -1759,7 +1759,7 @@ Co-Pilot Configuration
 delete-resource-on-finalize (bool)
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-Instructs the system to delete the resource on finalize. This ensures that no resources are kept around (potentially consuming cluster resources). This, however, will cause k8s log links to expire as soon as the resource is finalized.
+Instructs the system to delete the resource upon successful execution of a k8s pod rather than have the k8s garbage collector clean it up. This ensures that no resources are kept around (potentially consuming cluster resources). This, however, will cause k8s log links to expire as soon as the resource is finalized.
 
 **Default Value**: 
 


### PR DESCRIPTION
Specify how resource is cleaned up after successful execution of a k8s pod
[Issue](https://github.com/flyteorg/flyte/issues/2650)
Signed-off-by: SmritiSatyanV <smriti@union.ai>


Signed-off-by: SmritiSatyanV <94349093+SmritiSatyanV@users.noreply.github.com>