### PR TITLE
Moving from flyteplugins - Use dask cuda worker when GPU resource > 0

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/dask/dask.go
+++ b/flyteplugins/go/tasks/plugins/k8s/dask/dask.go
@@ -187,6 +187,11 @@ func createWorkerSpec(cluster plugins.DaskWorkerGroup, podSpec *v1.PodSpec, prim
 			memory := limits.Memory().String()
 			workerArgs = append(workerArgs, "--memory-limit", memory)
 		}
+		// If limits includes gpu, assume dask cuda worker cli startup
+		// https://docs.rapids.ai/api/dask-cuda/nightly/quickstart.html#dask-cuda-worker
+		if !limits.Name(flytek8s.ResourceNvidiaGPU, "0").IsZero() {
+			workerArgs[0] = "dask-cuda-worker"
+		}
 	}
 	primaryContainer.Args = workerArgs
 

--- a/flyteplugins/go/tasks/plugins/k8s/dask/dask_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/dask/dask_test.go
@@ -369,6 +369,34 @@ func TestBuildResourceDaskDefaultResoureRequirements(t *testing.T) {
 	assert.Contains(t, workerSpec.Containers[0].Args, "2G")
 }
 
+func TestBuildResourceGPUCudaWorkerArgs(t *testing.T) {
+	protobufResources := core.Resources{
+		Limits: []*core.Resources_ResourceEntry{
+			{
+				Name:  core.Resources_GPU,
+				Value: "1",
+			},
+		},
+	}
+	expectedResources, _ := flytek8s.ToK8sResourceRequirements(&protobufResources)
+
+	flyteWorkflowResources := v1.ResourceRequirements{}
+
+	daskResourceHandler := daskResourceHandler{}
+	taskTemplate := dummyDaskTaskTemplate("", &protobufResources)
+	taskContext := dummyDaskTaskContext(taskTemplate, &flyteWorkflowResources, false)
+	resource, err := daskResourceHandler.BuildResource(context.TODO(), taskContext)
+	assert.Nil(t, err)
+	assert.NotNil(t, resource)
+	daskJob, ok := resource.(*daskAPI.DaskJob)
+	assert.True(t, ok)
+
+	// Default Workers
+	workerSpec := daskJob.Spec.Cluster.Spec.Worker.Spec
+	assert.Equal(t, *expectedResources, workerSpec.Containers[0].Resources)
+	assert.Contains(t, workerSpec.Containers[0].Args, "dask-cuda-worker")
+}
+
 func TestBuildResourcesDaskCustomResoureRequirements(t *testing.T) {
 	protobufResources := core.Resources{
 		Requests: []*core.Resources_ResourceEntry{


### PR DESCRIPTION
# TL;DR
If a gpu has been specified in the dask plugin resource, assume we want to use `dask cuda worker` i.e. that dask-cuda is present on the specified image.

## Type
 - [x] Feature
 - [x] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Currently we build an arg to submit to the container and inject values such as threads and memory from the limits specified in the resources object in the dask plugin object. [Dask cuda](https://github.com/rapidsai/dask-cuda) gives us many built in gpu tools and all that is required is to ensure dask cuda is installed and then to start out workers with `dask-cuda-worker`. So, in order to accomodate, we simply check for gpu limits in the dask plugin resources and overwrite the first arg to `dask-cuda-worker`.