### PR TITLE
Update helm dependency before kustomize build

### DIFF
--- a/docker/sandbox-bundled/Makefile
+++ b/docker/sandbox-bundled/Makefile
@@ -18,6 +18,7 @@ flyte:
 .PHONY: manifests
 manifests:
 	mkdir -p manifests
+	helm dependency update ../../charts/flyte-sandbox
 	kustomize build \
 		--enable-helm \
 		--load-restrictor=LoadRestrictionsNone \
@@ -51,13 +52,13 @@ start:
 			--volume $(PWD)/.kube:/.kube \
 			--volume $(HOME)/.flyte/sandbox:/var/lib/flyte/config \
 			--volume flyte-sandbox:/var/lib/flyte/storage \
-			--publish "6443" \
+			--publish "6443":"6443" \
 			--publish "30000:30000" \
 			--publish "30001:30001" \
 			--publish "30002:30002" \
 			--publish "30080:30080" \
 			$(FLYTE_SANDBOX_IMAGE)
-
+		export KUBECONFIG=.kube/kubeconfig
 .PHONY: kubeconfig
 .SILENT: kubeconfig
 kubeconfig:

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -762,7 +762,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: cUFUNG5OdFBhQzNtNDhTNA==
+  haSharedSecret: R2ZBT0pkdGtuZ0tQeHFuSg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1246,7 +1246,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 0038e3c3b085694a01a9bb8080015c29d017af712e359119bd1b312fb261ffc6
+        checksum/secret: b7af65b89a798a2365e092b31a46eaacce978a64328b65fea14f014dee5e5d79
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: a25jV2szcXA0bThKek5mVw==
+  haSharedSecret: NjRUSFFsdTFmWTRIMjdidA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -875,7 +875,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 36998c3b283688740f6ea909fc86fa24b4fa3886b980b61e4634ff95d27e6410
+        checksum/secret: 65be01926fb2783a4fb52f21e30f126a85ff29b0e0fead341247f06035e07118
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## Describe your changes
Failed to build the image for single binary.
```
$ make build
 => => exporting manifest sha256:fd5ffa0a5cbfaf72dd4bc89f70be185c856e26656bc6b7456a87600636c0fdac                0.0s
 => => exporting config sha256:83112bc87339d549419c587008ed89b886ce3b34432ccb8a371bf58744eed15b                  0.0s
 => => sending tarball                                                                                           1.9s
mkdir -p manifests
kustomize build \
		--enable-helm \
		--load-restrictor=LoadRestrictionsNone \
		kustomize/complete > manifests/complete.yaml
Error: Error: An error occurred while checking for chart dependencies. You may need to run `helm dependency build` to fetch missing dependencies: found in Chart.yaml, but missing in charts/ directory: docker-registry, flyte-binary, kubernetes-dashboard, minio, postgresql
: unable to run: 'helm template flyte-sandbox --namespace flyte /Users/kevin/git/flyte/charts/flyte-sandbox --values /var/folders/by/42kc70lj1bb77klbhf2fmxx00000gn/T/kustomize-helm-4205539172/flyte-sandbox-kustomize-values.yaml' with env=[HELM_CONFIG_HOME=/var/folders/by/42kc70lj1bb77klbhf2fmxx00000gn/T/kustomize-helm-4205539172/helm HELM_CACHE_HOME=/var/folders/by/42kc70lj1bb77klbhf2fmxx00000gn/T/kustomize-helm-4205539172/helm/.cache HELM_DATA_HOME=/var/folders/by/42kc70lj1bb77klbhf2fmxx00000gn/T/kustomize-helm-4205539172/helm/.data] (is 'helm' installed?)
make: *** [manifests] Error 1
```

should run `helm dependency update` first.
btw, we should expose port 6443 and kubeconfig, so we will be able to connect to the k8s cluster.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots

```bash
(base) ➜  sandbox-bundled git:(backend-plugin-system-grpc) ✗ make start
[ -n "flyte-sandbox" ] || \
		docker volume create flyte-sandbox
[ -n "" ] || \
		docker run --detach --rm --privileged --name flyte-sandbox \
			--add-host "host.docker.internal:host-gateway" \
			--env FLYTE_DEV=False \
			--env K3S_KUBECONFIG_OUTPUT=/.kube/kubeconfig \
			--volume /Users/kevin/git/flyte/docker/sandbox-bundled/.kube:/.kube \
			--volume /Users/kevin/.flyte/sandbox:/var/lib/flyte/config \
			--volume flyte-sandbox:/var/lib/flyte/storage \
			--publish "6443":6443 \
			--publish "30000:30000" \
			--publish "30001:30001" \
			--publish "30002:30002" \
			--publish "30080:30080" \
			flyte-sandbox:latest
2cb1c659bbaad0cb1f8bbeb5a6d1e53b569f3dabb0fab8c3170abcc77d89dcdb
export KUBECONFIG=.kube/kubeconfig
(base) ➜  sandbox-bundled git:(backend-plugin-system-grpc) ✗ k get pods
No resources found in default namespace.
```

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
