### PR TITLE
Fix typo for enabling tensorflow plugin doc

### DIFF
--- a/rsts/deployment/plugins/k8s/index.rst
+++ b/rsts/deployment/plugins/k8s/index.rst
@@ -181,12 +181,12 @@ Create a file named ``values-override.yaml`` and add the following config to it:
                     - container
                     - sidecar
                     - k8s-array
-                    - Tensorflow
+                    - tensorflow
                   default-for-task-types:
                     container: container
                     sidecar: sidecar
                     container_array: k8s-array
-                    Tensorflow: Tensorflow
+                    tensorflow: tensorflow
    
    .. group-tab:: MPI
    


### PR DESCRIPTION
Tensorflow plugin should be enabled using lowercase letters. Here the typo made it uppercase. This patch fixes it.