### PR TITLE
Fallback to logs in propeller termination message by default

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -189,6 +189,7 @@ helm install gateway bitnami/contour -n flyte
 | flytepropeller.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to FlytePropeller pods |
 | flytepropeller.serviceAccount.create | bool | `true` | Should a service account be created for FlytePropeller |
 | flytepropeller.serviceAccount.imagePullSecrets | list | `[]` | ImagePullSecrets to automatically assign to the service account |
+| flytepropeller.terminationMessagePolicy | string | `"FallbackToLogsOnError"` | Error reporting |
 | flytepropeller.tolerations | list | `[]` | tolerations for Flytepropeller deployment |
 | flytescheduler.affinity | object | `{}` | affinity for Flytescheduler deployment |
 | flytescheduler.configPath | string | `"/etc/flyte/config/*.yaml"` | Default regex string for searching configuration files |

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -80,6 +80,9 @@ spec:
             mountPath: /etc/flyte/config
           - name: auth
             mountPath: /etc/secrets/
+        {{- if .Values.flytepropeller.terminationMessagePolicy }}
+        terminationMessagePolicy: "{{ .Values.flytepropeller.terminationMessagePolicy }}"
+        {{- end }}
       serviceAccountName: {{ template "flytepropeller.name" . }}
       volumes:
       - configMap:

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -209,6 +209,8 @@ flytepropeller:
       ephemeral-storage: 50Mi
       memory: 100Mi
   cacheSizeMbs: 0
+  # -- Error reporting
+  terminationMessagePolicy: FallbackToLogsOnError
   # -- Default regex string for searching configuration files
   configPath: /etc/flyte/config/*.yaml
 

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -1270,6 +1270,7 @@ spec:
             mountPath: /etc/flyte/config
           - name: auth
             mountPath: /etc/secrets/
+        terminationMessagePolicy: "FallbackToLogsOnError"
       serviceAccountName: flytepropeller
       volumes:
       - configMap:

--- a/deployment/eks/flyte_helm_dataplane_generated.yaml
+++ b/deployment/eks/flyte_helm_dataplane_generated.yaml
@@ -471,6 +471,7 @@ spec:
             mountPath: /etc/flyte/config
           - name: auth
             mountPath: /etc/secrets/
+        terminationMessagePolicy: "FallbackToLogsOnError"
       serviceAccountName: flytepropeller
       volumes:
       - configMap:

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -1389,6 +1389,7 @@ spec:
             mountPath: /etc/flyte/config
           - name: auth
             mountPath: /etc/secrets/
+        terminationMessagePolicy: "FallbackToLogsOnError"
       serviceAccountName: flytepropeller
       volumes:
       - configMap:

--- a/deployment/gcp/flyte_helm_dataplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_dataplane_generated.yaml
@@ -478,6 +478,7 @@ spec:
             mountPath: /etc/flyte/config
           - name: auth
             mountPath: /etc/secrets/
+        terminationMessagePolicy: "FallbackToLogsOnError"
       serviceAccountName: flytepropeller
       volumes:
       - configMap:

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -1411,6 +1411,7 @@ spec:
             mountPath: /etc/flyte/config
           - name: auth
             mountPath: /etc/secrets/
+        terminationMessagePolicy: "FallbackToLogsOnError"
       serviceAccountName: flytepropeller
       volumes:
       - configMap:

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -7160,6 +7160,7 @@ spec:
             mountPath: /etc/flyte/config
           - name: auth
             mountPath: /etc/secrets/
+        terminationMessagePolicy: "FallbackToLogsOnError"
       serviceAccountName: flytepropeller
       volumes:
       - configMap:


### PR DESCRIPTION
Add `terminationMessagePolicy` to the flytepropeller templates and set to `FallbackToLogsOnError` by default. This makes failure info available through the k8s pod status interface.