### PR TITLE
Fix multi-cluster support for syncresources helm deployment

### DIFF
--- a/charts/flyte-core/templates/clusterresourcesync/configmap.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/configmap.yaml
@@ -29,4 +29,10 @@ data:
   namespace_config.yaml: | {{ toYaml . | nindent 4 }}
   {{- end }}
 
+  {{- with .Values.configmap.clusters }}
+  clusters.yaml: |
+    clusters:
+      {{- tpl (toYaml .) $ | nindent 6 }}
+  {{- end }}
+
   {{- end }}

--- a/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
@@ -39,6 +39,8 @@ spec:
             name: resource-templates
           - mountPath: /etc/flyte/config
             name: config-volume
+          - mountPath: /var/run/credentials
+            name: flyte-admin-secrets
       serviceAccountName: {{ .Values.cluster_resource_manager.service_account_name }}
       volumes:  {{- include "databaseSecret.volume" . | nindent 8 }}
         - configMap:
@@ -47,6 +49,9 @@ spec:
         - configMap:
             name: flyte-clusterresourcesync-config
           name: config-volume
+        - name: flyte-admin-secrets
+          secret:
+            secretName: flyte-admin-secrets
         {{- if .Values.cluster_resource_manager.config.cluster_resources.standaloneDeployment }}
         - name: auth
           secret:

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -337,6 +337,10 @@ data:
       name: staging
     - id: production
       name: production
+  clusters.yaml: |
+    clusters:
+      clusterConfigs: []
+      labelClusterMap: {}
 ---
 # Source: flyte-core/templates/console/configmap.yaml
 apiVersion: v1
@@ -1018,7 +1022,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "96ecbccfd19ea2e8268104eae476320f13d53bfa83ddae7ac29d072b3fbc238"
+        configChecksum: "55ce597c10b17ef6e891f0c9242b17aafb3d7b4e4e414d0a5078d71ad9c804f"
       labels: 
         app.kubernetes.io/name: flyteclusterresourcesync
         app.kubernetes.io/instance: flyte
@@ -1042,6 +1046,8 @@ spec:
             name: resource-templates
           - mountPath: /etc/flyte/config
             name: config-volume
+          - mountPath: /var/run/credentials
+            name: flyte-admin-secrets
       serviceAccountName: flyteadmin
       volumes:
         - name: db-pass
@@ -1053,6 +1059,9 @@ spec:
         - configMap:
             name: flyte-clusterresourcesync-config
           name: config-volume
+        - name: flyte-admin-secrets
+          secret:
+            secretName: flyte-admin-secrets
 ---
 # Source: flyte-core/templates/console/deployment.yaml
 apiVersion: apps/v1

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -303,6 +303,10 @@ data:
       name: staging
     - id: production
       name: production
+  clusters.yaml: |
+    clusters:
+      clusterConfigs: []
+      labelClusterMap: {}
 ---
 # Source: flyte-core/templates/console/configmap.yaml
 apiVersion: v1
@@ -724,7 +728,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "96ecbccfd19ea2e8268104eae476320f13d53bfa83ddae7ac29d072b3fbc238"
+        configChecksum: "55ce597c10b17ef6e891f0c9242b17aafb3d7b4e4e414d0a5078d71ad9c804f"
       labels: 
         app.kubernetes.io/name: flyteclusterresourcesync
         app.kubernetes.io/instance: flyte
@@ -748,6 +752,8 @@ spec:
             name: resource-templates
           - mountPath: /etc/flyte/config
             name: config-volume
+          - mountPath: /var/run/credentials
+            name: flyte-admin-secrets
       serviceAccountName: flyteadmin
       volumes:
         - name: db-pass
@@ -759,6 +765,9 @@ spec:
         - configMap:
             name: flyte-clusterresourcesync-config
           name: config-volume
+        - name: flyte-admin-secrets
+          secret:
+            secretName: flyte-admin-secrets
 ---
 # Source: flyte-core/templates/console/deployment.yaml
 apiVersion: apps/v1

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -334,6 +334,10 @@ data:
       name: staging
     - id: production
       name: production
+  clusters.yaml: |
+    clusters:
+      clusterConfigs: []
+      labelClusterMap: {}
 ---
 # Source: flyte-core/templates/console/configmap.yaml
 apiVersion: v1
@@ -1049,7 +1053,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "96ecbccfd19ea2e8268104eae476320f13d53bfa83ddae7ac29d072b3fbc238"
+        configChecksum: "55ce597c10b17ef6e891f0c9242b17aafb3d7b4e4e414d0a5078d71ad9c804f"
       labels: 
         app.kubernetes.io/name: flyteclusterresourcesync
         app.kubernetes.io/instance: flyte
@@ -1073,6 +1077,8 @@ spec:
             name: resource-templates
           - mountPath: /etc/flyte/config
             name: config-volume
