### PR TITLE
Use additional ca-certificates in flyte sandbox configuration directory

### DIFF
--- a/docker/sandbox-bundled/Dockerfile
+++ b/docker/sandbox-bundled/Dockerfile
@@ -42,5 +42,8 @@ COPY --from=bootstrap /flyteorg/build/dist/flyte-sandbox-bootstrap /bin/
 
 VOLUME /var/lib/flyte/storage
 
+# Set environment variable for picking up additional CA certificates
+ENV SSL_CERT_DIR /var/lib/flyte/config/ca-certificates
+
 ENTRYPOINT [ "/bin/k3d-entrypoint.sh" ]
 CMD [ "server", "--disable=traefik", "--disable=servicelb" ]


### PR DESCRIPTION
Following k3s instructions here: https://ranchermanager.docs.rancher.com/v2.5/reference-guides/single-node-rancher-in-docker/advanced-options#custom-ca-certificate

Placing extra CA certs in PEM format within `~/.flyte/sandbox/ca-certificates` will suffice to add those to the sandbox trust store.