### PR TITLE
Revert "Add note about python 3.10 on Mac M1's"

### DIFF
--- a/rsts/getting_started/index.rst
+++ b/rsts/getting_started/index.rst
@@ -22,19 +22,6 @@ Install `Flytekit <https://pypi.org/project/flytekit/>`__, Flyte's Python SDK.
   pip install flytekit
 
 
-.. dropdown:: :fa:`info-circle` Please read on if you're running python 3.10 on a Mac M1
-    :title: text-muted
-    :animate: fade-in-slide-down
-
-    Before proceeding, install ``grpcio`` by building it locally via:
-
-    .. prompt:: bash
-
-        pip install --no-binary :all: grpcio --ignore-installed
-
-    Visit https://github.com/flyteorg/flyte/issues/2486 for more details.
-
-
 Example: Computing Descriptive Statistics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Reverts flyteorg/flyte#2487

hey I have verified if you are using python 3.10 with Mac M1's, `pip install flyekit` would work ... 

grpcio                   1.46.5
grpcio-status            1.46.5

and above works fine ...


https://github.com/flyteorg/flyte/issues/3132
