### PR TITLE
Moving from flytepropeller - Add support namespace override

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -105,7 +105,8 @@ func (e *PluginManager) addObjectMetadata(taskCtx pluginsCore.TaskExecutionMetad
 	o.SetLabels(pluginsUtils.UnionMaps(cfg.DefaultLabels, o.GetLabels(), pluginsUtils.CopyMap(taskCtx.GetLabels())))
 	o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
 
-	if !e.plugin.GetProperties().DisableInjectOwnerReferences {
+	// Cross-namespace owner references are disallowed in Kubernetes
+	if o.GetNamespace() == taskCtx.GetNamespace() && !e.plugin.GetProperties().DisableInjectOwnerReferences {
 		o.SetOwnerReferences([]metav1.OwnerReference{taskCtx.GetOwnerReference()})
 	}
 

--- a/flytepropeller/pkg/controller/nodes/task/k8s/task_exec_context.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/task_exec_context.go
@@ -31,6 +31,7 @@ type TaskExecutionMetadata struct {
 
 	annotations map[string]string
 	labels      map[string]string
+	namespace   string
 }
 
 func (t TaskExecutionMetadata) GetLabels() map[string]string {
@@ -39,6 +40,10 @@ func (t TaskExecutionMetadata) GetLabels() map[string]string {
 
 func (t TaskExecutionMetadata) GetAnnotations() map[string]string {
 	return t.annotations
+}
+
+func (t TaskExecutionMetadata) GetNamespace() string {
+	return t.namespace
 }
 
 // newTaskExecutionMetadata creates a TaskExecutionMetadata with secrets serialized as annotations and a label added
@@ -57,10 +62,15 @@ func newTaskExecutionMetadata(tCtx pluginsCore.TaskExecutionMetadata, taskTmpl *
 			secrets.PodLabel: secrets.PodLabelValue,
 		}
 	}
+	namespace := tCtx.GetNamespace()
+	if len(taskTmpl.Metadata.Namespace) > 0 {
+		namespace = taskTmpl.Metadata.Namespace
+	}
 
 	return TaskExecutionMetadata{
 		TaskExecutionMetadata: tCtx,
 		annotations:           utils.UnionMaps(tCtx.GetAnnotations(), secretsMap),
 		labels:                utils.UnionMaps(tCtx.GetLabels(), injectSecretsLabel),
+		namespace:             namespace,
 	}, nil
 }


### PR DESCRIPTION
# TL;DR
- Instead of setting the namespace for the k8s resource every time, we set it only when the k8s resource's namespace is None
- Only add an owner reference if the task's namespace matches the Flyteworkflow's.
https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owner-references-in-object-specifications

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3898

## Follow-up issue
_NA_