### PR TITLE
Fix: Set flyteadmin gRPC port to 80 in ingress if using TLS between load balancer and backend

### DIFF
--- a/charts/flyte-core/templates/common/ingress.yaml
+++ b/charts/flyte-core/templates/common/ingress.yaml
@@ -1,4 +1,8 @@
 {{- define "grpcRoutes" -}}
+{{- $grpcPort := 81 -}}
+{{- if eq .Values.configmap.adminServer.server.security.secure true -}}
+  {{- $grpcPort = 80 -}}
+{{- end }}
 # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
 - path: /flyteidl.service.SignalService
   pathType: ImplementationSpecific
@@ -7,10 +11,10 @@
     service:
       name: flyteadmin
       port:
-        number: 81
+        number: {{ $grpcPort }}
 {{- else }}
     serviceName: flyteadmin
-    servicePort: 81
+    servicePort: {{ $grpcPort }}
 {{- end }}
 - path: /flyteidl.service.SignalService/*
   pathType: ImplementationSpecific
@@ -19,10 +23,10 @@
     service:
       name: flyteadmin
       port:
-        number: 81
+        number: {{ $grpcPort }}
 {{- else }}
     serviceName: flyteadmin
-    servicePort: 81
+    servicePort: {{ $grpcPort }}
 {{- end }}
 - path: /flyteidl.service.AdminService
   pathType: ImplementationSpecific
@@ -31,10 +35,10 @@
     service:
       name: flyteadmin
       port:
-        number: 81
+        number: {{ $grpcPort }}
 {{- else }}
     serviceName: flyteadmin
-    servicePort: 81
+    servicePort: {{ $grpcPort }}
 {{- end }}
 - path: /flyteidl.service.AdminService/*
   pathType: ImplementationSpecific
@@ -43,10 +47,10 @@
     service:
       name: flyteadmin
       port:
-        number: 81
+        number: {{ $grpcPort }}
 {{- else }}
     serviceName: flyteadmin
-    servicePort: 81
+    servicePort: {{ $grpcPort }}
 {{- end }}
 - path: /flyteidl.service.DataProxyService
   pathType: ImplementationSpecific
@@ -55,10 +59,10 @@
     service:
       name: flyteadmin
       port:
-        number: 81
+        number: {{ $grpcPort }}
 {{- else }}
     serviceName: flyteadmin
-    servicePort: 81
+    servicePort: {{ $grpcPort }}
 {{- end }}
 - path: /flyteidl.service.DataProxyService/*
   pathType: ImplementationSpecific
@@ -67,10 +71,10 @@
     service:
       name: flyteadmin
       port:
-        number: 81
+        number: {{ $grpcPort }}
 {{- else }}
     serviceName: flyteadmin
-    servicePort: 81
+    servicePort: {{ $grpcPort }}
 {{- end }}
 - path: /flyteidl.service.AuthMetadataService
   pathType: ImplementationSpecific
@@ -79,10 +83,10 @@
     service:
       name: flyteadmin
       port:
-        number: 81
+        number: {{ $grpcPort }}
 {{- else }}
     serviceName: flyteadmin
-    servicePort: 81
+    servicePort: {{ $grpcPort }}
 {{- end }}
 - path: /flyteidl.service.AuthMetadataService/*
   pathType: ImplementationSpecific
@@ -91,10 +95,10 @@
     service:
       name: flyteadmin
       port:
-        number: 81
+        number: {{ $grpcPort }}
 {{- else }}
     serviceName: flyteadmin
-    servicePort: 81
+    servicePort: {{ $grpcPort }}
 {{- end }}
 - path: /flyteidl.service.IdentityService
   pathType: ImplementationSpecific
@@ -103,10 +107,10 @@
     service:
       name: flyteadmin
       port:
-        number: 81
+        number: {{ $grpcPort }}
 {{- else }}
     serviceName: flyteadmin
-    servicePort: 81
+    servicePort: {{ $grpcPort }}
 {{- end }}
 - path: /flyteidl.service.IdentityService/*
   pathType: ImplementationSpecific
@@ -115,10 +119,10 @@
     service:
       name: flyteadmin
       port:
-        number: 81
+        number: {{ $grpcPort }}
 {{- else }}
     serviceName: flyteadmin
-    servicePort: 81
+    servicePort: {{ $grpcPort }}
 {{- end }}
 - path: /grpc.health.v1.Health
   pathType: ImplementationSpecific
@@ -127,10 +131,10 @@
     service:
       name: flyteadmin
       port:
-        number: 81
+        number: {{ $grpcPort }}
 {{- else }}
     serviceName: flyteadmin
-    servicePort: 81
+    servicePort: {{ $grpcPort }}
 {{- end }}
 - path: /grpc.health.v1.Health/*
   pathType: ImplementationSpecific
@@ -139,10 +143,10 @@
     service:
       name: flyteadmin
       port:
-        number: 81
+        number: {{ $grpcPort }}
 {{- else }}
     serviceName: flyteadmin
-    servicePort: 81
+    servicePort: {{ $grpcPort }}
 {{- end }}
   {{- end }}
   {{- if .Values.common.ingress.enabled }}

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -1570,6 +1570,7 @@ spec:
           #   path: /*
           #   pathType: ImplementationSpecific
           #
+          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
           - path: /flyteidl.service.SignalService
             pathType: ImplementationSpecific

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -1198,6 +1198,7 @@ spec:
           #   path: /*
           #   pathType: ImplementationSpecific
           #
+          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
           - path: /flyteidl.service.SignalService
             pathType: ImplementationSpecific

--- a/deployment/eks/flyte_helm_dataplane_generated.yaml
+++ b/deployment/eks/flyte_helm_dataplane_generated.yaml
@@ -771,6 +771,7 @@ spec:
           #   path: /*
           #   pathType: ImplementationSpecific
           #
+          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
           - path: /flyteidl.service.SignalService
             pathType: ImplementationSpecific

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -1689,6 +1689,7 @@ spec:
           #   path: /*
           #   pathType: ImplementationSpecific
           #
+          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
           - path: /flyteidl.service.SignalService
             pathType: ImplementationSpecific

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -1192,6 +1192,7 @@ spec:
       http:
         paths:
           #
+          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
           - path: /flyteidl.service.SignalService
             pathType: ImplementationSpecific

--- a/deployment/gcp/flyte_helm_dataplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_dataplane_generated.yaml
@@ -757,6 +757,7 @@ spec:
       http:
         paths:
           #
+          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
           - path: /flyteidl.service.SignalService
             pathType: ImplementationSpecific

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -1690,6 +1690,7 @@ spec:
       http:
         paths:
           #
+          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
           - path: /flyteidl.service.SignalService
             pathType: ImplementationSpecific

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -7701,6 +7701,7 @@ spec:
                 name: flyteadmin
                 port:
                   number: 80
+          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
           - path: /flyteidl.service.SignalService
             pathType: ImplementationSpecific


### PR DESCRIPTION
## Describe your changes

Flyte can be configured to use TLS between the ingress (or rather load balancer) and the flyteadmin backend.

*This is required for instance in GKE clusters when using the GCE ingress controller (instead of nginx) since gRPC requires http2 and http2 between GCE load balancers and backends in GKE clusters requires TLS ([source](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-http2#:~:text=Note%3A%20To%20ensure%20the%20load%20balancer%20can%20make%20a%20correct%20HTTP2%20request%20to%20your%20backend%2C%20your%20backend%20must%20be%20configured%20with%20SSL.)):*

> Note: To ensure the load balancer can make a correct HTTP2 request to your backend, your backend must be configured with SSL.


Whether flyteadmin uses TLS (and with which certificate) is controlled in the helm values file via:

```yaml
configmap:
  adminServer:
    security:
      secure: true
      ssl:
        certificateFile: "/etc/tls/cert.pem"
        keyFile: "/etc/tls/key.pem"
```

(The certificate and key needs to be mounted into flyteadmin e.g. via a secret. Can be self-signed.)

However, in case TLS is enabled, flyteadmin **doesn't** seve the http server on port 80 and the gRPC server on port 81 but actually a single http(s) server that wraps both of them on port 80!

---

Details:

In flyteadmin's main `serve` entrypoint there is a [decision gate](https://github.com/flyteorg/flyteadmin/blob/d492640dbd9e72b9a50259799aba76ce85b16313/pkg/server/service.go#L55) whether `serverConfig.Security.Secure`.

* If no, we go into [`serveGatewayInsecure`](https://github.com/flyteorg/flyteadmin/blob/d492640dbd9e72b9a50259799aba76ce85b16313/pkg/server/service.go#L276)
    * In this case, the gRPC server is started in a go-routine [here](https://github.com/flyteorg/flyteadmin/blob/d492640dbd9e72b9a50259799aba76ce85b16313/pkg/server/service.go#L330) while the separate http server is started afterwards [here](https://github.com/flyteorg/flyteadmin/blob/d492640dbd9e72b9a50259799aba76ce85b16313/pkg/server/service.go#L367). 
* If, however, `serverConfig.Security.Secure` is true, we instead go into [`serveGatewaySecure`](https://github.com/flyteorg/flyteadmin/blob/d492640dbd9e72b9a50259799aba76ce85b16313/pkg/server/service.go#L389)
    * Instead of separate http and gRPC servers, a [single one wrapping both](https://github.com/flyteorg/flyteadmin/blob/d492640dbd9e72b9a50259799aba76ce85b16313/pkg/server/service.go#L459) is started [here](https://github.com/flyteorg/flyteadmin/blob/d492640dbd9e72b9a50259799aba76ce85b16313/pkg/server/service.go#L468) with TLS. This server routes to the actual http or gRPC server [here](https://github.com/flyteorg/flyteadmin/blob/d492640dbd9e72b9a50259799aba76ce85b16313/pkg/server/service.go#L378). 

In the second case, all requests for flyteadmin, including gRPC, have to be sent to port 80.

---

This is not accounted for in the ingress template of the helm chart. Activating TLS for flyteadmin, thus, breaks the deployment.

This PR fixes this.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.