### PR TITLE
Format go imports (flytestdlib)

### DIFF
--- a/flytestdlib/.golangci.yml
+++ b/flytestdlib/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - deadcode
     - errcheck
     - gas
+    - gci
     - goconst
     - goimports
     - golint
@@ -28,3 +29,12 @@ linters:
     - unparam
     - unused
     - varcheck
+
+linters-settings:
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - prefix(github.com/flyteorg)
+    skip-generated: true

--- a/flytestdlib/boilerplate/flyte/golang_support_tools/tools.go
+++ b/flytestdlib/boilerplate/flyte/golang_support_tools/tools.go
@@ -6,7 +6,8 @@ package tools
 import (
 	_ "github.com/EngHabu/mockery/cmd/mockery"
 	_ "github.com/alvaroloes/enumer"
-	_ "github.com/flyteorg/flyte/flytestdlib/cli/pflags"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
+
+	_ "github.com/flyteorg/flyte/flytestdlib/cli/pflags"
 )

--- a/flytestdlib/boilerplate/flyte/golang_test_targets/download_tooling.sh
+++ b/flytestdlib/boilerplate/flyte/golang_test_targets/download_tooling.sh
@@ -19,6 +19,7 @@ tools=(
   "github.com/EngHabu/mockery/cmd/mockery"
   "github.com/flyteorg/flytestdlib/cli/pflags@latest"
   "github.com/golangci/golangci-lint/cmd/golangci-lint"
+  "github.com/daixiang0/gci"
   "github.com/alvaroloes/enumer"
   "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
 )

