### PR TITLE
Fix stow token scope for GKE >= 1.25.0

### DIFF
--- a/charts/flyte-binary/templates/configmap.yaml
+++ b/charts/flyte-binary/templates/configmap.yaml
@@ -103,7 +103,7 @@ data:
         config:
           json: ""
           project_id: {{ required "GCP project required for GCS storage provider" .providerConfig.gcs.project }}
-          scopes: https://www.googleapis.com/auth/devstorage.read_write
+          scopes: https://www.googleapis.com/auth/cloud-platform
         {{- else }}
         {{- printf "Invalid value for storage provider. Expected one of (s3, gcs), but got: %s" .provider | fail }}
         {{- end }}

--- a/charts/flyte-core/templates/_helpers.tpl
+++ b/charts/flyte-core/templates/_helpers.tpl
@@ -161,7 +161,7 @@ storage:
     config:
       json: ""
       project_id: {{ .Values.storage.gcs.projectId }}
-      scopes: https://www.googleapis.com/auth/devstorage.read_write
+      scopes: https://www.googleapis.com/auth/cloud-platform
   container: {{ .Values.storage.bucketName | quote }}
 {{- else if eq .Values.storage.type "sandbox" }}
   type: minio

--- a/deployment/gcp/flyte_generated.yaml
+++ b/deployment/gcp/flyte_generated.yaml
@@ -8071,7 +8071,7 @@ data:
           json: ""
           # TODO: replace <project-id> with the GCP project ID
           project_id: <project-id>
-          scopes: https://www.googleapis.com/auth/devstorage.read_write
+          scopes: https://www.googleapis.com/auth/cloud-platform
       # TODO replace with the container (bucket) in GCS used by Flyte as intermediate store
       container: "flyte"
       # NOTE this cache configuration is purely for propeller. But since we are having a common storage
@@ -8084,7 +8084,7 @@ data:
         maxDownloadMBs: 10
 kind: ConfigMap
 metadata:
-  name: datacatalog-config-d56hkd9229
+  name: datacatalog-config-mk4gcdf6db
   namespace: flyte
 ---
 apiVersion: v1
@@ -8182,7 +8182,7 @@ data:
           json: ""
           # TODO: replace <project-id> with the GCP project ID
           project_id: <project-id>
-          scopes: https://www.googleapis.com/auth/devstorage.read_write
+          scopes: https://www.googleapis.com/auth/cloud-platform
       # TODO replace with the container (bucket) in GCS used by Flyte as intermediate store
       container: "flyte"
       # NOTE this cache configuration is purely for propeller. But since we are having a common storage
@@ -8206,7 +8206,7 @@ data:
         gpu: 1
 kind: ConfigMap
 metadata:
-  name: flyte-admin-config-7g6ctk6762
+  name: flyte-admin-config-gf99k75c82
   namespace: flyte
 ---
 apiVersion: v1
@@ -8350,7 +8350,7 @@ data:
           json: ""
           # TODO: replace <project-id> with the GCP project ID
           project_id: <project-id>
-          scopes: https://www.googleapis.com/auth/devstorage.read_write
+          scopes: https://www.googleapis.com/auth/cloud-platform
       # TODO replace with the container (bucket) in GCS used by Flyte as intermediate store
       container: "flyte"
       # NOTE this cache configuration is purely for propeller. But since we are having a common storage
@@ -8374,7 +8374,7 @@ data:
         stackdriver-logresourcename: k8s_container
 kind: ConfigMap
 metadata:
-  name: flyte-propeller-config-fgbm2gk6tt
+  name: flyte-propeller-config-kgbdtkgf56
   namespace: flyte
 ---
 apiVersion: v1
@@ -8722,7 +8722,7 @@ spec:
       - emptyDir: {}
         name: shared-data
       - configMap:
-          name: datacatalog-config-d56hkd9229
+          name: datacatalog-config-mk4gcdf6db
         name: config-volume
       - name: db-pass
         secret:
@@ -8806,7 +8806,7 @@ spec:
       serviceAccountName: flyte-pod-webhook
       volumes:
       - configMap:
-          name: flyte-propeller-config-fgbm2gk6tt
+          name: flyte-propeller-config-kgbdtkgf56
         name: config-volume
       - name: webhook-certs
         secret:
@@ -8958,7 +8958,7 @@ spec:
       - emptyDir: {}
         name: scratch
       - configMap:
-          name: flyte-admin-config-7g6ctk6762
+          name: flyte-admin-config-gf99k75c82
         name: config-volume
       - configMap:
           name: clusterresource-template-4fbh4bk26k
@@ -9066,7 +9066,7 @@ spec:
       serviceAccountName: flytepropeller
       volumes:
       - configMap:
-          name: flyte-propeller-config-fgbm2gk6tt
+          name: flyte-propeller-config-kgbdtkgf56
         name: config-volume
       - name: auth
         secret:
