### PR TITLE
Add explicit check for k3s server startup completion

### DIFF
--- a/docker/sandbox-lite/flyte-entrypoint-dind.sh
+++ b/docker/sandbox-lite/flyte-entrypoint-dind.sh
@@ -24,7 +24,7 @@ file="/var/run/docker.pid"
 if [ -f "$file" ] ; then
     rm "$file"
 fi
-dockerd  &> /var/log/dockerd.log &
+dockerd &> /var/log/dockerd.log &
 DOCKERD_PID=$!
 timeout "$FLYTE_TIMEOUT" sh -c "until docker info &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for dockerd to start"; exit 1 )
 echo "Done."
@@ -34,7 +34,8 @@ echo "Starting k3s cluster..."
 KUBERNETES_API_PORT=${KUBERNETES_API_PORT:-6443}
 k3s server --docker --no-deploy=traefik --no-deploy=servicelb --no-deploy=local-storage --no-deploy=metrics-server --https-listen-port=${KUBERNETES_API_PORT} &> /var/log/k3s.log &
 K3S_PID=$!
-timeout "$FLYTE_TIMEOUT" sh -c "until k3s kubectl explain deployment &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for the Kubernetes cluster to start"; exit 1 )
+timeout "$FLYTE_TIMEOUT" sh -c "until k3s kubectl get node $HOSTNAME &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for the Kubernetes cluster to start"; exit 1 )
+k3s kubectl wait node $HOSTNAME --for condition=Ready --timeout ${FLYTE_TIMEOUT}s &> /dev/null || ( echo >&2 "Timed out while waiting for the Kubernetes cluster to be ready"; exit 1 )
 echo "Done."
 
 # Deploy flyte

--- a/docker/sandbox/flyte-entrypoint-default.sh
+++ b/docker/sandbox/flyte-entrypoint-default.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 cgroup-v2-hack.sh
 
 trap 'pkill -P $$' EXIT
+FLYTE_TIMEOUT=${FLYTE_TIMEOUT:-600}
 
 monitor() {
     while : ; do
@@ -25,7 +26,7 @@ if [ -f "$file" ] ; then
 fi
 dockerd &> /var/log/dockerd.log &
 DOCKERD_PID=$!
-timeout 600 sh -c "until docker info &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for dockerd to start"; exit 1 )
+timeout "$FLYTE_TIMEOUT" sh -c "until docker info &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for dockerd to start"; exit 1 )
 echo "Done."
 
 # Start k3s
@@ -33,7 +34,8 @@ echo "Starting k3s cluster..."
 KUBERNETES_API_PORT=${KUBERNETES_API_PORT:-6443}
 k3s server --docker --no-deploy=traefik --no-deploy=servicelb --no-deploy=local-storage --no-deploy=metrics-server --https-listen-port=${KUBERNETES_API_PORT} &> /var/log/k3s.log &
 K3S_PID=$!
-timeout 600 sh -c "until k3s kubectl explain deployment &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for the Kubernetes cluster to start"; exit 1 )
+timeout "$FLYTE_TIMEOUT" sh -c "until k3s kubectl get node $HOSTNAME &> /dev/null; do sleep 1; done" || ( echo >&2 "Timed out while waiting for the Kubernetes cluster to start"; exit 1 )
+k3s kubectl wait node $HOSTNAME --for condition=Ready --timeout ${FLYTE_TIMEOUT}s &> /dev/null || ( echo >&2 "Timed out while waiting for the Kubernetes cluster to be ready"; exit 1 )
 echo "Done."
 
 echo "Deploying Flyte..."


### PR DESCRIPTION
# Overview
When deploying the flyte-sandbox-lite image I ran into races between `k3s server` and `helm upgrade`. Previously the entrypoint scripts waited for `k3s kubectl explain deployment` to complete successfully. With this change we now explicitly wait on the node to be up and ready.

# Testing
```
$ docker build -t flyte-sandbox-lite --target=dind --compress=true -f ./docker/sandbox-lite/Dockerfile .
$ docker run --rm -it --privileged flyte-sandbox-lite

$ docker build -t flyte-sandbox --target=dind --compress=true -f ./docker/sandbox/Dockerfile .
$ docker run --rm -it --privileged flyte-sandbox
```
