### PR TITLE
Fix commonAnnotations indent in deployment.yaml

### DIFF
--- a/charts/flyte-binary/templates/deployment.yaml
+++ b/charts/flyte-binary/templates/deployment.yaml
@@ -47,10 +47,10 @@ spec:
         checksum/auth-client-secret: {{ include (print $.Template.BasePath "/auth-client-secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.commonAnnotations }}
-        {{- tpl ( .Values.commonAnnotations | toYaml ) . | nindent 4 }}
+        {{- tpl ( .Values.commonAnnotations | toYaml ) . | nindent 8 }}
         {{- end }}
         {{- if .Values.deployment.podAnnotations }}
-        {{- tpl ( .Values.deployment.podAnnotations | toYaml ) . | nindent 4 }}
+        {{- tpl ( .Values.deployment.podAnnotations | toYaml ) . | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.deployment.extraPodSpec }}


### PR DESCRIPTION
## Describe your changes

Fix indentation for annotations and labels in podTemplateSpec in deployment. (commonAnnotations)

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
