### PR TITLE
feat: Allow "audience" param to be set in values.yaml - Flyte-Binary (000-core.yaml)

### DIFF
--- a/charts/flyte-binary/templates/configmap.yaml
+++ b/charts/flyte-binary/templates/configmap.yaml
@@ -23,6 +23,9 @@ data:
     admin:
       {{- if .Values.configuration.auth.enabled }}
       clientId: {{ .Values.configuration.auth.internal.clientId }}
+      {{- if .Values.configuration.auth.internal.audience }}
+      audience: {{ .Values.configuration.auth.internal.audience }}
+      {{- end }}
       {{- end }}
       endpoint: localhost:8089
       insecure: true

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -91,6 +91,8 @@ configuration:
       # clientSecret Flyte application client secret
       clientSecret: ""
     # internal Configuration for internal authentication
+    # The settings for internal still need to be defined if you wish to use an external auth server
+    # These credentials are used during communication beteween the FlyteAdmin and Propeller microservices
     internal:
       # clientId Client ID for internal authentication - set to flytepropeller or external auth server
       clientId: flytepropeller
@@ -98,6 +100,8 @@ configuration:
       clientSecret: ""
       # clientSecretHash Bcrypt hash of clientSecret
       clientSecretHash: ""
+      # Uncomment next line if needed - set this field if your external Auth server (ex. Auth0) requires an audience parameter
+      # audience: ""
     # flyteClient Configuration for Flyte client authentication
     flyteClient:
       # clientId Client ID for Flyte client authentication
@@ -107,8 +111,8 @@ configuration:
       # scopes Scopes for Flyte client authentication
       scopes:
         - all
-      # Uncomment next line if needed - set this field if your external Auth server (ex. Auth0) requires an audience parameter
-      # audience: ""
+      # audience Audience for Flyte client authentication
+      audience: ""
     # authorizedUris Set of URIs that clients are allowed to visit the service on
     authorizedUris: []
   # co-pilot Configuration for Flyte CoPilot

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -92,7 +92,7 @@ configuration:
       clientSecret: ""
     # internal Configuration for internal authentication
     internal:
-      # clientId Client ID for internal authentication
+      # clientId Client ID for internal authentication - set to flytepropeller or external auth server
       clientId: flytepropeller
       # clientSecret Client secret for internal authentication
       clientSecret: ""
@@ -107,8 +107,8 @@ configuration:
       # scopes Scopes for Flyte client authentication
       scopes:
         - all
-      # audience Audience for Flyte client authentication
-      audience: ""
+      # Uncomment next line if needed - set this field if your external Auth server (ex. Auth0) requires an audience parameter
+      # audience: ""
     # authorizedUris Set of URIs that clients are allowed to visit the service on
     authorizedUris: []
   # co-pilot Configuration for Flyte CoPilot


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

## Tracking issue

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

Closes  #3662  #3659

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Describe your changes

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

[x] - Add `audience` parameter under `auth.internal` in values.yaml & templates ( For Flyte-Binary/Auth0 credentials flow)
[x] - Add comment in values.yaml describing how `internal` settings correlate to external auth server

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
