### PR TITLE
Revert "starting controller runtime manager"

### DIFF
--- a/cmd/single/start.go
+++ b/cmd/single/start.go
@@ -133,14 +133,6 @@ func startPropeller(ctx context.Context, cfg Propeller) error {
 		})
 	}
 
-	g.Go(func() error {
-		err := propellerEntrypoint.StartControllerManager(childCtx, mgr)
-		if err != nil {
-			logger.Fatalf(childCtx, "Failed to start controller manager. Error: %v", err)
-		}
-		return err
-	})
-
 	if !cfg.Disabled {
 		g.Go(func() error {
 			logger.Infof(childCtx, "Starting Flyte Propeller...")


### PR DESCRIPTION
Reverts flyteorg/flyte#3471

```
{"json":{"src":"entrypoint.go:55"},"level":"info","msg":"Starting controller-runtime manager","ts":"2023-03-17T18:46:00Z"}
panic: close of closed channel

goroutine 5276 [running]:
sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).Start.func3()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.1/pkg/manager/internal.go:493 +0xb6
created by sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).Start
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.1/pkg/manager/internal.go:483 +0x553
```