### PR TITLE
Not revisiting task nodes and correctly incrementing parallelism

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/handler.go
+++ b/flytepropeller/pkg/controller/nodes/task/handler.go
@@ -570,6 +570,12 @@ func (t Handler) Handle(ctx context.Context, nCtx interfaces.NodeExecutionContex
 		}
 		if pluginTrns.IsPreviouslyObserved() {
 			logger.Debugf(ctx, "No state change for Task, previously observed same transition. Short circuiting.")
+			logger.Infof(ctx, "Parallelism now set to [%d].", nCtx.ExecutionContext().IncrementParallelism())
+
+			// This is a hack to ensure that we do not re-evaluate the same node again in the same round.
+			if err := nCtx.NodeStateWriter().PutTaskNodeState(ts); err != nil {
+				return handler.UnknownTransition, err
+			}
 			return pluginTrns.FinalTransition(ctx)
 		}
 	}

--- a/flytepropeller/pkg/controller/nodes/task/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/handler_test.go
@@ -530,13 +530,12 @@ func Test_task_Handle_NoCatalog(t *testing.T) {
 		expectedState              fakeplugins.NextPhaseState
 	}
 	type want struct {
-		handlerPhase    handler.EPhase
-		wantErr         bool
-		event           bool
-		eventPhase      core.TaskExecution_Phase
-		skipStateUpdate bool
-		incrParallel    bool
-		checkpoint      bool
+		handlerPhase handler.EPhase
+		wantErr      bool
+		event        bool
+		eventPhase   core.TaskExecution_Phase
+		incrParallel bool
+		checkpoint   bool
 	}
 	tests := []struct {
 		name string
@@ -666,10 +665,9 @@ func Test_task_Handle_NoCatalog(t *testing.T) {
 				},
 			},
 			want{
-				handlerPhase:    handler.EPhaseRunning,
-				event:           false,
-				skipStateUpdate: true,
-				incrParallel:    true,
+				handlerPhase: handler.EPhaseRunning,
+				event:        false,
+				incrParallel: true,
 			},
 		},
 		{
@@ -738,13 +736,8 @@ func Test_task_Handle_NoCatalog(t *testing.T) {
 						expectedPhase = pluginCore.PhasePermanentFailure
 					}
 				}
-				if tt.want.skipStateUpdate {
-					assert.Equal(t, pluginCore.PhaseUndefined, state.s.PluginPhase)
-					assert.Equal(t, uint32(0), state.s.PluginPhaseVersion)
-				} else {
-					assert.Equal(t, expectedPhase.String(), state.s.PluginPhase.String())
-					assert.Equal(t, tt.args.expectedState.PhaseVersion, state.s.PluginPhaseVersion)
-				}
+				assert.Equal(t, expectedPhase.String(), state.s.PluginPhase.String())
+				assert.Equal(t, tt.args.expectedState.PhaseVersion, state.s.PluginPhaseVersion)
 				if tt.want.checkpoint {
 					assert.Equal(t, "s3://sandbox/x/name-n1-1/_flytecheckpoints",
 						got.Info().GetInfo().TaskNodeInfo.TaskNodeMetadata.CheckpointUri)


### PR DESCRIPTION
## Tracking issue
_NA_

## Describe your changes
Currently, if the plugin state has already been observed we immediately return without incrementing `parallelism` or marking the task as "dirty", indicating that it has already been processed this round. This means that, in scenarios where a task is the downstream dependency of multiple nodes, tasks may be unnecessarily evaluated multiple times within a single round. More seriously, if the task state has no changed (ex. in same phase as previous round) then additional tasks will be scheduled to satisfy the parallelism. This means that, effectively `max_parallelism` settings may be ignored.

In this PR we correctly increment `parallelism` if the state has already been seen and mark the task node as "dirty" to indicate that it should not be evaluated again this round.

## Check all the applicable boxes 

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots
_NA_

## Note to reviewers
_NA_
