### PR TITLE
Bump flytepropeller to fix recovery with flyte decks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/flyteorg/datacatalog v1.0.35
 	github.com/flyteorg/flyteadmin v1.1.54
-	github.com/flyteorg/flytepropeller v1.1.47
+	github.com/flyteorg/flytepropeller v1.1.50
 	github.com/flyteorg/flytestdlib v1.0.13
 	github.com/golang/glog v1.0.0
 	github.com/spf13/cobra v1.4.0
@@ -72,7 +72,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/flyteorg/flyteidl v1.2.5 // indirect
-	github.com/flyteorg/flyteplugins v1.0.18 // indirect
+	github.com/flyteorg/flyteplugins v1.0.20 // indirect
 	github.com/flyteorg/stow v0.3.6 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -394,10 +394,10 @@ github.com/flyteorg/flyteadmin v1.1.54 h1:sFCUFeTW2eFBXSQHdToFbnjHF2rYQkAMktXEeV
 github.com/flyteorg/flyteadmin v1.1.54/go.mod h1:bn3aF7Q8hbWn5KtbkOfwP4/Epgkw5aZ0s/67NrY47mY=
 github.com/flyteorg/flyteidl v1.2.5 h1:oPs0PX9opR9JtWjP5ZH2YMChkbGGL45PIy+90FlaxYc=
 github.com/flyteorg/flyteidl v1.2.5/go.mod h1:OJAq333OpInPnMhvVz93AlEjmlQ+t0FAD4aakIYE4OU=
-github.com/flyteorg/flyteplugins v1.0.18 h1:DOyxAFaS4luv7H9XRKUpHbO09imsG4LP8Du515FGXyM=
-github.com/flyteorg/flyteplugins v1.0.18/go.mod h1:ZbZVBxEWh8Icj1AgfNKg0uPzHHGd9twa4eWcY2Yt6xE=
-github.com/flyteorg/flytepropeller v1.1.47 h1:k+moR+YGOyKJnYHDZjBBXvwnuZJ7IhK/PRv/9Ak/QIs=
-github.com/flyteorg/flytepropeller v1.1.47/go.mod h1:vZlQTBOsddrNGxmA0To+B2ld3VFg6sRWwcC4KU7+g9A=
+github.com/flyteorg/flyteplugins v1.0.20 h1:8ZGN2c0iaZa3d/UmN2VYozLBRhthAIO48aD5g8Wly7s=
+github.com/flyteorg/flyteplugins v1.0.20/go.mod h1:ZbZVBxEWh8Icj1AgfNKg0uPzHHGd9twa4eWcY2Yt6xE=
+github.com/flyteorg/flytepropeller v1.1.50 h1:g9PElCv7dDggqUvrE3g2D+YpNzLavPZluGK+odOS8uE=
+github.com/flyteorg/flytepropeller v1.1.50/go.mod h1:zstMUz30mIskZB4uMkObzOj3CjsGfXIV/+nVxlOmI7I=
 github.com/flyteorg/flytestdlib v1.0.0/go.mod h1:QSVN5wIM1lM9d60eAEbX7NwweQXW96t5x4jbyftn89c=
 github.com/flyteorg/flytestdlib v1.0.13 h1:mmU+k0Bc7HB5kWCgxoNJ9lZeD9tV1c7e5oCgyXKgO8c=
 github.com/flyteorg/flytestdlib v1.0.13/go.mod h1:nIBmBHtjTJvhZEn3e/EwVC/iMkR2tUX8hEiXjRBpH/s=


### PR DESCRIPTION
## Describe your changes
FlytePropeller recovery on tasks without a Flyte Deck [did not work](https://github.com/flyteorg/flyte/issues/3114). This was fixed in [this PR](https://github.com/flyteorg/flytepropeller/pull/506) and should be propagated through to the single binary.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots
_NA_

## Note to reviewers
_NA_
