### PR TITLE
Rename grpc histogram metrics flag for consistency with flytepropeller

### DIFF
--- a/flyteadmin/pkg/config/config.go
+++ b/flyteadmin/pkg/config/config.go
@@ -50,7 +50,7 @@ type GrpcConfig struct {
 	Port                     int  `json:"port" pflag:",On which grpc port to serve admin"`
 	ServerReflection         bool `json:"serverReflection" pflag:",Enable GRPC Server Reflection"`
 	MaxMessageSizeBytes      int  `json:"maxMessageSizeBytes" pflag:",The max size in bytes for incoming gRPC messages"`
-	EnableGrpcLatencyMetrics bool `json:"enable-grpc-latency-metrics" pflag:",Enable grpc latency metrics. Note Histograms metrics can be expensive on Prometheus servers."`
+	EnableGrpcLatencyMetrics bool `json:"enableGrpcLatencyMetrics" pflag:",Enable grpc latency metrics. Note Histograms metrics can be expensive on Prometheus servers."`
 }
 
 // KubeClientConfig contains the configuration used by flyteadmin to configure its internal Kubernetes Client.

--- a/flyteadmin/pkg/config/config.go
+++ b/flyteadmin/pkg/config/config.go
@@ -47,10 +47,10 @@ type DataProxyUploadConfig struct {
 }
 
 type GrpcConfig struct {
-	Port                 int  `json:"port" pflag:",On which grpc port to serve admin"`
-	ServerReflection     bool `json:"serverReflection" pflag:",Enable GRPC Server Reflection"`
-	MaxMessageSizeBytes  int  `json:"maxMessageSizeBytes" pflag:",The max size in bytes for incoming gRPC messages"`
-	EnableGrpcHistograms bool `json:"enableGrpcHistograms" pflag:",Enable grpc histograms"`
+	Port                     int  `json:"port" pflag:",On which grpc port to serve admin"`
+	ServerReflection         bool `json:"serverReflection" pflag:",Enable GRPC Server Reflection"`
+	MaxMessageSizeBytes      int  `json:"maxMessageSizeBytes" pflag:",The max size in bytes for incoming gRPC messages"`
+	EnableGrpcLatencyMetrics bool `json:"enable-grpc-latency-metrics" pflag:",Enable grpc latency metrics. Note Histograms metrics can be expensive on Prometheus servers."`
 }
 
 // KubeClientConfig contains the configuration used by flyteadmin to configure its internal Kubernetes Client.

--- a/flyteadmin/pkg/config/serverconfig_flags.go
+++ b/flyteadmin/pkg/config/serverconfig_flags.go
@@ -66,7 +66,7 @@ func (cfg ServerConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "grpc.port"), defaultServerConfig.GrpcConfig.Port, "On which grpc port to serve admin")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "grpc.serverReflection"), defaultServerConfig.GrpcConfig.ServerReflection, "Enable GRPC Server Reflection")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "grpc.maxMessageSizeBytes"), defaultServerConfig.GrpcConfig.MaxMessageSizeBytes, "The max size in bytes for incoming gRPC messages")
-	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "grpc.enableGrpcHistograms"), defaultServerConfig.GrpcConfig.EnableGrpcHistograms, "Enable grpc histograms")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "grpc.enable-grpc-latency-metrics"), defaultServerConfig.GrpcConfig.EnableGrpcLatencyMetrics, "Enable grpc latency metrics. Note Histograms metrics can be expensive on Prometheus servers.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "thirdPartyConfig.flyteClient.clientId"), defaultServerConfig.DeprecatedThirdPartyConfig.FlyteClientConfig.ClientID, "public identifier for the app which handles authorization for a Flyte deployment")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "thirdPartyConfig.flyteClient.redirectUri"), defaultServerConfig.DeprecatedThirdPartyConfig.FlyteClientConfig.RedirectURI, "This is the callback uri registered with the app which handles authorization for a Flyte deployment")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "thirdPartyConfig.flyteClient.scopes"), defaultServerConfig.DeprecatedThirdPartyConfig.FlyteClientConfig.Scopes, "Recommended scopes for the client to request.")

