### PR TITLE
Add separate step for binary tagging in Flyte release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -26,6 +26,31 @@ jobs:
           CUSTOM_TAG: ${{ github.event.inputs.version }}
           RELEASE_BRANCHES: master
 
+  publish-flyte-binary-image:
+    name: Publish flyte binary image for the release version
+    runs-on: ubuntu-latest
+    needs: [ bump-version ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: "${{ secrets.FLYTE_BOT_USERNAME }}"
+          password: "${{ secrets.FLYTE_BOT_PAT }}"
+
+      - name: Tag Image to release version
+        run: |
+          docker pull ghcr.io/flyteorg/flyte-binary:${{ github.sha }}
+          docker tag ghcr.io/flyteorg/flyte-binary:${{ github.sha }} ghcr.io/flyteorg/flyte-binary-release:${{ needs.bump-version.outputs.version }}
+          docker push ghcr.io/flyteorg/flyte-binary-release:${{ needs.bump-version.outputs.version }}
+
+          docker tag ghcr.io/flyteorg/flyte-binary:${{ github.sha }} ghcr.io/flyteorg/flyte-binary-release:latest
+          docker push ghcr.io/flyteorg/flyte-binary-release:latest
+
   publish-flyte-component-image:
     name: Publish flyte component image for the release version
     runs-on: ubuntu-latest
@@ -40,7 +65,6 @@ jobs:
               datacatalog,
               flytescheduler,
               flytecopilot,
-              flyte-binary,
           ]
     steps:
       - name: Checkout

--- a/.github/workflows/single-binary.yml
+++ b/.github/workflows/single-binary.yml
@@ -21,8 +21,6 @@ on:
       - docker/sandbox-bundled/**
       - Dockerfile
       - go.*
-  release:
-    types: [published]
 
 jobs:
   trigger-single-binary-build:

--- a/.github/workflows/single-binary.yml
+++ b/.github/workflows/single-binary.yml
@@ -13,14 +13,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - .github/workflows/single-binary.yml
-      - charts/flyte-binary/**
-      - charts/flyte-sandbox/**
-      - cmd/**
-      - docker/sandbox-bundled/**
-      - Dockerfile
-      - go.*
 
 jobs:
   trigger-single-binary-build:


### PR DESCRIPTION
## Describe your changes

* Update the release job to rely on the fact that the `single-binary.yml` job has already pushed to tag with the release version.
* Remove the publish step from `single-binary.yml`
* Always run single-binary build on merge to master
