### PR TITLE
Increase limits of stalebot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,3 +18,5 @@ jobs:
         exempt-issue-labels: "needs discussion"  # Comma-separated list of labels.
         days-before-stale: 270
         days-before-close: 7
+        ascending: true # https://github.com/actions/stale#ascending
+        operations-per-run: 500


### PR DESCRIPTION
## Describe your changes
By default stalebot only handles 30 issues at a time (as can be evidenced by its first [run](https://github.com/flyteorg/flyte/actions/runs/5957979371)). This PR bumps this limit to 500. Also, let's favor older issues before the limit is hit.
