### PR TITLE
Update the item only if it exists in the cache

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/internal/webapi/monitor_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/internal/webapi/monitor_test.go
@@ -37,7 +37,7 @@ func Test_monitor(t *testing.T) {
 	client.OnStatusMatch(ctx, mock.Anything).Return(core2.PhaseInfoSuccess(nil), nil)
 
 	wg := sync.WaitGroup{}
-	wg.Add(4)
+	wg.Add(8)
 	cacheObj, err := cache.NewAutoRefreshCache(rand.String(5), func(ctx context.Context, batch cache.Batch) (updatedBatch []cache.ItemSyncResponse, err error) {
 		wg.Done()
 		t.Logf("Syncing Item [%+v]", batch[0])

--- a/flytestdlib/cache/auto_refresh.go
+++ b/flytestdlib/cache/auto_refresh.go
@@ -332,7 +332,7 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 
 			for _, item := range updatedBatch {
 				if item.Action == Update {
-					// Add adds the item if it has been evicted or updates an existing one.
+					// Updates an existing item.
 					w.Update(item.ID, item.Item)
 				}
 			}

--- a/flytestdlib/cache/auto_refresh.go
+++ b/flytestdlib/cache/auto_refresh.go
@@ -175,7 +175,7 @@ func (w *autoRefresh) Start(ctx context.Context) error {
 	return nil
 }
 
-// Update updates the item in the cache only if it exists, return true if we updated the item.
+// Update updates the item only if it exists in the cache, return true if we updated the item.
 func (w *autoRefresh) Update(id ItemID, item Item) (ok bool) {
 	w.lock.Lock()
 	ok = w.lruMap.Contains(id)
@@ -186,6 +186,7 @@ func (w *autoRefresh) Update(id ItemID, item Item) (ok bool) {
 	return ok
 }
 
+// Delete deletes the item from the cache if it exists.
 func (w *autoRefresh) Delete(key interface{}) {
 	w.lock.Lock()
 	w.toDelete.Remove(key)

--- a/flytestdlib/cache/auto_refresh_test.go
+++ b/flytestdlib/cache/auto_refresh_test.go
@@ -62,7 +62,7 @@ func syncTerminalItem(_ context.Context, batch Batch) ([]ItemSyncResponse, error
 	panic("This should never be called")
 }
 
-func TestCacheThree(t *testing.T) {
+func TestCacheFour(t *testing.T) {
 	testResyncPeriod := time.Millisecond
 	rateLimiter := workqueue.DefaultControllerRateLimiter()
 
@@ -139,6 +139,34 @@ func TestCacheThree(t *testing.T) {
 		// Wait half a second for all resync periods to complete
 		// If the cache tries to enqueue the item, a panic will be thrown.
 		time.Sleep(500 * time.Millisecond)
+
+		cancel()
+	})
+
+	t.Run("Test update and delete cache", func(t *testing.T) {
+		cache, err := NewAutoRefreshCache("fake3", syncTerminalItem, rateLimiter, testResyncPeriod, 10, 2, promutils.NewTestScope())
+		assert.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		assert.NoError(t, cache.Start(ctx))
+
+		itemID := "dummy_id"
+		_, err = cache.GetOrCreate(itemID, terminalCacheItem{
+			val: 0,
+		})
+		assert.NoError(t, err)
+
+		// Wait half a second for all resync periods to complete
+		// If the cache tries to enqueue the item, a panic will be thrown.
+		time.Sleep(500 * time.Millisecond)
+
+		err = cache.DeleteDelayed(itemID)
+		assert.NoError(t, err)
+
+		time.Sleep(500 * time.Millisecond)
+		item, err := cache.Get(itemID)
+		assert.Nil(t, item)
+		assert.Error(t, err)
 
 		cancel()
 	})

--- a/rsts/deployment/index.rst
+++ b/rsts/deployment/index.rst
@@ -36,7 +36,7 @@ plugins, authentication, performance tuning, and maintaining Flyte as a producti
        :text: 🤖 Agent Setup
        :classes: btn-block stretched-link
     ^^^^^^^^^^^^
-    Enable Flyte agents to extend Flyte's capabilities, including features like File sesnor, Databricks job, and Snowflake query services.
+    Enable Flyte agents to extend Flyte's capabilities, including features like File sensor, Databricks job, and Snowflake query services.
 
     ---
 


### PR DESCRIPTION
# TL;DR
I found that Propeller keeps sending the request to the agent even workflow is done.

The work queue only has unique items, so we add `itemID` to it. The workers won't process the item again after the task is done. 

Before:
||enqueueBatches| workqueue | sync (10 workers) |
|----|----|-----|----|
| t1 | obj(1) | obj(1) |  |
| t2 |  |  |  |
| t3 | obj(2)  |  obj(1), obj(2) |  |
| t4 |  |  |  |
| t5 | obj(1) | obj(1), obj(2), obj(1) |  |
| t6 |  |  | obj(1), obj(2), obj(1) |

After:
||enqueueBatches| workqueue | sync (10 workers) |
|----|----|-----|----|
| t1 | 1 | 1 |  |
| t2 |  |  |  |
| t3 | 2  |  1, 2 |  |
| t4 |  |  |  |
| t5 | 1 | 1, 2 |  |
| t6 |  |  | 1, 2 |



100 workflows, each has 100 tasks.
Before:
<img width="848" alt="image" src="https://github.com/flyteorg/flytestdlib/assets/37936015/13c8c06c-87ec-4909-898b-e06e298a54f7">

After:
<img width="854" alt="image" src="https://github.com/flyteorg/flytestdlib/assets/37936015/3e2043af-296b-4592-a1c4-d4cfe3c2cfed">


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_