--- a/flyteadmin/pkg/config/serverconfig_flags.go
+++ b/flyteadmin/pkg/config/serverconfig_flags.go
@@ -66,7 +66,7 @@ func (cfg ServerConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "grpc.port"), defaultServerConfig.GrpcConfig.Port, "On which grpc port to serve admin")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "grpc.serverReflection"), defaultServerConfig.GrpcConfig.ServerReflection, "Enable GRPC Server Reflection")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "grpc.maxMessageSizeBytes"), defaultServerConfig.GrpcConfig.MaxMessageSizeBytes, "The max size in bytes for incoming gRPC messages")
-	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "grpc.enable-grpc-latency-metrics"), defaultServerConfig.GrpcConfig.EnableGrpcLatencyMetrics, "Enable grpc latency metrics. Note Histograms metrics can be expensive on Prometheus servers.")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "grpc.enableGrpcLatencyMetrics"), defaultServerConfig.GrpcConfig.EnableGrpcLatencyMetrics, "Enable grpc latency metrics. Note Histograms metrics can be expensive on Prometheus servers.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "thirdPartyConfig.flyteClient.clientId"), defaultServerConfig.DeprecatedThirdPartyConfig.FlyteClientConfig.ClientID, "public identifier for the app which handles authorization for a Flyte deployment")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "thirdPartyConfig.flyteClient.redirectUri"), defaultServerConfig.DeprecatedThirdPartyConfig.FlyteClientConfig.RedirectURI, "This is the callback uri registered with the app which handles authorization for a Flyte deployment")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "thirdPartyConfig.flyteClient.scopes"), defaultServerConfig.DeprecatedThirdPartyConfig.FlyteClientConfig.Scopes, "Recommended scopes for the client to request.")

--- a/flyteadmin/pkg/config/serverconfig_flags_test.go
+++ b/flyteadmin/pkg/config/serverconfig_flags_test.go
@@ -323,14 +323,14 @@ func TestServerConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
-	t.Run("Test_grpc.enableGrpcHistograms", func(t *testing.T) {
+	t.Run("Test_grpc.enable-grpc-latency-metrics", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := "1"
 
-			cmdFlags.Set("grpc.enableGrpcHistograms", testValue)
-			if vBool, err := cmdFlags.GetBool("grpc.enableGrpcHistograms"); err == nil {
-				testDecodeJson_ServerConfig(t, fmt.Sprintf("%v", vBool), &actual.GrpcConfig.EnableGrpcHistograms)
+			cmdFlags.Set("grpc.enable-grpc-latency-metrics", testValue)
+			if vBool, err := cmdFlags.GetBool("grpc.enable-grpc-latency-metrics"); err == nil {
+				testDecodeJson_ServerConfig(t, fmt.Sprintf("%v", vBool), &actual.GrpcConfig.EnableGrpcLatencyMetrics)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/flyteadmin/pkg/config/serverconfig_flags_test.go
+++ b/flyteadmin/pkg/config/serverconfig_flags_test.go
@@ -323,13 +323,13 @@ func TestServerConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
-	t.Run("Test_grpc.enable-grpc-latency-metrics", func(t *testing.T) {
+	t.Run("Test_grpc.enableGrpcLatencyMetrics", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := "1"
 
-			cmdFlags.Set("grpc.enable-grpc-latency-metrics", testValue)
-			if vBool, err := cmdFlags.GetBool("grpc.enable-grpc-latency-metrics"); err == nil {
+			cmdFlags.Set("grpc.enableGrpcLatencyMetrics", testValue)
+			if vBool, err := cmdFlags.GetBool("grpc.enableGrpcLatencyMetrics"); err == nil {
 				testDecodeJson_ServerConfig(t, fmt.Sprintf("%v", vBool), &actual.GrpcConfig.EnableGrpcLatencyMetrics)
 
 			} else {

--- a/flyteadmin/pkg/server/service.go
+++ b/flyteadmin/pkg/server/service.go
@@ -80,7 +80,7 @@ func newGRPCServer(ctx context.Context, pluginRegistry *plugins.Registry, cfg *c
 	pluginRegistry.RegisterDefault(plugins.PluginIDUnaryServiceMiddleware, grpcmiddleware.ChainUnaryServer(
 		RequestIDInterceptor, auth.BlanketAuthorization, auth.ExecutionUserIdentifierInterceptor))
 
-	if cfg.GrpcConfig.EnableGrpcHistograms {
+	if cfg.GrpcConfig.EnableGrpcLatencyMetrics {
 		logger.Debugf(ctx, "enabling grpc histogram metrics")
 		grpcprometheus.EnableHandlingTimeHistogram()
 	}


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4214


## Describe your changes

See PR title, the recently added admin config option doesn't conform to the existing flytepropeller one

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
