### PR TITLE
Add Kubernetes objects for dev mode with single-binary sandbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,23 +11,18 @@ TIMESTAMP := $(shell date '+%Y-%m-%d')
 PACKAGE ?=github.com/flyteorg/flytestdlib
 LD_FLAGS="-s -w -X $(PACKAGE)/version.Version=$(GIT_VERSION) -X $(PACKAGE)/version.Build=$(GIT_HASH) -X $(PACKAGE)/version.BuildTime=$(TIMESTAMP)"
 
+.PHONY: cmd/single/dist
+cmd/single/dist: export FLYTECONSOLE_VERSION ?= latest
+cmd/single/dist:
+	script/get_flyteconsole_dist.sh
+
 .PHONY: compile
-compile:
-	@if [ ! -d "cmd/single/dist" ]; then\
-		docker create --name flyteconsole ghcr.io/flyteorg/flyteconsole-release;\
-        	docker cp flyteconsole:/app/dist cmd/single;\
-        	docker rm -f flyteconsole;\
-        fi
+compile: cmd/single/dist
 	go build -tags console -v -o flyte -ldflags=$(LD_FLAGS) ./cmd/
 	mv ./flyte ${GOPATH}/bin || echo "Skipped copying 'flyte' to ${GOPATH}/bin"
 
 .PHONY: linux_compile
-linux_compile:
-	@if [ ! -d "cmd/single/dist" ]; then\
-		docker create --name flyteconsole ghcr.io/flyteorg/flyteconsole-release;\
-		docker cp flyteconsole:/app/dist cmd/single;\
-		docker rm -f flyteconsole;\
-	fi
+linux_compile: cmd/single/dist
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0  go build -tags console -v -o /artifacts/flyte -ldflags=$(LD_FLAGS) ./cmd/
 
 .PHONY: update_boilerplate

--- a/charts/flyte-sandbox/README.md
+++ b/charts/flyte-sandbox/README.md
@@ -84,8 +84,9 @@ A Helm chart for the Flyte local sandbox
 | postgresql.primary.service.nodePorts.postgresql | int | `30001` |  |
 | postgresql.primary.service.type | string | `"NodePort"` |  |
 | postgresql.shmVolume.enabled | bool | `false` |  |
-| proxy.enabled | bool | `true` |  |
-| proxy.image.pullPolicy | string | `"Never"` |  |
-| proxy.image.repository | string | `"envoyproxy/envoy"` |  |
-| proxy.image.tag | string | `"sandbox"` |  |
+| sandbox.dev | bool | `false` |  |
+| sandbox.proxy.enabled | bool | `true` |  |
+| sandbox.proxy.image.pullPolicy | string | `"Never"` |  |
+| sandbox.proxy.image.repository | string | `"envoyproxy/envoy"` |  |
+| sandbox.proxy.image.tag | string | `"sandbox"` |  |
 

--- a/charts/flyte-sandbox/templates/_helpers.tpl
+++ b/charts/flyte-sandbox/templates/_helpers.tpl
@@ -75,3 +75,10 @@ Name of Envoy proxy configmap
 {{- define "flyte-sandbox.proxyConfigMapName" -}}
 {{- printf "%s-proxy-config" (include "flyte-sandbox.fullname" .) -}}
 {{- end }}
+
+{{/*
+Name of development-mode Flyte headless service
+*/}}
+{{- define "flyte-sandbox.localHeadlessService" -}}
+{{- printf "%s-local" (include "flyte-sandbox.fullname" .) -}}
+{{- end }}

--- a/charts/flyte-sandbox/templates/local/endpoint.yaml
+++ b/charts/flyte-sandbox/templates/local/endpoint.yaml
@@ -1,0 +1,22 @@
+{{- if and ( not ( index .Values "flyte-binary" "enabled" ) ) .Values.sandbox.dev }}
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ include "flyte-sandbox.localHeadlessService" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "flyte-sandbox.labels" . | nindent 4 }}
+subsets:
+  - addresses:
+      - ip: '%{HOST_GATEWAY_IP}%'
+    ports:
+      - name: http
+        port: 8088
+        protocol: TCP
+      - name: grpc
+        port: 8089
+        protocol: TCP
+      - name: webhook
+        port: 9443
+        protocol: TCP
+{{- end }}

