### PR TITLE
Fix databricks plugin

### DIFF
--- a/flyteplugins/go/tasks/plugins/webapi/databricks/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/databricks/plugin.go
@@ -228,7 +228,7 @@ func (p Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phase
 	case http.StatusAccepted:
 		return core.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion, taskInfo), nil
 	case http.StatusOK:
-		if lifeCycleState == "TERMINATED" {
+		if lifeCycleState == "TERMINATED" || lifeCycleState == "SKIPPED" || lifeCycleState == "INTERNAL_ERROR" {
 			if resultState == "SUCCESS" {
 				if err := writeOutput(ctx, taskCtx); err != nil {
 					pluginsCore.PhaseInfoFailure(string(rune(statusCode)), "failed to write output", taskInfo)

--- a/flyteplugins/go/tasks/plugins/webapi/databricks/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/databricks/plugin.go
@@ -144,7 +144,7 @@ func (p Plugin) Create(ctx context.Context, taskCtx webapi.TaskExecutionContextR
 		return nil, nil, pluginErrors.Wrapf(pluginErrors.RuntimeFailure, err,
 			"Unable to fetch statementHandle from http response")
 	}
-	runID := fmt.Sprintf("%v", data["run_id"])
+	runID := fmt.Sprintf("%.0f", data["run_id"])
 
 	return ResourceMetaWrapper{runID, p.cfg.DatabricksInstance, token},
 		ResourceWrapper{StatusCode: resp.StatusCode}, nil

--- a/flyteplugins/go/tasks/plugins/webapi/databricks/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/databricks/plugin.go
@@ -152,13 +152,17 @@ func (p Plugin) Create(ctx context.Context, taskCtx webapi.TaskExecutionContextR
 
 func (p Plugin) Get(ctx context.Context, taskCtx webapi.GetContext) (latest webapi.Resource, err error) {
 	exec := taskCtx.ResourceMeta().(ResourceMetaWrapper)
+	logger.Info(ctx, "Get databricks job status", "runID", exec.RunID)
+	logger.Info(ctx, "Get databricks job token", "token", exec.Token)
 	req, err := buildRequest(get, nil, p.cfg.databricksEndpoint,
 		p.cfg.DatabricksInstance, exec.Token, exec.RunID, false)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to build databricks job request [%v]", err)
 		return nil, err
 	}
+	logger.Info(ctx, "Get databricks job request", "req", req)
 	resp, err := p.client.Do(req)
+	logger.Info(ctx, "Get databricks job response", "resp", resp)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to get databricks job status [%v]", resp)
 		return nil, err

--- a/flyteplugins/go/tasks/plugins/webapi/databricks/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/databricks/plugin.go
@@ -152,17 +152,14 @@ func (p Plugin) Create(ctx context.Context, taskCtx webapi.TaskExecutionContextR
 
 func (p Plugin) Get(ctx context.Context, taskCtx webapi.GetContext) (latest webapi.Resource, err error) {
 	exec := taskCtx.ResourceMeta().(ResourceMetaWrapper)
-	logger.Info(ctx, "Get databricks job status", "runID", exec.RunID)
-	logger.Info(ctx, "Get databricks job token", "token", exec.Token)
 	req, err := buildRequest(get, nil, p.cfg.databricksEndpoint,
 		p.cfg.DatabricksInstance, exec.Token, exec.RunID, false)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to build databricks job request [%v]", err)
 		return nil, err
 	}
-	logger.Info(ctx, "Get databricks job request", "req", req)
 	resp, err := p.client.Do(req)
-	logger.Info(ctx, "Get databricks job response", "resp", resp)
+	logger.Debugf(ctx, "Get databricks job response", "resp", resp)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to get databricks job status [%v]", resp)
 		return nil, err


### PR DESCRIPTION
## Tracking issue
The databricks plugin does not check for all possible terminal states as returned from the Databricks Jobs API. As a result, if the Databricks jobs API returns a state which the plugin is not written to recognise, the plugin will think that the job is still in a running phase.

https://github.com/flyteorg/flyte/issues/4243

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Describe your changes
Transition task status to `Failure` if the lifeCycleState is `SKIPPED` or `INTERNAL_ERROR`

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
