### PR TITLE
Fix: Prevent unintended use of proxy authorization when no command is provided

### DIFF
--- a/flyteidl/clients/go/admin/auth_interceptor.go
+++ b/flyteidl/clients/go/admin/auth_interceptor.go
@@ -109,7 +109,7 @@ func setHTTPClientContext(ctx context.Context, cfg *Config, proxyCredentialsFutu
 		transport.Proxy = http.ProxyURL(&cfg.HTTPProxyURL.URL)
 	}
 
-	if len(cfg.ProxyCommand) > 0 {
+	if cfg.ProxyCommand != nil && len(cfg.ProxyCommand) > 0 {
 		httpClient.Transport = &proxyAuthTransport{
 			transport:              transport,
 			proxyCredentialsFuture: proxyCredentialsFuture,

--- a/flyteidl/clients/go/admin/auth_interceptor.go
+++ b/flyteidl/clients/go/admin/auth_interceptor.go
@@ -109,7 +109,7 @@ func setHTTPClientContext(ctx context.Context, cfg *Config, proxyCredentialsFutu
 		transport.Proxy = http.ProxyURL(&cfg.HTTPProxyURL.URL)
 	}
 
-	if cfg.ProxyCommand != nil {
+	if len(cfg.ProxyCommand) > 0 {
 		httpClient.Transport = &proxyAuthTransport{
 			transport:              transport,
 			proxyCredentialsFuture: proxyCredentialsFuture,

--- a/flyteidl/clients/go/admin/client.go
+++ b/flyteidl/clients/go/admin/client.go
@@ -153,7 +153,7 @@ func NewAdminConnection(ctx context.Context, cfg *Config, proxyCredentialsFuture
 
 	opts = append(opts, GetAdditionalAdminClientConfigOptions(cfg)...)
 
-	if cfg.ProxyCommand != nil {
+	if len(cfg.ProxyCommand) > 0 {
 		opts = append(opts, grpc.WithChainUnaryInterceptor(NewProxyAuthInterceptor(cfg, proxyCredentialsFuture)))
 		opts = append(opts, grpc.WithPerRPCCredentials(proxyCredentialsFuture))
 	}

--- a/flyteidl/clients/go/admin/client.go
+++ b/flyteidl/clients/go/admin/client.go
@@ -153,7 +153,7 @@ func NewAdminConnection(ctx context.Context, cfg *Config, proxyCredentialsFuture
 
 	opts = append(opts, GetAdditionalAdminClientConfigOptions(cfg)...)
 
-	if len(cfg.ProxyCommand) > 0 {
+	if cfg.ProxyCommand != nil && len(cfg.ProxyCommand) > 0 {
 		opts = append(opts, grpc.WithChainUnaryInterceptor(NewProxyAuthInterceptor(cfg, proxyCredentialsFuture)))
 		opts = append(opts, grpc.WithPerRPCCredentials(proxyCredentialsFuture))
 	}


### PR DESCRIPTION
## Describe your changes

@andrewwdye noticed that the newly introduced proxy authorization in the admin client breaks propeller, see https://github.com/flyteorg/flyte/pull/4216#event-10638102477.

I ran flytepropeller locally in a debugger (with the flyte-core helm chart deployed in the cluster and flyteadmin and datacatalog port-forwarded).

With the debugger, I confirmed that [this](https://github.com/flyteorg/flyte/blob/68c055b7b51eebc4cf009b5caf488026328cfcc0/flyteidl/clients/go/admin/client.go#L157) if statement which adds proxy authorization is hit even if no proxy command is provided in the platform config.

The reason is that I check for `cfg.ProxyCommand != nil` but the default value of proxy command is [empty string slice  ](https://github.com/flyteorg/flyte/blob/68c055b7b51eebc4cf009b5caf488026328cfcc0/flyteidl/clients/go/admin/config.go#L77) so it is never `nil`.

With flytepropeller running locally in my IDE, I confirmed that:

1. with the fix introduced by this PR, the error reported by @andrewwdye is gone and that workflows can be executed again
2. that if one does configure a proxy command, that the proxy auth interceptor is still added to the dial options

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
