### PR TITLE
Support `make lint` auto fix `goimport packages`  in all flyte components

### DIFF
--- a/boilerplate/flyte/golang_test_targets/Makefile
+++ b/boilerplate/flyte/golang_test_targets/Makefile
@@ -17,7 +17,7 @@ generate: download_tooling #generate go code
 
 .PHONY: lint
 lint: codespell download_tooling #lints the package for common code smells
-	GL_DEBUG=linters_output,env golangci-lint run --deadline=5m --exclude deprecated -v
+	GL_DEBUG=linters_output,env golangci-lint run --fix --deadline=5m --exclude deprecated -v
 
 # If code is failing goimports linter, this will fix.
 # skips 'vendor'

--- a/datacatalog/boilerplate/flyte/golang_test_targets/Makefile
+++ b/datacatalog/boilerplate/flyte/golang_test_targets/Makefile
@@ -14,7 +14,7 @@ generate: download_tooling #generate go code
 
 .PHONY: lint
 lint: download_tooling #lints the package for common code smells
-	GL_DEBUG=linters_output,env golangci-lint run --deadline=5m --exclude deprecated -v
+	GL_DEBUG=linters_output,env golangci-lint run --fix --deadline=5m --exclude deprecated -v
 
 # If code is failing goimports linter, this will fix.
 # skips 'vendor'

--- a/flyteadmin/boilerplate/flyte/golang_test_targets/Makefile
+++ b/flyteadmin/boilerplate/flyte/golang_test_targets/Makefile
@@ -14,7 +14,7 @@ generate: download_tooling #generate go code
 
 .PHONY: lint
 lint: download_tooling #lints the package for common code smells
-	GL_DEBUG=linters_output,env golangci-lint run --deadline=5m --exclude deprecated -v
+	GL_DEBUG=linters_output,env golangci-lint run --fix --deadline=5m --exclude deprecated -v
 
 # If code is failing goimports linter, this will fix.
 # skips 'vendor'

--- a/flytecopilot/boilerplate/flyte/golang_test_targets/Makefile
+++ b/flytecopilot/boilerplate/flyte/golang_test_targets/Makefile
@@ -14,7 +14,7 @@ generate: download_tooling #generate go code
 
 .PHONY: lint
 lint: download_tooling #lints the package for common code smells
-	GL_DEBUG=linters_output,env golangci-lint run --deadline=5m --exclude deprecated -v
+	GL_DEBUG=linters_output,env golangci-lint run --fix --deadline=5m --exclude deprecated -v
 
 # If code is failing goimports linter, this will fix.
 # skips 'vendor'

--- a/flyteidl/boilerplate/flyte/golang_test_targets/Makefile
+++ b/flyteidl/boilerplate/flyte/golang_test_targets/Makefile
@@ -14,7 +14,7 @@ generate: download_tooling #generate go code
 
 .PHONY: lint
 lint: download_tooling #lints the package for common code smells
-	GL_DEBUG=linters_output,env golangci-lint run --deadline=5m --exclude deprecated -v
+	GL_DEBUG=linters_output,env golangci-lint run --fix --deadline=5m --exclude deprecated -v
 
 # If code is failing goimports linter, this will fix.
 # skips 'vendor'

--- a/flyteplugins/boilerplate/flyte/golang_test_targets/Makefile
+++ b/flyteplugins/boilerplate/flyte/golang_test_targets/Makefile
@@ -14,7 +14,7 @@ generate: download_tooling #generate go code
 
 .PHONY: lint
 lint: download_tooling #lints the package for common code smells
-	GL_DEBUG=linters_output,env golangci-lint run --deadline=5m --exclude deprecated -v
+	GL_DEBUG=linters_output,env golangci-lint run --fix --deadline=5m --exclude deprecated -v
 
 # If code is failing goimports linter, this will fix.
 # skips 'vendor'

--- a/flytepropeller/boilerplate/flyte/golang_test_targets/Makefile
+++ b/flytepropeller/boilerplate/flyte/golang_test_targets/Makefile
@@ -14,7 +14,7 @@ generate: download_tooling #generate go code
 
 .PHONY: lint
 lint: download_tooling #lints the package for common code smells
-	GL_DEBUG=linters_output,env golangci-lint run --deadline=5m --exclude deprecated -v
+	GL_DEBUG=linters_output,env golangci-lint run --fix --deadline=5m --exclude deprecated -v
 
 # If code is failing goimports linter, this will fix.
 # skips 'vendor'

--- a/flytestdlib/boilerplate/flyte/golang_test_targets/Makefile
+++ b/flytestdlib/boilerplate/flyte/golang_test_targets/Makefile
@@ -14,7 +14,7 @@ generate: download_tooling #generate go code
 
 .PHONY: lint
 lint: download_tooling #lints the package for common code smells
-	GL_DEBUG=linters_output,env golangci-lint run --deadline=5m --exclude deprecated -v
+	GL_DEBUG=linters_output,env golangci-lint run --fix --deadline=5m --exclude deprecated -v
 
 # If code is failing goimports linter, this will fix.
 # skips 'vendor'


### PR DESCRIPTION
## Describe your changes
Right now, users don't need to type `make lint; make goimports` to lint the golang files.
They just need to type `make lint` only.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots
![image](https://github.com/flyteorg/flyte/assets/76461262/6d21d348-40c9-40db-9962-99692eb9a4da)
You can see the line here.
`GL_DEBUG=linters_output,env golangci-lint run --fix --deadline=5m --exclude deprecated -v`
