### PR TITLE
starting controller runtime manager

### DIFF
--- a/cmd/single/start.go
+++ b/cmd/single/start.go
@@ -133,6 +133,14 @@ func startPropeller(ctx context.Context, cfg Propeller) error {
 		})
 	}
 
+	g.Go(func() error {
+		err := propellerEntrypoint.StartControllerManager(childCtx, mgr)
+		if err != nil {
+			logger.Fatalf(childCtx, "Failed to start controller manager. Error: %v", err)
+		}
+		return err
+	})
+
 	if !cfg.Disabled {
 		g.Go(func() error {
 			logger.Infof(childCtx, "Starting Flyte Propeller...")


### PR DESCRIPTION
## Tracking issue
_NA_

## Describe your changes
Starting the k8s controller runtime manager so that watches on k8s resources work in plugins. This is necessary to ensure propeller promptly evaluates the workflow after a change in task status is detected.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots
_NA_

## Note to reviewers
_NA_
