### PR TITLE
Add Additional gRPC service handler hook

### DIFF
--- a/flyteadmin/pkg/common/service.go
+++ b/flyteadmin/pkg/common/service.go
@@ -1,0 +1,11 @@
+package common
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+// RegisterAdditionalGRPCService is the interface for the plugin hook for additional GRPC service handlers which
+// should be also served on the flyteadmin gRPC server.
+type RegisterAdditionalGRPCService = func(ctx context.Context, grpcServer *grpc.Server) error

--- a/flyteadmin/pkg/server/service.go
+++ b/flyteadmin/pkg/server/service.go
@@ -130,6 +130,13 @@ func newGRPCServer(ctx context.Context, pluginRegistry *plugins.Registry, cfg *c
 
 	service.RegisterSignalServiceServer(grpcServer, rpc.NewSignalServer(ctx, configuration, scope.NewSubScope("signal")))
 
+	additionalService := plugins.Get[common.RegisterAdditionalGRPCService](pluginRegistry, plugins.PluginIDAdditionalGRPCService)
+	if additionalService != nil {
+		if err := additionalService(ctx, grpcServer); err != nil {
+			return nil, err
+		}
+	}
+
 	healthServer := health.NewServer()
 	healthServer.SetServingStatus("flyteadmin", grpc_health_v1.HealthCheckResponse_SERVING)
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)

--- a/flyteadmin/plugins/registry.go
+++ b/flyteadmin/plugins/registry.go
@@ -14,6 +14,7 @@ const (
 	PluginIDUnaryServiceMiddleware PluginID = "UnaryServiceMiddleware"
 	PluginIDPreRedirectHook        PluginID = "PreRedirectHook"
 	PluginIDLogoutHook             PluginID = "LogoutHook"
+	PluginIDAdditionalGRPCService  PluginID = "AdditionalGRPCService"
 )
 
 type AtomicRegistry struct {


### PR DESCRIPTION
## Describe your changes

Extends the plugin registry with a configurable gPRC service handler hook to serve additional endpoints on the flyteadmin gRPC server.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
