### PR TITLE
Moving from flyteplugins - Override Ray config with fields for namespace, service account, pod resources

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -33,6 +33,8 @@ import (
 
 const testImage = "image://"
 const serviceAccount = "ray_sa"
+const serviceAccountOverride = "ray_sa_override"
+const namespaceOverride = "ray_namespace_override"
 
 var (
 	dummyEnvVars = []*core.KeyValuePair{
@@ -41,6 +43,52 @@ var (
 
 	testArgs = []string{
 		"test-args",
+	}
+
+	headResourceOverride = core.Resources{
+		Requests: []*core.Resources_ResourceEntry{
+			{
+				Name:  core.Resources_CPU,
+				Value: "1000m",
+			},
+			{
+				Name:  core.Resources_MEMORY,
+				Value: "2Gi",
+			},
+		},
+		Limits: []*core.Resources_ResourceEntry{
+			{
+				Name:  core.Resources_CPU,
+				Value: "2000m",
+			},
+			{
+				Name:  core.Resources_MEMORY,
+				Value: "4Gi",
+			},
+		},
+	}
+
+	workerResourceOverride = core.Resources{
+		Requests: []*core.Resources_ResourceEntry{
+			{
+				Name:  core.Resources_CPU,
+				Value: "5",
+			},
+			{
+				Name:  core.Resources_MEMORY,
+				Value: "10G",
+			},
+		},
+		Limits: []*core.Resources_ResourceEntry{
+			{
+				Name:  core.Resources_CPU,
+				Value: "10",
+			},
+			{
+				Name:  core.Resources_MEMORY,
+				Value: "20G",
+			},
+		},
 	}
 
 	resourceRequirements = &corev1.ResourceRequirements{
@@ -64,6 +112,17 @@ func dummyRayCustomObj() *plugins.RayJob {
 		RayCluster: &plugins.RayCluster{
 			HeadGroupSpec:   &plugins.HeadGroupSpec{RayStartParams: map[string]string{"num-cpus": "1"}},
 			WorkerGroupSpec: []*plugins.WorkerGroupSpec{{GroupName: workerGroupName, Replicas: 3}},
+		},
+	}
+}
+
+func dummyRayCustomObjWithOverrides() *plugins.RayJob {
+	return &plugins.RayJob{
+		RayCluster: &plugins.RayCluster{
+			K8SServiceAccount: serviceAccountOverride,
+			Namespace: namespaceOverride,
+			HeadGroupSpec:   &plugins.HeadGroupSpec{RayStartParams: map[string]string{"num-cpus": "1"}, Resources: &headResourceOverride},
+			WorkerGroupSpec: []*plugins.WorkerGroupSpec{{GroupName: workerGroupName, Replicas: 3, Resources: &workerResourceOverride}},
 		},
 	}
 }
@@ -172,6 +231,7 @@ func TestBuildResourceRay(t *testing.T) {
 	assert.True(t, ok)
 
 	headReplica := int32(1)
+<<<<<<< HEAD
 	assert.Equal(t, ray.Spec.RayClusterSpec.HeadGroupSpec.Replicas, &headReplica)
 	assert.Equal(t, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.ServiceAccountName, serviceAccount)
 	assert.Equal(t, ray.Spec.RayClusterSpec.HeadGroupSpec.RayStartParams,
@@ -192,6 +252,72 @@ func TestBuildResourceRay(t *testing.T) {
 	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Annotations, map[string]string{"annotation-1": "val1"})
 	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Labels, map[string]string{"label-1": "val1"})
 	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Tolerations, toleration)
+=======
+	assert.Equal(t, &headReplica, ray.Spec.RayClusterSpec.HeadGroupSpec.Replicas)
+	assert.Equal(t, serviceAccount, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.ServiceAccountName)
+	assert.Equal(t, map[string]string{"dashboard-host": "0.0.0.0", "include-dashboard": "true", "node-ip-address": "$MY_POD_IP", "num-cpus": "1"},
+		ray.Spec.RayClusterSpec.HeadGroupSpec.RayStartParams)
+	assert.Equal(t, map[string]string{"annotation-1": "val1"}, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Annotations)
+	assert.Equal(t, map[string]string{"label-1": "val1"}, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Labels)
+	assert.Equal(t, toleration, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Tolerations)
+
+	workerReplica := int32(3)
+	assert.Equal(t, &workerReplica, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas)
+	assert.Equal(t, &workerReplica, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].MinReplicas)
+	assert.Equal(t, &workerReplica, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].MaxReplicas)
+	assert.Equal(t, workerGroupName, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName)
+	assert.Equal(t, serviceAccount, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.ServiceAccountName)
+	assert.Equal(t, map[string]string{"node-ip-address": "$MY_POD_IP"}, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].RayStartParams)
+	assert.Equal(t, map[string]string{"annotation-1": "val1"}, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Annotations)
+	assert.Equal(t, map[string]string{"label-1": "val1"}, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Labels)
+	assert.Equal(t, toleration, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Tolerations)
+}
+
+func TestBuildResourceRayWithOverrides(t *testing.T) {
+	rayJobResourceHandler := rayJobResourceHandler{}
+	taskTemplate := dummyRayTaskTemplate("ray-id", dummyRayCustomObjWithOverrides())
+	expectedHeadResources, _ := flytek8s.ToK8sResourceRequirements(&headResourceOverride)
+	expectedWorkerResources, _ := flytek8s.ToK8sResourceRequirements(&workerResourceOverride)
+	toleration := []corev1.Toleration{{
+		Key:      "storage",
+		Value:    "dedicated",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}}
+	err := config.SetK8sPluginConfig(&config.K8sPluginConfig{DefaultTolerations: toleration})
+	assert.Nil(t, err)
+
+	RayResource, err := rayJobResourceHandler.BuildResource(context.TODO(), dummyRayTaskContext(taskTemplate))
+	assert.Nil(t, err)
+
+	assert.NotNil(t, RayResource)
+	ray, ok := RayResource.(*rayv1alpha1.RayJob)
+	assert.True(t, ok)
+
+	headReplica := int32(1)
+	assert.Equal(t, namespaceOverride, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.ObjectMeta.Namespace)
+	assert.Equal(t, &headReplica, ray.Spec.RayClusterSpec.HeadGroupSpec.Replicas)
+	assert.Equal(t, serviceAccountOverride, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.ServiceAccountName)
+	assert.Equal(t, map[string]string{"dashboard-host": "0.0.0.0", "include-dashboard": "true", "node-ip-address": "$MY_POD_IP", "num-cpus": "1"},
+		ray.Spec.RayClusterSpec.HeadGroupSpec.RayStartParams)
+	assert.Equal(t, map[string]string{"annotation-1": "val1"}, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Annotations)
+	assert.Equal(t, map[string]string{"label-1": "val1"}, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Labels)
+	assert.Equal(t, toleration, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Tolerations)
+	assert.Equal(t, *expectedHeadResources, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources)
+
+	workerReplica := int32(3)
+	assert.Equal(t, namespaceOverride, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.ObjectMeta.Namespace)
+	assert.Equal(t, &workerReplica, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas)
+	assert.Equal(t, &workerReplica, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].MinReplicas)
+	assert.Equal(t, &workerReplica, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].MaxReplicas)
+	assert.Equal(t, workerGroupName, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName)
+	assert.Equal(t, serviceAccountOverride, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.ServiceAccountName)
+	assert.Equal(t, map[string]string{"node-ip-address": "$MY_POD_IP"}, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].RayStartParams)
+	assert.Equal(t, map[string]string{"annotation-1": "val1"}, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Annotations)
+	assert.Equal(t, map[string]string{"label-1": "val1"}, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Labels)
+	assert.Equal(t, toleration, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Tolerations)
+	assert.Equal(t, *expectedWorkerResources, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources)
+>>>>>>> flyteplugins/add-ray-head-worker-resources
 }
 
 func TestDefaultStartParameters(t *testing.T) {


### PR DESCRIPTION
As per our conversation with the Union AI, we are making the following changes to the Ray plugin to enable more parameters to be configurable on the user side using flytekit SDK.

see:  https://github.com/flyteorg/flyteidl/pull/429

_- Use #patch, #minor or #major in the pull-request title to bump the corresponding version. Otherwise, the patch version
will be bumped. [More details](https://github.com/marketplace/actions/github-tag-bump)_

# TL;DR
_Please replace this text with a description of what this PR accomplishes._

## Type
 - [ ] Bug Fix
 - [x ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_