### PR TITLE
Fix k8s log template for flyte-sandbox-lite

### DIFF
--- a/flyte.yaml
+++ b/flyte.yaml
@@ -69,6 +69,7 @@ plugins:
   logs:
     kubernetes-enabled: true
     kubernetes-url: "http://localhost:30082"
+    kubernetes-template-uri: "http://localhost:30082/#/log/{{ .namespace }}/{{ .podName }}/pod?namespace={{ .namespace }}"
 cluster_resources:
   refreshInterval: 5m
   templatePath: "/etc/flyte/clusterresource/templates"


### PR DESCRIPTION
Signed-off-by: Andrew Dye <andrewwdye@gmail.com>

The flyte-sandbox-lite tasks logs template [defaults to](https://github.com/flyteorg/flyteplugins/blob/master/go/tasks/logs/config.go#L46) `http://localhost:30082/#!/log/...`, which is invalid. The correct form, at least for the kubernetes dashboard deployed in sandbox is `http://localhost:30082/#/log/...`. This change sets the template in the config file. Note this is consistent with the [value set for flyte-sandbox](https://github.com/flyteorg/flyte/blob/master/charts/flyte-core/values-sandbox.yaml#L85).

Not sure of the history of the `/#!/log` form, but possible we want to change the default in flyteplugins instead.