### PR TITLE
Restore deprecated NotificationsConfig.Region field

### DIFF
--- a/charts/flyte-core/templates/admin/configmap.yaml
+++ b/charts/flyte-core/templates/admin/configmap.yaml
@@ -48,6 +48,11 @@ data:
   notifications.yaml: |
     notifications:
       type: {{ .Values.workflow_notifications.config.notifications.type }}
+      {{- if not .Values.workflow_notifications.config.notifications.aws }}
+      {{- with .Values.workflow_notifications.config.notifications.region }}
+      region: {{ tpl . $ }}
+      {{- end }}
+      {{- end }}
       {{- if eq .Values.workflow_notifications.config.notifications.type "aws" }}
       {{- with .Values.workflow_notifications.config.notifications.aws }}
       aws: {{ tpl (toYaml .) $ | nindent 8 }}


### PR DESCRIPTION
## Tracking issue

Fixes #3070

## Describe your changes

This change
* Restores population of the `NotificationConfig.Region` field from the flyte-core configmap template. This was removed in #4055. While the config struct field has a comment indicating deprecated, the alternative `NotificationConfig.AWSConfig.Region` is not consumed everywhere yet. It is not safe to stop populating this field yet, and is in fact required for all existing versions of flyteadmin to use NotificationsProcessor and Emailer. The deprecated field is only populated in the absence of the `aws` block.
* Updates flyteadmin to consume `NotificationConfig.AWSConfig.Region` and only fallback to the deprecated field if necessary.

## Testing
I ran through a couple EKS and GCP helm templating scenarios to verify the fix correctly populates the deprecated region field if used and no other changes otherwise.

**EKS with deprecated region field**
```
❯ cat values-eks-notifications-deprecated.yaml
workflow_notifications:
  enabled: true
  config:
    notifications:
      type: aws
      region: "{{ .Values.userSettings.accountRegion }}"
```
Before:
```
❯ helm template flyte-core -f flyte-core/values-eks.yaml -f values-eks-notifications-deprecated.yaml | grep notifications.yaml -A3
  notifications.yaml: |
    notifications:
      type: aws
      publisher:
```

After:
```
❯ helm template flyte-core -f flyte-core/values-eks.yaml -f values-eks-notifications-deprecated.yaml | grep notifications.yaml -A4
  notifications.yaml: |
    notifications:
      type: aws
      region: <AWS_REGION>
      publisher:

❯ diff generated-old-eks-deprecated.yaml generated-new-eks-deprecated.yaml
3a4
>       region: <AWS_REGION>
```

**EKS with AWS region field**
```
❯ helm template flyte-core -f flyte-core/values-eks.yaml -f values-eks-notifications.yaml | grep notifications.yaml -A14 > generated-old-eks.yaml

❯ helm template flyte-core -f flyte-core/values-eks.yaml -f values-eks-notifications.yaml | grep notifications.yaml -A15 > generated-new-eks.yaml

❯ diff generated-old-eks.yaml generated-new-eks.yaml

```

**GCP**
```
❯ cat values-gcp-notifications.yaml
workflow_notifications:
  enabled: true
  config:
    notifications:
      type: gcp
      gcp:
        projectId: foo
      publisher:
        topicName: "arn:aws:sns:{{ .Values.userSettings.accountRegion }}:{{ .Values.userSettings.accountNumber }}:flyte-notifications-topic"
      processor:
        queueName: flyte-notifications-queue
        accountId: "{{ .Values.userSettings.accountNumber }}"
      emailer:
        subject: "Flyte: {{ project }}/{{ domain }}/{{ launch_plan.name }} has {{ phase }}"
        sender: "flyte@example.com"
        body: |
         "Execution {{ workflow.project }}/{{ workflow.domain }}/{{ workflow.name }}/{{ name }} has {{ phase }}.
          Details: https://flyte.example.com/console/projects/{{ project }}/domains/{{ domain }}/executions/{{ name }}.
          {{ error }}"

❯ helm template flyte-core -f flyte-core/values-gcp.yaml -f values-gcp-notifications.yaml | grep notifications.yaml -A14 > generated-old-gcp.yaml

❯ helm template flyte-core -f flyte-core/values-gcp.yaml -f values-gcp-notifications.yaml | grep notifications.yaml -A14 > generated-new-gcp.yaml

❯ diff generated-old-gcp.yaml generated-new-gcp.yaml

```

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.