+          - mountPath: /var/run/credentials
+            name: flyte-admin-secrets
       serviceAccountName: flyteadmin
       volumes:
         - name: db-pass
@@ -1084,6 +1090,9 @@ spec:
         - configMap:
             name: flyte-clusterresourcesync-config
           name: config-volume
+        - name: flyte-admin-secrets
+          secret:
+            secretName: flyte-admin-secrets
 ---
 # Source: flyte-core/templates/console/deployment.yaml
 apiVersion: apps/v1

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -313,6 +313,10 @@ data:
   namespace_config.yaml: | 
     namespace_mapping:
       template: '{{ domain }}'
+  clusters.yaml: |
+    clusters:
+      clusterConfigs: []
+      labelClusterMap: {}
 ---
 # Source: flyte-core/templates/console/configmap.yaml
 apiVersion: v1
@@ -739,7 +743,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2a1e5e5cff9966c9658d2b665fc4787ef644d6eb43b0954a3eb59df94c0c678"
+        configChecksum: "dc18f5d54e0770c574e6b0693724047e22063030259104eebb554398d63209f"
       labels: 
         app.kubernetes.io/name: flyteclusterresourcesync
         app.kubernetes.io/instance: flyte
@@ -763,6 +767,8 @@ spec:
             name: resource-templates
           - mountPath: /etc/flyte/config
             name: config-volume
+          - mountPath: /var/run/credentials
+            name: flyte-admin-secrets
       serviceAccountName: flyteadmin
       volumes:
         - name: db-pass
@@ -774,6 +780,9 @@ spec:
         - configMap:
             name: flyte-clusterresourcesync-config
           name: config-volume
+        - name: flyte-admin-secrets
+          secret:
+            secretName: flyte-admin-secrets
 ---
 # Source: flyte-core/templates/console/deployment.yaml
 apiVersion: apps/v1

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -344,6 +344,10 @@ data:
   namespace_config.yaml: | 
     namespace_mapping:
       template: '{{ domain }}'
+  clusters.yaml: |
+    clusters:
+      clusterConfigs: []
+      labelClusterMap: {}
 ---
 # Source: flyte-core/templates/console/configmap.yaml
 apiVersion: v1
@@ -1072,7 +1076,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2a1e5e5cff9966c9658d2b665fc4787ef644d6eb43b0954a3eb59df94c0c678"
+        configChecksum: "dc18f5d54e0770c574e6b0693724047e22063030259104eebb554398d63209f"
       labels: 
         app.kubernetes.io/name: flyteclusterresourcesync
         app.kubernetes.io/instance: flyte
@@ -1096,6 +1100,8 @@ spec:
             name: resource-templates
           - mountPath: /etc/flyte/config
             name: config-volume
+          - mountPath: /var/run/credentials
+            name: flyte-admin-secrets
       serviceAccountName: flyteadmin
       volumes:
         - name: db-pass
@@ -1107,6 +1113,9 @@ spec:
         - configMap:
             name: flyte-clusterresourcesync-config
           name: config-volume
+        - name: flyte-admin-secrets
+          secret:
+            secretName: flyte-admin-secrets
 ---
 # Source: flyte-core/templates/console/deployment.yaml
 apiVersion: apps/v1

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -444,6 +444,10 @@ data:
       name: staging
     - id: production
       name: production
+  clusters.yaml: |
+    clusters:
+      clusterConfigs: []
+      labelClusterMap: {}
 ---
 # Source: flyte/charts/flyte/templates/console/configmap.yaml
 apiVersion: v1
@@ -6841,7 +6845,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c9c09c6c4db7eb63d15b3c38ac229d0df28647bb980aaf23a0be22a37f33d94"
+        configChecksum: "475154c41cdb06999025ab796aa1264fa3d235df51ac088a39c89c7ce300408"
       labels: 
         app.kubernetes.io/name: flyteclusterresourcesync
         app.kubernetes.io/instance: flyte
@@ -6864,6 +6868,8 @@ spec:
             name: resource-templates
           - mountPath: /etc/flyte/config
             name: config-volume
+          - mountPath: /var/run/credentials
+            name: flyte-admin-secrets
       serviceAccountName: flyteadmin
       volumes:
         
@@ -6873,6 +6879,9 @@ spec:
         - configMap:
             name: flyte-clusterresourcesync-config
           name: config-volume
+        - name: flyte-admin-secrets
+          secret:
+            secretName: flyte-admin-secrets
 ---
 # Source: flyte/charts/flyte/templates/console/deployment.yaml
 apiVersion: apps/v1


### PR DESCRIPTION
This PR adds the missing `clusters` configmap as well as cluster credentials to the `syncresources` deployment of the `flyte-core` helm chart.

The changes assumes the appropriate cluster credentials existing in the `flyteadmin.secrets` config (as used by `flyteadmin`) and the secret for it exists. We could extract that into a separate secret for `syncresources` if needed, however that might just duplicate data that'll most likely be there in the first place anyways.

Fixes #3001 