### PR TITLE
Replace installation instructions for pytorch operator with training operator

### DIFF
--- a/rsts/deployment/plugins/k8s/index.rst
+++ b/rsts/deployment/plugins/k8s/index.rst
@@ -48,18 +48,18 @@ Install the K8S Operator
 
   .. group-tab:: PyTorch
   
-     Clone the PyTorch repository:
+     Clone the training-operator repository:
    
      .. code-block:: bash
    
-        git clone https://github.com/kubeflow/pytorch-operator.git
+        git clone https://github.com/kubeflow/training-operator.git
    
-     Build and apply the PyTorch operator:
+     Build and apply the training-operator:
    
      .. code-block:: bash
    
         export KUBECONFIG=$KUBECONFIG:~/.kube/config:~/.flyte/k3s/k3s.yaml
-        kustomize build pytorch-operator/manifests/overlays/kubeflow | kubectl apply -f -
+        kustomize build training-operator/manifests/overlays/kubeflow | kubectl apply -f -
   
   .. group-tab:: TensorFlow
   
@@ -69,7 +69,7 @@ Install the K8S Operator
    
         git clone https://github.com/kubeflow/training-operator.git
    
-     Build and apply the TensorFlow operator:
+     Build and apply the training-operator:
    
      .. code-block:: bash
    

--- a/rsts/deployment/plugins/k8s/index.rst
+++ b/rsts/deployment/plugins/k8s/index.rst
@@ -46,22 +46,7 @@ Install the K8S Operator
 
 .. tabs::
 
-  .. group-tab:: PyTorch
-  
-     Clone the training-operator repository:
-   
-     .. code-block:: bash
-   
-        git clone https://github.com/kubeflow/training-operator.git
-   
-     Build and apply the training-operator:
-   
-     .. code-block:: bash
-   
-        export KUBECONFIG=$KUBECONFIG:~/.kube/config:~/.flyte/k3s/k3s.yaml
-        kustomize build training-operator/manifests/overlays/kubeflow | kubectl apply -f -
-  
-  .. group-tab:: TensorFlow
+  .. group-tab:: PyTorch and TensorFlow
   
      Clone the training-operator repository:
    


### PR DESCRIPTION
## Describe your changes

This PR updates the installation instructions accordingly. For the tensorflow operator this was already documented correctly. I copied the installation instructions from there.

The kubeflow pytorch operator has been deprecated in favor of the new training operator.

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

