### PR TITLE
update schedules.rst

### DIFF
--- a/rsts/concepts/schedules.rst
+++ b/rsts/concepts/schedules.rst
@@ -48,25 +48,6 @@ A cron expression represents a set of times, with the help of 5 space-separated 
 
 **Note**: The 'Month' and 'Day of week' fields are case insensitive.
 
-Short hand cron formats/predefined schedules
-----------------------------------------------
-
-+------------------------+--------------------------------------------+---------------+
-| Entry                  | Description                                | Equivalent To |
-+========================+============================================+===============+
-| @yearly (or @annually) | Run once a year, midnight, Jan. 1st        | 0 0 1 1 *     |
-+------------------------+--------------------------------------------+---------------+
-| @monthly               | Run once a month, midnight, first of month | 0 0 1 * *     |
-+------------------------+--------------------------------------------+---------------+
-| @weekly                | Run once a week, midnight between Sat/Sun  | 0 0 * * 0     |
-+------------------------+--------------------------------------------+---------------+
-| @daily (or @midnight)  | Run once a day, midnight                   | 0 0 * * *     |
-+------------------------+--------------------------------------------+---------------+
-| @hourly                | Run once an hour, beginning of hour        | 0 * * * *     |
-+------------------------+--------------------------------------------+---------------+
-
-The string field of the schedule should be populated. :ref:`Here <cookbook:Cron Schedules>` is an example.
-
 
 Cron schedules
 ----------------


### PR DESCRIPTION
Delete shorthand cron formats since flytekit doesn’t support this format at the moment though the scheduler does. 
[Slack conversation](https://flyte-org.slack.com/archives/CP2HDHKE1/p1663571417467739) 


Signed-off-by: SmritiSatyanV <94349093+SmritiSatyanV@users.noreply.github.com>