### PR TITLE
Moving from flyteplugins - Implement Spark pod template tolerations

### DIFF
--- a/flyteplugins/go.mod
+++ b/flyteplugins/go.mod
@@ -135,6 +135,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
+<<<<<<< HEAD
 replace (
 	github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
 	github.com/flyteorg/flyte/datacatalog => ../datacatalog
@@ -144,3 +145,8 @@ replace (
 	github.com/flyteorg/flyte/flytestdlib => ../flytestdlib
 	github.com/flyteorg/flyteidl => ../flyteidl
 )
+=======
+replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
+
+replace github.com/flyteorg/flyteidl => /Users/andrew/dev/forks/flyteidl
+>>>>>>> flyteplugins/spark-pod-templates

--- a/flyteplugins/go.mod
+++ b/flyteplugins/go.mod
@@ -135,7 +135,6 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-<<<<<<< HEAD
 replace (
 	github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
 	github.com/flyteorg/flyte/datacatalog => ../datacatalog
@@ -143,10 +142,5 @@ replace (
 	github.com/flyteorg/flyte/flyteplugins => ../flyteplugins
 	github.com/flyteorg/flyte/flytepropeller => ../flytepropeller
 	github.com/flyteorg/flyte/flytestdlib => ../flytestdlib
-	github.com/flyteorg/flyteidl => ../flyteidl
+	github.com/flyteorg/flyteidl => /Users/andrew/dev/forks/flyteidl
 )
-=======
-replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
-
-replace github.com/flyteorg/flyteidl => /Users/andrew/dev/forks/flyteidl
->>>>>>> flyteplugins/spark-pod-templates

--- a/flyteplugins/go.sum
+++ b/flyteplugins/go.sum
@@ -213,11 +213,8 @@ github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQL
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-<<<<<<< HEAD
-=======
 github.com/flyteorg/flytestdlib v1.0.24 h1:jDvymcjlsTRCwOtxPapro0WZBe3isTz+T3Tiq+mZUuk=
 github.com/flyteorg/flytestdlib v1.0.24/go.mod h1:6nXa5g00qFIsgdvQ7jKQMJmDniqO0hG6Z5X5olfduqQ=
->>>>>>> flyteplugins/spark-pod-templates
 github.com/flyteorg/stow v0.3.7 h1:Cx7j8/Ux6+toD5hp5fy++927V+yAcAttDeQAlUD/864=
 github.com/flyteorg/stow v0.3.7/go.mod h1:5dfBitPM004dwaZdoVylVjxFT4GWAgI0ghAndhNUzCo=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/flyteplugins/go.sum
+++ b/flyteplugins/go.sum
@@ -213,6 +213,11 @@ github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQL
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+<<<<<<< HEAD
+=======
+github.com/flyteorg/flytestdlib v1.0.24 h1:jDvymcjlsTRCwOtxPapro0WZBe3isTz+T3Tiq+mZUuk=
+github.com/flyteorg/flytestdlib v1.0.24/go.mod h1:6nXa5g00qFIsgdvQ7jKQMJmDniqO0hG6Z5X5olfduqQ=
+>>>>>>> flyteplugins/spark-pod-templates
 github.com/flyteorg/stow v0.3.7 h1:Cx7j8/Ux6+toD5hp5fy++927V+yAcAttDeQAlUD/864=
 github.com/flyteorg/stow v0.3.7/go.mod h1:5dfBitPM004dwaZdoVylVjxFT4GWAgI0ghAndhNUzCo=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/flyteplugins/go/tasks/pluginmachinery/core/exec_metadata.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/exec_metadata.go
@@ -44,6 +44,6 @@ type TaskExecutionMetadata interface {
 	GetSecurityContext() core.SecurityContext
 	IsInterruptible() bool
 	GetPlatformResources() *v1.ResourceRequirements
-	GetInterruptibleFailureThreshold() uint32
+	GetInterruptibleFailureThreshold() int32
 	GetEnvironmentVariables() map[string]string
 }

--- a/flyteplugins/go/tasks/pluginmachinery/core/mocks/task_execution_metadata.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/mocks/task_execution_metadata.go
@@ -92,7 +92,7 @@ type TaskExecutionMetadata_GetInterruptibleFailureThreshold struct {
 	*mock.Call
 }
 
-func (_m TaskExecutionMetadata_GetInterruptibleFailureThreshold) Return(_a0 uint32) *TaskExecutionMetadata_GetInterruptibleFailureThreshold {
+func (_m TaskExecutionMetadata_GetInterruptibleFailureThreshold) Return(_a0 int32) *TaskExecutionMetadata_GetInterruptibleFailureThreshold {
 	return &TaskExecutionMetadata_GetInterruptibleFailureThreshold{Call: _m.Call.Return(_a0)}
 }
 
@@ -107,14 +107,14 @@ func (_m *TaskExecutionMetadata) OnGetInterruptibleFailureThresholdMatch(matcher
 }
 
 // GetInterruptibleFailureThreshold provides a mock function with given fields:
-func (_m *TaskExecutionMetadata) GetInterruptibleFailureThreshold() uint32 {
+func (_m *TaskExecutionMetadata) GetInterruptibleFailureThreshold() int32 {
 	ret := _m.Called()
 
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(uint32)
+		r0 = ret.Get(0).(int32)
 	}
 
 	return r0

--- a/flyteplugins/go/tasks/plugins/array/k8s/subtask_exec_context.go
+++ b/flyteplugins/go/tasks/plugins/array/k8s/subtask_exec_context.go
@@ -268,7 +268,7 @@ func NewSubTaskExecutionMetadata(taskExecutionMetadata pluginsCore.TaskExecution
 	}
 
 	subTaskExecutionID := NewSubTaskExecutionID(taskExecutionMetadata.GetTaskExecutionID(), executionIndex, retryAttempt)
-	interruptible := taskExecutionMetadata.IsInterruptible() && uint32(systemFailures) < taskExecutionMetadata.GetInterruptibleFailureThreshold()
+	interruptible := taskExecutionMetadata.IsInterruptible() && int32(systemFailures) < taskExecutionMetadata.GetInterruptibleFailureThreshold()
 	return SubTaskExecutionMetadata{
 		taskExecutionMetadata,
 		utils.UnionMaps(taskExecutionMetadata.GetAnnotations(), secretsMap),

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/protobuf/types/known/structpb"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"strconv"
@@ -20,14 +21,22 @@ import (
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/logs"
 	pluginsCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 
+<<<<<<< HEAD
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/k8s"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
+=======
+	v1 "k8s.io/api/core/v1"
+>>>>>>> flyteplugins/spark-pod-templates
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/k8s"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
+
 	sparkOp "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"regexp"
 	"strings"
@@ -59,6 +68,21 @@ func validateSparkJob(sparkJob *plugins.SparkJob) error {
 
 func (sparkResourceHandler) GetProperties() k8s.PluginProperties {
 	return k8s.PluginProperties{}
+}
+
+func getTolerations(podSpecPb *structpb.Struct) ([]v1.Toleration, error) {
+	tolerations := make([]v1.Toleration, 0)
+	tolerations = append(tolerations, config.GetK8sPluginConfig().DefaultTolerations...)
+	if podSpecPb != nil {
+		var podSpec v1.PodSpec
+		err := utils.UnmarshalStruct(podSpecPb, &podSpec)
+		if err != nil {
+			return nil, errors.Wrapf(errors.BadTaskSpecification, err,
+				"invalid pod spec [%v], failed to unmarshal", podSpec)
+		}
+		tolerations = append(tolerations, podSpec.Tolerations...)
+	}
+	return tolerations, nil
 }
 
 // Creates a new Job that will execute the main container as well as any generated types the result from the execution.
@@ -99,6 +123,11 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 	if len(serviceAccountName) == 0 {
 		serviceAccountName = sparkTaskType
 	}
+
+	tolerations, err := getTolerations(sparkJob.GetDriverPod().GetPodSpec())
+	if err != nil {
+		return nil, err
+	}
 	driverSpec := sparkOp.DriverSpec{
 		SparkPodSpec: sparkOp.SparkPodSpec{
 			Affinity:         config.GetK8sPluginConfig().DefaultAffinity,
@@ -108,12 +137,17 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 			Image:            &container.Image,
 			SecurityContenxt: config.GetK8sPluginConfig().DefaultPodSecurityContext.DeepCopy(),
 			DNSConfig:        config.GetK8sPluginConfig().DefaultPodDNSConfig.DeepCopy(),
-			Tolerations:      config.GetK8sPluginConfig().DefaultTolerations,
+			Tolerations:      tolerations,
 			SchedulerName:    &config.GetK8sPluginConfig().SchedulerName,
 			NodeSelector:     config.GetK8sPluginConfig().DefaultNodeSelector,
 			HostNetwork:      config.GetK8sPluginConfig().EnableHostNetworkingPod,
 		},
 		ServiceAccount: &serviceAccountName,
+	}
+
+	tolerations, err = getTolerations(sparkJob.GetExecutorPod().GetPodSpec())
+	if err != nil {
+		return nil, err
 	}
 
 	executorSpec := sparkOp.ExecutorSpec{
@@ -125,7 +159,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 			EnvVars:          sparkEnvVars,
 			SecurityContenxt: config.GetK8sPluginConfig().DefaultPodSecurityContext.DeepCopy(),
 			DNSConfig:        config.GetK8sPluginConfig().DefaultPodDNSConfig.DeepCopy(),
-			Tolerations:      config.GetK8sPluginConfig().DefaultTolerations,
+			Tolerations:      tolerations,
 			SchedulerName:    &config.GetK8sPluginConfig().SchedulerName,
 			NodeSelector:     config.GetK8sPluginConfig().DefaultNodeSelector,
 			HostNetwork:      config.GetK8sPluginConfig().EnableHostNetworkingPod,

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -3,44 +3,30 @@ package spark
 import (
 	"context"
 	"fmt"
-
-	"google.golang.org/protobuf/types/known/structpb"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
+	"regexp"
 	"strconv"
+	"strings"
+	"time"
 
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/tasklog"
-
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core/template"
-
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
+	sparkOp "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
+	"google.golang.org/protobuf/types/known/structpb"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/errors"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/logs"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery"
 	pluginsCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
-
-<<<<<<< HEAD
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core/template"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/k8s"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/tasklog"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
-=======
-	v1 "k8s.io/api/core/v1"
->>>>>>> flyteplugins/spark-pod-templates
-	"k8s.io/client-go/kubernetes/scheme"
-
-	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/k8s"
-	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
-
-	sparkOp "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
-
-	"regexp"
-	"strings"
-	"time"
 )
 
 const KindSparkApplication = "SparkApplication"

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
@@ -6,27 +6,21 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/k8s"
-
-	"github.com/stretchr/testify/mock"
-
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/logs"
-
-	pluginsCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
-
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core/mocks"
-
-	pluginIOMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-
 	sj "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	"github.com/golang/protobuf/jsonpb"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/logs"
+	pluginsCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core/mocks"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
+	pluginIOMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/k8s"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
 )

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
@@ -21,13 +21,14 @@ import (
 	pluginIOMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
 
 	sj "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
-	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
 	"github.com/golang/protobuf/jsonpb"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
 )
 
 const sparkMainClass = "MainClass"
@@ -87,7 +88,8 @@ func TestGetEventInfo(t *testing.T) {
 			},
 		},
 	}))
-	taskCtx := dummySparkTaskContext(dummySparkTaskTemplate("blah-1", dummySparkConf), false)
+	sparkJob := dummySparkCustomObj(dummySparkConf)
+	taskCtx := dummySparkTaskContext(dummySparkTaskTemplate("blah-1", sparkJob), false)
 	info, err := getEventInfoForSpark(taskCtx, dummySparkApplication(sj.RunningState))
 	assert.NoError(t, err)
 	assert.Len(t, info.Logs, 6)
@@ -157,7 +159,8 @@ func TestGetTaskPhase(t *testing.T) {
 	sparkResourceHandler := sparkResourceHandler{}
 
 	ctx := context.TODO()
-	taskCtx := dummySparkTaskContext(dummySparkTaskTemplate("", dummySparkConf), false)
+	sparkJob := dummySparkCustomObj(dummySparkConf)
+	taskCtx := dummySparkTaskContext(dummySparkTaskTemplate("", sparkJob), false)
 	taskPhase, err := sparkResourceHandler.GetTaskPhase(ctx, taskCtx, dummySparkApplication(sj.NewState))
 	assert.NoError(t, err)
 	assert.Equal(t, taskPhase.Phase(), pluginsCore.PhaseQueued)
@@ -242,7 +245,6 @@ func dummySparkApplication(state sj.ApplicationStateType) *sj.SparkApplication {
 
 func dummySparkCustomObj(sparkConf map[string]string) *plugins.SparkJob {
 	sparkJob := plugins.SparkJob{}
-
 	sparkJob.MainClass = sparkMainClass
 	sparkJob.MainApplicationFile = sparkApplicationFile
 	sparkJob.SparkConf = sparkConf
@@ -250,9 +252,7 @@ func dummySparkCustomObj(sparkConf map[string]string) *plugins.SparkJob {
 	return &sparkJob
 }
 
-func dummySparkTaskTemplate(id string, sparkConf map[string]string) *core.TaskTemplate {
-
-	sparkJob := dummySparkCustomObj(sparkConf)
+func dummySparkTaskTemplate(id string, sparkJob *plugins.SparkJob) *core.TaskTemplate {
 	sparkJobJSON, err := utils.MarshalToString(sparkJob)
 	if err != nil {
 		panic(err)
@@ -335,7 +335,8 @@ func TestBuildResourceSpark(t *testing.T) {
 	sparkResourceHandler := sparkResourceHandler{}
 
 	// Case1: Valid Spark Task-Template
-	taskTemplate := dummySparkTaskTemplate("blah-1", dummySparkConf)
+	sparkJob := dummySparkCustomObj(dummySparkConf)
+	taskTemplate := dummySparkTaskTemplate("blah-1", sparkJob)
 
 	// Set spark custom feature config.
 	assert.NoError(t, setSparkConfig(&Config{
@@ -619,7 +620,8 @@ func TestBuildResourceSpark(t *testing.T) {
 	dummyConfWithRequest["spark.kubernetes.driver.request.cores"] = "3"
 	dummyConfWithRequest["spark.kubernetes.executor.request.cores"] = "4"
 
-	taskTemplate = dummySparkTaskTemplate("blah-1", dummyConfWithRequest)
+	sparkJob = dummySparkCustomObj(dummyConfWithRequest)
+	taskTemplate = dummySparkTaskTemplate("blah-1", sparkJob)
 	resource, err = sparkResourceHandler.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, false))
 	assert.Nil(t, err)
 	assert.NotNil(t, resource)
@@ -676,6 +678,76 @@ func TestBuildResourceSpark(t *testing.T) {
 	resource, err = sparkResourceHandler.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, false))
 	assert.NotNil(t, err)
 	assert.Nil(t, resource)
+}
+
+func TestBuildResourcePodTemplate(t *testing.T) {
+	defaultToleration := corev1.Toleration{
+
+		Key:      "x/flyte",
+		Value:    "default",
+		Operator: "Equal",
+	}
+	err := config.SetK8sPluginConfig(&config.K8sPluginConfig{
+		DefaultTolerations: []corev1.Toleration{
+			defaultToleration,
+		},
+	})
+	assert.NoError(t, err)
+	sparkJob := dummySparkCustomObj(dummySparkConf)
+	extraDriverToleration := corev1.Toleration{
+		Key:      "x/flyte",
+		Value:    "extra-driver",
+		Operator: "Equal",
+	}
+	podSpec := corev1.PodSpec{
+		Tolerations: []corev1.Toleration{
+			extraDriverToleration,
+		},
+	}
+	driverPodSpecPb := structpb.Struct{}
+	err = utils.MarshalStruct(&podSpec, &driverPodSpecPb)
+	assert.NoError(t, err)
+	sparkJob.DriverPodValue = &plugins.SparkJob_DriverPod{
+		DriverPod: &core.K8SPod{
+			PodSpec: &driverPodSpecPb,
+		},
+	}
+	extraExecutorToleration := corev1.Toleration{
+		Key:      "x/flyte",
+		Value:    "extra-executor",
+		Operator: "Equal",
+	}
+	podSpec = corev1.PodSpec{
+		Tolerations: []corev1.Toleration{
+			extraExecutorToleration,
+		},
+	}
+	execPodSpecPb := structpb.Struct{}
+	err = utils.MarshalStruct(&podSpec, &execPodSpecPb)
+	assert.NoError(t, err)
+	sparkJob.ExecutorPodValue = &plugins.SparkJob_ExecutorPod{
+		ExecutorPod: &core.K8SPod{
+			PodSpec: &execPodSpecPb,
+		},
+	}
+	taskTemplate := dummySparkTaskTemplate("blah-1", sparkJob)
+	sparkResourceHandler := sparkResourceHandler{}
+	resource, err := sparkResourceHandler.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, false))
+	assert.Nil(t, err)
+
+	assert.NotNil(t, resource)
+	sparkApp, ok := resource.(*sj.SparkApplication)
+	assert.True(t, ok)
+	assert.Equal(t, 2, len(sparkApp.Spec.Driver.Tolerations))
+	assert.Equal(t, sparkApp.Spec.Driver.Tolerations, []corev1.Toleration{
+		defaultToleration,
+		extraDriverToleration,
+	})
+	assert.Equal(t, 2, len(sparkApp.Spec.Executor.Tolerations))
+	assert.Equal(t, sparkApp.Spec.Executor.Tolerations, []corev1.Toleration{
+		defaultToleration,
+		extraExecutorToleration,
+	})
 }
 
 func TestGetPropertiesSpark(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/flyteorg/flyte/flyteplugins v0.0.0-00010101000000-000000000000 // indirect
-	github.com/flyteorg/flyteidl v0.0.0-00010101000000-000000000000 // indirect
+	github.com/flyteorg/flyteidl v1.5.13 // indirect
 	github.com/flyteorg/stow v0.3.7 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect


### PR DESCRIPTION
# TL;DR
Populate driver and executor tolerations from optional pod templates. This is an initial step narrowly focused on pod tolerations, to be followed by a more generic solution that handles all pod template functionality.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This change builds on optional Spark pod template changes added in https://github.com/flyteorg/flyteidl/pull/450. For now appends tolerations from the driver and executor pod templates, if any, to the defaults used to build the SparkApplicationSpec. A follow up PR will refactor the Spark plugin and pod_helper.go to reuse [ToK8sPodSpec](https://github.com/flyteorg/flyteplugins/blob/6048689ca61f318ba30ac3e0df8729918314035e/go/tasks/pluginmachinery/flytek8s/pod_helper.go#L258) in order to consume other aspect of pod templates, as is done for other plugins.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/4105