### PR TITLE
Fix wrong configmap name in Auth tutorial

### DIFF
--- a/rsts/deployment/cluster_config/auth_setup.rst
+++ b/rsts/deployment/cluster_config/auth_setup.rst
@@ -144,7 +144,7 @@ Apply Configuration
 
    .. prompt:: bash
 
-      kubectl edit configmap -n flyte flyte-admin-config
+      kubectl edit configmap -n flyte flyte-admin-base-config
 
    Follow the inline comments to make the necessary changes:
 


### PR DESCRIPTION
See configmap name [here](https://github.com/flyteorg/flyte/blob/e40426e24e500b2031e9ba6d8ae28790c5a7fbd1/charts/flyte-core/templates/admin/configmap.yaml#L18).

Signed-off-by: Fabio M. Graetz, Ph.D. <fabiograetz@googlemail.com>