@@ -9329,7 +9329,7 @@ spec:
               name: clusterresource-template-4fbh4bk26k
             name: resource-templates
           - configMap:
-              name: flyte-admin-config-7g6ctk6762
+              name: flyte-admin-config-gf99k75c82
             name: config-volume
           - name: db-pass
             secret:

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -169,7 +169,7 @@ data:
         config:
           json: ""
           project_id: <PROJECT-ID>
-          scopes: https://www.googleapis.com/auth/devstorage.read_write
+          scopes: https://www.googleapis.com/auth/cloud-platform
       container: "<BUCKETNAME>"
       enable-multicontainer: false
       limits:
@@ -371,7 +371,7 @@ data:
         config:
           json: ""
           project_id: <PROJECT-ID>
-          scopes: https://www.googleapis.com/auth/devstorage.read_write
+          scopes: https://www.googleapis.com/auth/cloud-platform
       container: "<BUCKETNAME>"
       enable-multicontainer: false
       limits:
@@ -571,7 +571,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "03a38330f086ba10896963aad5434645a54487ca0818f810df0549bf0436be9"
+        configChecksum: "2e169a911a8234dd42d06ca0887279093f4ed36033d0543749ce126b26b50f3"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -859,7 +859,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5decd5143258340704503cb1c89d283b3fa311a33792c0a2751edc6d21b1e94"
+        configChecksum: "bc69ed841506b28a42ac19bd0884d483472b3d11fe85fe7e546b879aeb30a85"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -950,7 +950,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "03a38330f086ba10896963aad5434645a54487ca0818f810df0549bf0436be9"
+        configChecksum: "2e169a911a8234dd42d06ca0887279093f4ed36033d0543749ce126b26b50f3"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte

--- a/deployment/gcp/flyte_helm_dataplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_dataplane_generated.yaml
@@ -172,7 +172,7 @@ data:
         config:
           json: ""
           project_id: <PROJECT-ID>
-          scopes: https://www.googleapis.com/auth/devstorage.read_write
+          scopes: https://www.googleapis.com/auth/cloud-platform
       container: "<BUCKETNAME>"
       enable-multicontainer: false
       limits:
@@ -434,7 +434,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "fe5c992d51159e4ad600993479272953d271a33402834861c4c73ed1204fbad"
+        configChecksum: "2b07a0c9c6c35263389e46c712af516b2151764867ec2bdd64e5467e0be9b2b"
       labels: 
         app.kubernetes.io/name: flytepropeller
         app.kubernetes.io/instance: flyte
@@ -515,7 +515,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.1.64
       annotations:
-        configChecksum: "fe5c992d51159e4ad600993479272953d271a33402834861c4c73ed1204fbad"
+        configChecksum: "2b07a0c9c6c35263389e46c712af516b2151764867ec2bdd64e5467e0be9b2b"
     spec:
       securityContext:
         fsGroup: 65534

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -200,7 +200,7 @@ data:
         config:
           json: ""
           project_id: <PROJECT-ID>
-          scopes: https://www.googleapis.com/auth/devstorage.read_write
+          scopes: https://www.googleapis.com/auth/cloud-platform
       container: "<BUCKETNAME>"
       enable-multicontainer: false
       limits:
@@ -402,7 +402,7 @@ data:
         config:
           json: ""
           project_id: <PROJECT-ID>
-          scopes: https://www.googleapis.com/auth/devstorage.read_write
+          scopes: https://www.googleapis.com/auth/cloud-platform
       container: "<BUCKETNAME>"
       enable-multicontainer: false
       limits:
@@ -551,7 +551,7 @@ data:
         config:
           json: ""
           project_id: <PROJECT-ID>
-          scopes: https://www.googleapis.com/auth/devstorage.read_write
+          scopes: https://www.googleapis.com/auth/cloud-platform
       container: "<BUCKETNAME>"
       enable-multicontainer: false
       limits:
@@ -904,7 +904,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "03a38330f086ba10896963aad5434645a54487ca0818f810df0549bf0436be9"
+        configChecksum: "2e169a911a8234dd42d06ca0887279093f4ed36033d0543749ce126b26b50f3"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -1192,7 +1192,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5decd5143258340704503cb1c89d283b3fa311a33792c0a2751edc6d21b1e94"
+        configChecksum: "bc69ed841506b28a42ac19bd0884d483472b3d11fe85fe7e546b879aeb30a85"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -1283,7 +1283,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "03a38330f086ba10896963aad5434645a54487ca0818f810df0549bf0436be9"
+        configChecksum: "2e169a911a8234dd42d06ca0887279093f4ed36033d0543749ce126b26b50f3"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte
@@ -1371,7 +1371,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "fe5c992d51159e4ad600993479272953d271a33402834861c4c73ed1204fbad"
+        configChecksum: "2b07a0c9c6c35263389e46c712af516b2151764867ec2bdd64e5467e0be9b2b"
       labels: 
         app.kubernetes.io/name: flytepropeller
         app.kubernetes.io/instance: flyte