--- a/charts/flyte-sandbox/templates/local/service.yaml
+++ b/charts/flyte-sandbox/templates/local/service.yaml
@@ -1,0 +1,21 @@
+{{- if and ( not ( index .Values "flyte-binary" "enabled" ) ) .Values.sandbox.dev }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "flyte-sandbox.localHeadlessService" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "flyte-sandbox.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8088
+      protocol: TCP
+    - name: grpc
+      port: 8089
+      protocol: TCP
+    - name: webhook
+      port: 9443
+      protocol: TCP
+{{- end }}

--- a/charts/flyte-sandbox/templates/proxy/configmap.yaml
+++ b/charts/flyte-sandbox/templates/proxy/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.proxy.enabled }}
+{{- if .Values.sandbox.proxy.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -29,6 +29,7 @@ data:
                                         domains:
                                             - "*"
                                         routes:
+                                            {{- if or ( index .Values "flyte-binary" "enabled" ) .Values.sandbox.dev }}
                                             - match:
                                                   path: "/"
                                               redirect:
@@ -105,6 +106,7 @@ data:
                                                   prefix: "/flyteidl.service.SignalService"
                                               route:
                                                   cluster: flyte_grpc
+                                            {{- end }}
                                             {{- if index .Values "kubernetes-dashboard" "enabled" }}
                                             - match:
                                                   path: "/kubernetes-dashboard"
@@ -132,6 +134,7 @@ data:
                                     typed_config:
                                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
         clusters:
+            {{- if or ( index .Values "flyte-binary" "enabled" ) .Values.sandbox.dev }}
             - name: flyte
               connect_timeout: 0.25s
               type: STRICT_DNS
@@ -143,7 +146,11 @@ data:
                             - endpoint:
                                   address:
                                       socket_address:
+                                          {{- if index .Values "flyte-binary" "enabled" }}
                                           address: {{ .Release.Name }}-flyte-binary
+                                          {{- else }}
+                                          address: {{ include "flyte-sandbox.localHeadlessService" . }}
+                                          {{- end }}
                                           port_value: 8088
             - name: flyte_grpc
               connect_timeout: 0.25s
@@ -157,8 +164,13 @@ data:
                             - endpoint:
                                   address:
                                       socket_address:
+                                          {{- if index .Values "flyte-binary" "enabled" }}
                                           address: {{ .Release.Name }}-flyte-binary
+                                          {{- else }}
+                                          address: {{ include "flyte-sandbox.localHeadlessService" . }}
+                                          {{- end }}
                                           port_value: 8089
+            {{- end }}
             {{- if index .Values "kubernetes-dashboard" "enabled" }}
             - name: kubernetes-dashboard
               connect_timeout: 0.25s

--- a/charts/flyte-sandbox/templates/proxy/deployment.yaml
+++ b/charts/flyte-sandbox/templates/proxy/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.proxy.enabled }}
+{{- if .Values.sandbox.proxy.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: proxy
-          {{- with .Values.proxy.image }}
+          {{- with .Values.sandbox.proxy.image }}
           image: {{ printf "%s:%s" .repository .tag | quote }}
           imagePullPolicy: {{ .pullPolicy | quote }}
           {{- end }}

--- a/charts/flyte-sandbox/templates/proxy/service.yaml
+++ b/charts/flyte-sandbox/templates/proxy/service.yaml
@@ -1,8 +1,9 @@
-{{- if .Values.proxy.enabled }}
+{{- if .Values.sandbox.proxy.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "flyte-sandbox.fullname" . }}
+  name: {{ include "flyte-sandbox.fullname" . }}-proxy
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "flyte-sandbox.labels" . | nindent 4 }}
 spec:

--- a/charts/flyte-sandbox/values.yaml
+++ b/charts/flyte-sandbox/values.yaml
@@ -112,9 +112,13 @@ postgresql:
       enabled: true
       storageClass: local-path
 
-proxy:
-  enabled: true
-  image:
-    repository: envoyproxy/envoy
-    tag: sandbox
-    pullPolicy: Never
+sandbox:
+  # dev Routes requests to an instance of Flyte running locally on a developer's
+  # development environment. This is only usable if the flyte-binary chart is disabled.
+  dev: false
+  proxy:
+    enabled: true
+    image:
+      repository: envoyproxy/envoy
+      tag: sandbox
+      pullPolicy: Never

