### PR TITLE
Update README with list of features that provide reproducibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ Live roadmap for the project can be found @[Github Live Roadmap](https://github.
   - [Flytekit plugins](https://docs.flyte.org/projects/cookbook/en/latest/plugins.html) with first-class support in Python
   - Arbitrary Flytekit-less containers tasks ([RawContainer](https://docs.flyte.org/projects/cookbook/en/latest/auto/core/containerization/raw_container.html))
 - Guaranteed **[reproducibility](https://docs.flyte.org/projects/cookbook/en/latest/auto/core/flyte_basics/task_cache.html)** of pipelines via:
+  - Versioned data, code, and models
+  - Automatically tracked executions
+  - Declarative pipelines
 - **Multi-cloud support** (AWS, GCP, and others)
 - No single point of failure, and is resilient by design
 - Automated notifications to Slack, Email, and Pagerduty


### PR DESCRIPTION
Currently this phrase is interrupted as there is no list after the `via:` 
```
 - Guaranteed **[reproducibility](https://docs.flyte.org/projects/cookbook/en/latest/auto/core/flyte_basics/task_cache.html)** of pipelines via:
```

Two solutions could be:
- to remove totaly the `via:`
- to provide the list that was removed in commit 80baa791c02e82cc258c1dfd7184e1b9440a386d, which gives more hints about how reproducibility can be achieved

```
 - Guaranteed **[reproducibility](https://docs.flyte.org/projects/cookbook/en/latest/auto/core/flyte_basics/task_cache.html)** of pipelines via:
-  - Versioned data, code, and models
-  - Automatically tracked executions
-  - Declarative pipelines
```