### PR TITLE
Allow specifying default cluster pool assignments in admin config

### DIFF
--- a/charts/flyte-core/templates/admin/configmap.yaml
+++ b/charts/flyte-core/templates/admin/configmap.yaml
@@ -37,6 +37,9 @@ data:
 {{- with .Values.configmap.namespace_config }}
   namespace_config.yaml: | {{ toYaml . | nindent 4 }}
 {{- end }}
+  {{- with .Values.configmap.clusterpool_config }}
+  clusterpool_config.yaml: | {{ toYaml . | nindent 4 }}
+{{- end }}
   storage.yaml: | {{ tpl (include "storage" .) $ | nindent 4 }}
 {{- with .Values.configmap.task_resource_defaults }}
   task_resource_defaults.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}


### PR DESCRIPTION
## Tracking issue

N/A

## Describe your changes
Allows specifying cluster pools in helm chart. Change added in flyteadmin here: https://github.com/flyteorg/flyte/commit/07ff7305fcc104d341e5ccf2fe73e7b668b57a38

Tested by setting
```
clusterpool_config:
  clusterPools:
    clusterPoolAssignments:
      development:
        pool: pool1
```

in values.yaml and asserting that generated helm chart changes rendered:
```
+  clusterpool_config.yaml: | 
+    clusterPools:
+      clusterPoolAssignments:
+        development:
+          pool: pool1
````

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
