### PR TITLE
Format go imports (datacatalog)

### DIFF
--- a/datacatalog/.golangci.yml
+++ b/datacatalog/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - deadcode
     - errcheck
     - gas
+    - gci
     - goconst
     - goimports
     - golint
@@ -28,3 +29,12 @@ linters:
     - unparam
     - unused
     - varcheck
+
+linters-settings:
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - prefix(github.com/flyteorg)
+    skip-generated: true

--- a/datacatalog/boilerplate/flyte/golang_support_tools/tools.go
+++ b/datacatalog/boilerplate/flyte/golang_support_tools/tools.go
@@ -6,7 +6,8 @@ package tools
 import (
 	_ "github.com/EngHabu/mockery/cmd/mockery"
 	_ "github.com/alvaroloes/enumer"
-	_ "github.com/flyteorg/flyte/flytestdlib/cli/pflags"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
+
+	_ "github.com/flyteorg/flyte/flytestdlib/cli/pflags"
 )

--- a/datacatalog/boilerplate/flyte/golang_test_targets/download_tooling.sh
+++ b/datacatalog/boilerplate/flyte/golang_test_targets/download_tooling.sh
@@ -19,6 +19,7 @@ tools=(
   "github.com/EngHabu/mockery/cmd/mockery"
   "github.com/flyteorg/flytestdlib/cli/pflags@latest"
   "github.com/golangci/golangci-lint/cmd/golangci-lint"
+  "github.com/daixiang0/gci"
   "github.com/alvaroloes/enumer"
   "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
 )

