### PR TITLE
Add gh workflow to publish flyteidl release to PyPI and npm

### DIFF
--- a/.github/workflows/flyteidl-release.yml
+++ b/.github/workflows/flyteidl-release.yml
@@ -1,0 +1,51 @@
+name: Upload flyteidl to PyPI and npm
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: flyteidl
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Autobump version
+        run: |
+          # from refs/tags/v1.2.3 get 1.2.3
+          VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
+          VERSION=$VERSION make -C flyteidl update_pyversion
+        shell: bash
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Autobump version
+        run: |
+          # from refs/tags/v1.2.3 get 1.2.3
+          VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
+          VERSION=$VERSION make update_npmversion
+        shell: bash
+      - run: |
+          npm install
+      - run: |
+          npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/script/release.sh
+++ b/script/release.sh
@@ -6,7 +6,7 @@ set -ex
 # TODO(monorepo): This only works if we have at least one component tag per release.
 #                 In other words, if we have two consecutive releases the latest tag in the second release is going to point to an invalid
 #                 tag (because there will not be images tagged with the previous release tag).
-LATEST_TAG=$(git tag | sed 's#[^/]*/##' | sort | tail -n 1)
+LATEST_TAG=$(git tag | sed 's#[^/]*/##' | sort --version-sort | tail -n1)
 FLYTEKIT_TAG=$(curl --silent "https://api.github.com/repos/flyteorg/flytekit/releases/latest" | jq -r .tag_name | sed 's/^v//')
 FLYTECONSOLE_TAG=$(curl --silent "https://api.github.com/repos/flyteorg/flyteconsole/releases/latest" | jq -r .tag_name)
 


### PR DESCRIPTION
## Describe your changes

This PR adds a github workflow to publish flyteidl to PyPI and npm, those were moved from their original places in the flyteidl repo (https://github.com/flyteorg/flyteidl/blob/master/.github/workflows/pythonpublish.yaml and https://github.com/flyteorg/flyteidl/blob/master/.github/workflows/npmpublish.yaml). 

I also fixed the way we're pulling the latest tag to be used in the release. The `--version-sort` instructs `sort` to use semantic versions. 

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
