### PR TITLE
Revert "[Monorepo] Enable proxy-authorization in admin client (#4189)"

### DIFF
--- a/flyteidl/clients/go/admin/auth_interceptor_test.go
+++ b/flyteidl/clients/go/admin/auth_interceptor_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -115,8 +114,7 @@ func newAuthMetadataServer(t testing.TB, port int, impl service.AuthMetadataServ
 func Test_newAuthInterceptor(t *testing.T) {
 	t.Run("Other Error", func(t *testing.T) {
 		f := NewPerRPCCredentialsFuture()
-		p := NewPerRPCCredentialsFuture()
-		interceptor := NewAuthInterceptor(&Config{}, &mocks.TokenCache{}, f, p)
+		interceptor := NewAuthInterceptor(&Config{}, &mocks.TokenCache{}, f)
 		otherError := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			return status.New(codes.Canceled, "").Err()
 		}
@@ -148,12 +146,11 @@ func Test_newAuthInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		f := NewPerRPCCredentialsFuture()
-		p := NewPerRPCCredentialsFuture()
 		interceptor := NewAuthInterceptor(&Config{
 			Endpoint:              config.URL{URL: *u},
 			UseInsecureConnection: true,
 			AuthType:              AuthTypeClientSecret,
-		}, &mocks.TokenCache{}, f, p)
+		}, &mocks.TokenCache{}, f)
 		unauthenticated := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			return status.New(codes.Unauthenticated, "").Err()
 		}
@@ -180,13 +177,11 @@ func Test_newAuthInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		f := NewPerRPCCredentialsFuture()
-		p := NewPerRPCCredentialsFuture()
-
 		interceptor := NewAuthInterceptor(&Config{
 			Endpoint:              config.URL{URL: *u},
 			UseInsecureConnection: true,
 			AuthType:              AuthTypeClientSecret,
-		}, &mocks.TokenCache{}, f, p)
+		}, &mocks.TokenCache{}, f)
 		authenticated := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			return nil
 		}
@@ -221,13 +216,11 @@ func Test_newAuthInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		f := NewPerRPCCredentialsFuture()
-		p := NewPerRPCCredentialsFuture()
-
 		interceptor := NewAuthInterceptor(&Config{
 			Endpoint:              config.URL{URL: *u},
 			UseInsecureConnection: true,
 			AuthType:              AuthTypeClientSecret,
-		}, &mocks.TokenCache{}, f, p)
+		}, &mocks.TokenCache{}, f)
 		unauthenticated := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			return status.New(codes.Aborted, "").Err()
 		}