--- a/docker/sandbox-bundled/Makefile
+++ b/docker/sandbox-bundled/Makefile
@@ -43,6 +43,7 @@ start: FLYTE_DEV := False
 start:
 	[ -n "$(shell docker ps --filter name=^flyte-sandbox$$ --format {{.Names}})" ] || \
 		docker run --detach --rm --privileged --name flyte-sandbox \
+			--add-host "host.docker.internal:host-gateway" \
 			--env FLYTE_DEV=$(FLYTE_DEV) \
 			--env K3S_KUBECONFIG_OUTPUT=/.kube/kubeconfig \
 			--volume $(PWD)/.kube:/.kube \

--- a/docker/sandbox-bundled/Makefile
+++ b/docker/sandbox-bundled/Makefile
@@ -39,9 +39,11 @@ build: flyte manifests
 
 .PHONY: start
 start: FLYTE_SANDBOX_IMAGE := flyte-sandbox:latest
+start: FLYTE_DEV := False
 start:
 	[ -n "$(shell docker ps --filter name=^flyte-sandbox$$ --format {{.Names}})" ] || \
 		docker run --detach --rm --privileged --name flyte-sandbox \
+			--env FLYTE_DEV=$(FLYTE_DEV) \
 			--env K3S_KUBECONFIG_OUTPUT=/.kube/kubeconfig \
 			--volume $(PWD)/.kube:/.kube \
 			--publish "6443" \

--- a/docker/sandbox-bundled/bin/k3d-entrypoint-load-manifest.sh
+++ b/docker/sandbox-bundled/bin/k3d-entrypoint-load-manifest.sh
@@ -7,7 +7,7 @@ REPLACEMENTS=$(mktemp)
 trap 'rm -f ${REPLACEMENTS}' EXIT
 
 cat << EOF > ${REPLACEMENTS}
-s/%{HOST_GATEWAY_IP}%/$(ip route | awk '/default/ {print $3}')/g
+s/%{HOST_GATEWAY_IP}%/$(awk '/host.docker.internal/ {print $1}' /etc/hosts)/g
 EOF
 
 TEMPLATE=/var/lib/rancher/k3s/server/manifests-staging/complete.yaml

--- a/docker/sandbox-bundled/kustomize/dev/kustomization.yaml
+++ b/docker/sandbox-bundled/kustomize/dev/kustomization.yaml
@@ -7,6 +7,8 @@ helmCharts:
   valuesInline:
     flyte-binary:
       enabled: false
+    sandbox:
+      dev: true
 namespace: flyte
 resources:
 - ../namespace.yaml

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -741,7 +741,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: Y2FvUHdKb1U3bENqU2o4RQ==
+  haSharedSecret: ZUlpUG1DMzdZVEpQc1BGQw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -891,7 +891,7 @@ metadata:
     app.kubernetes.io/name: flyte-sandbox
     app.kubernetes.io/version: 1.16.0
     helm.sh/chart: flyte-sandbox-0.1.0
-  name: sandbox-flyte-sandbox
+  name: sandbox-flyte-sandbox-proxy
   namespace: flyte
 spec:
   ports:
@@ -1043,7 +1043,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 044987b193c168f87ad6b75510b710dae15de36461cb822559e13e6f3bf1789a
-        checksum/secret: e852f9e87464782ba96aab43776db1b88cd2e0c14cfd9c4acdec46c6c5652ce1
+        checksum/secret: cff13f32c1b7f5e2e7eb4161640ba531f0403501d00df53a73b260f4d21e0418
       labels:
         app: docker-registry
         release: sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -442,7 +442,7 @@ data:
                             - endpoint:
                                   address:
                                       socket_address:
-                                          address: sandbox-flyte-binary
+                                          address: sandbox-flyte-sandbox-local
                                           port_value: 8088
             - name: flyte_grpc
               connect_timeout: 0.25s
@@ -456,7 +456,7 @@ data:
                             - endpoint:
                                   address:
                                       socket_address:
-                                          address: sandbox-flyte-binary
+                                          address: sandbox-flyte-sandbox-local
                                           port_value: 8089
             - name: kubernetes-dashboard
               connect_timeout: 0.25s
