### PR TITLE
Automatic unassign for stale issues

### DIFF
--- a/.github/workflows/label_stale_issues.yml
+++ b/.github/workflows/label_stale_issues.yml
@@ -2,7 +2,7 @@
 # Runs everday at 00:00
 #-------------------------------------------------------------
 
-name: Check stale
+name: Check stale issues
 
 on:
   schedule:

--- a/.github/workflows/label_stale_issues.yml
+++ b/.github/workflows/label_stale_issues.yml
@@ -14,11 +14,11 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           include-only-assigned: true
-          days-before-issue-stale: 14
+          days-before-issue-stale: 30
           days-before-close: -1
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
+          stale-issue-message: "This issue is marked stale because it has been open for 30 days with no activity."

--- a/.github/workflows/label_stale_issues.yml
+++ b/.github/workflows/label_stale_issues.yml
@@ -19,6 +19,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           include-only-assigned: true
           days-before-issue-stale: 30
-          days-before-close: -1
+          days-before-issue-close: -1
           stale-issue-label: "stale"
           stale-issue-message: "This issue is marked stale because it has been open for 30 days with no activity."

--- a/.github/workflows/label_stale_issues.yml
+++ b/.github/workflows/label_stale_issues.yml
@@ -1,0 +1,24 @@
+# Labels all issues with no activity for 14 days as "stale"
+# Runs everday at 00:00
+#-------------------------------------------------------------
+
+name: Check stale
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          include-only-assigned: true
+          days-before-issue-stale: 14
+          days-before-close: -1
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."

--- a/.github/workflows/unassign_stale_issue.yml
+++ b/.github/workflows/unassign_stale_issue.yml
@@ -1,0 +1,19 @@
+# Automatically unassign stale issue
+#------------------------------------------------------------
+
+name: Unassign-stale
+on:
+  issues:
+    types: [ labeled ]
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'stale'
+    steps:
+      - name: unassign-stale
+        run: |
+          echo "Unassigning issue ${{ github.event.issue.number }}"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -d '{"assignees": []}' \
+              https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+          echo "Unassigned"

--- a/.github/workflows/unassign_stale_issue.yml
+++ b/.github/workflows/unassign_stale_issue.yml
@@ -13,7 +13,8 @@ jobs:
       - name: unassign-stale
         run: |
           echo "Unassigning issue ${{ github.event.issue.number }}"
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              -d '{"assignees": []}' \
+          curl -X DELETE \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -d '{"assignees": ["${{ github.event.issue.assignee }}"]}' \
               https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
           echo "Unassigned"

--- a/.github/workflows/unassign_stale_issue.yml
+++ b/.github/workflows/unassign_stale_issue.yml
@@ -1,7 +1,7 @@
 # Automatically unassign stale issue
 #------------------------------------------------------------
 
-name: Unassign-stale
+name: Unassign stale issues
 on:
   issues:
     types: [ labeled ]

--- a/.github/workflows/unassign_stale_issue.yml
+++ b/.github/workflows/unassign_stale_issue.yml
@@ -5,6 +5,8 @@ name: Unassign stale issues
 on:
   issues:
     types: [ labeled ]
+env:
+  assignees: "[\"${{ join(github.event.issue.assignees.*.login, '\", \"') }}\"]"
 jobs:
   one:
     runs-on: ubuntu-latest
@@ -15,6 +17,6 @@ jobs:
           echo "Unassigning issue ${{ github.event.issue.number }}"
           curl -X DELETE \
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              -d '{"assignees": ["${{ github.event.issue.assignee }}"]}' \
+              -d '{"assignees": ${{ env.assignees }} }' \
               https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
           echo "Unassigned"


### PR DESCRIPTION
Added 2 github actions:
1. Labels all issues inactive for 14 days as "stale"
2. Unassigns an issue whenever it is labeled as "stale"