### PR TITLE
Moving from flytepropeller - Parallelize Node Evaluations

### DIFF
--- a/flytepropeller/pkg/controller/executors/execution_context.go
+++ b/flytepropeller/pkg/controller/executors/execution_context.go
@@ -1,7 +1,12 @@
 package executors
 
 import (
+<<<<<<< HEAD
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
+=======
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
+>>>>>>> flytepropeller/feature/parallel-node-executions
 )
 
 // go:generate mockery -case=underscore
@@ -35,12 +40,18 @@ type ControlFlow interface {
 	IncrementParallelism() uint32
 }
 
+type NodeExecutor interface {
+	AddNodeFuture(func(chan<- NodeExecutionResult))
+	Wait() (NodeStatus, error)
+}
+
 type ExecutionContext interface {
 	ImmutableExecutionContext
 	TaskDetailsGetter
 	SubWorkflowGetter
 	ParentInfoGetter
 	ControlFlow
+	NodeExecutor
 }
 
 type execContext struct {
@@ -49,6 +60,7 @@ type execContext struct {
 	TaskDetailsGetter
 	SubWorkflowGetter
 	parentInfo ImmutableParentInfo
+	NodeExecutor
 }
 
 func (e execContext) GetParentInfo() ImmutableParentInfo {
@@ -83,6 +95,82 @@ func (c *controlFlow) IncrementParallelism() uint32 {
 	return c.v
 }
 
+type NodeExecutionResult struct {
+	Err        error
+	NodeStatus NodeStatus
+}
+
+type nodeExecutor struct {
+	nodeFutures []<-chan NodeExecutionResult
+}
+
+func (n *nodeExecutor) AddNodeFuture(f func(chan<- NodeExecutionResult)) {
+	nodeFuture := make(chan NodeExecutionResult, 1)
+	go f(nodeFuture)
+	n.nodeFutures = append(n.nodeFutures, nodeFuture)
+}
+
+func (n *nodeExecutor) Wait() (NodeStatus, error) {
+	if len(n.nodeFutures) == 0 {
+		return NodeStatusComplete, nil
+	}
+
+	// If any downstream node is failed, fail, all
+	// Else if all are success then success
+	// Else if any one is running then Downstream is still running
+	allCompleted := true
+	partialNodeCompletion := false
+	onFailurePolicy := v1alpha1.WorkflowOnFailurePolicy(core.WorkflowMetadata_FAIL_IMMEDIATELY)
+	//onFailurePolicy := execContext.GetOnFailurePolicy() // TODO @hamersaw - need access to this
+	stateOnComplete := NodeStatusComplete
+	for _, nodeFuture := range n.nodeFutures {
+		nodeExecutionResult := <-nodeFuture
+		state := nodeExecutionResult.NodeStatus
+		err := nodeExecutionResult.Err
+		if err != nil { // TODO @hamersaw - do we want to fail right away? or wait until all nodes are done?
+			return NodeStatusUndefined, err
+		}
+
+		if state.HasFailed() || state.HasTimedOut() {
+			// TODO @hamersaw - Debug?
+			//logger.Debugf(ctx, "Some downstream node has failed. Failed: [%v]. TimedOut: [%v]. Error: [%s]", state.HasFailed(), state.HasTimedOut(), state.Err)
+			if onFailurePolicy == v1alpha1.WorkflowOnFailurePolicy(core.WorkflowMetadata_FAIL_AFTER_EXECUTABLE_NODES_COMPLETE) {
+				// If the failure policy allows other nodes to continue running, do not exit the loop,
+				// Keep track of the last failed state in the loop since it'll be the one to return.
+				// TODO: If multiple nodes fail (which this mode allows), consolidate/summarize failure states in one.
+				stateOnComplete = state
+			} else {
+				return state, nil
+			}
+		} else if !state.IsComplete() {
+			// A Failed/Timedout node is implicitly considered "complete" this means none of the downstream nodes from
+			// that node will ever be allowed to run.
+			// This else block, therefore, deals with all other states. IsComplete will return true if and only if this
+			// node as well as all of its downstream nodes have finished executing with success statuses. Otherwise we
+			// mark this node's state as not completed to ensure we will visit it again later.
+			allCompleted = false
+		}
+
+		if state.PartiallyComplete() {
+			// This implies that one of the downstream nodes has just succeeded and workflow is ready for propagation
+			// We do not propagate in current cycle to make it possible to store the state between transitions
+			partialNodeCompletion = true
+		}
+	}
+
+	if allCompleted {
+		// TODO @hamersaw - Debug?
+		//logger.Debugf(ctx, "All downstream nodes completed")
+		return stateOnComplete, nil
+	}
+
+	if partialNodeCompletion {
+		return NodeStatusSuccess, nil
+	}
+
+	return NodeStatusPending, nil
+}
+
 func NewExecutionContextWithTasksGetter(prevExecContext ExecutionContext, taskGetter TaskDetailsGetter) ExecutionContext {
 	return NewExecutionContext(prevExecContext, taskGetter, prevExecContext, prevExecContext.GetParentInfo(), prevExecContext)
 }
@@ -102,6 +190,7 @@ func NewExecutionContext(immExecContext ImmutableExecutionContext, tasksGetter T
 		SubWorkflowGetter:         workflowGetter,
 		parentInfo:                parentInfo,
 		ControlFlow:               flow,
+		NodeExecutor:              &nodeExecutor{},
 	}
 }
 

--- a/flytepropeller/pkg/controller/nodes/branch/handler.go
+++ b/flytepropeller/pkg/controller/nodes/branch/handler.go
@@ -147,7 +147,10 @@ func (b *branchHandler) recurseDownstream(ctx context.Context, nCtx interfaces.N
 	if err != nil {
 		return handler.UnknownTransition, err
 	}
-	downstreamStatus, err := b.nodeExecutor.RecursiveNodeHandler(ctx, execContext, dag, nCtx.ContextualNodeLookup(), branchTakenNode)
+	if err := b.nodeExecutor.RecursiveNodeHandler(ctx, execContext, dag, nCtx.ContextualNodeLookup(), branchTakenNode); err != nil {
+		return handler.UnknownTransition, err
+	}
+	downstreamStatus, err := execContext.Wait()
 	if err != nil {
 		return handler.UnknownTransition, err
 	}

--- a/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go
@@ -267,7 +267,10 @@ func (d dynamicNodeTaskNodeHandler) buildDynamicWorkflow(ctx context.Context, nC
 func (d dynamicNodeTaskNodeHandler) progressDynamicWorkflow(ctx context.Context, execContext executors.ExecutionContext, dynamicWorkflow v1alpha1.ExecutableWorkflow, nl executors.NodeLookup,
 	nCtx interfaces.NodeExecutionContext, prevState handler.DynamicNodeState) (handler.Transition, handler.DynamicNodeState, error) {
 
-	state, err := d.nodeExecutor.RecursiveNodeHandler(ctx, execContext, dynamicWorkflow, nl, dynamicWorkflow.StartNode())
+	if err := d.nodeExecutor.RecursiveNodeHandler(ctx, execContext, dynamicWorkflow, nl, dynamicWorkflow.StartNode()); err != nil {
+		return handler.UnknownTransition, prevState, err
+	}
+	state, err := execContext.Wait()
 	if err != nil {
 		return handler.UnknownTransition, prevState, err
 	}

--- a/flytepropeller/pkg/controller/nodes/interfaces/node.go
+++ b/flytepropeller/pkg/controller/nodes/interfaces/node.go
@@ -76,8 +76,12 @@ type Node interface {
 	// - 1. It finds a blocking node (not ready, or running)
 	// - 2. A node fails and hence the workflow will fail
 	// - 3. The final/end node has completed and the workflow should be stopped
+<<<<<<< HEAD:flytepropeller/pkg/controller/nodes/interfaces/node.go
 	RecursiveNodeHandler(ctx context.Context, execContext executors.ExecutionContext, dag executors.DAGStructure,
 		nl executors.NodeLookup, currentNode v1alpha1.ExecutableNode) (NodeStatus, error)
+=======
+	RecursiveNodeHandler(ctx context.Context, execContext ExecutionContext, dag DAGStructure, nl NodeLookup, currentNode v1alpha1.ExecutableNode) error
+>>>>>>> flytepropeller/feature/parallel-node-executions:flytepropeller/pkg/controller/executors/node.go
 
 	// This aborts the given node. If the given node is complete then it recursively finds the running nodes and aborts them
 	AbortHandler(ctx context.Context, execContext executors.ExecutionContext, dag executors.DAGStructure,

--- a/flytepropeller/pkg/controller/nodes/subworkflow/subworkflow.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/subworkflow.go
@@ -71,7 +71,10 @@ func (s *subworkflowHandler) handleSubWorkflow(ctx context.Context, nCtx interfa
 		return handler.UnknownTransition, err
 	}
 	execContext := executors.NewExecutionContextWithParentInfo(nCtx.ExecutionContext(), newParentInfo)
-	state, err := s.nodeExecutor.RecursiveNodeHandler(ctx, execContext, subworkflow, nl, subworkflow.StartNode())
+	if err := s.nodeExecutor.RecursiveNodeHandler(ctx, execContext, subworkflow, nl, subworkflow.StartNode()); err != nil {
+		return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoUndefined), err
+	}
+	state, err := execContext.Wait()
 	if err != nil {
 		return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoUndefined), err
 	}
@@ -150,7 +153,10 @@ func (s *subworkflowHandler) HandleFailureNodeOfSubWorkflow(ctx context.Context,
 		if err != nil {
 			return handler.UnknownTransition, err
 		}
-		state, err := s.nodeExecutor.RecursiveNodeHandler(ctx, execContext, subworkflow, nl, subworkflow.GetOnFailureNode())
+		if err := s.nodeExecutor.RecursiveNodeHandler(ctx, execContext, subworkflow, nl, subworkflow.GetOnFailureNode()); err != nil {
+			return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoUndefined), err
+		}
+		state, err := execContext.Wait()
 		if err != nil {
 			return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoUndefined), err
 		}

--- a/flytepropeller/pkg/controller/workflow/executor.go
+++ b/flytepropeller/pkg/controller/workflow/executor.go
@@ -146,7 +146,11 @@ func (c *workflowExecutor) handleRunningWorkflow(ctx context.Context, w *v1alpha
 			Message: "Start node not found"}), nil
 	}
 	execcontext := executors.NewExecutionContext(w, w, w, nil, executors.InitializeControlFlow())
-	state, err := c.nodeExecutor.RecursiveNodeHandler(ctx, execcontext, w, w, startNode)
+	err := c.nodeExecutor.RecursiveNodeHandler(ctx, execcontext, w, w, startNode)
+	if err != nil {
+		return StatusRunning, err
+	}
+	state, err := execcontext.Wait()
 	if err != nil {
 		return StatusRunning, err
 	}
@@ -173,7 +177,10 @@ func (c *workflowExecutor) handleFailureNode(ctx context.Context, w *v1alpha1.Fl
 	execErr := executionErrorOrDefault(w.GetExecutionStatus().GetExecutionError(), w.GetExecutionStatus().GetMessage())
 	errorNode := w.GetOnFailureNode()
 	execcontext := executors.NewExecutionContext(w, w, w, nil, executors.InitializeControlFlow())
-	state, err := c.nodeExecutor.RecursiveNodeHandler(ctx, execcontext, w, w, errorNode)
+	if err := c.nodeExecutor.RecursiveNodeHandler(ctx, execcontext, w, w, errorNode); err != nil {
+		return StatusFailureNode(execErr), err
+	}
+	state, err := execcontext.Wait()
 	if err != nil {
 		return StatusFailureNode(execErr), err
 	}


### PR DESCRIPTION
# TL;DR
This PR parallelizes node evaluations by using go channels to call the `handleNode` function in a separate go routine and then waiting on all evaluations before compiling overall workflow status.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3866

## Follow-up issue
_NA_