@@ -253,8 +246,6 @@ func TestMaterializeCredentials(t *testing.T) {
 		assert.NoError(t, err)
 
 		f := NewPerRPCCredentialsFuture()
-		p := NewPerRPCCredentialsFuture()
-
 		err = MaterializeCredentials(ctx, &Config{
 			Endpoint:              config.URL{URL: *u},
 			UseInsecureConnection: true,
@@ -263,7 +254,7 @@ func TestMaterializeCredentials(t *testing.T) {
 			Scopes:                []string{"all"},
 			Audience:              "http://localhost:30081",
 			AuthorizationHeader:   "authorization",
-		}, &mocks.TokenCache{}, f, p)
+		}, &mocks.TokenCache{}, f)
 		assert.NoError(t, err)
 	})
 	t.Run("Failed to fetch client metadata", func(t *testing.T) {
@@ -280,119 +271,13 @@ func TestMaterializeCredentials(t *testing.T) {
 		assert.NoError(t, err)
 
 		f := NewPerRPCCredentialsFuture()
-		p := NewPerRPCCredentialsFuture()
-
 		err = MaterializeCredentials(ctx, &Config{
 			Endpoint:              config.URL{URL: *u},
 			UseInsecureConnection: true,
 			AuthType:              AuthTypeClientSecret,
 			TokenURL:              fmt.Sprintf("http://localhost:%d/api/v1/token", port),
 			Scopes:                []string{"all"},
-		}, &mocks.TokenCache{}, f, p)
+		}, &mocks.TokenCache{}, f)
 		assert.EqualError(t, err, "failed to fetch client metadata. Error: rpc error: code = Unknown desc = expected err")
-	})
-}
-
-func TestNewProxyAuthInterceptor(t *testing.T) {
-	cfg := &Config{
-		ProxyCommand: []string{"echo", "test-token"},
-	}
-
-	p := NewPerRPCCredentialsFuture()
-
-	interceptor := NewProxyAuthInterceptor(cfg, p)
-
-	ctx := context.Background()
-	method := "/test.method"
-	req := "request"
-	reply := "reply"
-	cc := new(grpc.ClientConn)
-
-	errorInvoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
-		return errors.New("test error")
-	}
-
-	// Call should return an error and trigger the interceptor to materialize proxy auth credentials
-	err := interceptor(ctx, method, req, reply, cc, errorInvoker)
-	assert.Error(t, err)
-
-	// Check if proxyCredentialsFuture contains a proxy auth header token
-	creds, err := p.Get().GetRequestMetadata(ctx, "")
-	assert.True(t, p.IsInitialized())
-	assert.NoError(t, err)
-	assert.Equal(t, "Bearer test-token", creds[ProxyAuthorizationHeader])
-}
-
-type testRoundTripper struct {
-	RoundTripFunc func(req *http.Request) (*http.Response, error)
-}
-
-func (t *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	return t.RoundTripFunc(req)
-}
-
-func TestSetHTTPClientContext(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("no proxy command and no proxy url", func(t *testing.T) {
-		cfg := &Config{}
-
-		newCtx := setHTTPClientContext(ctx, cfg, nil)
-
-		httpClient, ok := newCtx.Value(oauth2.HTTPClient).(*http.Client)
-		assert.True(t, ok)
-
-		transport, ok := httpClient.Transport.(*http.Transport)
-		assert.True(t, ok)
-		assert.Nil(t, transport.Proxy)
-	})
-
-	t.Run("proxy url", func(t *testing.T) {
-		cfg := &Config{
-			HTTPProxyURL: config.
-				URL{URL: url.URL{
-				Scheme: "http",
-				Host:   "localhost:8080",
-			}},
-		}
-		newCtx := setHTTPClientContext(ctx, cfg, nil)
-
-		httpClient, ok := newCtx.Value(oauth2.HTTPClient).(*http.Client)
-		assert.True(t, ok)
-
-		transport, ok := httpClient.Transport.(*http.Transport)
-		assert.True(t, ok)
-		assert.NotNil(t, transport.Proxy)
-	})
-
-	t.Run("proxy command adds proxy-authorization header", func(t *testing.T) {
-		cfg := &Config{
-			ProxyCommand: []string{"echo", "test-token-http-client"},
-		}
-
-		p := NewPerRPCCredentialsFuture()
-		err := MaterializeProxyAuthCredentials(ctx, cfg, p)
-		assert.NoError(t, err)
-
-		newCtx := setHTTPClientContext(ctx, cfg, p)
-
-		httpClient, ok := newCtx.Value(oauth2.HTTPClient).(*http.Client)
-		assert.True(t, ok)
-
-		pat, ok := httpClient.Transport.(*proxyAuthTransport)
-		assert.True(t, ok)
-
-		testRoundTripper := &testRoundTripper{
-			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
-				// Check if the ProxyAuthorizationHeader is correctly set
-				assert.Equal(t, "Bearer test-token-http-client", req.Header.Get(ProxyAuthorizationHeader))
-				return &http.Response{StatusCode: http.StatusOK}, nil
-			},
-		}
-		pat.transport = testRoundTripper
-
-		req, _ := http.NewRequest("GET", "http://example.com", nil)
-		_, err = httpClient.Do(req)
-		assert.NoError(t, err)
 	})
 }

