### PR TITLE
Add default project if SeedProjects is not set

### DIFF
--- a/cmd/single/start.go
+++ b/cmd/single/start.go
@@ -2,6 +2,7 @@ package single
 
 import (
 	"context"
+
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,7 +66,12 @@ func startAdmin(ctx context.Context, cfg Admin) error {
 	}
 
 	logger.Infof(ctx, "Seeding default projects...")
-	if err := adminServer.SeedProjects(ctx, cfg.SeedProjects); err != nil {
+	projects := []string{"flytesnacks"}
+	if len(cfg.SeedProjects) != 0 {
+		projects = cfg.SeedProjects
+	}
+	logger.Infof(ctx, "Seeding default projects...",projects)
+	if err := adminServer.SeedProjects(ctx, projects); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

## Tracking issue

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Describe your changes

After [PR3631](https://github.com/flyteorg/flyte/pull/3631), If `SeedProjects` is not set, there will be no default project in the console. This change may impact backward compatibility and could potentially create hurdles for new users. Specifically, those following the startup guide to build a local cluster and run sample files from the Flytesnacks repository may encounter difficulties.


For example, A new user might run:


```shell
# build the local cluster and start the flyte
cd /home/ubuntu
# install jq
sudo apt-get -y install jq

# install flytekit
pip install flytekit
export PATH=$PATH:~/.local/bin

# install flytectl
git clone https://github.com/flyteorg/flytectl.git
cd flytectl
sudo bash ./install.sh -b /usr/local/bin v0.6.17
cd ..
export FLYTECTL_CONFIG=/root/.flyte/config-sandbox.yaml

# start k3scluster, create pod for postgres, minio and dashboard
flytectl demo start --dev --image pingsutw/sandbox-lite-test

# connect to k3scluster
export KUBECONFIG=$KUBECONFIG:/root/.flyte/k3s/k3s.yaml
kubectl get pod -n flyte # check


# build and run all other the flyte components
git clone https://github.com/flyteorg/flyte.git
cd flyte
# replace with your repo
# go mod edit -replace github.com/flyteorg/flyteplugins=github.com/flyteorg/flyteplugins@v1.0.37
go mod tidy
sudo make compile
flyte start --config flyte_local.yaml

```

then, when the new user try to test the sample files under Flytesnacks repository after [PR3631](https://github.com/flyteorg/flyte/pull/3631):
```shell
cd /home/ubuntu

export PATH=$PATH:~/.local/bin
export FLYTECTL_CONFIG=/root/.flyte/config-sandbox.yaml
export KUBECONFIG=$KUBECONFIG:/root/.kube/config:/root/.flyte/k3s/k3s.yaml

# run an sample to test
git clone https://github.com/flyteorg/flytesnacks
cd flytesnacks/cookbook
pip install -r core/requirements.txt
# python3 core/flyte_basics/hello_world.py
# pyflyte run core/flyte_basics/hello_world.py my_wf
pyflyte run --remote core/flyte_basics/hello_world.py my_wf

```

Will get error becasue flytesnacks project does not exist:
```

2023/05/17 04:24:07 /root/go/pkg/mod/gorm.io/gorm@v1.24.1-0.20221019064659-5dd2bb482755/callbacks.go:134 record not found
[0.817ms] [rows:0] SELECT * FROM "projects" WHERE "projects"."identifier" = 'flytesnacks' LIMIT 1
{"json":{"src":"task_manager.go:70"},"level":"debug","msg":"Task [resource_type:TASK project:\"flytesnacks\" domain:\"development\" name:\"core.flyte_basics.hello_world.say_hello\" version:\"0Dj6bF9kDPwqJuKCrijznA==\" ] failed validation with err:

```

So, this PR add back the `flytesnacks` if `SeedProjects` is not set.



<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Screenshots

Checks: with out setting `SeedProjects`:
<img width="1728" alt="image" src="https://github.com/flyteorg/flyte/assets/51814063/0ca88e02-498a-4544-a836-549522ffe944">

Checks:  setting `SeedProjects`:
<img width="1728" alt="image" src="https://github.com/flyteorg/flyte/assets/51814063/4a2202b5-ad17-4b52-b288-f5af8dec9aaa">



<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
