### PR TITLE
Add 'additionalContainers' value for flyteadmin

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -130,6 +130,7 @@ helm install gateway bitnami/contour -n flyte
 | db.datacatalog.database.username | string | `"postgres"` |  |
 | deployRedoc | bool | `false` |  |
 | external_events | object | `{"aws":{"region":"us-east-2"},"enable":false,"eventsPublisher":{"eventTypes":["all"],"topicName":"arn:aws:sns:us-east-2:123456:123-my-topic"},"type":"aws"}` | **Optional Component** External events are used to send events (unprocessed, as Admin see them) to an SNS topic (or gcp equivalent) The config is here as an example only - if not enabled, it won't be used. |
+| flyteadmin.additionalContainers | object | `{}` | Appends additional containers to the containers list. May include template values. |
 | flyteadmin.additionalVolumeMounts | list | `[]` |  |
 | flyteadmin.additionalVolumes | list | `[]` |  |
 | flyteadmin.affinity | object | `{}` | affinity for Flyteadmin deployment |

--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -133,6 +133,9 @@ spec:
         {{- with .Values.flyteadmin.additionalVolumeMounts -}}
         {{ tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
+      {{- with .Values.flyteadmin.additionalContainers -}}
+      {{- tpl (toYaml .) $ | nindent 6}}
+      {{- end }}
       serviceAccountName: {{ template "flyteadmin.name" . }}
       volumes: {{- include "databaseSecret.volume" . | nindent 8 }}
         - emptyDir: {}

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -77,6 +77,8 @@ flyteadmin:
   secrets: {}
   additionalVolumes: []
   additionalVolumeMounts: []
+  # -- Appends additional containers to the containers list. May include template values.
+  additionalContainers: {}
   # -- Appends extra command line arguments to the serve command
   extraArgs: {}
   # -- Sets priorityClassName for flyteadmin pod(s).


### PR DESCRIPTION
This change adds an optional value to append containers to the flyteadmin containters list. This can be used to co-deploy sidecar functionality.

Verified that the following local changes
```
   # -- Appends additional containers to the containers list. May include template values.
-  additionalContainers: {}
+  additionalContainers:
+  - command:
+    - flyteadmin
+    - --config
+    - "{{ .Values.flyteadmin.configPath }}"
+    - ...
```
Produce the expected output
```
--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -965,6 +965,11 @@ spec:
           name: clusters-config-volume
         - mountPath: /etc/secrets/
           name: admin-secrets
+      - command:
+        - flyteadmin
+        - --config
+        - '/etc/flyte/config/*.yaml'
+        - '...'
       serviceAccountName: flyteadmin
       volumes:
         - name: db-pass
```