### PR TITLE
Add LimitRange resource permission to flyteadmin serviceaccount

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -160,9 +160,13 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flyteadmin deployment |
 | flyteadmin.secrets | object | `{}` |  |
 | flyteadmin.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"loadBalancerSourceRanges":[],"type":"ClusterIP"}` | Service settings for Flyteadmin |
-| flyteadmin.serviceAccount | object | `{"alwaysCreate":false,"annotations":{},"create":true,"createClusterRole":true,"imagePullSecrets":[]}` | Configuration for service accounts for FlyteAdmin |
+| flyteadmin.serviceAccount | object | `{"alwaysCreate":false,"annotations":{},"clusterRole":{"apiGroups":["","flyte.lyft.com","rbac.authorization.k8s.io"],"resources":["configmaps","flyteworkflows","namespaces","pods","resourcequotas","roles","rolebindings","secrets","services","serviceaccounts","spark-role","limitranges"],"verbs":["*"]},"create":true,"createClusterRole":true,"imagePullSecrets":[]}` | Configuration for service accounts for FlyteAdmin |
 | flyteadmin.serviceAccount.alwaysCreate | bool | `false` | Should a service account always be created for flyteadmin even without an actual flyteadmin deployment running (e.g. for multi-cluster setups) |
 | flyteadmin.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Flyteadmin pods |
+| flyteadmin.serviceAccount.clusterRole | object | `{"apiGroups":["","flyte.lyft.com","rbac.authorization.k8s.io"],"resources":["configmaps","flyteworkflows","namespaces","pods","resourcequotas","roles","rolebindings","secrets","services","serviceaccounts","spark-role","limitranges"],"verbs":["*"]}` | Configuration for ClusterRole created for Flyteadmin |
+| flyteadmin.serviceAccount.clusterRole.apiGroups | list | `["","flyte.lyft.com","rbac.authorization.k8s.io"]` | Specifies the API groups that this ClusterRole can access |
+| flyteadmin.serviceAccount.clusterRole.resources | list | `["configmaps","flyteworkflows","namespaces","pods","resourcequotas","roles","rolebindings","secrets","services","serviceaccounts","spark-role","limitranges"]` | Specifies the resources that this ClusterRole can access |
+| flyteadmin.serviceAccount.clusterRole.verbs | list | `["*"]` | Specifies the verbs (actions) that this ClusterRole can perform on the specified resources |
 | flyteadmin.serviceAccount.create | bool | `true` | Should a service account be created for flyteadmin |
 | flyteadmin.serviceAccount.createClusterRole | bool | `true` | Should a ClusterRole be created for Flyteadmin |
 | flyteadmin.serviceAccount.imagePullSecrets | list | `[]` | ImagePullSecrets to automatically assign to the service account |

--- a/charts/flyte-core/templates/admin/rbac.yaml
+++ b/charts/flyte-core/templates/admin/rbac.yaml
@@ -23,26 +23,9 @@ metadata:
   name: {{ template "flyte.namespace" . -}}-{{- template "flyteadmin.name" . }}
   labels: {{ include "flyteadmin.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - ""
-  - flyte.lyft.com
-  - rbac.authorization.k8s.io
-  resources:
-  - configmaps
-  - flyteworkflows
-  - namespaces
-  - pods
-  - resourcequotas
-  - roles
-  - rolebindings
-  - secrets
-  - services
-  - serviceaccounts
-  - spark-role
-  - limitranges
-  verbs:
-  - '*'
-
+- apiGroups: {{ toYaml .Values.flyteadmin.serviceAccount.clusterRole.apiGroups | nindent 2 }}
+  resources: {{ toYaml .Values.flyteadmin.serviceAccount.clusterRole.resources | nindent 2 }}
+  verbs: {{ toYaml .Values.flyteadmin.serviceAccount.clusterRole.verbs | nindent 2 }}
 ---
 {{- if $.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/flyte-core/templates/admin/rbac.yaml
+++ b/charts/flyte-core/templates/admin/rbac.yaml
@@ -39,6 +39,7 @@ rules:
   - services
   - serviceaccounts
   - spark-role
+  - limitranges
   verbs:
   - '*'
 

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -66,6 +66,30 @@ flyteadmin:
     imagePullSecrets: []
     # -- Should a ClusterRole be created for Flyteadmin
     createClusterRole: true
+    # -- Configuration for ClusterRole created for Flyteadmin
+    clusterRole:
+      # -- Specifies the API groups that this ClusterRole can access
+      apiGroups:
+        - ""
+        - "flyte.lyft.com"
+        - "rbac.authorization.k8s.io"
+      # -- Specifies the resources that this ClusterRole can access
+      resources:
+        - configmaps
+        - flyteworkflows
+        - namespaces
+        - pods
+        - resourcequotas
+        - roles
+        - rolebindings
+        - secrets
+        - services
+        - serviceaccounts
+        - spark-role
+        - limitranges
+      # -- Specifies the verbs (actions) that this ClusterRole can perform on the specified resources
+      verbs:
+        - '*'
   # -- Annotations for Flyteadmin pods
   podAnnotations: {}
   # -- nodeSelector for Flyteadmin deployment
@@ -575,6 +599,7 @@ configmap:
       eventVersion: 2
       testing:
         host: http://flyteadmin
+      
     # -- Authentication configuration
     auth:
       authorizedUris:

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -572,6 +572,7 @@ rules:
   - services
   - serviceaccounts
   - spark-role
+  - limitranges
   verbs:
   - '*'
 ---

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -556,11 +556,11 @@ metadata:
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
+- apiGroups: 
   - ""
   - flyte.lyft.com
   - rbac.authorization.k8s.io
-  resources:
+  resources: 
   - configmaps
   - flyteworkflows
   - namespaces
@@ -573,7 +573,7 @@ rules:
   - serviceaccounts
   - spark-role
   - limitranges
-  verbs:
+  verbs: 
   - '*'
 ---
 # Source: flyte-core/templates/propeller/rbac.yaml

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -409,11 +409,11 @@ metadata:
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
+- apiGroups: 
   - ""
   - flyte.lyft.com
   - rbac.authorization.k8s.io
-  resources:
+  resources: 
   - configmaps
   - flyteworkflows
   - namespaces
@@ -426,7 +426,7 @@ rules:
   - serviceaccounts
   - spark-role
   - limitranges
-  verbs:
+  verbs: 
   - '*'
 ---
 # Source: flyte-core/templates/admin/rbac.yaml

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -425,6 +425,7 @@ rules:
   - services
   - serviceaccounts
   - spark-role
+  - limitranges
   verbs:
   - '*'
 ---

--- a/deployment/eks/flyte_helm_dataplane_generated.yaml
+++ b/deployment/eks/flyte_helm_dataplane_generated.yaml
@@ -237,6 +237,7 @@ rules:
   - services
   - serviceaccounts
   - spark-role
+  - limitranges
   verbs:
   - '*'
 ---

--- a/deployment/eks/flyte_helm_dataplane_generated.yaml
+++ b/deployment/eks/flyte_helm_dataplane_generated.yaml
@@ -221,11 +221,11 @@ metadata:
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
+- apiGroups: 
   - ""
   - flyte.lyft.com
   - rbac.authorization.k8s.io
-  resources:
+  resources: 
   - configmaps
   - flyteworkflows
   - namespaces
@@ -238,7 +238,7 @@ rules:
   - serviceaccounts
   - spark-role
   - limitranges
-  verbs:
+  verbs: 
   - '*'
 ---
 # Source: flyte-core/templates/propeller/rbac.yaml

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -587,11 +587,11 @@ metadata:
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
+- apiGroups: 
   - ""
   - flyte.lyft.com
   - rbac.authorization.k8s.io
-  resources:
+  resources: 
   - configmaps
   - flyteworkflows
   - namespaces
@@ -604,7 +604,7 @@ rules:
   - serviceaccounts
   - spark-role
   - limitranges
-  verbs:
+  verbs: 
   - '*'
 ---
 # Source: flyte-core/templates/propeller/rbac.yaml

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -603,6 +603,7 @@ rules:
   - services
   - serviceaccounts
   - spark-role
+  - limitranges
   verbs:
   - '*'
 ---

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -422,11 +422,11 @@ metadata:
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
+- apiGroups: 
   - ""
   - flyte.lyft.com
   - rbac.authorization.k8s.io
-  resources:
+  resources: 
   - configmaps
   - flyteworkflows
   - namespaces
@@ -439,7 +439,7 @@ rules:
   - serviceaccounts
   - spark-role
   - limitranges
-  verbs:
+  verbs: 
   - '*'
 ---
 # Source: flyte-core/templates/admin/rbac.yaml

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -438,6 +438,7 @@ rules:
   - services
   - serviceaccounts
   - spark-role
+  - limitranges
   verbs:
   - '*'
 ---

--- a/deployment/gcp/flyte_helm_dataplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_dataplane_generated.yaml
@@ -245,6 +245,7 @@ rules:
   - services
   - serviceaccounts
   - spark-role
+  - limitranges
   verbs:
   - '*'
 ---

--- a/deployment/gcp/flyte_helm_dataplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_dataplane_generated.yaml
@@ -229,11 +229,11 @@ metadata:
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
+- apiGroups: 
   - ""
   - flyte.lyft.com
   - rbac.authorization.k8s.io
-  resources:
+  resources: 
   - configmaps
   - flyteworkflows
   - namespaces
@@ -246,7 +246,7 @@ rules:
   - serviceaccounts
   - spark-role
   - limitranges
-  verbs:
+  verbs: 
   - '*'
 ---
 # Source: flyte-core/templates/propeller/rbac.yaml

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -624,6 +624,7 @@ rules:
   - services
   - serviceaccounts
   - spark-role
+  - limitranges
   verbs:
   - '*'
 ---

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -608,11 +608,11 @@ metadata:
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
+- apiGroups: 
   - ""
   - flyte.lyft.com
   - rbac.authorization.k8s.io
-  resources:
+  resources: 
   - configmaps
   - flyteworkflows
   - namespaces
@@ -625,7 +625,7 @@ rules:
   - serviceaccounts
   - spark-role
   - limitranges
-  verbs:
+  verbs: 
   - '*'
 ---
 # Source: flyte-core/templates/propeller/rbac.yaml

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -5501,11 +5501,11 @@ metadata:
     helm.sh/chart: flyte-v0.1.10
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
+- apiGroups: 
   - ""
   - flyte.lyft.com
   - rbac.authorization.k8s.io
-  resources:
+  resources: 
   - configmaps
   - flyteworkflows
   - namespaces
@@ -5518,7 +5518,7 @@ rules:
   - serviceaccounts
   - spark-role
   - limitranges
-  verbs:
+  verbs: 
   - '*'
 ---
 # Source: flyte/charts/flyte/templates/propeller/rbac.yaml

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -5517,6 +5517,7 @@ rules:
   - services
   - serviceaccounts
   - spark-role
+  - limitranges
   verbs:
   - '*'
 ---


### PR DESCRIPTION
We deploy use LimitRanges for flyte created namespaces. It would be practical if syncresources can also create this, otherwise we would need to create the rbac resources ourselves 