@@ -523,7 +523,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: R1o3S2xMUUhjTklKdUFhOA==
+  haSharedSecret: NmpvNENzWU9nV1NibEltVw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -581,6 +581,31 @@ metadata:
 type: Opaque
 ---
 apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    app.kubernetes.io/instance: sandbox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: flyte-sandbox
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: flyte-sandbox-0.1.0
+  name: sandbox-flyte-sandbox-local
+  namespace: flyte
+subsets:
+- addresses:
+  - ip: '%{HOST_GATEWAY_IP}%'
+  ports:
+  - name: http
+    port: 8088
+    protocol: TCP
+  - name: grpc
+    port: 8089
+    protocol: TCP
+  - name: webhook
+    port: 9443
+    protocol: TCP
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -611,7 +636,31 @@ metadata:
     app.kubernetes.io/name: flyte-sandbox
     app.kubernetes.io/version: 1.16.0
     helm.sh/chart: flyte-sandbox-0.1.0
-  name: sandbox-flyte-sandbox
+  name: sandbox-flyte-sandbox-local
+  namespace: flyte
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 8088
+    protocol: TCP
+  - name: grpc
+    port: 8089
+    protocol: TCP
+  - name: webhook
+    port: 9443
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: sandbox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: flyte-sandbox
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: flyte-sandbox-0.1.0
+  name: sandbox-flyte-sandbox-proxy
   namespace: flyte
 spec:
   ports:
@@ -763,7 +812,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 044987b193c168f87ad6b75510b710dae15de36461cb822559e13e6f3bf1789a
-        checksum/secret: 259b65b8d801f1fb4a4cf936da375c9268594733a3bc0baf9c4300aa5b6feafc
+        checksum/secret: fe51b7ebb34d9c23bdcb3b2952f608993d990821cefe5928e175c14403b01716
       labels:
         app: docker-registry
         release: sandbox

--- a/flyte-single-binary-local.yaml
+++ b/flyte-single-binary-local.yaml
@@ -4,7 +4,8 @@
 # 1. Copy this file to ~/.flyte/config.yaml
 # 2. Replace instance of $HOME with the realpath of your home directory
 # 3. Run sandbox in development mode: `flytectl demo start --dev`
-# 4. Start Flyte locally: `POD_NAMESPACE=flyte go run cmd/main.go start --config ~/.flyte/config.yaml`
+# 4. Fetch Flyteconsole distribution: `make cmd/single/dist`
+# 4. Start Flyte locally: `POD_NAMESPACE=flyte go run -tags console cmd/main.go start --config ~/.flyte/config.yaml`
 
 admin:
   endpoint: localhost:8089

--- a/flyte-single-binary-local.yaml
+++ b/flyte-single-binary-local.yaml
@@ -1,11 +1,11 @@
 # This is a sample configuration file for running single-binary Flyte locally against
 # a sandbox.
 # Usage:
-# 1. Copy this file to ~/.flyte/config.yaml
+# 1. Copy this file to ~/.flyte/local-dev-config.yaml`
 # 2. Replace instance of $HOME with the realpath of your home directory
 # 3. Run sandbox in development mode: `flytectl demo start --dev`
 # 4. Fetch Flyteconsole distribution: `make cmd/single/dist`
-# 4. Start Flyte locally: `POD_NAMESPACE=flyte go run -tags console cmd/main.go start --config ~/.flyte/config.yaml`
+# 4. Start Flyte locally: `POD_NAMESPACE=flyte go run -tags console cmd/main.go start --config ~/.flyte/local-dev-config.yaml`
 
 admin:
   endpoint: localhost:8089

