### PR TITLE
Make fetching HttpClient optional from context in PKCE auth flow

### DIFF
--- a/flyteidl/clients/go/admin/pkce/auth_flow_orchestrator.go
+++ b/flyteidl/clients/go/admin/pkce/auth_flow_orchestrator.go
@@ -67,6 +67,7 @@ func (f TokenOrchestrator) FetchTokenFromAuthFlow(ctx context.Context) (*oauth2.
 	// Pass along http client used in oauth2
 	httpClient, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
 	if !ok {
+		logger.Debugf(ctx, "using default http client instead")
 		httpClient = http.DefaultClient
 	}
 

--- a/flyteidl/clients/go/admin/pkce/auth_flow_orchestrator.go
+++ b/flyteidl/clients/go/admin/pkce/auth_flow_orchestrator.go
@@ -2,7 +2,6 @@ package pkce
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -68,7 +67,7 @@ func (f TokenOrchestrator) FetchTokenFromAuthFlow(ctx context.Context) (*oauth2.
 	// Pass along http client used in oauth2
 	httpClient, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
 	if !ok {
-		return nil, errors.New("Unable to retrieve httpClient used in oauth2 from context")
+		httpClient = http.DefaultClient
 	}
 
 	serveMux.HandleFunc(redirectURL.Path, getAuthServerCallbackHandler(f.ClientConfig, pkceCodeVerifier,

--- a/flyteidl/clients/go/admin/pkce/auth_flow_orchestrator_test.go
+++ b/flyteidl/clients/go/admin/pkce/auth_flow_orchestrator_test.go
@@ -2,6 +2,7 @@ package pkce
 
 import (
 	"context"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,5 +30,10 @@ func TestFetchFromAuthFlow(t *testing.T) {
 		refreshedToken, err := orchestrator.FetchTokenFromAuthFlow(ctx)
 		assert.Nil(t, refreshedToken)
 		assert.NotNil(t, err)
+		// Throws an exitError since browser cannot be opened.
+		// But this makes sure that atleast code is tested till the browser action is invoked.
+		// Earlier change had broken this by introducing a hard dependency on the http Client from the context
+		_, isAnExitError := err.(*exec.ExitError)
+		assert.True(t, isAnExitError)
 	})
 }

--- a/flyteidl/clients/go/admin/pkce/auth_flow_orchestrator_test.go
+++ b/flyteidl/clients/go/admin/pkce/auth_flow_orchestrator_test.go
@@ -31,7 +31,7 @@ func TestFetchFromAuthFlow(t *testing.T) {
 		assert.Nil(t, refreshedToken)
 		assert.NotNil(t, err)
 		// Throws an exitError since browser cannot be opened.
-		// But this makes sure that atleast code is tested till the browser action is invoked.
+		// But this makes sure that at least code is tested till the browser action is invoked.
 		// Earlier change had broken this by introducing a hard dependency on the http Client from the context
 		_, isAnExitError := err.(*exec.ExitError)
 		assert.True(t, isAnExitError)


### PR DESCRIPTION
## Tracking issue


## Describe your changes
Previous PR introduced authentication with proxy http Client but it added a hard dependency to fetch this from the context .
This causes regression in cases the context is not set with this object.

Current change makes it backward compatible by using the default http client in case the context is not set with it.


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

Tested this change locally by pulling this commit as saw authentication working fine in the broken environments

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
