### PR TITLE
Fix selector for flyte-binary to distinguish from flyte-sandbox-proxy

### DIFF
--- a/charts/flyte-binary/templates/_helpers.tpl
+++ b/charts/flyte-binary/templates/_helpers.tpl
@@ -31,11 +31,19 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Base labels
+*/}}
+{{- define "flyte-binary.baseLabels" -}}
+app.kubernetes.io/name: {{ include "flyte-binary.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "flyte-binary.labels" -}}
 helm.sh/chart: {{ include "flyte-binary.chart" . }}
-{{ include "flyte-binary.selectorLabels" . }}
+{{ include "flyte-binary.baseLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -46,8 +54,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "flyte-binary.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "flyte-binary.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "flyte-binary.baseLabels" . }}
+app.kubernetes.io/component: flyte-binary
 {{- end }}
 
 {{/*

--- a/charts/flyte-sandbox/templates/proxy/service.yaml
+++ b/charts/flyte-sandbox/templates/proxy/service.yaml
@@ -14,6 +14,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "flyte-sandbox.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: proxy
+    {{- include "flyte-sandbox.proxySelectorLabels" . | nindent 4 }}
 {{- end }}

--- a/deployment/sandbox-binary/flyte_sandbox_binary_helm_generated.yaml
+++ b/deployment/sandbox-binary/flyte_sandbox_binary_helm_generated.yaml
@@ -268,6 +268,7 @@ spec:
   selector:
     app.kubernetes.io/name: flyte-binary
     app.kubernetes.io/instance: flyte
+    app.kubernetes.io/component: flyte-binary
 ---
 # Source: flyte-binary/templates/service/http.yaml
 apiVersion: v1
@@ -299,6 +300,7 @@ spec:
   selector:
     app.kubernetes.io/name: flyte-binary
     app.kubernetes.io/instance: flyte
+    app.kubernetes.io/component: flyte-binary
 ---
 # Source: flyte-binary/templates/service/webhook.yaml
 apiVersion: v1
@@ -322,6 +324,7 @@ spec:
   selector:
     app.kubernetes.io/name: flyte-binary
     app.kubernetes.io/instance: flyte
+    app.kubernetes.io/component: flyte-binary
 ---
 # Source: flyte-binary/templates/deployment.yaml
 apiVersion: apps/v1
@@ -344,11 +347,13 @@ spec:
     matchLabels:
       app.kubernetes.io/name: flyte-binary
       app.kubernetes.io/instance: flyte
+      app.kubernetes.io/component: flyte-binary
   template:
     metadata:
       labels:
         app.kubernetes.io/name: flyte-binary
         app.kubernetes.io/instance: flyte
+        app.kubernetes.io/component: flyte-binary
       annotations:
         checksum/configuration: ad26141a590bda863600191912e25b9ff98789a3c07a7932d13ccf90218ed1b5
         checksum/cluster-resource-templates: 7dfa59f3d447e9c099b8f8ffad3af466fecbc9cf9f8c97295d9634254a55d4ae

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -784,7 +784,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: SzlHZ0doUHFQaEswZTBEWQ==
+  haSharedSecret: WGJrSFh4aU9RNnNydndwTA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -906,6 +906,7 @@ spec:
     port: 8089
     targetPort: grpc
   selector:
+    app.kubernetes.io/component: flyte-binary
     app.kubernetes.io/instance: flyte-sandbox
     app.kubernetes.io/name: flyte-sandbox
   type: ClusterIP
@@ -935,6 +936,7 @@ spec:
     port: 8000
     targetPort: agent-grpc
   selector:
+    app.kubernetes.io/component: flyte-binary
     app.kubernetes.io/instance: flyte-sandbox
     app.kubernetes.io/name: flyte-sandbox
   type: ClusterIP
@@ -1078,6 +1080,7 @@ spec:
     port: 443
     targetPort: webhook
   selector:
+    app.kubernetes.io/component: flyte-binary
     app.kubernetes.io/instance: flyte-sandbox
     app.kubernetes.io/name: flyte-sandbox
   type: ClusterIP
@@ -1177,6 +1180,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/component: flyte-binary
       app.kubernetes.io/instance: flyte-sandbox
       app.kubernetes.io/name: flyte-sandbox
   strategy:
@@ -1188,6 +1192,7 @@ spec:
         checksum/configuration: 8118b13cf076cdede0f232d5c1babb77d378cc2aa486840ed46a21b5ab4480ea
         checksum/db-password-secret: 669e1cdf4633c6dd40085f78d1bb6b9672d8120ff1f62077a879a4d46db133e2
       labels:
+        app.kubernetes.io/component: flyte-binary
         app.kubernetes.io/instance: flyte-sandbox
         app.kubernetes.io/name: flyte-sandbox
     spec:
@@ -1299,7 +1304,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: a9517655e17e8f68a20248fbb76c1d65f57c7d2e30d8dd58e86b4c859017f270
+        checksum/secret: 11ef7c305f97399d6a6efcc6abc5f63b400d5b6eecaabf957ceb586d530e303e
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: TmJ6QldYSHBnaFBJaEQ3NQ==
+  haSharedSecret: dXdBYnZRYzc3WUNhZ2ZpWg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -875,7 +875,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 0ea5a0f5db0680e8f00da24466ac135454104a626fbc465af8b2a069830ecdb0
+        checksum/secret: 0144dca4bc3b9d98825349febc9dc1b5d7ecd4a916286d814ff2f4b4cf315e7b
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
This PR adds a new selector label for `flyte-binary` to distinguish it from the proxy.