### PR TITLE
Use debian bookworm as single binary base image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG FLYTECONSOLE_VERSION=latest
 FROM ghcr.io/flyteorg/flyteconsole:${FLYTECONSOLE_VERSION} AS flyteconsole
 
 
-FROM --platform=${BUILDPLATFORM} golang:1.19.1-bullseye AS flytebuilder
+FROM --platform=${BUILDPLATFORM} golang:1.19.13-bookworm AS flytebuilder
 
 ARG TARGETARCH
 ENV GOARCH "${TARGETARCH}"
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/r
     go build -tags console -v -o dist/flyte cmd/main.go
 
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG FLYTE_VERSION
 ENV FLYTE_VERSION "${FLYTE_VERSION}"


### PR DESCRIPTION
## Describe your changes

Use a newer version of debian as base image. This brings a newer version of openssl and other updates:

```
❯ docker run --rm -it debian:bullseye-slim bash -c "apt-get update && apt-get install --no-install-recommends --yes ca-certificates tini && openssl version" | grep OpenSSL
OpenSSL 1.1.1w  11 Sep 2023

❯ docker run --rm -it debian:bookworm-slim bash -c "apt-get update && apt-get install --no-install-recommends --yes ca-certificates tini && openssl version" | grep OpenSSL
OpenSSL 3.0.11 19 Sep 2023 (Library: OpenSSL 3.0.11 19 Sep 2023)
```

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
