### PR TITLE
[Monorepo] Bump flyteplugins to v1.1.32

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/core/exec_metadata.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/exec_metadata.go
@@ -44,6 +44,6 @@ type TaskExecutionMetadata interface {
 	GetSecurityContext() core.SecurityContext
 	IsInterruptible() bool
 	GetPlatformResources() *v1.ResourceRequirements
-	GetInterruptibleFailureThreshold() uint32
+	GetInterruptibleFailureThreshold() int32
 	GetEnvironmentVariables() map[string]string
 }

--- a/flyteplugins/go/tasks/pluginmachinery/core/mocks/task_execution_metadata.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/mocks/task_execution_metadata.go
@@ -92,7 +92,7 @@ type TaskExecutionMetadata_GetInterruptibleFailureThreshold struct {
 	*mock.Call
 }
 
-func (_m TaskExecutionMetadata_GetInterruptibleFailureThreshold) Return(_a0 uint32) *TaskExecutionMetadata_GetInterruptibleFailureThreshold {
+func (_m TaskExecutionMetadata_GetInterruptibleFailureThreshold) Return(_a0 int32) *TaskExecutionMetadata_GetInterruptibleFailureThreshold {
 	return &TaskExecutionMetadata_GetInterruptibleFailureThreshold{Call: _m.Call.Return(_a0)}
 }
 
@@ -107,14 +107,14 @@ func (_m *TaskExecutionMetadata) OnGetInterruptibleFailureThresholdMatch(matcher
 }
 
 // GetInterruptibleFailureThreshold provides a mock function with given fields:
-func (_m *TaskExecutionMetadata) GetInterruptibleFailureThreshold() uint32 {
+func (_m *TaskExecutionMetadata) GetInterruptibleFailureThreshold() int32 {
 	ret := _m.Called()
 
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(uint32)
+		r0 = ret.Get(0).(int32)
 	}
 
 	return r0

--- a/flyteplugins/go/tasks/plugins/array/k8s/subtask_exec_context.go
+++ b/flyteplugins/go/tasks/plugins/array/k8s/subtask_exec_context.go
@@ -268,7 +268,7 @@ func NewSubTaskExecutionMetadata(taskExecutionMetadata pluginsCore.TaskExecution
 	}
 
 	subTaskExecutionID := NewSubTaskExecutionID(taskExecutionMetadata.GetTaskExecutionID(), executionIndex, retryAttempt)
-	interruptible := taskExecutionMetadata.IsInterruptible() && uint32(systemFailures) < taskExecutionMetadata.GetInterruptibleFailureThreshold()
+	interruptible := taskExecutionMetadata.IsInterruptible() && int32(systemFailures) < taskExecutionMetadata.GetInterruptibleFailureThreshold()
 	return SubTaskExecutionMetadata{
 		taskExecutionMetadata,
 		utils.UnionMaps(taskExecutionMetadata.GetAnnotations(), secretsMap),


### PR DESCRIPTION
## Describe your changes

This PR brings https://github.com/flyteorg/flyteplugins/pull/403 to the monorepo. Notice that flytepropeller unit tests are [failing with](https://github.com/flyteorg/flyte/actions/runs/6386959399/job/17334832996?pr=4124) (and possibly other failures):
```
go test ./... -race -coverprofile=coverage.txt -covermode=atomic
# github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task
Error: pkg/controller/nodes/task/taskexec_context.go:134:9: cannot use t.tm (variable of type taskExecutionMetadata) as type "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core".TaskExecutionMetadata in return statement:
	taskExecutionMetadata does not implement "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core".TaskExecutionMetadata (wrong type for GetInterruptibleFailureThreshold method)
		have GetInterruptibleFailureThreshold() uint32
		want GetInterruptibleFailureThreshold() int32
```
