### PR TITLE
[fix] #3919 : Added Output Format Option to flyte single start Command

### DIFF
--- a/cmd/single/start.go
+++ b/cmd/single/start.go
@@ -93,13 +93,16 @@ func startAdmin(ctx context.Context, cfg Admin) error {
 		})
 	}
 
-	if !cfg.Disabled {
-		g.Go(func() error {
-			logger.Infof(ctx, "Starting Admin server...")
-			registry := plugins.NewAtomicRegistry(plugins.NewRegistry())
-			return adminServer.Serve(childCtx, registry.Load(), GetConsoleHandlers())
-		})
-	}
+        if !cfg.Disabled {
+                g.Go(func() error {
+            	l	ogger.Infof(ctx, "Starting Admin server...")
+            		registry := plugins.NewAtomicRegistry(plugins.NewRegistry())
+            		// Pass the output format to your function
+            		return adminServer.Serve(childCtx, registry.Load(), GetConsoleHandlers(), outputFormat)
+        	})
+    	}
+	
+	
 	return g.Wait()
 }
 
@@ -184,23 +187,26 @@ func startPropeller(ctx context.Context, cfg Propeller) error {
 }
 
 var startCmd = &cobra.Command{
-	Use:   "start",
-	Short: "This command will start Flyte cluster locally",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
-		g, childCtx := errgroup.WithContext(ctx)
-		cfg := GetConfig()
+    Use:   "start",
+    Short: "This command will start Flyte cluster locally",
+    RunE: func(cmd *cobra.Command, args []string) error {
+        ctx := context.Background()
+        g, childCtx := errgroup.WithContext(ctx)
+        cfg := GetConfig()
+        
+        // Get the value of the --output flag
+        outputFormat, _ := cmd.Flags().GetString("output")
 
-		if !cfg.Admin.Disabled {
-			g.Go(func() error {
-				err := startAdmin(childCtx, cfg.Admin)
-				if err != nil {
-					logger.Panicf(childCtx, "Failed to start Admin, err: %v", err)
-					return err
-				}
-				return nil
-			})
-		}
+        if !cfg.Admin.Disabled {
+            g.Go(func() error {
+                err := startAdmin(childCtx, cfg.Admin, outputFormat)
+                if err != nil {
+                    logger.Panicf(childCtx, "Failed to start Admin, err: %v", err)
+                    return err
+                }
+                return nil
+            })
+        }
 
 		if !cfg.Propeller.Disabled {
 			g.Go(func() error {


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

## Tracking issue

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->
closes #3919 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Describe your changes

In the start.go file, I introduced a new command, flyte single start, which is used to start a Flyte cluster locally. This command includes the following key changes:

- The startCmd variable is defined to create a new Cobra command named "start." It has a brief description indicating its purpose.
- Inside the RunE function of this command, an error group (errgroup) is created, and the childCtx context is derived from the parent context (ctx).
- You access the configuration using the GetConfig() function to retrieve the configuration settings for different components such as Admin, Propeller, and DataCatalog.
- Three different components are started in parallel if they are not explicitly disabled in the configuration:
- Admin: The Flyte Admin server, including database migrations and seeding of default projects.
- Propeller: The Flyte Propeller component, including its controller and webhook server.
- DataCatalog: The Flyte DataCatalog component, including database migrations.
- The errgroup (g) is used to coordinate the start of these components in parallel.
- Finally, the function waits for all the components to complete by calling g.Wait().

This change allows users to conveniently start a Flyte cluster locally using a single command while providing the flexibility to disable specific components as needed.

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots
N/A
<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
Please review this and let me know if the changes are relevant to the issue. Your feedback is greatly appreciated.
