### PR TITLE
Moving from flyteplugins - updated maptask log links to use original index

### DIFF
--- a/flyteplugins/go/tasks/plugins/array/awsbatch/executor.go
+++ b/flyteplugins/go/tasks/plugins/array/awsbatch/executor.go
@@ -111,7 +111,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 	if p == arrayCore.PhaseStart && nextPhase != arrayCore.PhaseStart {
 		// if transitioning from PhaseStart to another phase then cache lookups have completed
 		externalResources, err = arrayCore.InitializeExternalResources(ctx, tCtx, pluginState.State,
-			func(tCtx core.TaskExecutionContext, childIndex int) string {
+			func(tCtx core.TaskExecutionContext, executionIndex, originalIndex int) string {
 				// subTaskIDs for the the aws_batch are generated based on the job ID, therefore
 				// to initialize we default to an empty string which will be updated later.
 				return ""

--- a/flyteplugins/go/tasks/plugins/array/core/metadata.go
+++ b/flyteplugins/go/tasks/plugins/array/core/metadata.go
@@ -13,7 +13,7 @@ import (
 // initial state of the subtask. This involves labeling all cached subtasks as successful with a
 // cache hit and initializing others to undefined state.
 func InitializeExternalResources(ctx context.Context, tCtx core.TaskExecutionContext, state *State,
-	generateSubTaskID func(core.TaskExecutionContext, int) string) ([]*core.ExternalResource, error) {
+	generateSubTaskID func(core.TaskExecutionContext, int, int) string) ([]*core.ExternalResource, error) {
 	externalResources := make([]*core.ExternalResource, state.GetOriginalArraySize())
 
 	taskTemplate, err := tCtx.TaskReader().Read(ctx)
@@ -51,7 +51,7 @@ func InitializeExternalResources(ctx context.Context, tCtx core.TaskExecutionCon
 			cachedSubTaskCount++
 		}
 
-		subTaskID := generateSubTaskID(tCtx, childIndex)
+		subTaskID := generateSubTaskID(tCtx, childIndex, i)
 		externalResources[i] = &core.ExternalResource{
 			ExternalID:   subTaskID,
 			CacheStatus:  cacheStatus,

--- a/flyteplugins/go/tasks/plugins/array/core/metadata_test.go
+++ b/flyteplugins/go/tasks/plugins/array/core/metadata_test.go
@@ -48,7 +48,7 @@ func TestInitializeExternalResources(t *testing.T) {
 	}
 
 	externalResources, err := InitializeExternalResources(ctx, tCtx, &state,
-		func(_ core.TaskExecutionContext, i int) string {
+		func(_ core.TaskExecutionContext, i, j int) string {
 			return ""
 		},
 	)

--- a/flyteplugins/go/tasks/plugins/array/k8s/executor.go
+++ b/flyteplugins/go/tasks/plugins/array/k8s/executor.go
@@ -94,8 +94,8 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 			// job configuration has then been validated and all of the metadata necessary to report subtask
 			// status (ie. cache hit / etc) is available.
 			externalResources, err = arrayCore.InitializeExternalResources(ctx, tCtx, nextState,
-				func(tCtx core.TaskExecutionContext, childIndex int) string {
-					subTaskExecutionID := NewSubTaskExecutionID(tCtx.TaskExecutionMetadata().GetTaskExecutionID(), childIndex, 0)
+				func(tCtx core.TaskExecutionContext, executionIndex, originalIndex int) string {
+					subTaskExecutionID := NewSubTaskExecutionID(tCtx.TaskExecutionMetadata().GetTaskExecutionID(), executionIndex, originalIndex, 0)
 					return subTaskExecutionID.GetGeneratedName()
 				},
 			)


### PR DESCRIPTION
# TL;DR
Updated the maptask log links to use the subtask original index rather than the execution index.

**NOTE**: This change means that log links will not match the pod name in scenarios where the subtask execution and original indicies differ (ex. cache hits).

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_