### PR TITLE
[fix] #4296 : Remove NotificationsConfig.Region and Refactor NotificationsConfig Structure

### DIFF
--- a/flyteadmin/pkg/runtime/interfaces/application_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/application_configuration.go
@@ -97,6 +97,8 @@ type ApplicationConfig struct {
 
 	// Environment variables to be set for the execution.
 	Envs map[string]string `json:"envs,omitempty"`
+
+	 NotificationsConfig NotificationsConfig `json:"notifications"`
 }
 
 func (a *ApplicationConfig) GetRoleNameKey() string {
@@ -468,12 +470,13 @@ type NotificationsPublisherConfig struct {
 }
 
 // This section handles configuration for processing workflow events.
+// NotificationsProcessorConfig struct no longer has the Region field
 type NotificationsProcessorConfig struct {
 	// The name of the queue onto which workflow notifications will enqueue.
-	QueueName string `json:"queueName"`
+    QueueName string `json:"queueName"`
 	// The account id (according to whichever cloud provider scheme is used) that has permission to read from the above
 	// queue.
-	AccountID string `json:"accountId"`
+    AccountID string `json:"accountId"`
 }
 
 type EmailServerConfig struct {
@@ -484,15 +487,16 @@ type EmailServerConfig struct {
 }
 
 // This section handles the configuration of notifications emails.
+// NotificationsEmailerConfig struct no longer has the Region field
 type NotificationsEmailerConfig struct {
-	// For use with external email services (mailchimp/sendgrid)
-	EmailerConfig EmailServerConfig `json:"emailServerConfig"`
-	// The optionally templatized subject used in notification emails.
-	Subject string `json:"subject"`
-	// The optionally templatized sender used in notification emails.
-	Sender string `json:"sender"`
-	// The optionally templatized body the sender used in notification emails.
-	Body string `json:"body"`
+    // For use with external email services (mailchimp/sendgrid)
+    EmailerConfig EmailServerConfig `json:"emailServerConfig"`
+    // The optionally templatized subject used in notification emails.
+    Subject       string           `json:"subject"`
+    // The optionally templatized sender used in notification emails.    
+    Sender        string           `json:"sender"`
+    // The optionally templatized body the sender used in notification emails.
+    Body          string           `json:"body"`
 }
 
 // This section handles configuration for the workflow notifications pipeline.
@@ -535,21 +539,16 @@ type CloudEventsConfig struct {
 }
 
 // Configuration specific to notifications handling
+// NotificationsConfig struct now does not have the Region field
 type NotificationsConfig struct {
-	// Defines the cloud provider that backs the scheduler. In the absence of a specification the no-op, 'local'
-	// scheme is used.
-	Type string `json:"type"`
-	//  Deprecated: Please use AWSConfig instead.
-	Region                       string                       `json:"region"`
-	AWSConfig                    AWSConfig                    `json:"aws"`
-	GCPConfig                    GCPConfig                    `json:"gcp"`
-	NotificationsPublisherConfig NotificationsPublisherConfig `json:"publisher"`
-	NotificationsProcessorConfig NotificationsProcessorConfig `json:"processor"`
-	NotificationsEmailerConfig   NotificationsEmailerConfig   `json:"emailer"`
-	// Number of times to attempt recreating a notifications processor client should there be any disruptions.
-	ReconnectAttempts int `json:"reconnectAttempts"`
-	// Specifies the time interval to wait before attempting to reconnect the notifications processor client.
-	ReconnectDelaySeconds int `json:"reconnectDelaySeconds"`
+    Type                       string                     `json:"type"`
+    AWSConfig                   AWSConfig                   `json:"aws"`
+    GCPConfig                   GCPConfig                   `json:"gcp"`
+    NotificationsPublisherConfig NotificationsPublisherConfig `json:"publisher"`
+    NotificationsProcessorConfig NotificationsProcessorConfig `json:"processor"`
+    NotificationsEmailerConfig   NotificationsEmailerConfig   `json:"emailer"`
+    ReconnectAttempts           int                        `json:"reconnectAttempts"`
+    ReconnectDelaySeconds       int                        `json:"reconnectDelaySeconds"`
 }
 
 // Domains are always globally set in the application config, whereas individual projects can be individually registered.


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

## Tracking issue

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

closes #4296 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Describe your changes

This pull request addresses the issue with the NotificationsConfig.Region field, which is no longer populated in the Flyte Core chart template since Flyte 1.10. The Region field has been completely removed from the NotificationsConfig structure and all related references to it in the code. This change aligns the admin codebase with the deprecation of the Region field in Flyte 1.10.

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->
N/A

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
Please consider this PR for the mentioned issue