@@ -1452,7 +1452,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.1.64
       annotations:
-        configChecksum: "fe5c992d51159e4ad600993479272953d271a33402834861c4c73ed1204fbad"
+        configChecksum: "2b07a0c9c6c35263389e46c712af516b2151764867ec2bdd64e5467e0be9b2b"
     spec:
       securityContext:
         fsGroup: 65534

--- a/kustomize/overlays/gcp/flyte/config/common/storage.yaml
+++ b/kustomize/overlays/gcp/flyte/config/common/storage.yaml
@@ -6,7 +6,7 @@ storage:
       json: ""
       # TODO: replace <project-id> with the GCP project ID
       project_id: <project-id>
-      scopes: https://www.googleapis.com/auth/devstorage.read_write
+      scopes: https://www.googleapis.com/auth/cloud-platform
   # TODO replace with the container (bucket) in GCS used by Flyte as intermediate store
   container: "flyte"
   # NOTE this cache configuration is purely for propeller. But since we are having a common storage


### PR DESCRIPTION
## Describe your changes

The previous default scope for stow in GCP
`https://www.googleapis.com/auth/devstorage.read_write` seems to be no longer enough in GKE versions >=1.25.0. We could not find any release notes from Google pointing in this direction but noticed that Flyte would no longer work after we updated the GKE cluster version to 1.25.5.

Fast registration failed with this error response from `flyteadmin`:
```py
..
  File "/opt/pyenv-root/versions/3.9.12/lib/python3.9/site-packages/flytekit/remote/remote.py", line 580, in fast_package
    return self._upload_file(pathlib.Path(zip_file))
  File "/opt/pyenv-root/versions/3.9.12/lib/python3.9/site-packages/flytekit/remote/remote.py", line 598, in _upload_file
    upload_location = self.client.get_upload_signed_url(
  File "/opt/pyenv-root/versions/3.9.12/lib/python3.9/site-packages/flytekit/clients/friendly.py", line 998, in get_upload_signed_url
    return super(SynchronousFlyteClient, self).create_upload_location(
  File "/opt/pyenv-root/versions/3.9.12/lib/python3.9/site-packages/flytekit/clients/raw.py", line 41, in handler
    return fn(*args, **kwargs)
  File "/opt/pyenv-root/versions/3.9.12/lib/python3.9/site-packages/flytekit/clients/raw.py", line 856, in create_upload_location
    return self._dataproxy_stub.CreateUploadLocation(create_upload_location_request, metadata=self._metadata)
  File "/opt/pyenv-root/versions/3.9.12/lib/python3.9/site-packages/grpc/_channel.py", line 946, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/opt/pyenv-root/versions/3.9.12/lib/python3.9/site-packages/grpc/_channel.py", line 849, in _end_unary_response_blocking
    raise _InactiveRpcError(state)
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.INTERNAL
        details = "failed to create a signed url. Error: unable to sign bytes: googleapi: Error 403: Request had insufficient authentication scopes.
Details:
[
  {
    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
    "domain": "googleapis.com",
    "metadata": {
      "method": "google.iam.credentials.v1.IAMCredentials.SignBlob",
      "service": "iamcredentials.googleapis.com"
    },
    "reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT"
  }
]"
        debug_error_string = "UNKNOWN:Error received from peer ipv4:{removed} {created_time:"2023-02-20T11:01:31.243469439+00:00", grpc_status:13, grpc_message:"failed to create a signed url. Error: unable to sign bytes: googleapi: Error 403: Request had insufficient authentication scopes.\nDetails:\n[\n  {\n    \"@type\": \"type.googleapis.com/google.rpc.ErrorInfo\",\n    \"domain\": \"googleapis.com\",\n    \"metadata\": {\n      \"method\": \"google.iam.credentials.v1.IAMCredentials.SignBlob\",\n      \"service\": \"iamcredentials.googleapis.com\"\n    },\n    \"reason\": \"ACCESS_TOKEN_SCOPE_INSUFFICIENT\"\n  }\n]"}" 
```

## Check all the applicable boxes

- [ ] I updated the documentation accordingly. (no documentation needs to be updated?)
- [x] All new and existing tests passed. (I ran the helm and kustomize test targets)
- [x] All commits are signed-off.

## Note to reviewers

We started a discussion in [Slack](https://flyte-org.slack.com/archives/CP2HDHKE1/p1676894193668299) on this issue. @wild-endeavor .

As far as we know there is no more restrictive scope available. We checked [this Google page](https://developers.google.com/identity/protocols/oauth2/scopes#iamcredentials) and it seems like `google.iam.credentials.v1.IAMCredentials.SignBlob` is only available in the `cloud-platform` scope.
We also tried `https://www.googleapis.com/auth/devstorage.full_control` and it was not enough.
