### PR TITLE
Add GRPC as backend protocol version instead of HTTP2 for values eks.

### DIFF
--- a/charts/flyte-core/values-eks.yaml
+++ b/charts/flyte-core/values-eks.yaml
@@ -141,7 +141,7 @@ common:
       # -- Instruct ALB Controller to not create multiple load balancers (and hence maintain a single endpoint for both GRPC and Http)
       alb.ingress.kubernetes.io/group.name: flyte
     separateGrpcIngressAnnotations:
-      alb.ingress.kubernetes.io/backend-protocol-version: HTTP2
+      alb.ingress.kubernetes.io/backend-protocol-version: GRPC
   databaseSecret:
     name: db-pass
     secretManifest:

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -1552,7 +1552,7 @@ metadata:
     alb.ingress.kubernetes.io/tags: service_instance=production
     kubernetes.io/ingress.class: alb
     nginx.ingress.kubernetes.io/app-root: /console
-    alb.ingress.kubernetes.io/backend-protocol-version: HTTP2
+    alb.ingress.kubernetes.io/backend-protocol-version: GRPC
     nginx.ingress.kubernetes.io/backend-protocol: GRPC
 spec:
   rules:

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -1181,7 +1181,7 @@ metadata:
     alb.ingress.kubernetes.io/tags: service_instance=production
     kubernetes.io/ingress.class: alb
     nginx.ingress.kubernetes.io/app-root: /console
-    alb.ingress.kubernetes.io/backend-protocol-version: HTTP2
+    alb.ingress.kubernetes.io/backend-protocol-version: GRPC
     nginx.ingress.kubernetes.io/backend-protocol: GRPC
 spec:
   rules:

--- a/deployment/eks/flyte_helm_dataplane_generated.yaml
+++ b/deployment/eks/flyte_helm_dataplane_generated.yaml
@@ -753,7 +753,7 @@ metadata:
     alb.ingress.kubernetes.io/tags: service_instance=production
     kubernetes.io/ingress.class: alb
     nginx.ingress.kubernetes.io/app-root: /console
-    alb.ingress.kubernetes.io/backend-protocol-version: HTTP2
+    alb.ingress.kubernetes.io/backend-protocol-version: GRPC
     nginx.ingress.kubernetes.io/backend-protocol: GRPC
 spec:
   rules:

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -1671,7 +1671,7 @@ metadata:
     alb.ingress.kubernetes.io/tags: service_instance=production
     kubernetes.io/ingress.class: alb
     nginx.ingress.kubernetes.io/app-root: /console
-    alb.ingress.kubernetes.io/backend-protocol-version: HTTP2
+    alb.ingress.kubernetes.io/backend-protocol-version: GRPC
     nginx.ingress.kubernetes.io/backend-protocol: GRPC
 spec:
   rules:


### PR DESCRIPTION
This PR solved the problem mentioned in this Slack thread: https://flyte-org.slack.com/archives/C01P3B761A6/p1657134258930409

In short: The backend protocol should be GRPC as `flytectl` talks to `flyteadmin` through `GRPC`.
My Flyte on EKS Deployment could not communicate with Flyte Admin as long as I did not apply this fix.  