--- a/flyteidl/clients/go/admin/client.go
+++ b/flyteidl/clients/go/admin/client.go
@@ -110,9 +110,9 @@ func getAuthenticationDialOption(ctx context.Context, cfg *Config, tokenSourcePr
 }
 
 // InitializeAuthMetadataClient creates a new anonymously Auth Metadata Service client.
-func InitializeAuthMetadataClient(ctx context.Context, cfg *Config, proxyCredentialsFuture *PerRPCCredentialsFuture) (client service.AuthMetadataServiceClient, err error) {
+func InitializeAuthMetadataClient(ctx context.Context, cfg *Config) (client service.AuthMetadataServiceClient, err error) {
 	// Create an unauthenticated connection to fetch AuthMetadata
-	authMetadataConnection, err := NewAdminConnection(ctx, cfg, proxyCredentialsFuture)
+	authMetadataConnection, err := NewAdminConnection(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialized admin connection. Error: %w", err)
 	}
@@ -120,11 +120,11 @@ func InitializeAuthMetadataClient(ctx context.Context, cfg *Config, proxyCredent
 	return service.NewAuthMetadataServiceClient(authMetadataConnection), nil
 }
 
-func NewAdminConnection(ctx context.Context, cfg *Config, proxyCredentialsFuture *PerRPCCredentialsFuture, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+func NewAdminConnection(ctx context.Context, cfg *Config, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	if opts == nil {
 		// Initialize opts list to the potential number of options we will add. Initialization optimizes memory
 		// allocation.
-		opts = make([]grpc.DialOption, 0, 7)
+		opts = make([]grpc.DialOption, 0, 5)
 	}
 
 	if cfg.UseInsecureConnection {
@@ -153,11 +153,6 @@ func NewAdminConnection(ctx context.Context, cfg *Config, proxyCredentialsFuture
 
 	opts = append(opts, GetAdditionalAdminClientConfigOptions(cfg)...)
 
-	if cfg.ProxyCommand != nil {
-		opts = append(opts, grpc.WithChainUnaryInterceptor(NewProxyAuthInterceptor(cfg, proxyCredentialsFuture)))
-		opts = append(opts, grpc.WithPerRPCCredentials(proxyCredentialsFuture))
-	}
-
 	return grpc.Dial(cfg.Endpoint.String(), opts...)
 }
 
@@ -177,17 +172,15 @@ func InitializeAdminClient(ctx context.Context, cfg *Config, opts ...grpc.DialOp
 // for the process. Note that if called with different cfg/dialoptions, it will not refresh the connection.
 func initializeClients(ctx context.Context, cfg *Config, tokenCache cache.TokenCache, opts ...grpc.DialOption) (*Clientset, error) {
 	credentialsFuture := NewPerRPCCredentialsFuture()
-	proxyCredentialsFuture := NewPerRPCCredentialsFuture()
-
 	opts = append(opts,
-		grpc.WithChainUnaryInterceptor(NewAuthInterceptor(cfg, tokenCache, credentialsFuture, proxyCredentialsFuture)),
+		grpc.WithChainUnaryInterceptor(NewAuthInterceptor(cfg, tokenCache, credentialsFuture)),
 		grpc.WithPerRPCCredentials(credentialsFuture))
 
 	if cfg.DefaultServiceConfig != "" {
 		opts = append(opts, grpc.WithDefaultServiceConfig(cfg.DefaultServiceConfig))
 	}
 
-	adminConnection, err := NewAdminConnection(ctx, cfg, proxyCredentialsFuture, opts...)
+	adminConnection, err := NewAdminConnection(ctx, cfg, opts...)
 	if err != nil {
 		logger.Panicf(ctx, "failed to initialized Admin connection. Err: %s", err.Error())
 	}

--- a/flyteidl/clients/go/admin/config.go
+++ b/flyteidl/clients/go/admin/config.go
@@ -74,8 +74,6 @@ type Config struct {
 
 	Command []string `json:"command" pflag:",Command for external authentication token generation"`
 
-	ProxyCommand []string `json:"proxyCommand" pflag:",Command for external proxy-authorization token generation"`
-
 	// Set the gRPC service config formatted as a json string https://github.com/grpc/grpc/blob/master/doc/service_config.md
 	// eg. {"loadBalancingConfig": [{"round_robin":{}}], "methodConfig": [{"name":[{"service": "foo", "method": "bar"}, {"service": "baz"}], "timeout": "1.000000001s"}]}
 	// find the full schema here https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto#L625

--- a/flyteidl/clients/go/admin/config_flags.go
+++ b/flyteidl/clients/go/admin/config_flags.go
@@ -75,7 +75,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "deviceFlowConfig.timeout"), defaultConfig.DeviceFlowConfig.Timeout.String(), "amount of time the device flow should complete or else it will be cancelled.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "deviceFlowConfig.pollInterval"), defaultConfig.DeviceFlowConfig.PollInterval.String(), "amount of time the device flow would poll the token endpoint if auth server doesn't return a polling interval. Okta and google IDP do return an interval'")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "command"), defaultConfig.Command, "Command for external authentication token generation")
-	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "proxyCommand"), defaultConfig.ProxyCommand, "Command for external proxy-authorization token generation")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultServiceConfig"), defaultConfig.DefaultServiceConfig, "")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "httpProxyURL"), defaultConfig.HTTPProxyURL.String(), "OPTIONAL: HTTP Proxy to be used for OAuth requests.")
 	return cmdFlags

--- a/flyteidl/clients/go/admin/config_flags_test.go
+++ b/flyteidl/clients/go/admin/config_flags_test.go
@@ -449,20 +449,6 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
-	t.Run("Test_proxyCommand", func(t *testing.T) {
-
-		t.Run("Override", func(t *testing.T) {
-			testValue := join_Config(defaultConfig.ProxyCommand, ",")
-
-			cmdFlags.Set("proxyCommand", testValue)
-			if vStringSlice, err := cmdFlags.GetStringSlice("proxyCommand"); err == nil {
-				testDecodeRaw_Config(t, join_Config(vStringSlice, ","), &actual.ProxyCommand)
-
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
-	})
 	t.Run("Test_defaultServiceConfig", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/flyteidl/clients/go/admin/pkce/auth_flow_orchestrator.go
+++ b/flyteidl/clients/go/admin/pkce/auth_flow_orchestrator.go
@@ -2,7 +2,6 @@ package pkce
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -64,15 +63,8 @@ func (f TokenOrchestrator) FetchTokenFromAuthFlow(ctx context.Context) (*oauth2.
 	serveMux := http.NewServeMux()
 	server := &http.Server{Addr: redirectURL.Host, Handler: serveMux, ReadHeaderTimeout: 0}
 	// Register the call back handler
-
-	// Pass along http client used in oauth2
-	httpClient, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
-	if !ok {
-		return nil, errors.New("Unable to retrieve httpClient used in oauth2 from context")
-	}
-
 	serveMux.HandleFunc(redirectURL.Path, getAuthServerCallbackHandler(f.ClientConfig, pkceCodeVerifier,
-		tokenChannel, errorChannel, stateString, httpClient)) // the oauth2 callback endpoint
+		tokenChannel, errorChannel, stateString)) // the oauth2 callback endpoint
 	defer server.Close()
 
 	go func() {

--- a/flyteidl/clients/go/admin/pkce/handle_app_call_back.go
+++ b/flyteidl/clients/go/admin/pkce/handle_app_call_back.go
@@ -11,7 +11,7 @@ import (
 )
 
 func getAuthServerCallbackHandler(c *oauth.Config, codeVerifier string, tokenChannel chan *oauth2.Token,
-	errorChannel chan error, stateString string, client *http.Client) func(rw http.ResponseWriter, req *http.Request) {
+	errorChannel chan error, stateString string) func(rw http.ResponseWriter, req *http.Request) {
 
 	return func(rw http.ResponseWriter, req *http.Request) {
 		_, _ = rw.Write([]byte(`<h1>Flyte Authentication</h1>`))
@@ -43,8 +43,7 @@ func getAuthServerCallbackHandler(c *oauth.Config, codeVerifier string, tokenCha
 		var opts []oauth2.AuthCodeOption
 		opts = append(opts, oauth2.SetAuthURLParam("code_verifier", codeVerifier))
 
-		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
-		token, err := c.Exchange(ctx, req.URL.Query().Get("code"), opts...)
+		token, err := c.Exchange(context.Background(), req.URL.Query().Get("code"), opts...)
 		if err != nil {
 			errorChannel <- fmt.Errorf("error while exchanging auth code due to %v", err)
 			_, _ = rw.Write([]byte(fmt.Sprintf(`<p>Couldn't get access token due to error: %s</p>`, err.Error())))

--- a/flyteidl/clients/go/admin/pkce/handle_app_call_back_test.go
+++ b/flyteidl/clients/go/admin/pkce/handle_app_call_back_test.go
@@ -25,7 +25,7 @@ func HandleAppCallBackSetup(t *testing.T, state string) (tokenChannel chan *oaut
 	errorChannel = make(chan error, 1)
 	tokenChannel = make(chan *oauth2.Token)
 	testAuthConfig = &oauth.Config{Config: &oauth2.Config{}, DeviceEndpoint: "dummyDeviceEndpoint"}
-	callBackFn = getAuthServerCallbackHandler(testAuthConfig, "", tokenChannel, errorChannel, state, &http.Client{})
+	callBackFn = getAuthServerCallbackHandler(testAuthConfig, "", tokenChannel, errorChannel, state)
 	assert.NotNil(t, callBackFn)
 	req = &http.Request{
 		Method: http.MethodGet,


### PR DESCRIPTION
## Describe your changes

Looks like this may have broken propeller -> admin events when auth is enabled

```
panic({0x25fb2e0, 0xc0024577d0})
	/usr/local/go/src/runtime/panic.go:884 +0x212
github.com/flyteorg/flyte/flyteidl/clients/go/admin/externalprocess.Execute({0x423f5f8?, 0x8?, 0x7f15bee905b8?})
	/go/src/github.com/flyteorg/flyteidl/clients/go/admin/externalprocess/command_executor.go:6 +0x68
github.com/flyteorg/flyte/flyteidl/clients/go/admin.ExternalTokenSourceProvider.GetTokenSource({{0x423f5f8?, 0x40dc87?, 0x18?}}, {0x248cec0?, 0x7f1597747501?})
	/go/src/github.com/flyteorg/flyteidl/clients/go/admin/token_source_provider.go:119 +0x25
github.com/flyteorg/flyte/flyteidl/clients/go/admin.GetProxyTokenSource({0x2d1cc90, 0xc00133c6c0}, 0xdb6d77?)
	/go/src/github.com/flyteorg/flyteidl/clients/go/admin/auth_interceptor.go:59 +0x9d
github.com/flyteorg/flyte/flyteidl/clients/go/admin.MaterializeProxyAuthCredentials({0x2d1cc90?, 0xc00133c6c0?}, 0xc0003ce280, 0x2d1cc90?)
	/go/src/github.com/flyteorg/flyteidl/clients/go/admin/auth_interceptor.go:67 +0x3a
github.com/flyteorg/flyte/flyteidl/clients/go/admin.NewProxyAuthInterceptor.func1({0x2d1cc90, 0xc00133c6c0}, {0x2833b6c, 0x32}, {0x26400e0, 0xc0015c5440}, {0x25ff2c0, 0xc0005290c0}, 0x8?, 0x28f81b8, ...)
	/go/src/github.com/flyteorg/flyteidl/clients/go/admin/auth_interceptor.go:165 +0xe6
...
github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service.(*adminServiceClient).CreateWorkflowEvent(0xc00098d228, {0x2d1ccc8, 0xc0025848d0}, 0xc00065ebd0?, {0x0, 0x0, 0x0})
	/go/src/github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/service/admin.pb.go:576 +0xc9
```

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

