### PR TITLE
Start metrics server in a goroutine

### DIFF
--- a/flytestdlib/profutils/server.go
+++ b/flytestdlib/profutils/server.go
@@ -100,11 +100,14 @@ func StartProfilingServer(ctx context.Context, pprofPort int) error {
 		Addr:         fmt.Sprintf(":%d", pprofPort),
 	}
 
-	e := srv.ListenAndServe()
-	if e != nil {
-		logger.Errorf(ctx, "Failed to start profiling server. Error: %v", e)
-		return fmt.Errorf("failed to start profiling server, %s", e)
-	}
+	go func() {
+		e := srv.ListenAndServe()
+		if e != nil {
+			logger.Errorf(ctx, "Failed to start profiling server. Error: %v", e)
+		}
+	}()
+
+	srv.Shutdown(ctx)
 
 	return nil
 }

--- a/flytestdlib/profutils/server.go
+++ b/flytestdlib/profutils/server.go
@@ -107,9 +107,7 @@ func StartProfilingServer(ctx context.Context, pprofPort int) error {
 		}
 	}()
 
-	srv.Shutdown(ctx)
-
-	return nil
+	return srv.Shutdown(ctx)
 }
 
 func configureGlobalHTTPHandler(handlers map[string]http.Handler) error {


### PR DESCRIPTION
## Describe your changes

Start metrics server in a separate go routine to prevent this [errGroup.Wait()](https://github.com/flyteorg/flyte/blob/master/cmd/single/start.go#L173) from hanging.

As part of this investigation we realized that our usage of `errGroup` is not correct, since we mix them with panics and logrus `Fatalf` (which exit the process and set its status to 1). I opened https://github.com/flyteorg/flyte/issues/4255 to track this.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