--- a/flyte-single-binary-local.yaml
+++ b/flyte-single-binary-local.yaml
@@ -1,0 +1,91 @@
+# This is a sample configuration file for running single-binary Flyte locally against
+# a sandbox.
+# Usage:
+# 1. Copy this file to ~/.flyte/config.yaml
+# 2. Replace instance of $HOME with the realpath of your home directory
+# 3. Run sandbox in development mode: `flytectl demo start --dev`
+# 4. Start Flyte locally: `POD_NAMESPACE=flyte go run cmd/main.go start --config ~/.flyte/config.yaml`
+
+admin:
+  endpoint: localhost:8089
+  insecure: true
+
+catalog-cache:
+  endpoint: localhost:8081
+  insecure: true
+  type: datacatalog
+
+cluster_resources:
+  standaloneDeployment: false
+  templatePath: $HOME/.flyte/cluster-resource-templates
+
+logger:
+  show-source: true
+  level: 6
+
+propeller:
+  create-flyteworkflow-crd: true
+  kube-config: $HOME/.flyte/state/kubeconfig
+  rawoutput-prefix: s3://my-s3-bucket/data
+
+server:
+  kube-config: $HOME/.flyte/state/kubeconfig
+
+webhook:
+  certDir: $HOME/.flyte/webhook-certs
+  localCert: true
+  secretName: sandbox-flyte-sandbox-webhook-secret
+  serviceName: sandbox-flyte-sandbox-local
+  servicePort: 9443
+
+tasks:
+  task-plugins:
+    enabled-plugins:
+      - container
+      - sidecar
+      - K8S-ARRAY
+    default-for-task-types:
+      - container: container
+      - container_array: K8S-ARRAY
+
+plugins:
+  logs:
+    kubernetes-enabled: true
+    kubernetes-template-uri: http://localhost:30080/kubernetes-dashboard/#/log/{{.namespace }}/{{ .podName }}/pod?namespace={{ .namespace }}
+    cloudwatch-enabled: false
+    stackdriver-enabled: false
+  k8s:
+    default-env-vars:
+    - FLYTE_AWS_ENDPOINT: http://sandbox-minio.flyte:9000
+    - FLYTE_AWS_ACCESS_KEY_ID: minio
+    - FLYTE_AWS_SECRET_ACCESS_KEY: miniostorage
+  k8s-array:
+    logs:
+      config:
+        kubernetes-enabled: true
+        kubernetes-template-uri: http://localhost:30080/kubernetes-dashboard/#/log/{{.namespace }}/{{ .podName }}/pod?namespace={{ .namespace }}
+        cloudwatch-enabled: false
+        stackdriver-enabled: false
+
+database:
+  postgres:
+    username: postgres
+    password: postgres
+    host: 127.0.0.1
+    port: 30001
+    dbname: flyte
+    options: "sslmode=disable"
+
+storage:
+  type: stow
+  stow:
+    kind: s3
+    config:
+      region: us-east-1
+      disable_ssl: true
+      v2_signing: true
+      endpoint: http://localhost:30002
+      auth_type: accesskey
+      access_key_id: minio
+      secret_key: miniostorage
+  container: my-s3-bucket

--- a/script/get_flyteconsole_dist.sh
+++ b/script/get_flyteconsole_dist.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -ex
+
+ARCH="$(uname -m)"
+case ${ARCH} in
+x86_64|amd64)
+  IMAGE_ARCH=amd64
+  ;;
+aarch64|arm64)
+  IMAGE_ARCH=arm64
+  ;;
+*)
+  >&2 echo "ERROR: Unsupported architecture: ${ARCH}"
+  exit 1
+  ;;
+esac
+
+FLYTECONSOLE_IMAGE="ghcr.io/flyteorg/flyteconsole:${FLYTECONSOLE_VERSION:-latest}"
+IMAGE_DIGEST="$(docker manifest inspect --verbose ${FLYTECONSOLE_IMAGE} | \
+    jq --arg IMAGE_ARCH "${IMAGE_ARCH}" --raw-output \
+      '.[] | select(.Descriptor.platform.architecture == $IMAGE_ARCH) | .Descriptor.digest')"
+
+# Short circuit if we already have the correct distribution
+[ -f cmd/single/dist/.digest ] && grep -Fxq ${IMAGE_DIGEST} cmd/single/dist/.digest && exit 0
+
+# Create container from desired image
+CONTAINER_ID=$(docker create ghcr.io/flyteorg/flyteconsole:${FLYTECONSOLE_VERSION:-latest})
+trap 'docker rm -f ${CONTAINER_ID}' EXIT
+
+# Copy distribution
+rm -rf cmd/single/dist
+docker cp ${CONTAINER_ID}:/app/dist cmd/single/
+printf '%q' ${IMAGE_DIGEST} > cmd/single/dist/.digest


### PR DESCRIPTION
This PR completes support for running Flyte locally against a sandbox cluster running on your machine. Specifically, it adds:

1. Support for Propeller's secret webhook. It does so by creating a headless service pointing to the docker host's IP address. The host IP is injected via the `%{HOST_GATEWAY_IP}%` template variable.
2. Support for Flyteconsole while running Flyte locally.

