### PR TITLE
Add service account for agent

### DIFF
--- a/charts/flyte-core/templates/agent/rbac.yaml
+++ b/charts/flyte-core/templates/agent/rbac.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.flyteagent.enabled }}
+---
+{{- if .Values.flyteagent.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "flyteagent.name" . }}
+  namespace: {{ template "flyte.namespace" . }}
+  labels: {{ include "flyteagent.labels" . | nindent 4 }}
+  {{- with .Values.flyteagent.serviceAccount.annotations }}
+  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end}}
+{{- with .Values.flyteagent.serviceAccount.imagePullSecrets }}
+imagePullSecrets: {{ tpl (toYaml .) $ | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -39,6 +39,18 @@ metadata:
     helm.sh/chart: flyte-v0.1.10
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: flyte/charts/flyte/templates/agent/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyteagent
+  namespace: flyte
+  labels: 
+    app.kubernetes.io/name: flyteagent
+    app.kubernetes.io/instance: flyte
+    helm.sh/chart: flyte-v0.1.10
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: flyte/charts/flyte/templates/datacatalog/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -784,7 +784,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: ZHdWUkRjZ0c3eG96Q2pmdw==
+  haSharedSecret: SzlHZ0doUHFQaEswZTBEWQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1299,7 +1299,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 38bb3051ec8a9a1187a0b4bce306dd83e331e5ba23a719e905996a1db214d770
+        checksum/secret: a9517655e17e8f68a20248fbb76c1d65f57c7d2e30d8dd58e86b4c859017f270
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: RVlCdFpwQTI4SlVZYllzSg==
+  haSharedSecret: TmJ6QldYSHBnaFBJaEQ3NQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -875,7 +875,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 06215b00158e7a4db172bc01358fdc3846e476f94d0e653acc9aefedd4a765fc
+        checksum/secret: 0ea5a0f5db0680e8f00da24466ac135454104a626fbc465af8b2a069830ecdb0
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
As the title, add a service account without a role for the agent. people can add annotations, and image secrets for SA by updating the helm chart value.yaml