### PR TITLE
Support Azure Cloud Provider (via Stow)

### DIFF
--- a/charts/flyte-binary/README.md
+++ b/charts/flyte-binary/README.md
@@ -66,6 +66,10 @@ Chart for basic single Flyte executable deployment
 | configuration.logging.plugins.stackdriver.templateUri | string | `""` |  |
 | configuration.storage.metadataContainer | string | `"my-organization-flyte-container"` |  |
 | configuration.storage.provider | string | `"s3"` |  |
+| configuration.storage.providerConfig.azure.account | string | `"storage-account-name"` |  |
+| configuration.storage.providerConfig.azure.configDomainSuffix | string | `""` |  |
+| configuration.storage.providerConfig.azure.configUploadConcurrency | int | `4` |  |
+| configuration.storage.providerConfig.azure.key | string | `""` |  |
 | configuration.storage.providerConfig.gcs.project | string | `"my-organization-gcp-project"` |  |
 | configuration.storage.providerConfig.s3.accessKey | string | `""` |  |
 | configuration.storage.providerConfig.s3.authType | string | `"iam"` |  |

--- a/charts/flyte-binary/templates/_helpers.tpl
+++ b/charts/flyte-binary/templates/_helpers.tpl
@@ -99,6 +99,8 @@ Get the Flyte user data prefix.
 {{- printf "s3://%s/data" $userDataContainer -}}
 {{- else if eq "gcs" .Values.configuration.storage.provider -}}
 {{- printf "gs://%s/data" $userDataContainer -}}
+{{- else if eq "azure" .Values.configuration.storage.provider -}}
+{{- printf "abfs://%s/data" $userDataContainer -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/flyte-binary/templates/configmap.yaml
+++ b/charts/flyte-binary/templates/configmap.yaml
@@ -110,6 +110,21 @@ data:
           {{- printf "Invalid value for S3 storage provider authentication type. Expected one of (iam, accesskey), but got: %s" .authType | fail }}
           {{- end }}
         {{- end }}
+        {{- else if eq "azure" .provider }}
+        {{- with .providerConfig.azure }}
+        kind: azure
+        config:
+          account: {{ .account }}
+          {{- if .key }}
+          key: {{ .key }}
+          {{- end }}
+          {{- if .configDomainSuffix }}
+          configDomainSuffix: {{ .configDomainSuffix }}
+          {{- end }}
+          {{- if .configUploadConcurrency }}
+          configUploadConcurrency: {{ .configUploadConcurrency }}
+          {{- end }}
+        {{- end }}
         {{- else if eq "gcs" .provider }}
         kind: google
         config:

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -81,6 +81,16 @@ configuration:
       gcs:
         # project Google Cloud project in which bucket resides
         project: "my-organization-gcp-project"
+      # azure Provider configuration for Azure object store
+      azure:
+        # configDomainSuffix Domain name suffix
+        configDomainSuffix: ""
+        # configUploadConcurrency Upload Concurrency (default 4)
+        configUploadConcurrency: 4
+        # account Storage Account name
+        account: "storage-account-name"
+        # key Storage Account key if used
+        key: ""
   # logging Specify configuration for logs emitted by Flyte
   logging:
     # level Set the log level


### PR DESCRIPTION
## Describe your changes

1. Update configmap and helper to support Azure cloud storage.
2. Update values with sample config and regen helm doc readme.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X ] I updated the documentation accordingly.
- [X ] All new and existing tests passed.
- [X ] All commits are signed-off.

## Screenshots

## Note to reviewers
This will allow users of the `flyte-binary` chart to configure Azure storage accounts. The stow version bump is needed in order to use [Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet).

This PR does not include an implementation of [RemoteURLInterface](https://github.com/flyteorg/flyte/blob/master/flyteadmin/pkg/data/implementations/aws_remote_url.go), which would be required before using signed URLs in Azure. A potential fix is being discussed in [slack](https://flyte-org.slack.com/archives/CP2HDHKE1/p1698250094391179) and should not be difficult, but I'm not confident that support for signed URLs is required.

A storage key or workload identity needs to be configured for this to work end-to-end with task pods and azure blob storage via Stow. A workflow identity can be defined in the PodTemplate like [this](https://gist.github.com/cgrass/9ee4d60878c50f4c7525636cbde9b1da) example, and the service can be deployed using a values.yaml similar to [here](https://github.com/cgrass/flyte/blob/42d32461cd08d52104dd5bee2079f301b55b8c36/charts/flyte-binary/values.yaml). Should that configuration be documented in some other way?