### PR TITLE
Add KeepAliveParameters to agent client

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/io/mocks/output_reader.go
+++ b/flyteplugins/go/tasks/pluginmachinery/io/mocks/output_reader.go
@@ -5,8 +5,8 @@ package mocks
 import (
 	context "context"
 
-	core "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	io "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
+	core "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/flyteplugins/go/tasks/plugins/webapi/agent/config_test.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/config_test.go
@@ -27,6 +27,11 @@ func TestGetAndSetConfig(t *testing.T) {
 		},
 	}
 	cfg.DefaultAgent.DefaultTimeout = config.Duration{Duration: 10 * time.Second}
+	cfg.DefaultAgent.KeepAliveParameters = &KeepAliveParameters{
+		Time:                config.Duration{Duration: 10 * time.Second},
+		Timeout:             config.Duration{Duration: 5 * time.Second},
+		PermitWithoutStream: true,
+	}
 	cfg.Agents = map[string]*Agent{
 		"agent_1": {
 			Insecure:             cfg.DefaultAgent.Insecure,

--- a/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
@@ -5,13 +5,12 @@ import (
 	"crypto/x509"
 	"encoding/gob"
 	"fmt"
-
 	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/keepalive"
 
 	pluginErrors "github.com/flyteorg/flyte/flyteplugins/go/tasks/errors"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery"
@@ -245,6 +244,15 @@ func getClientFunc(ctx context.Context, agent *Agent, connectionCache map[*Agent
 
 	if len(agent.DefaultServiceConfig) != 0 {
 		opts = append(opts, grpc.WithDefaultServiceConfig(agent.DefaultServiceConfig))
+	}
+
+	if agent.KeepAliveParameters != nil {
+
+		opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                agent.KeepAliveParameters.Time.Duration,
+			Timeout:             agent.KeepAliveParameters.Timeout.Duration,
+			PermitWithoutStream: agent.KeepAliveParameters.PermitWithoutStream,
+		}))
 	}
 
 	var err error

--- a/flyteplugins/go/tasks/plugins/webapi/agent/plugin_test.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/plugin_test.go
@@ -65,7 +65,12 @@ func TestPlugin(t *testing.T) {
 	})
 
 	t.Run("test getClientFunc more config", func(t *testing.T) {
-		client, err := getClientFunc(context.Background(), &Agent{Endpoint: "localhost:80", Insecure: true, DefaultServiceConfig: "{\"loadBalancingConfig\": [{\"round_robin\":{}}]}"}, map[*Agent]*grpc.ClientConn{})
+		client, err := getClientFunc(context.Background(), &Agent{
+			Endpoint:             "localhost:80",
+			Insecure:             true,
+			DefaultServiceConfig: "{\"loadBalancingConfig\": [{\"round_robin\":{}}]}",
+			KeepAliveParameters:  &KeepAliveParameters{Time: config.Duration{Duration: 10 * time.Second}}},
+			map[*Agent]*grpc.ClientConn{})
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
 	})


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Describe your changes
Agents use headless services to balance client load. However, If [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) is used, propeller needs to be restarted to get a new set of IP addresses.

We could add `KeepAliveParameters` to gRPC client, so that propeller can get a new set of IPs every 10s by default.

- https://discuss.kubernetes.io/t/how-to-do-load-balance-with-grpc-connection-when-hpa-autoscaling-is-enabled/16612

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
