### PR TITLE
Fix getting started example: pass float instead of int parameter

### DIFF
--- a/rsts/getting_started/index.rst
+++ b/rsts/getting_started/index.rst
@@ -125,7 +125,7 @@ Run your workflow locally using ``pyflyte``, the CLI that ships with ``flytekit`
        .. code-block:: python
 
           if __name__ == "__main__":
-              wf(n=100, mean=1, sigma=2.0)
+              wf(n=100, mean=1.0, sigma=2.0)
 
        This becomes even more verbose if you want to pass in arguments:
 


### PR DESCRIPTION
Before:
```
flytekit.core.type_engine.TypeTransformerFailedError: Type of Val '1' is not an instance of <class 'float'>
```

After:
Can run main successfully

Signed-off-by: Robert Fink <rf@robertfink.de>