--- a/flytestdlib/boilerplate/flyte/golang_test_targets/goimports
+++ b/flytestdlib/boilerplate/flyte/golang_test_targets/goimports
@@ -6,3 +6,4 @@
 # TO OPT OUT OF UPDATES, SEE https://github.com/flyteorg/boilerplate/blob/master/Readme.rst
 
 goimports -w $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pkg/client/*" -not -path "./boilerplate/*")
+gci write -s standard -s default -s "prefix(github.com/flyteorg)" --custom-order --skip-generated .

--- a/flytestdlib/boilerplate/flyte/golangci_file/.golangci.yml
+++ b/flytestdlib/boilerplate/flyte/golangci_file/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - deadcode
     - errcheck
     - gas
+    - gci
     - goconst
     - goimports
     - golint
@@ -28,3 +29,12 @@ linters:
     - unparam
     - unused
     - varcheck
+
+linters-settings:
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - prefix(github.com/flyteorg)
+    skip-generated: true

--- a/flytestdlib/boilerplate/update.cfg
+++ b/flytestdlib/boilerplate/update.cfg
@@ -1,4 +1,5 @@
+flyte/code_of_conduct
 flyte/golang_test_targets
 flyte/golang_support_tools
+flyte/golangci_file
 flyte/pull_request_template
-flyte/code_of_conduct

--- a/flytestdlib/cache/auto_refresh.go
+++ b/flytestdlib/cache/auto_refresh.go
@@ -6,18 +6,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-
-	"k8s.io/client-go/util/workqueue"
-
-	"github.com/flyteorg/flyte/flytestdlib/errors"
-
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
+	"github.com/flyteorg/flyte/flytestdlib/errors"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 type ItemID = string

--- a/flytestdlib/cache/auto_refresh_example_test.go
+++ b/flytestdlib/cache/auto_refresh_example_test.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/flyteorg/flyte/flytestdlib/errors"
-
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 

--- a/flytestdlib/cache/auto_refresh_test.go
+++ b/flytestdlib/cache/auto_refresh_test.go
@@ -8,15 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/atomic"
-
+	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/flyteorg/flyte/flytestdlib/atomic"
 	"github.com/flyteorg/flyte/flytestdlib/errors"
-
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const fakeCacheItemValueLimit = 10

--- a/flytestdlib/cli/pflags/api/generator.go
+++ b/flytestdlib/cli/pflags/api/generator.go
@@ -7,11 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-
+	"github.com/ernesto-jimenez/gogen/gogenutil"
 	"golang.org/x/tools/go/packages"
 
-	"github.com/ernesto-jimenez/gogen/gogenutil"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 const (

--- a/flytestdlib/cli/pflags/cmd/root.go
+++ b/flytestdlib/cli/pflags/cmd/root.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/flyteorg/flyte/flytestdlib/cli/pflags/api"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/flytestdlib/cli/pflags/cmd/version.go
+++ b/flytestdlib/cli/pflags/cmd/version.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/flyteorg/flyte/flytestdlib/version"
 	"github.com/spf13/cobra"
+
+	"github.com/flyteorg/flyte/flytestdlib/version"
 )
 
 var versionCmd = &cobra.Command{

--- a/flytestdlib/config/config_cmd.go
+++ b/flytestdlib/config/config_cmd.go
@@ -8,11 +8,10 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/ghodss/yaml"
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/fatih/color"
+	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (

--- a/flytestdlib/config/regexp_test.go
+++ b/flytestdlib/config/regexp_test.go
@@ -6,9 +6,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/internal/utils"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytestdlib/internal/utils"
 )
 
 func TestRegexp_MarshalJSON(t *testing.T) {

--- a/flytestdlib/config/section.go
+++ b/flytestdlib/config/section.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/flyteorg/flyte/flytestdlib/atomic"
-
 	"github.com/spf13/pflag"
+
+	"github.com/flyteorg/flyte/flytestdlib/atomic"
 )
 
 type Section interface {

--- a/flytestdlib/config/section_test.go
+++ b/flytestdlib/config/section_test.go
@@ -10,13 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ghodss/yaml"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/flyteorg/flyte/flytestdlib/internal/utils"
-	"github.com/ghodss/yaml"
-	"github.com/spf13/pflag"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // Make sure existing config file(s) parse correctly before overriding them with this flag!

--- a/flytestdlib/config/tests/accessor_test.go
+++ b/flytestdlib/config/tests/accessor_test.go
@@ -16,14 +16,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ghodss/yaml"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
 	k8sRand "k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/flyteorg/flyte/flytestdlib/internal/utils"
-	"github.com/spf13/pflag"
-
-	"github.com/ghodss/yaml"
-	"github.com/stretchr/testify/assert"
 )
 
 type accessorCreatorFn func(registry config.Section, configPath string) config.Accessor

--- a/flytestdlib/config/tests/config_cmd_test.go
+++ b/flytestdlib/config/tests/config_cmd_test.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/config"
-
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytestdlib/config"
 )
 
 func executeCommand(root *cobra.Command, args ...string) (output string, err error) {

--- a/flytestdlib/config/tests/types_test.go
+++ b/flytestdlib/config/tests/types_test.go
@@ -1,13 +1,13 @@
 package tests
 
 import (
+	"encoding/json"
 	"fmt"
 
-	"encoding/json"
+	"github.com/spf13/pflag"
 
 	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/flyteorg/flyte/flytestdlib/config/viper"
-	"github.com/spf13/pflag"
 )
 
 const testNameFormatter = "[%v] %v"

--- a/flytestdlib/config/url_test.go
+++ b/flytestdlib/config/url_test.go
@@ -6,9 +6,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/internal/utils"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytestdlib/internal/utils"
 )
 
 func TestURL_MarshalJSON(t *testing.T) {

--- a/flytestdlib/config/viper/collection.go
+++ b/flytestdlib/config/viper/collection.go
@@ -7,14 +7,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/flyteorg/flyte/flytestdlib/errors"
-
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-
-	viperLib "github.com/spf13/viper"
-
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/pflag"
+	viperLib "github.com/spf13/viper"
+
+	"github.com/flyteorg/flyte/flytestdlib/errors"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 type Viper interface {

--- a/flytestdlib/config/viper/viper.go
+++ b/flytestdlib/config/viper/viper.go
@@ -10,23 +10,18 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
+	"github.com/fsnotify/fsnotify"
+	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-
-	stdLibErrs "github.com/flyteorg/flyte/flytestdlib/errors"
-
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	viperLib "github.com/spf13/viper"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/flyteorg/flyte/flytestdlib/config/files"
+	stdLibErrs "github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
-
-	"github.com/fsnotify/fsnotify"
-	"github.com/mitchellh/mapstructure"
-
-	"github.com/spf13/pflag"
-	viperLib "github.com/spf13/viper"
 )
 
 const (

--- a/flytestdlib/database/config_test.go
+++ b/flytestdlib/database/config_test.go
@@ -5,10 +5,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/flyteorg/flyte/flytestdlib/config/viper"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestParseDatabaseConfig(t *testing.T) {

--- a/flytestdlib/database/gorm.go
+++ b/flytestdlib/database/gorm.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-
 	gormLogger "gorm.io/gorm/logger"
+
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 // GetGormLogger converts between the flytestdlib configured log level to the equivalent gorm log level and outputs

--- a/flytestdlib/fastcheck/fastcheck_test.go
+++ b/flytestdlib/fastcheck/fastcheck_test.go
@@ -5,10 +5,11 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFilter(t *testing.T) {

--- a/flytestdlib/fastcheck/lru.go
+++ b/flytestdlib/fastcheck/lru.go
@@ -3,8 +3,9 @@ package fastcheck
 import (
 	"context"
 
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	cache "github.com/hashicorp/golang-lru"
+
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 // validate that it conforms to the interface

--- a/flytestdlib/ioutils/timed_readers_test.go
+++ b/flytestdlib/ioutils/timed_readers_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 func TestReadAll(t *testing.T) {

--- a/flytestdlib/logger/logger.go
+++ b/flytestdlib/logger/logger.go
@@ -10,9 +10,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-
 	"github.com/sirupsen/logrus"
+
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 )
 
 const (

--- a/flytestdlib/pbhash/pbhash.go
+++ b/flytestdlib/pbhash/pbhash.go
@@ -6,9 +6,10 @@ import (
 	"encoding/base64"
 
 	goObjectHash "github.com/benlaurie/objecthash/go/objecthash"
-	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 var marshaller = &jsonpb.Marshaler{}

--- a/flytestdlib/profutils/server.go
+++ b/flytestdlib/profutils/server.go
@@ -5,15 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof" // #nosec G108 Import for pprof server
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/version"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	// #nosec G108
-	_ "net/http/pprof" // Import for pprof server
 )
 
 const (

--- a/flytestdlib/profutils/server_test.go
+++ b/flytestdlib/profutils/server_test.go
@@ -6,11 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/version"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/flytestdlib/internal/utils"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/flyteorg/flyte/flytestdlib/version"
 )
 
 type MockResponseWriter struct {

--- a/flytestdlib/promutils/labeled/counter.go
+++ b/flytestdlib/promutils/labeled/counter.go
@@ -3,11 +3,11 @@ package labeled
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Counter represents a counter labeled with values from the context. See labeled.SetMetricsKeys for information about to

--- a/flytestdlib/promutils/labeled/counter_test.go
+++ b/flytestdlib/promutils/labeled/counter_test.go
@@ -5,12 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	"github.com/prometheus/client_golang/prometheus/testutil"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLabeledCounter(t *testing.T) {

--- a/flytestdlib/promutils/labeled/gauge.go
+++ b/flytestdlib/promutils/labeled/gauge.go
@@ -3,11 +3,11 @@ package labeled
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Gauge represents a gauge labeled with values from the context. See labeled.SetMetricsKeys for more information

--- a/flytestdlib/promutils/labeled/gauge_test.go
+++ b/flytestdlib/promutils/labeled/gauge_test.go
@@ -5,12 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	"github.com/prometheus/client_golang/prometheus/testutil"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLabeledGauge(t *testing.T) {

--- a/flytestdlib/promutils/labeled/keys_test.go
+++ b/flytestdlib/promutils/labeled/keys_test.go
@@ -3,8 +3,9 @@ package labeled
 import (
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 )
 
 func TestMetricKeys(t *testing.T) {

--- a/flytestdlib/promutils/labeled/stopwatch_test.go
+++ b/flytestdlib/promutils/labeled/stopwatch_test.go
@@ -6,12 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	"github.com/prometheus/client_golang/prometheus/testutil"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func ExampleStopWatch_Start() {

--- a/flytestdlib/promutils/labeled/summary.go
+++ b/flytestdlib/promutils/labeled/summary.go
@@ -3,11 +3,11 @@ package labeled
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Summary represents a summary labeled with values from the context. See labeled.SetMetricsKeys for information about

--- a/flytestdlib/promutils/labeled/summary_test.go
+++ b/flytestdlib/promutils/labeled/summary_test.go
@@ -5,12 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	"github.com/prometheus/client_golang/prometheus/testutil"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLabeledSummary(t *testing.T) {

--- a/flytestdlib/promutils/scope.go
+++ b/flytestdlib/promutils/scope.go
@@ -4,9 +4,8 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/rand"
-
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 const defaultScopeDelimiterStr = ":"

--- a/flytestdlib/promutils/scope_test.go
+++ b/flytestdlib/promutils/scope_test.go
@@ -4,10 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/rand"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 func TestDurationToString(t *testing.T) {

--- a/flytestdlib/promutils/workqueue.go
+++ b/flytestdlib/promutils/workqueue.go
@@ -17,9 +17,8 @@ limitations under the License.
 package promutils
 
 import (
-	"k8s.io/client-go/util/workqueue"
-
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/util/workqueue"
 )
 
 // Package prometheus sets the workqueue DefaultMetricsFactory to produce

--- a/flytestdlib/storage/cached_rawstore.go
+++ b/flytestdlib/storage/cached_rawstore.go
@@ -7,11 +7,10 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/errors"
-
 	"github.com/coocood/freecache"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/ioutils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"

--- a/flytestdlib/storage/config_test.go
+++ b/flytestdlib/storage/config_test.go
@@ -8,10 +8,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/config"
-	"github.com/flyteorg/flyte/flytestdlib/internal/utils"
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytestdlib/config"
+	"github.com/flyteorg/flyte/flytestdlib/internal/utils"
 )
 
 // Make sure existing config file(s) parse correctly before overriding them with this flag!

--- a/flytestdlib/storage/copy_impl_test.go
+++ b/flytestdlib/storage/copy_impl_test.go
@@ -7,10 +7,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/errors"
-
 	"github.com/stretchr/testify/assert"
 
+	"github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/ioutils"
 )
 

--- a/flytestdlib/storage/protobuf_store_test.go
+++ b/flytestdlib/storage/protobuf_store_test.go
@@ -9,13 +9,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/flyteorg/stow/s3"
 	"github.com/golang/protobuf/proto"
 	errs "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/stow/s3"
 )
 
 type mockProtoMessage struct {

--- a/flytestdlib/storage/rawstores_test.go
+++ b/flytestdlib/storage/rawstores_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/config"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytestdlib/config"
 )
 
 func Test_createHTTPClient(t *testing.T) {

--- a/flytestdlib/storage/storage.go
+++ b/flytestdlib/storage/storage.go
@@ -8,15 +8,14 @@ package storage
 
 import (
 	"context"
+	"io"
+	"net/url"
 	"strings"
 	"time"
 
-	"github.com/flyteorg/stow"
-
-	"io"
-	"net/url"
-
 	"github.com/golang/protobuf/proto"
+
+	"github.com/flyteorg/stow"
 )
 
 // DataReference defines a reference to data location.

--- a/flytestdlib/storage/storage_test.go
+++ b/flytestdlib/storage/storage_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 func TestDataReference_Split(t *testing.T) {

--- a/flytestdlib/storage/stow_store.go
+++ b/flytestdlib/storage/stow_store.go
@@ -11,13 +11,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	s32 "github.com/aws/aws-sdk-go/service/s3"
-	"github.com/flyteorg/stow"
-	"github.com/flyteorg/stow/azure"
-	"github.com/flyteorg/stow/google"
-	"github.com/flyteorg/stow/local"
-	"github.com/flyteorg/stow/oracle"
-	"github.com/flyteorg/stow/s3"
-	"github.com/flyteorg/stow/swift"
 	errs "github.com/pkg/errors"
 
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
@@ -25,6 +18,13 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
+	"github.com/flyteorg/stow"
+	"github.com/flyteorg/stow/azure"
+	"github.com/flyteorg/stow/google"
+	"github.com/flyteorg/stow/local"
+	"github.com/flyteorg/stow/oracle"
+	"github.com/flyteorg/stow/s3"
+	"github.com/flyteorg/stow/swift"
 )
 
 const (

--- a/flytestdlib/storage/stow_store_test.go
+++ b/flytestdlib/storage/stow_store_test.go
@@ -15,13 +15,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	s32 "github.com/aws/aws-sdk-go/service/s3"
-	"github.com/flyteorg/stow"
-	"github.com/flyteorg/stow/azure"
-	"github.com/flyteorg/stow/google"
-	"github.com/flyteorg/stow/local"
-	"github.com/flyteorg/stow/oracle"
-	"github.com/flyteorg/stow/s3"
-	"github.com/flyteorg/stow/swift"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
@@ -29,6 +22,13 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/internal/utils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
+	"github.com/flyteorg/stow"
+	"github.com/flyteorg/stow/azure"
+	"github.com/flyteorg/stow/google"
+	"github.com/flyteorg/stow/local"
+	"github.com/flyteorg/stow/oracle"
+	"github.com/flyteorg/stow/s3"
+	"github.com/flyteorg/stow/swift"
 )
 
 type mockStowLoc struct {

--- a/flytestdlib/storage/url_path.go
+++ b/flytestdlib/storage/url_path.go
@@ -3,11 +3,10 @@ package storage
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/pkg/errors"
-
-	"net/url"
 
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )

--- a/flytestdlib/storage/utils.go
+++ b/flytestdlib/storage/utils.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"os"
 
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	stdErrs "github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-
 	"github.com/flyteorg/stow"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/flytestdlib/storage/utils_test.go
+++ b/flytestdlib/storage/utils_test.go
@@ -5,10 +5,11 @@ import (
 	"syscall"
 	"testing"
 
-	flyteerrors "github.com/flyteorg/flyte/flytestdlib/errors"
-	"github.com/flyteorg/stow"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+
+	flyteerrors "github.com/flyteorg/flyte/flytestdlib/errors"
+	"github.com/flyteorg/stow"
 )
 
 func TestIsNotFound(t *testing.T) {

--- a/flytestdlib/tests/config_test.go
+++ b/flytestdlib/tests/config_test.go
@@ -9,14 +9,14 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytestdlib/config/viper"
+	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/flytestdlib/config"
+	"github.com/flyteorg/flyte/flytestdlib/config/viper"
 	"github.com/flyteorg/flyte/flytestdlib/internal/utils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-	"github.com/ghodss/yaml"
-	"github.com/stretchr/testify/assert"
 )
 
 // Make sure existing config file(s) parse correctly before overriding them with this flag!

--- a/flytestdlib/utils/auto_refresh_cache.go
+++ b/flytestdlib/utils/auto_refresh_cache.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 //go:generate mockery -all -case=underscore

--- a/flytestdlib/utils/marshal_utils_test.go
+++ b/flytestdlib/utils/marshal_utils_test.go
@@ -3,15 +3,14 @@ package utils
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/json"
-
 	"github.com/go-test/deep"
-	"github.com/stretchr/testify/assert"
-
-	"github.com/flyteorg/flyte/flytestdlib/utils/prototest"
 	"github.com/golang/protobuf/proto"
 	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/flyteorg/flyte/flytestdlib/utils/prototest"
 )
 
 type SimpleType struct {

--- a/flytestdlib/utils/rate_limiter.go
+++ b/flytestdlib/utils/rate_limiter.go
@@ -3,8 +3,9 @@ package utils
 import (
 	"context"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"golang.org/x/time/rate"
+
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 // Interface to use rate limiter

--- a/flytestdlib/utils/sequencer_test.go
+++ b/flytestdlib/utils/sequencer_test.go
@@ -1,10 +1,9 @@
 package utils
 
 import (
+	"fmt"
 	"sync"
 	"testing"
-
-	"fmt"
 
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
## Describe your changes
This change
1. Updates boilerplate with gci go import formatting changes from https://github.com/flyteorg/boilerplate/pull/85
2. Runs `make goimports` to sort go imports into exactly three sections
3. Runs `make lint` to verify results

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.