--- a/datacatalog/boilerplate/flyte/golang_test_targets/goimports
+++ b/datacatalog/boilerplate/flyte/golang_test_targets/goimports
@@ -6,3 +6,4 @@
 # TO OPT OUT OF UPDATES, SEE https://github.com/flyteorg/boilerplate/blob/master/Readme.rst
 
 goimports -w $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pkg/client/*" -not -path "./boilerplate/*")
+gci write -s standard -s default -s "prefix(github.com/flyteorg)" --custom-order --skip-generated .

--- a/datacatalog/boilerplate/flyte/golangci_file/.golangci.yml
+++ b/datacatalog/boilerplate/flyte/golangci_file/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - deadcode
     - errcheck
     - gas
+    - gci
     - goconst
     - goimports
     - golint
@@ -28,3 +29,12 @@ linters:
     - unparam
     - unused
     - varcheck
+
+linters-settings:
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - prefix(github.com/flyteorg)
+    skip-generated: true

--- a/datacatalog/cmd/entrypoints/migrate.go
+++ b/datacatalog/cmd/entrypoints/migrate.go
@@ -1,11 +1,11 @@
 package entrypoints
 
 import (
-	"github.com/flyteorg/flyte/datacatalog/pkg/repositories"
-
 	"context"
 
 	"github.com/spf13/cobra"
+
+	"github.com/flyteorg/flyte/datacatalog/pkg/repositories"
 )
 
 var parentMigrateCmd = &cobra.Command{

--- a/datacatalog/cmd/entrypoints/root.go
+++ b/datacatalog/cmd/entrypoints/root.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/flyteorg/flyte/flytestdlib/config/viper"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 var (

--- a/datacatalog/cmd/entrypoints/serve.go
+++ b/datacatalog/cmd/entrypoints/serve.go
@@ -3,6 +3,8 @@ package entrypoints
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/config"
 	"github.com/flyteorg/flyte/datacatalog/pkg/rpc/datacatalogservice"
 	"github.com/flyteorg/flyte/datacatalog/pkg/runtime"
@@ -10,8 +12,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/profutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-
-	"github.com/spf13/cobra"
 )
 
 var serveCmd = &cobra.Command{

--- a/datacatalog/cmd/entrypoints/serve_dummy.go
+++ b/datacatalog/cmd/entrypoints/serve_dummy.go
@@ -3,10 +3,11 @@ package entrypoints
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/config"
 	"github.com/flyteorg/flyte/datacatalog/pkg/rpc/datacatalogservice"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/spf13/cobra"
 )
 
 var serveDummyCmd = &cobra.Command{

--- a/datacatalog/cmd/main.go
+++ b/datacatalog/cmd/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/flyteorg/flyte/datacatalog/cmd/entrypoints"
 	"github.com/golang/glog"
+
+	"github.com/flyteorg/flyte/datacatalog/cmd/entrypoints"
 )
 
 func main() {

--- a/datacatalog/pkg/errors/errors_test.go
+++ b/datacatalog/pkg/errors/errors_test.go
@@ -1,9 +1,8 @@
 package errors
 
 import (
-	"testing"
-
 	"fmt"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"

--- a/datacatalog/pkg/manager/impl/artifact_data_store.go
+++ b/datacatalog/pkg/manager/impl/artifact_data_store.go
@@ -3,12 +3,13 @@ package impl
 import (
 	"context"
 
+	"google.golang.org/grpc/codes"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-	"google.golang.org/grpc/codes"
 )
 
 const artifactDataFile = "data.pb"

--- a/datacatalog/pkg/manager/impl/artifact_manager.go
+++ b/datacatalog/pkg/manager/impl/artifact_manager.go
@@ -5,22 +5,21 @@ import (
 	"strconv"
 	"time"
 
+	"google.golang.org/grpc/codes"
+
+	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/manager/impl/validators"
 	"github.com/flyteorg/flyte/datacatalog/pkg/manager/interfaces"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/transformers"
-
-	"github.com/flyteorg/flyte/datacatalog/pkg/common"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-	"google.golang.org/grpc/codes"
 )
 
 type artifactMetrics struct {

--- a/datacatalog/pkg/manager/impl/artifact_manager_test.go
+++ b/datacatalog/pkg/manager/impl/artifact_manager_test.go
@@ -3,11 +3,17 @@ package impl
 import (
 	"context"
 	stdErrors "errors"
+	"fmt"
 	"os"
 	"testing"
 	"time"
 
-	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
@@ -20,12 +26,6 @@ import (
 	mockScope "github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func init() {

--- a/datacatalog/pkg/manager/impl/dataset_manager.go
+++ b/datacatalog/pkg/manager/impl/dataset_manager.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"time"
 
+	"google.golang.org/grpc/codes"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/manager/impl/validators"
@@ -16,7 +18,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
-	"google.golang.org/grpc/codes"
 )
 
 type datasetMetrics struct {

--- a/datacatalog/pkg/manager/impl/dataset_manager_test.go
+++ b/datacatalog/pkg/manager/impl/dataset_manager_test.go
@@ -1,9 +1,14 @@
 package impl
 
 import (
+	"context"
 	"testing"
 
-	"context"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
@@ -14,11 +19,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	mockScope "github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func init() {

--- a/datacatalog/pkg/manager/impl/reservation_manager.go
+++ b/datacatalog/pkg/manager/impl/reservation_manager.go
@@ -4,19 +4,16 @@ import (
 	"context"
 	"time"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-
 	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
+	"github.com/flyteorg/flyte/datacatalog/pkg/manager/interfaces"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories"
 	repo_errors "github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/transformers"
-
-	"github.com/flyteorg/flyte/datacatalog/pkg/manager/interfaces"
-
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )
 
 type reservationMetrics struct {

--- a/datacatalog/pkg/manager/impl/reservation_manager_test.go
+++ b/datacatalog/pkg/manager/impl/reservation_manager_test.go
@@ -3,21 +3,20 @@ package impl
 import (
 	"context"
 	"fmt"
-
-	mockScope "github.com/flyteorg/flyte/flytestdlib/promutils"
-
 	"testing"
 	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc/codes"
 
 	errors2 "github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	errors3 "github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/mocks"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"google.golang.org/grpc/codes"
+	mockScope "github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 var tagName = "tag"

--- a/datacatalog/pkg/manager/impl/tag_manager.go
+++ b/datacatalog/pkg/manager/impl/tag_manager.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"time"
 
+	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/manager/impl/validators"
 	"github.com/flyteorg/flyte/datacatalog/pkg/manager/interfaces"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories"
-
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/transformers"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-
-	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"

--- a/datacatalog/pkg/manager/impl/tag_manager_test.go
+++ b/datacatalog/pkg/manager/impl/tag_manager_test.go
@@ -4,17 +4,17 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/mocks"
-	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-
-	"github.com/flyteorg/flyte/flytestdlib/contextutils"
-	mockScope "github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/mocks"
+	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
+	"github.com/flyteorg/flyte/flytestdlib/contextutils"
+	mockScope "github.com/flyteorg/flyte/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )
 
 func init() {

--- a/datacatalog/pkg/manager/impl/validators/errors.go
+++ b/datacatalog/pkg/manager/impl/validators/errors.go
@@ -3,10 +3,10 @@ package validators
 import (
 	"fmt"
 
-	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
+	"google.golang.org/grpc/codes"
 
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
-	"google.golang.org/grpc/codes"
+	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 )
 
 const missingFieldFormat = "missing %s"

--- a/datacatalog/pkg/manager/impl/validators/pagination_validator.go
+++ b/datacatalog/pkg/manager/impl/validators/pagination_validator.go
@@ -4,9 +4,10 @@ import (
 	"strconv"
 	"strings"
 
+	"google.golang.org/grpc/codes"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"google.golang.org/grpc/codes"
 )
 
 // The token is a string that should be opaque to the client

--- a/datacatalog/pkg/manager/impl/validators/partition_validator.go
+++ b/datacatalog/pkg/manager/impl/validators/partition_validator.go
@@ -3,9 +3,10 @@ package validators
 import (
 	"fmt"
 
+	"google.golang.org/grpc/codes"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"google.golang.org/grpc/codes"
 )
 
 const (

--- a/datacatalog/pkg/repositories/config/postgres.go
+++ b/datacatalog/pkg/repositories/config/postgres.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/flyteorg/flyte/flytestdlib/database"
-	stdlibLogger "github.com/flyteorg/flyte/flytestdlib/logger"
-	"github.com/flyteorg/flyte/flytestdlib/promutils"
-
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+
+	"github.com/flyteorg/flyte/flytestdlib/database"
+	stdlibLogger "github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 const (

--- a/datacatalog/pkg/repositories/config/postgres_test.go
+++ b/datacatalog/pkg/repositories/config/postgres_test.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
 	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/flyteorg/flyte/flytestdlib/database"
 	mockScope "github.com/flyteorg/flyte/flytestdlib/promutils"
-
-	"github.com/stretchr/testify/assert"
-
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 func TestConstructGormArgs(t *testing.T) {

--- a/datacatalog/pkg/repositories/errors/errors.go
+++ b/datacatalog/pkg/repositories/errors/errors.go
@@ -2,10 +2,11 @@
 package errors
 
 import (
-	"github.com/flyteorg/flyte/datacatalog/pkg/common"
-	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/codes"
+
+	"github.com/flyteorg/flyte/datacatalog/pkg/common"
+	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 )
 
 const (

--- a/datacatalog/pkg/repositories/errors/postgres.go
+++ b/datacatalog/pkg/repositories/errors/postgres.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-
 	"github.com/jackc/pgconn"
-
-	catalogErrors "github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"gorm.io/gorm"
+
+	catalogErrors "github.com/flyteorg/flyte/datacatalog/pkg/errors"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
 // Postgres error codes

--- a/datacatalog/pkg/repositories/factory.go
+++ b/datacatalog/pkg/repositories/factory.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/flyteorg/flyte/flytestdlib/database"
-
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/config"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/interfaces"
+	"github.com/flyteorg/flyte/flytestdlib/database"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 

--- a/datacatalog/pkg/repositories/gormimpl/artifact.go
+++ b/datacatalog/pkg/repositories/gormimpl/artifact.go
@@ -3,15 +3,15 @@ package gormimpl
 import (
 	"context"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 type artifactRepo struct {

--- a/datacatalog/pkg/repositories/gormimpl/artifact_test.go
+++ b/datacatalog/pkg/repositories/gormimpl/artifact_test.go
@@ -2,12 +2,12 @@ package gormimpl
 
 import (
 	"context"
+	"database/sql/driver"
 	"testing"
 
 	mocket "github.com/Selvatico/go-mocket"
 	"github.com/stretchr/testify/assert"
-
-	"database/sql/driver"
+	"google.golang.org/grpc/codes"
 
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	apiErrors "github.com/flyteorg/flyte/datacatalog/pkg/errors"
@@ -18,7 +18,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-	"google.golang.org/grpc/codes"
 )
 
 func init() {

--- a/datacatalog/pkg/repositories/gormimpl/dataset.go
+++ b/datacatalog/pkg/repositories/gormimpl/dataset.go
@@ -3,15 +3,15 @@ package gormimpl
 import (
 	"context"
 
-	idl_datacatalog "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
+	"gorm.io/gorm"
 
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
+	idl_datacatalog "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"gorm.io/gorm"
 )
 
 type dataSetRepo struct {

--- a/datacatalog/pkg/repositories/gormimpl/dataset_test.go
+++ b/datacatalog/pkg/repositories/gormimpl/dataset_test.go
@@ -2,15 +2,13 @@ package gormimpl
 
 import (
 	"context"
+	"database/sql/driver"
 	"testing"
 	"time"
 
 	mocket "github.com/Selvatico/go-mocket"
-	"google.golang.org/grpc/codes"
-
 	"github.com/stretchr/testify/assert"
-
-	"database/sql/driver"
+	"google.golang.org/grpc/codes"
 
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	datacatalog_error "github.com/flyteorg/flyte/datacatalog/pkg/errors"

--- a/datacatalog/pkg/repositories/gormimpl/filter_test.go
+++ b/datacatalog/pkg/repositories/gormimpl/filter_test.go
@@ -3,8 +3,9 @@ package gormimpl
 import (
 	"testing"
 
-	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 )
 
 func TestGormValueFilter(t *testing.T) {

--- a/datacatalog/pkg/repositories/gormimpl/join_test.go
+++ b/datacatalog/pkg/repositories/gormimpl/join_test.go
@@ -3,8 +3,9 @@ package gormimpl
 import (
 	"testing"
 
-	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 )
 
 func TestGormJoinCondition(t *testing.T) {

--- a/datacatalog/pkg/repositories/gormimpl/list.go
+++ b/datacatalog/pkg/repositories/gormimpl/list.go
@@ -3,13 +3,13 @@ package gormimpl
 import (
 	"fmt"
 
-	errors2 "github.com/flyteorg/flyte/datacatalog/pkg/errors"
-
-	"github.com/flyteorg/flyte/datacatalog/pkg/common"
-	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
-	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"google.golang.org/grpc/codes"
 	"gorm.io/gorm"
+
+	"github.com/flyteorg/flyte/datacatalog/pkg/common"
+	errors2 "github.com/flyteorg/flyte/datacatalog/pkg/errors"
+	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
+	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 )
 
 const (

--- a/datacatalog/pkg/repositories/gormimpl/list_test.go
+++ b/datacatalog/pkg/repositories/gormimpl/list_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	mocket "github.com/Selvatico/go-mocket"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/utils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestApplyFilter(t *testing.T) {

--- a/datacatalog/pkg/repositories/gormimpl/reservation.go
+++ b/datacatalog/pkg/repositories/gormimpl/reservation.go
@@ -2,20 +2,18 @@ package gormimpl
 
 import (
 	"context"
-
-	datacatalog_error "github.com/flyteorg/flyte/datacatalog/pkg/errors"
-	"google.golang.org/grpc/codes"
-
 	"time"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
+	"google.golang.org/grpc/codes"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
+	datacatalog_error "github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	errors2 "github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 type reservationRepo struct {

--- a/datacatalog/pkg/repositories/gormimpl/reservation_test.go
+++ b/datacatalog/pkg/repositories/gormimpl/reservation_test.go
@@ -6,19 +6,17 @@ import (
 	"testing"
 	"time"
 
+	mocket "github.com/Selvatico/go-mocket"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
-	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/interfaces"
-
 	apiErrors "github.com/flyteorg/flyte/datacatalog/pkg/errors"
-	"google.golang.org/grpc/codes"
-
-	mocket "github.com/Selvatico/go-mocket"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
+	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCreate(t *testing.T) {

--- a/datacatalog/pkg/repositories/gormimpl/sort_test.go
+++ b/datacatalog/pkg/repositories/gormimpl/sort_test.go
@@ -3,8 +3,9 @@ package gormimpl
 import (
 	"testing"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 )
 
 func TestSortAsc(t *testing.T) {

--- a/datacatalog/pkg/repositories/gormimpl/tag.go
+++ b/datacatalog/pkg/repositories/gormimpl/tag.go
@@ -3,13 +3,13 @@ package gormimpl
 import (
 	"context"
 
-	idl_datacatalog "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
+	"gorm.io/gorm"
 
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
+	idl_datacatalog "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"gorm.io/gorm"
 )
 
 type tagRepo struct {

--- a/datacatalog/pkg/repositories/gormimpl/tag_test.go
+++ b/datacatalog/pkg/repositories/gormimpl/tag_test.go
@@ -1,28 +1,23 @@
 package gormimpl
 
 import (
+	"context"
+	"database/sql/driver"
 	"testing"
 
-	"github.com/jackc/pgconn"
-
-	"gorm.io/gorm"
-
-	"context"
-
 	mocket "github.com/Selvatico/go-mocket"
+	"github.com/jackc/pgconn"
 	"github.com/stretchr/testify/assert"
-
-	"database/sql/driver"
+	"google.golang.org/grpc/codes"
+	"gorm.io/gorm"
 
 	datacatalog_error "github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
-
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/utils"
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
-	"google.golang.org/grpc/codes"
 )
 
 func init() {

--- a/datacatalog/pkg/repositories/handle.go
+++ b/datacatalog/pkg/repositories/handle.go
@@ -2,18 +2,16 @@ package repositories
 
 import (
 	"context"
-
-	"gorm.io/driver/sqlite"
-
 	"fmt"
 
-	"github.com/flyteorg/flyte/flytestdlib/database"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/config"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
+	"github.com/flyteorg/flyte/flytestdlib/database"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"gorm.io/gorm"
 )
 
 type DBHandle struct {

--- a/datacatalog/pkg/repositories/handle_test.go
+++ b/datacatalog/pkg/repositories/handle_test.go
@@ -2,17 +2,16 @@ package repositories
 
 import (
 	"context"
+	"database/sql/driver"
 	"path"
 	"testing"
 
 	mocket "github.com/Selvatico/go-mocket"
-	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/config"
-	"github.com/flyteorg/flyte/flytestdlib/database"
 	"github.com/stretchr/testify/assert"
 
-	"database/sql/driver"
-
+	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/config"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/utils"
+	"github.com/flyteorg/flyte/flytestdlib/database"
 )
 
 func TestCreateDB(t *testing.T) {

--- a/datacatalog/pkg/repositories/initialize.go
+++ b/datacatalog/pkg/repositories/initialize.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 	"reflect"
 
+	"github.com/jackc/pgconn"
+
 	errors2 "github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/runtime"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"github.com/jackc/pgconn"
 )
 
 var migrationsScope = promutils.NewScope("migrations")

--- a/datacatalog/pkg/repositories/postgres_repo.go
+++ b/datacatalog/pkg/repositories/postgres_repo.go
@@ -1,11 +1,12 @@
 package repositories
 
 import (
+	"gorm.io/gorm"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/gormimpl"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
-	"gorm.io/gorm"
 )
 
 type PostgresRepo struct {

--- a/datacatalog/pkg/repositories/transformers/artifact.go
+++ b/datacatalog/pkg/repositories/transformers/artifact.go
@@ -1,11 +1,12 @@
 package transformers
 
 import (
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc/codes"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"github.com/golang/protobuf/ptypes"
-	"google.golang.org/grpc/codes"
 )
 
 func CreateArtifactModel(request *datacatalog.CreateArtifactRequest, artifactData []models.ArtifactData, dataset models.Dataset) (models.Artifact, error) {

--- a/datacatalog/pkg/repositories/transformers/artifact_test.go
+++ b/datacatalog/pkg/repositories/transformers/artifact_test.go
@@ -2,14 +2,14 @@ package transformers
 
 import (
 	"testing"
-
 	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/stretchr/testify/assert"
 )
 
 func getTestArtifactData() []*datacatalog.ArtifactData {

--- a/datacatalog/pkg/repositories/transformers/dataset_test.go
+++ b/datacatalog/pkg/repositories/transformers/dataset_test.go
@@ -3,9 +3,10 @@ package transformers
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"github.com/stretchr/testify/assert"
 )
 
 var metadata = &datacatalog.Metadata{

--- a/datacatalog/pkg/repositories/transformers/filters.go
+++ b/datacatalog/pkg/repositories/transformers/filters.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
-
 	"github.com/flyteorg/flyte/datacatalog/pkg/manager/impl/validators"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/gormimpl"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"

--- a/datacatalog/pkg/repositories/transformers/filters_test.go
+++ b/datacatalog/pkg/repositories/transformers/filters_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"github.com/stretchr/testify/assert"
 )
 
 func assertJoinExpression(t *testing.T, joinCondition models.ModelJoinCondition, sourceTableName string, joiningTableName string, joiningTableAlias string, expectedJoinStatement string) {

--- a/datacatalog/pkg/repositories/transformers/pagination.go
+++ b/datacatalog/pkg/repositories/transformers/pagination.go
@@ -4,12 +4,13 @@ import (
 	"strconv"
 	"strings"
 
+	"google.golang.org/grpc/codes"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/gormimpl"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"google.golang.org/grpc/codes"
 )
 
 func ApplyPagination(paginationOpts *datacatalog.PaginationOptions, input *models.ListModelsInput) error {

--- a/datacatalog/pkg/repositories/transformers/pagination_test.go
+++ b/datacatalog/pkg/repositories/transformers/pagination_test.go
@@ -3,10 +3,11 @@ package transformers
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/common"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPaginationDefaults(t *testing.T) {

--- a/datacatalog/pkg/repositories/transformers/reservation.go
+++ b/datacatalog/pkg/repositories/transformers/reservation.go
@@ -3,13 +3,12 @@ package transformers
 import (
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc/codes"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-
-	"github.com/golang/protobuf/ptypes"
-
-	"google.golang.org/grpc/codes"
 )
 
 func FromReservationID(reservationID *datacatalog.ReservationID) models.ReservationKey {

--- a/datacatalog/pkg/repositories/transformers/reservation_test.go
+++ b/datacatalog/pkg/repositories/transformers/reservation_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFromReservationID(t *testing.T) {

--- a/datacatalog/pkg/repositories/transformers/tag_test.go
+++ b/datacatalog/pkg/repositories/transformers/tag_test.go
@@ -3,9 +3,10 @@ package transformers
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestToTagKey(t *testing.T) {

--- a/datacatalog/pkg/repositories/transformers/util.go
+++ b/datacatalog/pkg/repositories/transformers/util.go
@@ -1,10 +1,11 @@
 package transformers
 
 import (
-	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/codes"
+
+	"github.com/flyteorg/flyte/datacatalog/pkg/errors"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 )
 
 func marshalMetadata(metadata *datacatalog.Metadata) ([]byte, error) {

--- a/datacatalog/pkg/runtime/application_config_provider.go
+++ b/datacatalog/pkg/runtime/application_config_provider.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/flyteorg/flyte/flytestdlib/config"
-
 	"github.com/flyteorg/flyte/datacatalog/pkg/runtime/configs"
+	"github.com/flyteorg/flyte/flytestdlib/config"
 	"github.com/flyteorg/flyte/flytestdlib/database"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )

--- a/datacatalog/pull_request_template.md
+++ b/datacatalog/pull_request_template.md
@@ -1,6 +1,5 @@
 ## _Read then delete this section_
 
-
 _- Make sure to use a concise title for the pull-request._
 
 _- Use #patch, #minor or #major in the pull-request title to bump the corresponding version. Otherwise, the patch version


### PR DESCRIPTION
## Describe your changes
This change
1. Updates boilerplate with gci go import formatting changes from https://github.com/flyteorg/boilerplate/pull/85
2. Runs `make goimports` to sort go imports into exactly three sections
3. Runs `make lint` to verify results

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.