### PR TITLE
Format go imports (flytepropeller)

### DIFF
--- a/flytepropeller/.golangci.yml
+++ b/flytepropeller/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - deadcode
     - errcheck
     - gas
+    - gci
     - goconst
     - goimports
     - golint
@@ -28,3 +29,12 @@ linters:
     - unparam
     - unused
     - varcheck
+
+linters-settings:
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - prefix(github.com/flyteorg)
+    skip-generated: true

--- a/flytepropeller/boilerplate/flyte/golang_support_tools/tools.go
+++ b/flytepropeller/boilerplate/flyte/golang_support_tools/tools.go
@@ -6,7 +6,8 @@ package tools
 import (
 	_ "github.com/EngHabu/mockery/cmd/mockery"
 	_ "github.com/alvaroloes/enumer"
-	_ "github.com/flyteorg/flyte/flytestdlib/cli/pflags"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
+
+	_ "github.com/flyteorg/flyte/flytestdlib/cli/pflags"
 )

--- a/flytepropeller/boilerplate/flyte/golang_test_targets/download_tooling.sh
+++ b/flytepropeller/boilerplate/flyte/golang_test_targets/download_tooling.sh
@@ -19,6 +19,7 @@ tools=(
   "github.com/EngHabu/mockery/cmd/mockery"
   "github.com/flyteorg/flytestdlib/cli/pflags@latest"
   "github.com/golangci/golangci-lint/cmd/golangci-lint"
+  "github.com/daixiang0/gci"
   "github.com/alvaroloes/enumer"
   "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
 )

