### PR TITLE
update general.rst to show how PodTemplate can be used to configure K8s Pods

### DIFF
--- a/rsts/deployment/cluster_config/general.rst
+++ b/rsts/deployment/cluster_config/general.rst
@@ -255,21 +255,22 @@ If you have the default PodTemplate defined in the ``flyte`` namespace (where Fl
 An example PodTemplate is shown:
 
 .. code-block:: yaml
-     apiVersion: v1
-     kind: PodTemplate
-     metadata:
-       name: flyte-template
-       namespace: flyte
-     template:
-       metadata:
-         labels:
-         - foo
-         annotations:
-         - foo: initial-value
-         - bar: initial-value
-       spec:
-         containers:
-           - name: noop
+    
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      name: flyte-template
+      namespace: flyte
+    template:
+      metadata:
+        labels:
+          - foo
+        annotations:
+          - foo: initial-value
+          - bar: initial-value
+      spec:
+        containers:
+          - name: noop
            image: docker.io/rwgrim/docker-noop
          hostNetwork: false
 
@@ -293,17 +294,17 @@ The resultant Pod using the above default PodTemplate and K8s Plugin configurati
     apiVersion: v1
     kind: Pod
     metadata:
-       name: example-pod
-       namespace: flytesnacks-development
-       labels:
-       - foo // maintained initial value
-       - bar // value appended by k8s plugin configuration
-       annotations:
-       - foo: overridden-value // value overridden by k8s plugin configuration
-       - bar: initial-value // maintained initial value
-       - baz: non-overridden-value // value added by k8s plugin configuration
+      name: example-pod
+      namespace: flytesnacks-development
+      labels:
+        - foo // maintained initial value
+        - bar // value appended by k8s plugin configuration
+      annotations:
+        - foo: overridden-value // value overridden by k8s plugin configuration
+        - bar: initial-value // maintained initial value
+        - baz: non-overridden-value // value added by k8s plugin configuration
     spec:
-       containers:
+      containers:
          // omitted Flyte-specific overridden containers
        hostNetwork: true // overridden by the k8s plugin configuration
 

--- a/rsts/deployment/cluster_config/general.rst
+++ b/rsts/deployment/cluster_config/general.rst
@@ -73,7 +73,7 @@ Cluster Resources
 =================
 These are free-form key-value pairs used when filling the templates that the admin feeds into the cluster manager; the process that syncs Kubernetes resources.
 
-The keys represent templatized variables in `cluster resource template YAML <https://github.com/flyteorg/flyte/blob/1e3d515550cb338c2edb3919d79c6fa1f0da5a19/charts/flyte-core/values.yaml#L737,L760>`__ and the values are what you want to see filled in.
+The keys represent templatized variables in `cluster resource template <https://github.com/flyteorg/flyte/blob/1e3d515550cb338c2edb3919d79c6fa1f0da5a19/charts/flyte-core/values.yaml#L737,L760>`__ and the values are what you want to see filled in.
 
 In the absence of custom override values, you can use ``templateData`` from the `FlyteAdmin config <https://github.com/flyteorg/flyte/blob/1e3d515550cb338c2edb3919d79c6fa1f0da5a19/charts/flyte-core/values.yaml#L719,L734>`__ as a default. Flyte specifies these defaults by domain and applies them to every project-domain namespace combination.
 
@@ -162,7 +162,7 @@ The **attributes** associated with an execution queue must match the **tags** fo
 
     flytectl update execution-queue-attribute
 
-    Refer to the :ref:`docs <flytectl:flytectl_update_execution-queue-attribute>` to learn more about the command and its supported flag(s).
+Refer to the :ref:`docs <flytectl:flytectl_update_execution-queue-attribute>` to learn more about the command and its supported flag(s).
 
 You can view existing attributes for which tags can be assigned by visiting ``protocol://<host>/api/v1/matchable_attributes?resource_type=2`` and substitute the protocol and host appropriately.
 
@@ -176,8 +176,8 @@ And these can be defined at two levels of project-domain or project-domain-workf
 
     flytectl update workflow-execution-config
 
-    Refer to the :ref:`docs <flytectl:flytectl_update_workflow-execution-config>` to learn more about the command and its supported flag(s).
 
+Refer to the :ref:`docs <flytectl:flytectl_update_workflow-execution-config>` to learn more about the command and its supported flag(s).
 
 
 *********
@@ -212,3 +212,31 @@ Any inbound ``CreateExecution`` requests with **[Domain: Production, Project: wi
 Any inbound ``CreateExecution`` requests with **[Domain: Production, Project: widgetmodels]** for any workflow other than ``Demand`` and any launch plan will have a tag value "critical".
 
 All other inbound CreateExecution requests will use the default values specified in the FlyteAdmin config (if any).
+
+
+Configuring K8s Pod using a Default PodTemplate
+------------------------------------------------
+
+FlytePropeller supports configuration of all K8s Pods executed using the Pod plugin. This is accomplished by creating a default PodTemplate. This functionality requires the `default-pod-template-name <https://docs.flyte.org/en/latest/deployment/cluster_config/flytepropeller_config.html#default-pod-template-name-string>`__ configuration option to be set in FlytePropeller.
+
+When executing the K8s Pods, FlytePropeller attempts to use the PodTemplate in the namespace where the Pod would be created (for example, by default, a pod in the project ``flytesnacks`` and domain ``development`` will look for a PodTemplate in the ``flytesnacks-development`` namespace). If that PodTemplate doesn't exist, FlytePropeller attempts to find it in the namespace that it runs in.
+
+This PodTemplate is used as the base Pod. All other configuration options (such as task specific resources, Pod plugin configuration options, etc.) override the values set in the PodTemplate.
+
+.. note :: When setting up this configuration, K8s require PodTemplates to have a set container. In the implementation, we override this value because Flyte requires certain containers to be running. Therefore, when defining the default PodTemplates, you may set a noop container.
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      name: flyte-default-template
+      namespace: flyte
+    template:
+      metadata:
+      spec:
+        containers:
+          - name: noop
+            image: [docker.io/rwgrim/docker-noop](http://docker.io/rwgrim/docker-noop)
+
+The above defined container is never initialized or executed. It serves as a placeholder to validate the PodTemplate.

--- a/rsts/deployment/cluster_config/general.rst
+++ b/rsts/deployment/cluster_config/general.rst
@@ -214,56 +214,92 @@ Any inbound ``CreateExecution`` requests with **[Domain: Production, Project: wi
 All other inbound CreateExecution requests will use the default values specified in the FlyteAdmin config (if any).
 
 
-Configuring K8s Plugin for the Entire Platform
-----------------------------------------------
-
-You can set the configuration on FlytePropeller for the K8s pod and container plugins `here <https://github.com/flyteorg/flyteplugins/blob/902b902fcf487f30ebb5dbeee3bb14e17eb0ec21/go/tasks/pluginmachinery/flytek8s/config/config.go#L67-L162>`__. When you create a new pod in K8s, it is essentially an empty Pod, to begin with. In this empty Pod, the configuration values set in the previous step are applied to construct the Pod. 
-
-For example, if you have the configuration value set for ``EnableHostNetworkingPod`` in the K8s plugin configuration, the Pod would be initially empty. 
-
-.. code-block:: text
-
-    Pod {
-    }
-
-Once you apply the configuration, the Pod reflects the value set.
-
-.. code-block:: text
-
-    Pod {
-        EnableHostNetworkingPod: true,
-    }
-
 Configuring the K8s Pod using a Default PodTemplate
 ---------------------------------------------------
 
-A better technique would be to use the default PodTemplate that allows you to start with a base Pod and configure it in K8s. This method supports any configuration option within Flyte without requiring you to add a separate configuration option in the K8s plugin configuration. 
+You can use the default PodTemplate to configure a K8s Pod. Start with a base Pod and specify the configuration options to the Pod within Flyte. Thus, when a Pod is created in Flyte, it uses the default PodTemplate as the base Pod configuration. This default template supports any configuration options within Flyte without having to update the codebase, thereby eliminating the need to add a `separate configuration <https://github.com/flyteorg/flyteplugins/blob/902b902fcf487f30ebb5dbeee3bb14e17eb0ec21/go/tasks/pluginmachinery/flytek8s/config/config.go#L67-L162>`__ option in the K8s plugin configuration (which was previously the norm). 
 
-In addition to this, you can set the configuration based on namespace. Before this (as seen in the previous section), the K8s plugin configuration would apply to everything that FlytePropeller launched.
+Previously, when a new Pod was created in K8s, it used to be an empty Pod, to begin with. In this empty Pod, the separate configuration values updated in the codebase were applied to construct the new Pod. Thus, the K8s plugin configuration would apply to all Pods launched by FlytePropeller. 
 
-FlytePropeller supports the configuration of all K8s Pods executed using the Pod plugin. This is done by creating a default `PodTemplate <https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates>`__. This functionality requires the `default-pod-template-name <https://docs.flyte.org/en/latest/deployment/cluster_config/flytepropeller_config.html#default-pod-template-name-string>`__ configuration option to be set in FlytePropeller.
+An empty K8s PodTemplate:
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      name: flyte-template
+      namespace: flyte
+     
+When the configuration values are applied to it:
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      name: flyte-template
+      namespace: flyte
+    template:
+      metadata:
+       spec:
+        EnableHostNetworkingPod: true,
+
+
+Currently, FlytePropeller supports configuring all K8s Pods executed using the Pod plugin. This is done by creating a default `PodTemplate <https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates>`__ that uses the `default-pod-template-name <https://docs.flyte.org/en/latest/deployment/cluster_config/flytepropeller_config.html#default-pod-template-name-string>`__ configuration option that is set in FlytePropeller.
 
 This PodTemplate configuration is used as a base to construct every Pod. All other configuration options (such as task-specific resources, Pod plugin configuration options, etc.) override the values set in the PodTemplate.
 
-Using the previous example, you can create a PodTemplate in K8s.
+A default PodTemplate looks like this:
 
-.. code-block:: text
+.. code-block:: yaml
 
-    PodTemplate {
-        EnableHostNetworkingPod: true,
-    }
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      name: flyte-default-template
+      namespace: flytesnacks-development
+    template:
+      metadata:
+        labels:
+        - foo
+      spec:
+        containers:
+          - name: noop
+            image: docker.io/rwgrim/docker-noop
+        subdomain: "default-subdomain"
+        hostNetworking: true
 
-Next, create a Pod in Flyte, whose base configuration will be the same as the PodTemplate you created previously.
+You can build the Pod spec using the above PodTemplate. A sample spec is shown:
 
-.. code-block:: text
+.. code-block:: yaml
 
-    Pod {
-        EnableHostNetworkingPod: true,
-    }
+    plugins:
+      k8s:
+        default-annotations:
+          - annotationKey1: annotationValue1
 
-When executing the K8s Pods, FlytePropeller attempts to use the PodTemplate in the namespace where the Pod would be created (for example, by default, a pod in the project ``flytesnacks`` and domain ``development`` will look for a PodTemplate in the ``flytesnacks-development`` namespace). If that PodTemplate doesn't exist, FlytePropeller attempts to find the PodTemplate in the namespace that FlytePropeller runs in.
+After applying the above Pod spec to the K8s plugin configuration, the manifest looks like this:
 
-.. note :: When you are setting up this configuration, K8s requires PodTemplates to have a set container. In the implementation, we override this value because Flyte requires certain containers to be running. Therefore, when defining the default PodTemplates, you may set a noop container.
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      annotations:
+      - annotationKey1: annotationValue1
+      labels:
+      - foo
+    spec:
+      containers:
+      subdomain: "default-subdomain"
+
+Configuring Pods Based on Namespace
+------------------------------------
+
+When executing the K8s Pods, FlytePropeller attempts to use the PodTemplate in the namespace where the Pod would have been created (for example, by default, a Pod in the project ``flytesnacks`` and domain ``development`` will look for a PodTemplate in the ``flytesnacks-development`` namespace). If that PodTemplate doesn't exist, FlytePropeller attempts to find the PodTemplate in the namespace that FlytePropeller runs in.
+
+.. note :: When you are setting up the configuration, K8s requires PodTemplates to have a set container. In the implementation, you have to override this value because Flyte requires certain containers to be running. Therefore, when defining the default PodTemplates, you may set a noop container.
 
 .. code-block:: yaml
 

--- a/rsts/deployment/cluster_config/general.rst
+++ b/rsts/deployment/cluster_config/general.rst
@@ -277,13 +277,14 @@ An example PodTemplate is shown:
 In addition, the K8s plugin configuration in FlytePropeller defines the default Pod Labels, Annotations, and enables the host networking.
 
 .. code-block:: yaml
+    
     plugins:
        k8s:
         default-labels:
-           - bar
+          - bar
         default-annotations:
-           - foo: overridden-value
-           - baz: non-overridden-value
+          - foo: overridden-value
+          - baz: non-overridden-value
         enable-host-networking-pod: true
 
 To construct a Pod, FlytePropeller initializes a Pod definition using the default PodTemplate. This definition is applied to the K8s plugin configuration values, and any task-specific configuration is overlaid. During the process, when lists are merged, values are appended and when maps are merged, the values are overridden. 


### PR DESCRIPTION
[Issue](https://github.com/flyteorg/flyte/issues/2616)
Document how a default PodTemplate can be used to configure K8s Pods.
Signed-off-by: SmritiSatyanV smriti@union.ai