### PR TITLE
Close Stale Issues and PR's

### DIFF
--- a/.github/workflows/close-stale-pr-issue.yml
+++ b/.github/workflows/close-stale-pr-issue.yml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          stale-issue-message: 'This issue is stale because it has been open 35 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
-          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 50 days with no activity.'
-          close-pr-message: 'This PR was closed because it has been stalled for 50 days with no activity.'
-          days-before-issue-stale: 35
-          days-before-pr-stale: 45
-          days-before-issue-close: 30
-          days-before-pr-close: 30
+          stale-issue-message: 'This issue is stale because it has been open 15 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 10 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          days-before-issue-stale: 15
+          days-before-pr-stale: 30
+          days-before-issue-close: 10
+          days-before-pr-close: 10

--- a/.github/workflows/close-stale-pr-issue.yml
+++ b/.github/workflows/close-stale-pr-issue.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 35 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 50 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 50 days with no activity.'
+          days-before-issue-stale: 35
+          days-before-pr-stale: 45
+          days-before-issue-close: 30
+          days-before-pr-close: 30


### PR DESCRIPTION
Signed-off-by: Krishna Agarwal <dmkrishna.agarwal@gmail.com>

This GitHub action closes Close Stale Issues and PR's that have been stale for more than 50 days and also gives a warning comment. It also labels the PR or Issue with stale label.

A helpful bot to close or label stale issues and pr's

cc @samhita-alla and @cosmicBboy 