--- a/flytepropeller/boilerplate/flyte/golang_test_targets/goimports
+++ b/flytepropeller/boilerplate/flyte/golang_test_targets/goimports
@@ -6,3 +6,4 @@
 # TO OPT OUT OF UPDATES, SEE https://github.com/flyteorg/boilerplate/blob/master/Readme.rst
 
 goimports -w $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pkg/client/*" -not -path "./boilerplate/*")
+gci write -s standard -s default -s "prefix(github.com/flyteorg)" --custom-order --skip-generated .

--- a/flytepropeller/boilerplate/flyte/golangci_file/.golangci.yml
+++ b/flytepropeller/boilerplate/flyte/golangci_file/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - deadcode
     - errcheck
     - gas
+    - gci
     - goconst
     - goimports
     - golint
@@ -28,3 +29,12 @@ linters:
     - unparam
     - unused
     - varcheck
+
+linters-settings:
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - prefix(github.com/flyteorg)
+    skip-generated: true

--- a/flytepropeller/cmd/controller/cmd/init_certs.go
+++ b/flytepropeller/cmd/controller/cmd/init_certs.go
@@ -3,13 +3,11 @@ package cmd
 import (
 	"context"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
-	webhookConfig "github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook"
-
 	"github.com/spf13/cobra"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook"
+	webhookConfig "github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 )
 
 // initCertsCmd initializes x509 TLS Certificates and saves them to a secret.

--- a/flytepropeller/cmd/controller/cmd/root.go
+++ b/flytepropeller/cmd/controller/cmd/root.go
@@ -8,11 +8,21 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller"
 	config2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/signals"
-
 	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/flyteorg/flyte/flytestdlib/config/viper"
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
@@ -21,21 +31,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/version"
-
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
-	"golang.org/x/sync/errgroup"
-
-	"k8s.io/client-go/rest"
-	"k8s.io/klog"
-
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 const (

--- a/flytepropeller/cmd/controller/cmd/webhook.go
+++ b/flytepropeller/cmd/controller/cmd/webhook.go
@@ -3,28 +3,24 @@ package cmd
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/signals"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook"
 	webhookConfig "github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
-
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/profutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-
-	"github.com/spf13/cobra"
-
-	"golang.org/x/sync/errgroup"
-
-	"k8s.io/client-go/rest"
-
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var webhookCmd = &cobra.Command{

--- a/flytepropeller/cmd/controller/main.go
+++ b/flytepropeller/cmd/controller/main.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	_ "github.com/flyteorg/flyte/flytepropeller/plugins"
-
 	"github.com/flyteorg/flyte/flytepropeller/cmd/controller/cmd"
+	_ "github.com/flyteorg/flyte/flytepropeller/plugins"
 )
 
 func main() {

--- a/flytepropeller/cmd/kubectl-flyte/cmd/compile.go
+++ b/flytepropeller/cmd/kubectl-flyte/cmd/compile.go
@@ -5,12 +5,13 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	compilerErrors "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 )
 
 type CompileOpts struct {

--- a/flytepropeller/cmd/kubectl-flyte/cmd/create.go
+++ b/flytepropeller/cmd/kubectl-flyte/cmd/create.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/ghodss/yaml"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
@@ -19,9 +20,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	compilerErrors "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/transformers/k8s"
-
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/flytepropeller/cmd/kubectl-flyte/cmd/create_test.go
+++ b/flytepropeller/cmd/kubectl-flyte/cmd/create_test.go
@@ -9,15 +9,15 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/transformers/k8s"
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/assert"
 )
 
 var update = flag.Bool("update", false, "Update .golden files")

--- a/flytepropeller/cmd/kubectl-flyte/cmd/delete.go
+++ b/flytepropeller/cmd/kubectl-flyte/cmd/delete.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller"
 )
 
 type DeleteOpts struct {

--- a/flytepropeller/cmd/kubectl-flyte/cmd/get.go
+++ b/flytepropeller/cmd/kubectl-flyte/cmd/get.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 
 	gotree "github.com/DiSiqueira/GoTree"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
 	"github.com/spf13/cobra"
 	v12 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/flyteorg/flyte/flytepropeller/cmd/kubectl-flyte/cmd/printers"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 type GetOpts struct {

--- a/flytepropeller/cmd/kubectl-flyte/cmd/printers/node.go
+++ b/flytepropeller/cmd/kubectl-flyte/cmd/printers/node.go
@@ -9,9 +9,9 @@ import (
 
 	gotree "github.com/DiSiqueira/GoTree"
 	"github.com/fatih/color"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/encoding"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/encoding"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task"
 )

--- a/flytepropeller/cmd/kubectl-flyte/cmd/root.go
+++ b/flytepropeller/cmd/kubectl-flyte/cmd/root.go
@@ -8,16 +8,16 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/config/viper"
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/version"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	flyteclient "github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned"
-	"github.com/spf13/cobra"
+	"github.com/flyteorg/flyte/flytestdlib/config/viper"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/version"
 )
 
 func init() {

--- a/flytepropeller/cmd/kubectl-flyte/cmd/visualize.go
+++ b/flytepropeller/cmd/kubectl-flyte/cmd/visualize.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/visualize"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/visualize"
 )
 
 type VisualizeOpts struct {

--- a/flytepropeller/cmd/kubectl-flyte/main.go
+++ b/flytepropeller/cmd/kubectl-flyte/main.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"os"
 
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	"github.com/flyteorg/flyte/flytepropeller/cmd/kubectl-flyte/cmd"
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 func init() {

--- a/flytepropeller/cmd/manager/cmd/root.go
+++ b/flytepropeller/cmd/manager/cmd/root.go
@@ -7,24 +7,22 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/flyteorg/flyte/flytestdlib/config"
-	"github.com/flyteorg/flyte/flytestdlib/config/viper"
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/profutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/version"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 
 	"github.com/flyteorg/flyte/flytepropeller/manager"
 	managerConfig "github.com/flyteorg/flyte/flytepropeller/manager/config"
 	propellerConfig "github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/signals"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
-
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
+	"github.com/flyteorg/flyte/flytestdlib/config"
+	"github.com/flyteorg/flyte/flytestdlib/config/viper"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/profutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/version"
 )
 
 const (

--- a/flytepropeller/events/admin_eventsink.go
+++ b/flytepropeller/events/admin_eventsink.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	admin2 "github.com/flyteorg/flyte/flyteidl/clients/go/admin"
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/time/rate"
 
+	admin2 "github.com/flyteorg/flyte/flyteidl/clients/go/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
@@ -13,8 +15,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/fastcheck"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/golang/protobuf/proto"
-	"golang.org/x/time/rate"
 )
 
 type adminEventSink struct {

--- a/flytepropeller/events/admin_eventsink_integration_test.go
+++ b/flytepropeller/events/admin_eventsink_integration_test.go
@@ -12,13 +12,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/flyteidl/clients/go/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyte/flytestdlib/config"
-	"github.com/golang/protobuf/ptypes"
 )
 
 var (

--- a/flytepropeller/events/admin_eventsink_test.go
+++ b/flytepropeller/events/admin_eventsink_test.go
@@ -5,18 +5,19 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/clients/go/admin/mocks"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-	"github.com/flyteorg/flyte/flytepropeller/events/errors"
-	fastcheckMocks "github.com/flyteorg/flyte/flytestdlib/fastcheck/mocks"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/flyteorg/flyte/flyteidl/clients/go/admin/mocks"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
+	"github.com/flyteorg/flyte/flytepropeller/events/errors"
+	fastcheckMocks "github.com/flyteorg/flyte/flytestdlib/fastcheck/mocks"
 )
 
 var (

--- a/flytepropeller/events/errors/errors.go
+++ b/flytepropeller/events/errors/errors.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
-	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 type ErrorCode string

--- a/flytepropeller/events/errors/errors_test.go
+++ b/flytepropeller/events/errors/errors_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
 type testErrorWithReason struct {

--- a/flytepropeller/events/event_recorder.go
+++ b/flytepropeller/events/event_recorder.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/protobuf/proto"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyte/flytepropeller/events/errors"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-	"github.com/golang/protobuf/proto"
 )
 
 const MaxErrorMessageLength = 104857600 //100KB

--- a/flytepropeller/events/event_recorder_test.go
+++ b/flytepropeller/events/event_recorder_test.go
@@ -5,14 +5,14 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyte/flytepropeller/events/mocks"
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-
-	"github.com/stretchr/testify/assert"
 )
 
 var (

--- a/flytepropeller/events/eventsink_test.go
+++ b/flytepropeller/events/eventsink_test.go
@@ -9,10 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 )
 
 func TestFileEvent(t *testing.T) {

--- a/flytepropeller/events/local_eventsink.go
+++ b/flytepropeller/events/local_eventsink.go
@@ -7,9 +7,10 @@ import (
 	"os"
 	"sync"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 )
 
 type localSink struct {

--- a/flytepropeller/events/node_event_recorder.go
+++ b/flytepropeller/events/node_event_recorder.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"strings"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-	"github.com/golang/protobuf/proto"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 //go:generate mockery -all -output=mocks -case=underscore

--- a/flytepropeller/events/node_event_recorder_test.go
+++ b/flytepropeller/events/node_event_recorder_test.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-	"github.com/flyteorg/flyte/flytepropeller/events/mocks"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
-	storageMocks "github.com/flyteorg/flyte/flytestdlib/storage/mocks"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
+	"github.com/flyteorg/flyte/flytepropeller/events/mocks"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
+	storageMocks "github.com/flyteorg/flyte/flytestdlib/storage/mocks"
 )
 
 func getReferenceNodeEv() *event.NodeExecutionEvent {

--- a/flytepropeller/events/task_event_recorder.go
+++ b/flytepropeller/events/task_event_recorder.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"strings"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-	"github.com/golang/protobuf/proto"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 //go:generate mockery -all -output=mocks -case=underscore

--- a/flytepropeller/events/task_event_recorder_test.go
+++ b/flytepropeller/events/task_event_recorder_test.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-	"github.com/flyteorg/flyte/flytepropeller/events/mocks"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
-	storageMocks "github.com/flyteorg/flyte/flytestdlib/storage/mocks"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
+	"github.com/flyteorg/flyte/flytepropeller/events/mocks"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
+	storageMocks "github.com/flyteorg/flyte/flytestdlib/storage/mocks"
 )
 
 var taskID = &core.Identifier{

--- a/flytepropeller/events/workflow_event_recorder.go
+++ b/flytepropeller/events/workflow_event_recorder.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"strings"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-	"github.com/golang/protobuf/proto"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 //go:generate mockery -all -output=mocks -case=underscore

--- a/flytepropeller/events/workflow_event_recorder_test.go
+++ b/flytepropeller/events/workflow_event_recorder_test.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-	"github.com/flyteorg/flyte/flytepropeller/events/mocks"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
-	storageMocks "github.com/flyteorg/flyte/flytestdlib/storage/mocks"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
+	"github.com/flyteorg/flyte/flytepropeller/events/mocks"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
+	storageMocks "github.com/flyteorg/flyte/flytestdlib/storage/mocks"
 )
 
 func getReferenceWorkflowEv() *event.WorkflowExecutionEvent {

--- a/flytepropeller/manager/manager.go
+++ b/flytepropeller/manager/manager.go
@@ -5,28 +5,23 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/imdario/mergo"
+	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection"
+
 	managerConfig "github.com/flyteorg/flyte/flytepropeller/manager/config"
 	"github.com/flyteorg/flyte/flytepropeller/manager/shardstrategy"
 	propellerConfig "github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	leader "github.com/flyteorg/flyte/flytepropeller/pkg/leaderelection"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
-
 	stderrors "github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	"github.com/imdario/mergo"
-
-	"github.com/prometheus/client_golang/prometheus"
-
-	v1 "k8s.io/api/core/v1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/leaderelection"
 )
 
 const (

--- a/flytepropeller/manager/manager_test.go
+++ b/flytepropeller/manager/manager_test.go
@@ -5,18 +5,16 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	"github.com/flyteorg/flyte/flytepropeller/manager/shardstrategy"
-	"github.com/flyteorg/flyte/flytepropeller/manager/shardstrategy/mocks"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/flyteorg/flyte/flytepropeller/manager/shardstrategy"
+	"github.com/flyteorg/flyte/flytepropeller/manager/shardstrategy/mocks"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 var (

--- a/flytepropeller/manager/shardstrategy/environment.go
+++ b/flytepropeller/manager/shardstrategy/environment.go
@@ -3,9 +3,9 @@ package shardstrategy
 import (
 	"fmt"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
-
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
 )
 
 // EnvironmentShardStrategy assigns either project or domain identifiers to individual

--- a/flytepropeller/manager/shardstrategy/hash.go
+++ b/flytepropeller/manager/shardstrategy/hash.go
@@ -3,10 +3,10 @@ package shardstrategy
 import (
 	"fmt"
 
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
-
-	v1 "k8s.io/api/core/v1"
 )
 
 // HashShardStrategy evenly assigns disjoint keyspace responsibilities over a collection of pods.

--- a/flytepropeller/manager/shardstrategy/shard_strategy.go
+++ b/flytepropeller/manager/shardstrategy/shard_strategy.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"hash/fnv"
 
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/flyteorg/flyte/flytepropeller/manager/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
-
-	v1 "k8s.io/api/core/v1"
 )
 
 //go:generate mockery -name ShardStrategy -case=underscore

--- a/flytepropeller/manager/shardstrategy/shard_strategy_test.go
+++ b/flytepropeller/manager/shardstrategy/shard_strategy_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/flytepropeller/pkg/apis/flyteworkflow/crd.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/crd.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/branch.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/branch.go
@@ -3,8 +3,9 @@ package v1alpha1
 import (
 	"bytes"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/golang/protobuf/jsonpb"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 type Error struct {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/branch_test.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/branch_test.go
@@ -5,9 +5,10 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMarshalUnMarshal_BranchTask(t *testing.T) {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/error.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/error.go
@@ -3,8 +3,9 @@ package v1alpha1
 import (
 	"bytes"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/golang/protobuf/jsonpb"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 // Wrapper around core.Execution error. Execution Error has a protobuf enum and hence needs to be wrapped by custom marshaller

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/execution_config.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/execution_config.go
@@ -1,8 +1,9 @@
 package v1alpha1
 
 import (
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
 // This contains an OutputLocationPrefix. When running against AWS, this should be something of the form

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/execution_config_test.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/execution_config_test.go
@@ -1,10 +1,11 @@
 package v1alpha1
 
 import (
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 
-	"testing"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
 func TestRawOutputConfig(t *testing.T) {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/gate.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/gate.go
@@ -3,8 +3,9 @@ package v1alpha1
 import (
 	"bytes"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/golang/protobuf/jsonpb"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 type ConditionKind string

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/identifier.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/identifier.go
@@ -3,8 +3,9 @@ package v1alpha1
 import (
 	"bytes"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/golang/protobuf/jsonpb"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 type Identifier struct {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status.go
@@ -9,12 +9,12 @@ import (
 	"strconv"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytestdlib/bitarray"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type MutableStruct struct {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status_test.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status_test.go
@@ -6,12 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/flyteorg/flyte/flytestdlib/storage"
-
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/stretchr/testify/assert"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 func TestIsPhaseTerminal(t *testing.T) {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/nodes.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/nodes.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"time"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/golang/protobuf/jsonpb"
 	typesv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 var marshaler = jsonpb.Marshaler{}

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/register.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/register.go
@@ -1,10 +1,11 @@
 package v1alpha1
 
 import (
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow"
 )
 
 const FlyteWorkflowKind = "flyteworkflow"

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/tasks.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/tasks.go
@@ -3,8 +3,9 @@ package v1alpha1
 import (
 	"bytes"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/golang/protobuf/jsonpb"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 type TaskSpec struct {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/tasks_test.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/tasks_test.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
 func TestTaskSpec(t *testing.T) {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/workflow.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/workflow.go
@@ -5,14 +5,13 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 // Defines a non-configurable keyspace size for shard keys. This needs to be a small value because we use label

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/workflow_status.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/workflow_status.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"strconv"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
-
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const maxMessageSize = 1024

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/workflow_test.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/workflow_test.go
@@ -5,10 +5,11 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
 func TestMarshalUnmarshal_Connections(t *testing.T) {

--- a/flytepropeller/pkg/compiler/admin_test.go
+++ b/flytepropeller/pkg/compiler/admin_test.go
@@ -3,10 +3,11 @@ package compiler
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/stretchr/testify/assert"
 )
 
 var launchPlanIdentifier = core.Identifier{

--- a/flytepropeller/pkg/compiler/common/index.go
+++ b/flytepropeller/pkg/compiler/common/index.go
@@ -1,9 +1,10 @@
 package common
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Defines an index of nodebuilders based on the id.

--- a/flytepropeller/pkg/compiler/requirements_test.go
+++ b/flytepropeller/pkg/compiler/requirements_test.go
@@ -3,8 +3,9 @@ package compiler
 import (
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 func TestGetRequirements(t *testing.T) {

--- a/flytepropeller/pkg/compiler/task_compiler.go
+++ b/flytepropeller/pkg/compiler/task_compiler.go
@@ -3,14 +3,14 @@ package compiler
 import (
 	"fmt"
 
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func validateResource(resourceName core.Resources_ResourceName, resourceVal string, errs errors.CompileErrors) (ok bool) {

--- a/flytepropeller/pkg/compiler/task_compiler_test.go
+++ b/flytepropeller/pkg/compiler/task_compiler_test.go
@@ -3,13 +3,12 @@ package compiler
 import (
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/stretchr/testify/assert"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
 )
 
 func MakeResource(name core.Resources_ResourceName, v string) *core.Resources_ResourceEntry {

--- a/flytepropeller/pkg/compiler/test/compiler_test.go
+++ b/flytepropeller/pkg/compiler/test/compiler_test.go
@@ -11,25 +11,21 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/visualize"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
-
+	"github.com/ghodss/yaml"
+	"github.com/go-test/deep"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/go-test/deep"
-
-	"github.com/ghodss/yaml"
-
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/transformers/k8s"
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/assert"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/visualize"
 )
 
 var update = flag.Bool("update", false, "Update .golden files")

--- a/flytepropeller/pkg/compiler/transformers/k8s/inputs.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/inputs.go
@@ -1,11 +1,12 @@
 package k8s
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/validators"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func validateInputs(nodeID common.NodeID, iface *core.TypedInterface, inputs core.LiteralMap, errs errors.CompileErrors) (ok bool) {

--- a/flytepropeller/pkg/compiler/transformers/k8s/node.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/node.go
@@ -3,13 +3,14 @@ package k8s
 import (
 	"strings"
 
+	"github.com/go-test/deep"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-	"github.com/go-test/deep"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Gets the compiled subgraph if this node contains an inline-declared coreWorkflow. Otherwise nil.

--- a/flytepropeller/pkg/compiler/transformers/k8s/node_test.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/node_test.go
@@ -4,17 +4,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-
-	"github.com/stretchr/testify/assert"
-
-	"google.golang.org/protobuf/types/known/durationpb"
-
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func createNodeWithTask() *core.Node {

--- a/flytepropeller/pkg/compiler/transformers/k8s/utils.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/utils.go
@@ -3,11 +3,11 @@ package k8s
 import (
 	"math"
 
+	"github.com/golang/protobuf/ptypes"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
-	"github.com/golang/protobuf/ptypes"
 )
 
 func refInt(i int) *int {

--- a/flytepropeller/pkg/compiler/transformers/k8s/utils_test.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/utils_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/go-test/deep"
 	_struct "github.com/golang/protobuf/ptypes/struct"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestComputeRetryStrategy(t *testing.T) {

--- a/flytepropeller/pkg/compiler/transformers/k8s/workflow.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/workflow.go
@@ -6,12 +6,13 @@ import (
 	"hash/fnv"
 	"strings"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/flytepropeller/pkg/compiler/transformers/k8s/workflow_test.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/workflow_test.go
@@ -5,13 +5,14 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func createSampleMockWorkflow() *mockWorkflow {

--- a/flytepropeller/pkg/compiler/utils.go
+++ b/flytepropeller/pkg/compiler/utils.go
@@ -1,9 +1,10 @@
 package compiler
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func toInterfaceProviderMap(tasks []common.InterfaceProvider) map[string]common.InterfaceProvider {

--- a/flytepropeller/pkg/compiler/validators/bindings.go
+++ b/flytepropeller/pkg/compiler/validators/bindings.go
@@ -3,12 +3,12 @@ package validators
 import (
 	"reflect"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/typing"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	flyte "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	c "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/typing"
 )
 
 func validateBinding(w c.WorkflowBuilder, nodeID c.NodeID, nodeParam string, binding *flyte.BindingData,

--- a/flytepropeller/pkg/compiler/validators/bindings_test.go
+++ b/flytepropeller/pkg/compiler/validators/bindings_test.go
@@ -3,15 +3,14 @@ package validators
 import (
 	"testing"
 
-	c "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	c "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common/mocks"
 	compilerErrors "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 // LiteralToBinding converts a literal to a non-promise binding data.

--- a/flytepropeller/pkg/compiler/validators/branch.go
+++ b/flytepropeller/pkg/compiler/validators/branch.go
@@ -1,10 +1,11 @@
 package validators
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	flyte "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	c "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func validateBranchInterface(w c.WorkflowBuilder, node c.NodeBuilder, errs errors.CompileErrors) (iface *flyte.TypedInterface, ok bool) {

--- a/flytepropeller/pkg/compiler/validators/branch_test.go
+++ b/flytepropeller/pkg/compiler/validators/branch_test.go
@@ -3,12 +3,12 @@ package validators
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common/mocks"
 	compilerErrors "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-	"github.com/stretchr/testify/assert"
 )
 
 func createBooleanOperand(val bool) *core.Operand {

--- a/flytepropeller/pkg/compiler/validators/interface_test.go
+++ b/flytepropeller/pkg/compiler/validators/interface_test.go
@@ -5,17 +5,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	c "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func TestValidateInterface(t *testing.T) {

--- a/flytepropeller/pkg/compiler/validators/node_test.go
+++ b/flytepropeller/pkg/compiler/validators/node_test.go
@@ -3,13 +3,12 @@ package validators
 import (
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
+	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateBranchNode(t *testing.T) {

--- a/flytepropeller/pkg/compiler/validators/typing.go
+++ b/flytepropeller/pkg/compiler/validators/typing.go
@@ -3,8 +3,9 @@ package validators
 import (
 	"strings"
 
-	flyte "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	structpb "github.com/golang/protobuf/ptypes/struct"
+
+	flyte "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 type typeChecker interface {

--- a/flytepropeller/pkg/compiler/validators/typing_test.go
+++ b/flytepropeller/pkg/compiler/validators/typing_test.go
@@ -3,9 +3,10 @@ package validators
 import (
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 func TestSimpleLiteralCasting(t *testing.T) {

--- a/flytepropeller/pkg/compiler/validators/utils.go
+++ b/flytepropeller/pkg/compiler/validators/utils.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/exp/slices"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 func containsBindingByVariableName(bindings []*core.Binding, name string) (found bool) {

--- a/flytepropeller/pkg/compiler/validators/utils_test.go
+++ b/flytepropeller/pkg/compiler/validators/utils_test.go
@@ -3,9 +3,10 @@ package validators
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLiteralTypeForLiterals(t *testing.T) {

--- a/flytepropeller/pkg/compiler/workflow_compiler.go
+++ b/flytepropeller/pkg/compiler/workflow_compiler.go
@@ -34,14 +34,14 @@ package compiler
 import (
 	"strings"
 
+	// #noSA1019
+	"github.com/golang/protobuf/proto"
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	c "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
 	v "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/validators"
-
-	// #noSA1019
-	"github.com/golang/protobuf/proto"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Updates workflows and tasks references to reflect the needed ones for this workflow (ignoring subworkflows)

--- a/flytepropeller/pkg/compiler/workflow_compiler_test.go
+++ b/flytepropeller/pkg/compiler/workflow_compiler_test.go
@@ -5,16 +5,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common/mocks"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/errors"
 	v "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/validators"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/visualize"
-	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func createEmptyVariableMap() *core.VariableMap {

--- a/flytepropeller/pkg/controller/completed_workflows.go
+++ b/flytepropeller/pkg/controller/completed_workflows.go
@@ -4,8 +4,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
 const (

--- a/flytepropeller/pkg/controller/completed_workflows_test.go
+++ b/flytepropeller/pkg/controller/completed_workflows_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
 func TestIgnoreCompletedWorkflowsLabelSelector(t *testing.T) {

--- a/flytepropeller/pkg/controller/composite_workqueue.go
+++ b/flytepropeller/pkg/controller/composite_workqueue.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 // A CompositeWorkQueue can be used in cases where the work is enqueued by two sources. It can be enqueued by either

--- a/flytepropeller/pkg/controller/composite_workqueue_test.go
+++ b/flytepropeller/pkg/controller/composite_workqueue_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	config2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	"github.com/stretchr/testify/assert"
 
+	config2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNewCompositeWorkQueue(t *testing.T) {

--- a/flytepropeller/pkg/controller/config/config.go
+++ b/flytepropeller/pkg/controller/config/config.go
@@ -36,9 +36,10 @@ package config
 import (
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 //go:generate pflags Config --default-var=defaultConfig

--- a/flytepropeller/pkg/controller/controller.go
+++ b/flytepropeller/pkg/controller/controller.go
@@ -9,12 +9,27 @@ import (
 	"runtime/pprof"
 	"time"
 
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/balancer/roundrobin" //nolint
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/clock"
+	k8sInformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
 	"github.com/flyteorg/flyte/flyteidl/clients/go/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
-
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	flyteK8sConfig "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
-
 	"github.com/flyteorg/flyte/flytepropeller/events"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
@@ -34,37 +49,12 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/workflowstore"
 	leader "github.com/flyteorg/flyte/flytepropeller/pkg/leaderelection"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
-
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	stdErrs "github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-
-	"github.com/pkg/errors"
-
-	"github.com/prometheus/client_golang/prometheus"
-
-	"google.golang.org/grpc"
-	_ "google.golang.org/grpc/balancer/roundrobin" //nolint
-
-	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/clock"
-
-	k8sInformers "k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/leaderelection"
-	"k8s.io/client-go/tools/record"
-
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (

--- a/flytepropeller/pkg/controller/controller_test.go
+++ b/flytepropeller/pkg/controller/controller_test.go
@@ -6,17 +6,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	listers "github.com/flyteorg/flyte/flytepropeller/pkg/client/listers/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/labels"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )
 
 var wfs = []*v1alpha1.FlyteWorkflow{

--- a/flytepropeller/pkg/controller/executors/kube.go
+++ b/flytepropeller/pkg/controller/executors/kube.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/flyteorg/flyte/flytestdlib/fastcheck"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
 	"k8s.io/client-go/rest"
-
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/flyteorg/flyte/flytestdlib/fastcheck"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 //go:generate mockery -name Client -case=underscore

--- a/flytepropeller/pkg/controller/executors/kube_test.go
+++ b/flytepropeller/pkg/controller/executors/kube_test.go
@@ -6,13 +6,14 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )
 
 func TestIdFromObject(t *testing.T) {

--- a/flytepropeller/pkg/controller/garbage_collector.go
+++ b/flytepropeller/pkg/controller/garbage_collector.go
@@ -3,20 +3,19 @@ package controller
 import (
 	"context"
 	"runtime/pprof"
+	"strings"
 	"time"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
-	"strings"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned/typed/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/clock"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 type gcMetrics struct {

--- a/flytepropeller/pkg/controller/garbage_collector_test.go
+++ b/flytepropeller/pkg/controller/garbage_collector_test.go
@@ -7,16 +7,16 @@ import (
 	"testing"
 	"time"
 
-	config2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned/typed/flyteworkflow/v1alpha1"
-	"github.com/flyteorg/flyte/flytestdlib/config"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/stretchr/testify/assert"
 	corev1Types "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/clock"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned/typed/flyteworkflow/v1alpha1"
+	config2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flyte/flytestdlib/config"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 func TestNewGarbageCollector(t *testing.T) {

--- a/flytepropeller/pkg/controller/handler.go
+++ b/flytepropeller/pkg/controller/handler.go
@@ -7,23 +7,21 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	eventsErr "github.com/flyteorg/flyte/flytepropeller/events/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/transformers/k8s"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/workflowstore"
-
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // TODO Lets move everything to use controller runtime

--- a/flytepropeller/pkg/controller/handler_test.go
+++ b/flytepropeller/pkg/controller/handler_test.go
@@ -6,25 +6,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	eventErrors "github.com/flyteorg/flyte/flytepropeller/events/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	workflowErrors "github.com/flyteorg/flyte/flytepropeller/pkg/controller/workflow/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/workflowstore"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/workflowstore/mocks"
-
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 	storagemocks "github.com/flyteorg/flyte/flytestdlib/storage/mocks"
-
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type mockExecutor struct {

--- a/flytepropeller/pkg/controller/nodes/array/event_recorder.go
+++ b/flytepropeller/pkg/controller/nodes/array/event_recorder.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+
 	idlcore "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
-	"github.com/golang/protobuf/ptypes"
 )
 
 type arrayEventRecorder interface {

--- a/flytepropeller/pkg/controller/nodes/array/handler.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler.go
@@ -7,11 +7,9 @@ import (
 	"strconv"
 
 	idlcore "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/plugins/array/errorcollector"
-
 	"github.com/flyteorg/flyte/flytepropeller/events"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/validators"
@@ -22,7 +20,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/k8s"
-
 	"github.com/flyteorg/flyte/flytestdlib/bitarray"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"

--- a/flytepropeller/pkg/controller/nodes/array/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler_test.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	idlcore "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
+	pluginmocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
 	eventmocks "github.com/flyteorg/flyte/flytepropeller/events/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
@@ -20,18 +24,11 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
 	recoverymocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/recovery/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan"
-
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
-	pluginmocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-
 	"github.com/flyteorg/flyte/flytestdlib/bitarray"
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 var (

--- a/flytepropeller/pkg/controller/nodes/array/node_execution_context_builder.go
+++ b/flytepropeller/pkg/controller/nodes/array/node_execution_context_builder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"

--- a/flytepropeller/pkg/controller/nodes/array/utils_test.go
+++ b/flytepropeller/pkg/controller/nodes/array/utils_test.go
@@ -3,9 +3,9 @@ package array
 import (
 	"testing"
 
-	idlcore "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/stretchr/testify/assert"
+
+	idlcore "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 func TestAppendLiteral(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/branch/comparator_test.go
+++ b/flytepropeller/pkg/controller/nodes/branch/comparator_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestEvaluate_int(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/branch/evaluator.go
+++ b/flytepropeller/pkg/controller/nodes/branch/evaluator.go
@@ -3,13 +3,13 @@ package branch
 import (
 	"context"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flytestdlib/errors"
-	"github.com/flyteorg/flyte/flytestdlib/logger"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
+	"github.com/flyteorg/flyte/flytestdlib/errors"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 const ErrorCodeUserProvidedError = "UserProvidedError"

--- a/flytepropeller/pkg/controller/nodes/branch/evaluator_test.go
+++ b/flytepropeller/pkg/controller/nodes/branch/evaluator_test.go
@@ -5,15 +5,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/stretchr/testify/assert"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
 // Creates a ComparisonExpression, comparing 2 literals

--- a/flytepropeller/pkg/controller/nodes/branch/handler.go
+++ b/flytepropeller/pkg/controller/nodes/branch/handler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
@@ -13,7 +12,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
-
 	stdErrors "github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"

--- a/flytepropeller/pkg/controller/nodes/branch/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/branch/handler_test.go
@@ -5,29 +5,27 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/common"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	mocks3 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	v12 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	mocks3 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	mocks2 "github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 	execMocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 var eventConfig = &config.EventConfig{

--- a/flytepropeller/pkg/controller/nodes/cache.go
+++ b/flytepropeller/pkg/controller/nodes/cache.go
@@ -5,27 +5,23 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/encoding"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/common"
 	nodeserrors "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task"
-
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"github.com/pkg/errors"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // computeCatalogReservationOwnerID constructs a unique identifier which includes the nodes

--- a/flytepropeller/pkg/controller/nodes/cache_test.go
+++ b/flytepropeller/pkg/controller/nodes/cache_test.go
@@ -7,31 +7,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
+	catalogmocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog/mocks"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
 	executorsmocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
 	interfacesmocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
-
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
-	catalogmocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog/mocks"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
-
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var (

--- a/flytepropeller/pkg/controller/nodes/catalog/config.go
+++ b/flytepropeller/pkg/controller/nodes/catalog/config.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
-	"github.com/flyteorg/flyte/flytestdlib/config"
 	"google.golang.org/grpc"
 
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/catalog/datacatalog"
+	"github.com/flyteorg/flyte/flytestdlib/config"
 )
 
 //go:generate pflags Config --default-var defaultConfig

--- a/flytepropeller/pkg/controller/nodes/catalog/datacatalog/datacatalog.go
+++ b/flytepropeller/pkg/controller/nodes/catalog/datacatalog/datacatalog.go
@@ -6,22 +6,22 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
+	"github.com/golang/protobuf/ptypes"
 	grpcRetry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	grpcPrometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/pkg/errors"
-
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 var (

--- a/flytepropeller/pkg/controller/nodes/catalog/datacatalog/datacatalog_test.go
+++ b/flytepropeller/pkg/controller/nodes/catalog/datacatalog/datacatalog_test.go
@@ -6,25 +6,23 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flyteorg/flyte/flyteidl/clients/go/datacatalog/mocks"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
-	mocks2 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/golang/protobuf/ptypes"
+	"github.com/flyteorg/flyte/flyteidl/clients/go/datacatalog/mocks"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
+	mocks2 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )
 
 func init() {

--- a/flytepropeller/pkg/controller/nodes/catalog/datacatalog/transformer_test.go
+++ b/flytepropeller/pkg/controller/nodes/catalog/datacatalog/transformer_test.go
@@ -6,11 +6,12 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
-	"github.com/stretchr/testify/assert"
 )
 
 // add test for raarranged Literal maps for input values

--- a/flytepropeller/pkg/controller/nodes/common/utils.go
+++ b/flytepropeller/pkg/controller/nodes/common/utils.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/encoding"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 )

--- a/flytepropeller/pkg/controller/nodes/common/utils_test.go
+++ b/flytepropeller/pkg/controller/nodes/common/utils_test.go
@@ -3,8 +3,9 @@ package common
 import (
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
 type ParentInfo struct {

--- a/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"k8s.io/apimachinery/pkg/util/rand"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler"
@@ -20,8 +22,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 type dynamicWorkflowContext struct {

--- a/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow_test.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow_test.go
@@ -7,19 +7,15 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/encoding"
-	mocks3 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
-	storageMocks "github.com/flyteorg/flyte/flytestdlib/storage/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/encoding"
+	mocks3 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	mocks2 "github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
 	mocks4 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
@@ -27,6 +23,9 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
 	mocks5 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
+	storageMocks "github.com/flyteorg/flyte/flytestdlib/storage/mocks"
 )
 
 func Test_dynamicNodeHandler_buildContextualDynamicWorkflow_withLaunchPlans(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/dynamic/handler.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/handler.go
@@ -6,10 +6,8 @@ import (
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
@@ -18,7 +16,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
-
 	stdErrors "github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"

--- a/flytepropeller/pkg/controller/nodes/dynamic/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/handler_test.go
@@ -5,32 +5,28 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	v12 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
 	ioMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-
-	lpMocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	flyteMocks "github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	executorMocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/dynamic/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
 	nodeMocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
+	lpMocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks"
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 type dynamicNodeStateHolder struct {

--- a/flytepropeller/pkg/controller/nodes/dynamic/utils.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/utils.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/encoding"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"

--- a/flytepropeller/pkg/controller/nodes/dynamic/utils_test.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/utils_test.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"testing"
 
-	mocks2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	mocks2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
 )
 
 func TestHierarchicalNodeID(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/end/handler.go
+++ b/flytepropeller/pkg/controller/nodes/end/handler.go
@@ -3,13 +3,12 @@ package end
 import (
 	"context"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 type endHandler struct {

--- a/flytepropeller/pkg/controller/nodes/end/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/end/handler_test.go
@@ -5,24 +5,24 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	mocks2 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
 	"github.com/golang/protobuf/proto"
 	regErrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	mocks2 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	mocks3 "github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
 	flyteassert "github.com/flyteorg/flyte/flytepropeller/pkg/utils/assert"
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 var testScope = promutils.NewScope("end_test")

--- a/flytepropeller/pkg/controller/nodes/executor.go
+++ b/flytepropeller/pkg/controller/nodes/executor.go
@@ -21,11 +21,17 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
-
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyte/flytepropeller/events"
 	eventsErr "github.com/flyteorg/flyte/flytepropeller/events/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
@@ -38,23 +44,12 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/recovery"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task"
-
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
-
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	errors2 "github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"github.com/golang/protobuf/ptypes"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const cacheSerializedReason = "waiting on serialized cache"

--- a/flytepropeller/pkg/controller/nodes/executor_test.go
+++ b/flytepropeller/pkg/controller/nodes/executor_test.go
@@ -8,16 +8,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-
 	pluginscatalog "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
 	catalogmocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog/mocks"
 	mocks3 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-
 	"github.com/flyteorg/flyte/flytepropeller/events"
 	eventsErr "github.com/flyteorg/flyte/flytepropeller/events/errors"
 	eventMocks "github.com/flyteorg/flyte/flytepropeller/events/mocks"
@@ -34,21 +38,11 @@ import (
 	recoveryMocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/recovery/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan"
 	flyteassert "github.com/flyteorg/flyte/flytepropeller/pkg/utils/assert"
-
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 	storageMocks "github.com/flyteorg/flyte/flytestdlib/storage/mocks"
-
-	"github.com/golang/protobuf/proto"
-
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var fakeKubeClient = mocks4.NewFakeKubeClient()

--- a/flytepropeller/pkg/controller/nodes/factory/handler_factory.go
+++ b/flytepropeller/pkg/controller/nodes/factory/handler_factory.go
@@ -3,12 +3,11 @@ package factory
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
-
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
@@ -23,10 +22,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task"
-
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	"github.com/pkg/errors"
 )
 
 type handlerFactory struct {

--- a/flytepropeller/pkg/controller/nodes/gate/handler.go
+++ b/flytepropeller/pkg/controller/nodes/gate/handler.go
@@ -8,13 +8,11 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
-
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/storage"

--- a/flytepropeller/pkg/controller/nodes/gate/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/gate/handler_test.go
@@ -6,11 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/types/known/durationpb"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	ioMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	flyteMocks "github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
@@ -18,18 +21,10 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/gate/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	nodeMocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
-
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
-	"google.golang.org/protobuf/types/known/durationpb"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (

--- a/flytepropeller/pkg/controller/nodes/handler/state.go
+++ b/flytepropeller/pkg/controller/nodes/handler/state.go
@@ -4,11 +4,8 @@ import (
 	"time"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
-
 	"github.com/flyteorg/flyte/flytestdlib/bitarray"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )

--- a/flytepropeller/pkg/controller/nodes/handler/state_test.go
+++ b/flytepropeller/pkg/controller/nodes/handler/state_test.go
@@ -6,9 +6,9 @@ import (
 	"encoding/gob"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/k8s"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/k8s"
 )
 
 // A test to demonstrate how to unmarshal a serialized state from a workflow CRD.

--- a/flytepropeller/pkg/controller/nodes/handler/transition_info_test.go
+++ b/flytepropeller/pkg/controller/nodes/handler/transition_info_test.go
@@ -3,12 +3,11 @@ package handler
 import (
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
-	"github.com/golang/protobuf/proto"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPhaseInfoQueued(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/handler/transition_test.go
+++ b/flytepropeller/pkg/controller/nodes/handler/transition_test.go
@@ -3,11 +3,10 @@ package handler
 import (
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
-	"github.com/flyteorg/flyte/flytestdlib/storage"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 func AsPointer[T any](val T) *T {

--- a/flytepropeller/pkg/controller/nodes/interfaces/node.go
+++ b/flytepropeller/pkg/controller/nodes/interfaces/node.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 )

--- a/flytepropeller/pkg/controller/nodes/interfaces/node_exec_context.go
+++ b/flytepropeller/pkg/controller/nodes/interfaces/node_exec_context.go
@@ -3,19 +3,16 @@ package interfaces
 import (
 	"context"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
-
 	"github.com/flyteorg/flyte/flytepropeller/events"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
-
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 type TaskReader interface {

--- a/flytepropeller/pkg/controller/nodes/node_exec_context.go
+++ b/flytepropeller/pkg/controller/nodes/node_exec_context.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
-
 	"github.com/flyteorg/flyte/flytepropeller/events"
 	eventsErr "github.com/flyteorg/flyte/flytepropeller/events/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
@@ -19,13 +20,8 @@ import (
 	nodeerrors "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
-
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"github.com/pkg/errors"
-
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const NodeIDLabel = "node-id"

--- a/flytepropeller/pkg/controller/nodes/node_exec_context_test.go
+++ b/flytepropeller/pkg/controller/nodes/node_exec_context_test.go
@@ -6,10 +6,12 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyte/flytepropeller/events"
 	eventsErr "github.com/flyteorg/flyte/flytepropeller/events/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
@@ -17,14 +19,9 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 	mocks2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
-
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
-
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"github.com/stretchr/testify/assert"
 )
 
 type TaskReader struct{}

--- a/flytepropeller/pkg/controller/nodes/node_state_manager.go
+++ b/flytepropeller/pkg/controller/nodes/node_state_manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 )

--- a/flytepropeller/pkg/controller/nodes/output_resolver.go
+++ b/flytepropeller/pkg/controller/nodes/output_resolver.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
-
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 type VarName = string

--- a/flytepropeller/pkg/controller/nodes/output_resolver_test.go
+++ b/flytepropeller/pkg/controller/nodes/output_resolver_test.go
@@ -3,9 +3,10 @@ package nodes
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateAliasMap(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/predicate.go
+++ b/flytepropeller/pkg/controller/nodes/predicate.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 // Special enum to indicate if the node under consideration is ready to be executed or should be skipped

--- a/flytepropeller/pkg/controller/nodes/predicate_test.go
+++ b/flytepropeller/pkg/controller/nodes/predicate_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCanExecute(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/resolve_test.go
+++ b/flytepropeller/pkg/controller/nodes/resolve_test.go
@@ -4,20 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
-
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
 	flyteassert "github.com/flyteorg/flyte/flytepropeller/pkg/utils/assert"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 var testScope = promutils.NewScope("test")

--- a/flytepropeller/pkg/controller/nodes/setup_context.go
+++ b/flytepropeller/pkg/controller/nodes/setup_context.go
@@ -3,10 +3,9 @@ package nodes
 import (
 	"context"
 
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 type setupContext struct {

--- a/flytepropeller/pkg/controller/nodes/start/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/start/handler_test.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )
 
 func init() {

--- a/flytepropeller/pkg/controller/nodes/subworkflow/handler.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/handler.go
@@ -3,21 +3,17 @@ package subworkflow
 import (
 	"context"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/recovery"
-
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/recovery"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )
 
 type workflowNodeHandler struct {

--- a/flytepropeller/pkg/controller/nodes/subworkflow/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/handler_test.go
@@ -6,29 +6,27 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
-	mocks5 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/recovery/mocks"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	mocks4 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	mocks4 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	mocks2 "github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	execMocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	mocks3 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
+	mocks5 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/recovery/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks"
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 type workflowNodeStateHolder struct {

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/common"
@@ -14,12 +16,8 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/recovery"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan"
-
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type launchPlanHandler struct {

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/admin.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/admin.go
@@ -5,25 +5,20 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/client-go/util/workqueue"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
-
+	evtErr "github.com/flyteorg/flyte/flytepropeller/events/errors"
 	"github.com/flyteorg/flyte/flytestdlib/cache"
 	stdErr "github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	evtErr "github.com/flyteorg/flyte/flytepropeller/events/errors"
-
-	"github.com/golang/protobuf/ptypes/wrappers"
-
-	"golang.org/x/time/rate"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
-	"k8s.io/client-go/util/workqueue"
 )
 
 var isRecovery = true

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/admin_test.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/admin_test.go
@@ -6,19 +6,17 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-
-	"github.com/flyteorg/flyte/flytestdlib/cache"
-	mocks2 "github.com/flyteorg/flyte/flytestdlib/cache/mocks"
-
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	"github.com/flyteorg/flyte/flyteidl/clients/go/admin/mocks"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/flyteorg/flyte/flyteidl/clients/go/admin/mocks"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytestdlib/cache"
+	mocks2 "github.com/flyteorg/flyte/flytestdlib/cache/mocks"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 func TestAdminLaunchPlanExecutor_GetStatus(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/errors_test.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/errors_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/errors"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytestdlib/errors"
 )
 
 func TestRemoteError(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/noop.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/noop.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/flyteorg/flyte/flytestdlib/errors"
-
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/noop_test.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/noop_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 func TestFailFastWorkflowLauncher(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan_test.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan_test.go
@@ -6,29 +6,27 @@ import (
 	"reflect"
 	"testing"
 
-	mocks4 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-	mocks3 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
-	"github.com/flyteorg/flyte/flytestdlib/errors"
-
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
+	mocks4 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	mocks2 "github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
 	execMocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
+	mocks3 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
 	recoveryMocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/recovery/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
+	"github.com/flyteorg/flyte/flytestdlib/errors"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 func createInmemoryStore(t testing.TB) *storage.DataStore {

--- a/flytepropeller/pkg/controller/nodes/subworkflow/subworkflow.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/subworkflow.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
@@ -13,7 +12,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
-
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )

--- a/flytepropeller/pkg/controller/nodes/subworkflow/subworkflow_test.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/subworkflow_test.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/common"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	coreMocks "github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 	execMocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
 )
 

--- a/flytepropeller/pkg/controller/nodes/subworkflow/util.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/util.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/encoding"
 )
 

--- a/flytepropeller/pkg/controller/nodes/subworkflow/util_test.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/util_test.go
@@ -3,8 +3,9 @@ package subworkflow
 import (
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 func TestGetChildWorkflowExecutionID(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/task/backoff/controller.go
+++ b/flytepropeller/pkg/controller/nodes/task/backoff/controller.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	stdAtomic "github.com/flyteorg/flyte/flytestdlib/atomic"
-
 	"github.com/flyteorg/flyte/flytestdlib/logger"
-
-	"k8s.io/apimachinery/pkg/util/clock"
 )
 
 // Controller is a name-spaced collection of back-off handlers

--- a/flytepropeller/pkg/controller/nodes/task/backoff/handler.go
+++ b/flytepropeller/pkg/controller/nodes/task/backoff/handler.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/errors"
-	stdAtomic "github.com/flyteorg/flyte/flytestdlib/atomic"
-	"github.com/flyteorg/flyte/flytestdlib/logger"
 	v1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/clock"
+
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/errors"
+	stdAtomic "github.com/flyteorg/flyte/flytestdlib/atomic"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 var (

--- a/flytepropeller/pkg/controller/nodes/task/backoff/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/backoff/handler_test.go
@@ -8,17 +8,16 @@ import (
 	"testing"
 	"time"
 
-	stdAtomic "github.com/flyteorg/flyte/flytestdlib/atomic"
-
 	"github.com/stretchr/testify/assert"
-
-	taskErrors "github.com/flyteorg/flyte/flyteplugins/go/tasks/errors"
-	stdlibErrors "github.com/flyteorg/flyte/flytestdlib/errors"
 	v1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/clock"
+
+	taskErrors "github.com/flyteorg/flyte/flyteplugins/go/tasks/errors"
+	stdAtomic "github.com/flyteorg/flyte/flytestdlib/atomic"
+	stdlibErrors "github.com/flyteorg/flyte/flytestdlib/errors"
 )
 
 func TestComputeResourceAwareBackOffHandler_Handle(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/task/backoff/safe_resourcelist.go
+++ b/flytepropeller/pkg/controller/nodes/task/backoff/safe_resourcelist.go
@@ -4,10 +4,9 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // SyncResourceList is a thread-safe Map. It's meant to replace v1.ResourceList for concurrency-sensitive

--- a/flytepropeller/pkg/controller/nodes/task/cache.go
+++ b/flytepropeller/pkg/controller/nodes/task/cache.go
@@ -5,10 +5,8 @@ import (
 
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
-
 	errors2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
-
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )

--- a/flytepropeller/pkg/controller/nodes/task/config/config.go
+++ b/flytepropeller/pkg/controller/nodes/task/config/config.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/flyteorg/flyte/flytestdlib/config"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 //go:generate pflags Config

--- a/flytepropeller/pkg/controller/nodes/task/event_recorder_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/event_recorder_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/stretchr/testify/assert"
+
+	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 )
 
 func TestBufferedEventRecorder(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/task/fakeplugins/next_phase_state_plugin.go
+++ b/flytepropeller/pkg/controller/nodes/task/fakeplugins/next_phase_state_plugin.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/stretchr/testify/mock"
+
 	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-	"github.com/stretchr/testify/mock"
 )
 
 type NextPhaseState struct {

--- a/flytepropeller/pkg/controller/nodes/task/future_file_reader.go
+++ b/flytepropeller/pkg/controller/nodes/task/future_file_reader.go
@@ -4,12 +4,11 @@ import (
 	"context"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
 	"github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
-	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
 )
 
 // TODO this file exists only until we need to support dynamic nodes instead of closure.

--- a/flytepropeller/pkg/controller/nodes/task/handler.go
+++ b/flytepropeller/pkg/controller/nodes/task/handler.go
@@ -6,19 +6,19 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+	regErrors "github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-
 	pluginMachinery "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
 	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	pluginK8s "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/k8s"
-
 	eventsErr "github.com/flyteorg/flyte/flytepropeller/events/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	controllerConfig "github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
@@ -31,16 +31,11 @@ import (
 	rmConfig "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/resourcemanager/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/secretmanager"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
-
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	"github.com/golang/protobuf/ptypes"
-
-	regErrors "github.com/pkg/errors"
 )
 
 const pluginContextKey = contextutils.Key("plugin")

--- a/flytepropeller/pkg/controller/nodes/task/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/handler_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
@@ -19,7 +18,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery"
 	pluginCatalogMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog/mocks"
 	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
@@ -29,7 +27,6 @@ import (
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	pluginK8s "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/k8s"
 	pluginK8sMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/k8s/mocks"
-
 	eventsErr "github.com/flyteorg/flyte/flytepropeller/events/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	flyteMocks "github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
@@ -43,7 +40,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/fakeplugins"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/resourcemanager"
 	rmConfig "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/resourcemanager/config"
-
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"

--- a/flytepropeller/pkg/controller/nodes/task/k8s/event_watcher_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/event_watcher_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_collector.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_collector.go
@@ -7,14 +7,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )
 
 const resourceLevelMonitorCycleDuration = 10 * time.Second

--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_collector_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_collector_test.go
@@ -6,13 +6,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 var pods = []interface{}{

--- a/flytepropeller/pkg/controller/nodes/task/k8s/task_exec_context_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/task_exec_context_test.go
@@ -3,9 +3,10 @@ package k8s
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core/mocks"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_newTaskExecutionMetadata(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/task/remote_workflow_store.go
+++ b/flytepropeller/pkg/controller/nodes/task/remote_workflow_store.go
@@ -5,13 +5,12 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
 	"github.com/pkg/errors"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 type RemoteFileWorkflowStore struct {

--- a/flytepropeller/pkg/controller/nodes/task/remote_workflow_store_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/remote_workflow_store_test.go
@@ -4,20 +4,16 @@ import (
 	"context"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"github.com/go-test/deep"
-
 	"github.com/golang/protobuf/proto"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 func createInmemoryStore(t testing.TB) *storage.DataStore {

--- a/flytepropeller/pkg/controller/nodes/task/resourcemanager/redis_client.go
+++ b/flytepropeller/pkg/controller/nodes/task/resourcemanager/redis_client.go
@@ -3,10 +3,10 @@ package resourcemanager
 import (
 	"context"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/resourcemanager/config"
-
-	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/go-redis/redis"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/resourcemanager/config"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 //go:generate mockery -name RedisClient -case=underscore

--- a/flytepropeller/pkg/controller/nodes/task/resourcemanager/redis_resourcemanager.go
+++ b/flytepropeller/pkg/controller/nodes/task/resourcemanager/redis_resourcemanager.go
@@ -6,13 +6,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	rmConfig "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/resourcemanager/config"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // This is the key that will point to the Redis Set.

--- a/flytepropeller/pkg/controller/nodes/task/resourcemanager/redis_resourcemanager_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/resourcemanager/redis_resourcemanager_test.go
@@ -5,11 +5,12 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/resourcemanager/mocks"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func createMockNamespacedResourcesMap(mScope promutils.Scope) map[core.ResourceNamespace]*Resource {

--- a/flytepropeller/pkg/controller/nodes/task/resourcemanager/resourcemanager.go
+++ b/flytepropeller/pkg/controller/nodes/task/resourcemanager/resourcemanager.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )

--- a/flytepropeller/pkg/controller/nodes/task/resourcemanager/resourcemanager_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/resourcemanager/resourcemanager_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	core2 "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	rmConfig "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/resourcemanager/config"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/stretchr/testify/assert"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 func TestComposeTokenPrefix(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/task/secretmanager/secrets.go
+++ b/flytepropeller/pkg/controller/nodes/task/secretmanager/secrets.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	coreIdl "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 

--- a/flytepropeller/pkg/controller/nodes/task/setup_ctx.go
+++ b/flytepropeller/pkg/controller/nodes/task/setup_ctx.go
@@ -1,13 +1,11 @@
 package task
 
 import (
-	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
-
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
 	"k8s.io/apimachinery/pkg/types"
+
+	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 type setupContext struct {

--- a/flytepropeller/pkg/controller/nodes/task/setup_ctx_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/setup_ctx_test.go
@@ -3,10 +3,11 @@ package task
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/stretchr/testify/assert"
 )
 
 type dummySetupCtx struct {

--- a/flytepropeller/pkg/controller/nodes/task/taskexec_context.go
+++ b/flytepropeller/pkg/controller/nodes/task/taskexec_context.go
@@ -6,6 +6,9 @@ import (
 	"strconv"
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	pluginCatalog "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
 	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
@@ -21,8 +24,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 var (

--- a/flytepropeller/pkg/controller/nodes/task/taskexec_context_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/taskexec_context_test.go
@@ -5,35 +5,30 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
-
-	"k8s.io/apimachinery/pkg/api/resource"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/resourcemanager"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
-
-	mocks2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog/mocks"
-	pluginCoreMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core/mocks"
-	ioMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog/mocks"
+	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
+	pluginCoreMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core/mocks"
+	ioMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	flyteMocks "github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
+	mocks2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	nodeMocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/codex"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/resourcemanager"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/secretmanager"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 func TestHandler_newTaskExecutionContext(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/task/transformer_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/transformer_test.go
@@ -4,27 +4,23 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/golang/protobuf/proto"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
-	mocks2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
 	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
+	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	pluginMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core/mocks"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	mocks2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	nodemocks "github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces/mocks"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 const containerTaskType = "container"

--- a/flytepropeller/pkg/controller/nodes/task_reader.go
+++ b/flytepropeller/pkg/controller/nodes/task_reader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 

--- a/flytepropeller/pkg/controller/nodes/transformers.go
+++ b/flytepropeller/pkg/controller/nodes/transformers.go
@@ -6,21 +6,18 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/common"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
-
 	"github.com/flyteorg/flyte/flytestdlib/logger"
-
-	"github.com/golang/protobuf/ptypes"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // This is used by flyteadmin to indicate that the events will now contain populated IsParent and IsDynamic bits.

--- a/flytepropeller/pkg/controller/nodes/transformers_test.go
+++ b/flytepropeller/pkg/controller/nodes/transformers_test.go
@@ -3,19 +3,18 @@ package nodes
 import (
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
+	"github.com/flyteorg/flyte/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	mocks2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors/mocks"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/handler"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestToNodeExecutionEvent(t *testing.T) {

--- a/flytepropeller/pkg/controller/workers.go
+++ b/flytepropeller/pkg/controller/workers.go
@@ -6,12 +6,13 @@ import (
 	"runtime/pprof"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 type Handler interface {

--- a/flytepropeller/pkg/controller/workers_test.go
+++ b/flytepropeller/pkg/controller/workers_test.go
@@ -5,10 +5,10 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 var testLocalScope2 = promutils.NewScope("worker_pool")

--- a/flytepropeller/pkg/controller/workflow/executor.go
+++ b/flytepropeller/pkg/controller/workflow/executor.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
-
 	"github.com/flyteorg/flyte/flytepropeller/events"
 	eventsErr "github.com/flyteorg/flyte/flytepropeller/events/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
@@ -16,14 +18,10 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/workflow/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
-
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/record"
 )
 
 type workflowMetrics struct {

--- a/flytepropeller/pkg/controller/workflowstore/inmemory.go
+++ b/flytepropeller/pkg/controller/workflowstore/inmemory.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
 type InmemoryWorkflowStore struct {

--- a/flytepropeller/pkg/controller/workflowstore/passthrough.go
+++ b/flytepropeller/pkg/controller/workflowstore/passthrough.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
@@ -11,9 +13,6 @@ import (
 	listers "github.com/flyteorg/flyte/flytepropeller/pkg/client/listers/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/prometheus/client_golang/prometheus"
-
-	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 type workflowstoreMetrics struct {

--- a/flytepropeller/pkg/controller/workflowstore/passthrough_test.go
+++ b/flytepropeller/pkg/controller/workflowstore/passthrough_test.go
@@ -5,17 +5,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/stretchr/testify/assert"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
-	listers "github.com/flyteorg/flyte/flytepropeller/pkg/client/listers/flyteworkflow/v1alpha1"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned/fake"
-
-	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	listers "github.com/flyteorg/flyte/flytepropeller/pkg/client/listers/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 type mockWFNamespaceLister struct {

--- a/flytepropeller/pkg/controller/workflowstore/resource_version_caching.go
+++ b/flytepropeller/pkg/controller/workflowstore/resource_version_caching.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
-
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )

--- a/flytepropeller/pkg/controller/workflowstore/resource_version_caching_test.go
+++ b/flytepropeller/pkg/controller/workflowstore/resource_version_caching_test.go
@@ -5,22 +5,19 @@ import (
 	"fmt"
 	"testing"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	goObjectHash "github.com/benlaurie/objecthash/go/objecthash"
+	"github.com/stretchr/testify/assert"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	testing2 "k8s.io/client-go/testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-
-	goObjectHash "github.com/benlaurie/objecthash/go/objecthash"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned/fake"
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/stretchr/testify/assert"
-	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )
 
 const (

--- a/flytepropeller/pkg/controller/workflowstore/terminated_tracking.go
+++ b/flytepropeller/pkg/controller/workflowstore/terminated_tracking.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytestdlib/fastcheck"
-
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 

--- a/flytepropeller/pkg/controller/workflowstore/terminated_tracking_test.go
+++ b/flytepropeller/pkg/controller/workflowstore/terminated_tracking_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned/fake"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/flytepropeller/pkg/controller/workqueue.go
+++ b/flytepropeller/pkg/controller/workqueue.go
@@ -3,14 +3,12 @@ package controller
 import (
 	"context"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
 	"golang.org/x/time/rate"
-
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	// Setup workqueue metrics
-	_ "github.com/flyteorg/flyte/flytestdlib/promutils"
 	"k8s.io/client-go/util/workqueue"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	_ "github.com/flyteorg/flyte/flytestdlib/promutils" // Setup workqueue metrics
 )
 
 func NewWorkQueue(ctx context.Context, cfg config.WorkqueueConfig, name string) (workqueue.RateLimitingInterface, error) {

--- a/flytepropeller/pkg/controller/workqueue_test.go
+++ b/flytepropeller/pkg/controller/workqueue_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	config2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
-	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/stretchr/testify/assert"
+
+	config2 "github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flyte/flytestdlib/config"
 )
 
 func TestNewWorkQueue(t *testing.T) {

--- a/flytepropeller/pkg/leaderelection/leader_election.go
+++ b/flytepropeller/pkg/leaderelection/leader_election.go
@@ -5,16 +5,14 @@ import (
 	"fmt"
 	"os"
 
-	v12 "k8s.io/client-go/kubernetes/typed/coordination/v1"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-
 	"k8s.io/apimachinery/pkg/util/rand"
-
+	v12 "k8s.io/client-go/kubernetes/typed/coordination/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 )
 
 const (

--- a/flytepropeller/pkg/utils/assert/literals.go
+++ b/flytepropeller/pkg/utils/assert/literals.go
@@ -4,8 +4,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 func EqualPrimitive(t *testing.T, p1 *core.Primitive, p2 *core.Primitive) {

--- a/flytepropeller/pkg/utils/failing_datastore_test.go
+++ b/flytepropeller/pkg/utils/failing_datastore_test.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/storage"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 func TestFailingRawStore(t *testing.T) {

--- a/flytepropeller/pkg/utils/k8s.go
+++ b/flytepropeller/pkg/utils/k8s.go
@@ -7,11 +7,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
-	flyteScheme "github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned/scheme"
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/pkg/errors"
@@ -24,6 +19,12 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
+	flyteScheme "github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned/scheme"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 var NotTheOwnerError = errors.Errorf("FlytePropeller is not the owner")

--- a/flytepropeller/pkg/utils/k8s_test.go
+++ b/flytepropeller/pkg/utils/k8s_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 

--- a/flytepropeller/pkg/visualize/sort.go
+++ b/flytepropeller/pkg/visualize/sort.go
@@ -1,8 +1,9 @@
 package visualize
 
 import (
-	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/pkg/errors"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
 type VisitStatus int8

--- a/flytepropeller/pkg/visualize/visualize.go
+++ b/flytepropeller/pkg/visualize/visualize.go
@@ -5,10 +5,11 @@ import (
 	"reflect"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const executionEdgeLabel = "execution"

--- a/flytepropeller/pkg/webhook/aws_secret_manager.go
+++ b/flytepropeller/pkg/webhook/aws_secret_manager.go
@@ -7,10 +7,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/flytepropeller/pkg/webhook/aws_secret_manager_test.go
+++ b/flytepropeller/pkg/webhook/aws_secret_manager_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
-
 	"github.com/go-test/deep"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 )
 
 func TestAWSSecretManagerInjector_Inject(t *testing.T) {

--- a/flytepropeller/pkg/webhook/config/config.go
+++ b/flytepropeller/pkg/webhook/config/config.go
@@ -1,9 +1,10 @@
 package config
 
 import (
-	"github.com/flyteorg/flyte/flytestdlib/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/flyteorg/flyte/flytestdlib/config"
 )
 
 //go:generate enumer --type=SecretManagerType --trimprefix=SecretManagerType -json -yaml

--- a/flytepropeller/pkg/webhook/entrypoint.go
+++ b/flytepropeller/pkg/webhook/entrypoint.go
@@ -7,15 +7,16 @@ import (
 	"fmt"
 	"os"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
 	config2 "github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (

--- a/flytepropeller/pkg/webhook/gcp_secret_manager.go
+++ b/flytepropeller/pkg/webhook/gcp_secret_manager.go
@@ -7,10 +7,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/flytepropeller/pkg/webhook/gcp_secret_manager_test.go
+++ b/flytepropeller/pkg/webhook/gcp_secret_manager_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
-
 	"github.com/go-test/deep"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 )
 
 func TestGCPSecretManagerInjector_Inject(t *testing.T) {

--- a/flytepropeller/pkg/webhook/global_secrets.go
+++ b/flytepropeller/pkg/webhook/global_secrets.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
+	corev1 "k8s.io/api/core/v1"
 
 	coreIdl "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
-	corev1 "k8s.io/api/core/v1"
 )
 
 //go:generate mockery -all -case=underscore

--- a/flytepropeller/pkg/webhook/global_secrets_test.go
+++ b/flytepropeller/pkg/webhook/global_secrets_test.go
@@ -5,16 +5,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/go-test/deep"
-
-	coreIdl "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/mocks"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
+
+	coreIdl "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/mocks"
 )
 
 func TestGlobalSecrets_Inject(t *testing.T) {

--- a/flytepropeller/pkg/webhook/init_cert.go
+++ b/flytepropeller/pkg/webhook/init_cert.go
@@ -14,14 +14,15 @@ import (
 	"path"
 	"time"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
-	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
-	webhookConfig "github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
-	"github.com/flyteorg/flyte/flytestdlib/logger"
 	corev1 "k8s.io/api/core/v1"
 	kubeErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
+	webhookConfig "github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 type webhookCerts struct {

--- a/flytepropeller/pkg/webhook/k8s_secrets.go
+++ b/flytepropeller/pkg/webhook/k8s_secrets.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/flytepropeller/pkg/webhook/k8s_secrets_test.go
+++ b/flytepropeller/pkg/webhook/k8s_secrets_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	corev1 "k8s.io/api/core/v1"
 
 	coreIdl "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func TestK8sSecretInjector_Inject(t *testing.T) {

--- a/flytepropeller/pkg/webhook/pod.go
+++ b/flytepropeller/pkg/webhook/pod.go
@@ -36,21 +36,19 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
-
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s"
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils/secrets"
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	corev1 "k8s.io/api/core/v1"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils/secrets"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 const webhookName = "flyte-pod-webhook.flyte.org"

--- a/flytepropeller/pkg/webhook/pod_test.go
+++ b/flytepropeller/pkg/webhook/pod_test.go
@@ -5,21 +5,17 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
-
-	"k8s.io/client-go/tools/clientcmd/api/latest"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/mocks"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd/api/latest"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/mocks"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 func TestPodMutator_Mutate(t *testing.T) {

--- a/flytepropeller/pkg/webhook/secrets.go
+++ b/flytepropeller/pkg/webhook/secrets.go
@@ -3,17 +3,14 @@ package webhook
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	secretUtils "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils/secrets"
-
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/secretmanager"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
-
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/flytepropeller/pkg/webhook/secrets_test.go
+++ b/flytepropeller/pkg/webhook/secrets_test.go
@@ -5,16 +5,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
-
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/stretchr/testify/assert"
-
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/mocks"
-	"github.com/stretchr/testify/mock"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 func TestSecretsWebhook_Mutate(t *testing.T) {

--- a/flytepropeller/pkg/webhook/utils.go
+++ b/flytepropeller/pkg/webhook/utils.go
@@ -5,13 +5,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/encoding"
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
-
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/encoding"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 )
 
 func hasEnvVar(envVars []corev1.EnvVar, envVarKey string) bool {

--- a/flytepropeller/pkg/webhook/utils_test.go
+++ b/flytepropeller/pkg/webhook/utils_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/flytepropeller/pkg/webhook/vault_secret_manager.go
+++ b/flytepropeller/pkg/webhook/vault_secret_manager.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"path/filepath"
 
+	corev1 "k8s.io/api/core/v1"
+
 	coreIdl "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
-	corev1 "k8s.io/api/core/v1"
 )
 
 var (

--- a/flytepropeller/pkg/webhook/vault_secret_manager_test.go
+++ b/flytepropeller/pkg/webhook/vault_secret_manager_test.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"testing"
 
-	coreIdl "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 	"github.com/go-test/deep"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	coreIdl "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
 )
 
 var (


### PR DESCRIPTION
## Describe your changes
This change
1. Updates boilerplate with gci go import formatting changes from https://github.com/flyteorg/boilerplate/pull/85
2. Runs `make goimports` to sort go imports into exactly three sections
3. Runs `make lint` to verify results

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.