### PR TITLE
Add bump git tags workflow

### DIFF
--- a/.github/workflows/bump-tags.yml
+++ b/.github/workflows/bump-tags.yml
@@ -3,15 +3,18 @@ name: Bump git tags
 on:
   workflow_call:
     outputs:
-      version:
+      next_version:
         description: "Tag name"
-        value: ${{ jobs.bump_version.outputs.version }}
+        value: ${{ jobs.bump_version.outputs.next_version }}
+    secrets:
+      FLYTE_BOT_PAT:
+        required: true
 jobs:
   bump_version:
     name: Bump Version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.bump_version.outputs.tag }}
+      next_version: ${{ steps.get_semver.outputs.next_version }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -21,14 +24,14 @@ jobs:
         id: get_semver
         with:
           bump_level: "patch"
-      - name: Print current and next version
+      - name: Print current and next versions
         run: |
           echo "Current version: ${{ steps.get_semver.outputs.current_version  }}"
           echo "Next version: ${{ steps.get_semver.outputs.next_version }}"
       # Generate all tags for all components
       - uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.FLYTE_BOT_PAT }}
           script: |
             github.rest.git.createRef({
               owner: context.repo.owner,

--- a/.github/workflows/bump-tags.yml
+++ b/.github/workflows/bump-tags.yml
@@ -1,0 +1,54 @@
+name: Bump git tags
+
+on:
+  workflow_call:
+    outputs:
+      version:
+        description: "Tag name"
+        value: ${{ jobs.bump_version.outputs.version }}
+jobs:
+  bump_version:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump_version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      # Bump patch version
+      - uses: rickstaa/action-get-semver@v1
+        id: get_semver
+        with:
+          bump_level: "patch"
+      - name: Print current and next version
+        run: |
+          echo "Current version: ${{ steps.get_semver.outputs.current_version  }}"
+          echo "Next version: ${{ steps.get_semver.outputs.next_version }}"
+      # Generate all tags for all components
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${{ steps.get_semver.outputs.next_version }}`,
+              sha: context.sha
+            })
+            const components = [
+              "datacatalog",
+              "flyteadmin",
+              "flytecopilot",
+              "flyteplugins",
+              "flytepropeller",
+              "flytestdlib",
+            ];
+            for (const c of components) {
+              github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `refs/tags/${c}/${{ steps.get_semver.outputs.next_version }}`,
+                sha: context.sha
+              })
+            }

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -117,15 +117,16 @@ jobs:
       component: ${{ matrix.component }}
       go-version: ${{ needs.unpack-envvars.outputs.go-version }}
 
-  # TODO(monorepo): enable bump_version
-  # bump_version:
-  #   name: Bump Version
-  #   if: ${{ github.event_name != 'pull_request' }}
-  #   needs: [ endtoend,  integration, lint, tests, generate ] # Only to ensure it can successfully build
-  #   uses: flyteorg/flytetools/.github/workflows/bump_version.yml@master
-  #   secrets:
-  #     FLYTE_BOT_PAT: ${{ secrets.FLYTE_BOT_PAT }}
+  bump-tags:
+    name: Bump git tags
+    # TODO(monorepo): skip this if author is flyte-bot?
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: [ integration, lint, tests, generate ] # Only to ensure it can successfully build
+    uses: ./.github/workflows/bump-tags.yml
+    secrets:
+      FLYTE_BOT_PAT: ${{ secrets.FLYTE_BOT_PAT }}
 
+  # TODO(monorepo): we are not going to release any binary
   # goreleaser:
   #   name: Goreleaser
   #   needs: [ bump_version ] # Only to ensure it can successfully build
@@ -135,27 +136,24 @@ jobs:
   #   secrets:
   #     FLYTE_BOT_PAT: ${{ secrets.FLYTE_BOT_PAT }}
 
-  # push_docker_image:
-  #   name: Build & Push Image
-  #   # TODO(monorepo): depend on bump_version
-  #   # needs: [ bump_version ]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       component:
-  #         - datacatalog
-  #         - flyteadmin
-  #         - flytecopilot
-  #         - flytepropeller
-  #         - flytescheduler
-  #   uses: ./.github/workflows/publish.yml
-  #   with:
-  #     version: "test-version-monorepo"
-  #     component: ${{ matrix.component }}
-  #     dockerfile: Dockerfile.${{ matrix.component }}
-  #     # TODO(monorepo): set push to true once we depend on bump_version
-  #     # push: true
-  #     push: false
-  #   secrets:
-  #     FLYTE_BOT_PAT: ${{ secrets.FLYTE_BOT_PAT }}
-  #     FLYTE_BOT_USERNAME: ${{ secrets.FLYTE_BOT_USERNAME }}
+  push_docker_image:
+    name: Build & Push Image
+    needs: [ bump-tags ]
+    strategy:
+      fail-fast: false
+      matrix:
+        component:
+          - datacatalog
+          - flyteadmin
+          - flytecopilot
+          - flytepropeller
+          - flytescheduler
+    uses: ./.github/workflows/publish.yml
+    with:
+      version: ${{ needs.bump-tags.outputs.version }}
+      component: ${{ matrix.component }}
+      dockerfile: Dockerfile.${{ matrix.component }}
+      push: true
+    secrets:
+      FLYTE_BOT_PAT: ${{ secrets.FLYTE_BOT_PAT }}
+      FLYTE_BOT_USERNAME: ${{ secrets.FLYTE_BOT_USERNAME }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,9 +2,25 @@ name: Components Checks
 
 on:
   pull_request:
+    paths:
+      - 'datacatalog/**'
+      - 'flyteadmin/**'
+      - 'flytecopilot/**'
+      - 'flyteidl/**'
+      - 'flyteplugins/**'
+      - 'flytepropeller/**'
+      - 'flytestdlib/**'
   push:
     branches:
       - master
+    paths:
+      - 'datacatalog/**'
+      - 'flyteadmin/**'
+      - 'flytecopilot/**'
+      - 'flyteidl/**'
+      - 'flyteplugins/**'
+      - 'flytepropeller/**'
+      - 'flytestdlib/**'
 env:
   GO_VERSION: "1.19"
   PRIORITIES: "P0"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -87,6 +87,7 @@ jobs:
   integration:
     name: Integration Test
     needs:
+      - docker-build
       - unpack-envvars
     strategy:
       fail-fast: false

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -87,7 +87,6 @@ jobs:
   integration:
     name: Integration Test
     needs:
-      - docker-build
       - unpack-envvars
     strategy:
       fail-fast: false
@@ -121,7 +120,11 @@ jobs:
     name: Bump git tags
     # TODO(monorepo): skip this if author is flyte-bot?
     if: ${{ github.event_name != 'pull_request' }}
-    needs: [ integration, lint, tests, generate ] # Only to ensure it can successfully build
+    needs:
+      - integration
+      - lint
+      - unit-tests
+      - generate
     uses: ./.github/workflows/bump-tags.yml
     secrets:
       FLYTE_BOT_PAT: ${{ secrets.FLYTE_BOT_PAT }}
@@ -150,7 +153,7 @@ jobs:
           - flytescheduler
     uses: ./.github/workflows/publish.yml
     with:
-      version: ${{ needs.bump-tags.outputs.version }}
+      version: ${{ needs.bump-tags.outputs.next_version }}
       component: ${{ matrix.component }}
       dockerfile: Dockerfile.${{ matrix.component }}
       push: true

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Tag image to release version
         run: |
           for release in latest ${{ needs.bump-version.outputs.version }}; do
-            docker buildx imagetools create --tag "ghcr.io/flyteorg/flyte-binary-release:${release}" "ghcr.io/flyteorg/flyte-binary:sha-${{ github.sha }}"
+            docker buildx imagetools create --tag "ghcr.io/${{ github.repository_owner }}/flyte-binary-release:${release}" "ghcr.io/${{ github.repository_owner }}/flyte-binary:sha-${{ github.sha }}"
           done
 
   publish-flyte-component-image:
@@ -93,7 +93,7 @@ jobs:
       - name: Tag Image to release version
         run: |
           for release in latest ${{ needs.bump-version.outputs.version }}; do
-            docker buildx imagetools create --tag "ghcr.io/flyteorg/${{ matrix.component }}-release:${release}" "ghcr.io/flyteorg/${{ matrix.component }}:${{ steps.set_version.outputs.version }}"
+            docker buildx imagetools create --tag "ghcr.io/${{ github.repository_owner }}/${{ matrix.component }}-release:${release}" "ghcr.io/${{ github.repository_owner }}/${{ matrix.component }}:${{ steps.set_version.outputs.version }}"
           done
 
   helm-release:
@@ -116,7 +116,7 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
-      - name: Preprare Flyte Helm Release
+      - name: Prepare Flyte Helm Release
         env:
           VERSION: ${{ needs.bump-version.outputs.version }}
           REPOSITORY: "https://flyteorg.github.io/flyte"
@@ -138,7 +138,7 @@ jobs:
         with:
           fetch-depth: "0"
 
-      - name: Preprare Flyte Release
+      - name: Prepare Flyte Release
         env:
           VERSION: ${{ needs.bump-version.outputs.version }}
         run: |

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -45,4 +45,4 @@ jobs:
         working-directory: charts
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         run:
-          helm push ${{ matrix.chart }}-*.tgz oci://ghcr.io/flyteorg/helm-charts
+          helm push ${{ matrix.chart }}-*.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts

--- a/datacatalog/pull_request_template.md
+++ b/datacatalog/pull_request_template.md
@@ -1,5 +1,6 @@
 ## _Read then delete this section_
 
+
 _- Make sure to use a concise title for the pull-request._
 
 _- Use #patch, #minor or #major in the pull-request title to bump the corresponding version. Otherwise, the patch version


### PR DESCRIPTION
## Describe your changes

This PR adds a github workflow to bump the patch version of all necessary git tags (as described in https://go.dev/ref/mod#vcs-version). This is necessary so that downstream golang repositories can update to specific versions of components.

In terms of the mechanics of the gh workflow, on merges to master we bump the patch version of the latest tag and we use that version create tags for each component. For example, let's say that the we're updating to version v1.9.1, this is going to create 7 tags:
- v1.9.1
- datacatalog/v1.9.1
- flyteadmin/v1.9.1
- flytecopilot/v1.9.1
- flyteplugins/v1.9.1
- flytepropeller/v1.9.1
- flytestdlib/v1.9.1

I also took the chance to improve the fork-ability of the flyte repo. I also tested these changes on a fork.

A subsequent change is going to modify the release scripts.
