### PR TITLE
Upgrade contour to 1.16 to use ingress v1 API as v1beta1 is not supported since 1.22

### DIFF
--- a/kustomize/base/addons/contour_ingress_controller/kustomization.yaml
+++ b/kustomize/base/addons/contour_ingress_controller/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
-- https://raw.githubusercontent.com/projectcontour/contour/release-1.13/examples/render/contour.yaml
+- https://raw.githubusercontent.com/projectcontour/contour/release-1.16/examples/render/contour.yaml
 patchesStrategicMerge:
 - service.yaml


### PR DESCRIPTION
Installing the sandbox using kustomize on newer clusters will not have contour running succesfully, as v1.13 use ingress v1beta1 API, and it is not supported since kubernetes 1.22 (deprecated since 1.19).

This change will allow it running on kubernetes clusters 1.19 or later.
As design would be a better decision to make it compatible with latest version and break for older version (kubernetes 1.18 and pior).

