### PR TITLE
Reporting running if the primary container status is not yet reported

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -24,6 +24,7 @@ import (
 const PodKind = "pod"
 const OOMKilled = "OOMKilled"
 const Interrupted = "Interrupted"
+const PrimaryContainerNotFound = "PrimaryContainerNotFound"
 const SIGKILL = 137
 
 const defaultContainerTemplateName = "default"
@@ -746,7 +747,7 @@ func DeterminePrimaryContainerPhase(primaryContainerName string, statuses []v1.C
 	}
 
 	// If for some reason we can't find the primary container, always just return a permanent failure
-	return pluginsCore.PhaseInfoFailure("PrimaryContainerMissing",
+	return pluginsCore.PhaseInfoFailure(PrimaryContainerNotFound,
 		fmt.Sprintf("Primary container [%s] not found in pod's container statuses", primaryContainerName), info)
 }
 

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -1682,6 +1682,7 @@ func TestDeterminePrimaryContainerPhase(t *testing.T) {
 			secondaryContainer,
 		}, info)
 		assert.Equal(t, pluginsCore.PhasePermanentFailure, phaseInfo.Phase())
+		assert.Equal(t, PrimaryContainerNotFound, phaseInfo.Err().Code)
 		assert.Equal(t, "Primary container [primary] not found in pod's container statuses", phaseInfo.Err().Message)
 	})
 }

--- a/flyteplugins/go/tasks/plugins/k8s/pod/sidecar_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/pod/sidecar_test.go
@@ -844,6 +844,13 @@ func TestDemystifiedSidecarStatus_PrimaryRunning(t *testing.T) {
 
 func TestDemystifiedSidecarStatus_PrimaryMissing(t *testing.T) {
 	res := &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "Secondary",
+				},
+			},
+		},
 		Status: v1.PodStatus{
 			Phase: v1.PodRunning,
 			ContainerStatuses: []v1.ContainerStatus{
@@ -860,6 +867,34 @@ func TestDemystifiedSidecarStatus_PrimaryMissing(t *testing.T) {
 	phaseInfo, err := DefaultPodPlugin.GetTaskPhase(context.TODO(), taskCtx, res)
 	assert.Nil(t, err)
 	assert.Equal(t, pluginsCore.PhasePermanentFailure, phaseInfo.Phase())
+}
+
+// TODO @hamersaw
+func TestDemystifiedSidecarStatus_PrimaryNotExistsYet(t *testing.T) {
+	res := &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "Primary",
+				},
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name: "Secondary",
+				},
+			},
+		},
+	}
+	res.SetAnnotations(map[string]string{
+		flytek8s.PrimaryContainerKey: "Primary",
+	})
+	taskCtx := getDummySidecarTaskContext(&core.TaskTemplate{}, sidecarResourceRequirements, nil)
+	phaseInfo, err := DefaultPodPlugin.GetTaskPhase(context.TODO(), taskCtx, res)
+	assert.Nil(t, err)
+	assert.Equal(t, pluginsCore.PhaseRunning, phaseInfo.Phase())
 }
 
 func TestGetProperties(t *testing.T) {

--- a/flyteplugins/go/tasks/plugins/k8s/pod/sidecar_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/pod/sidecar_test.go
@@ -869,7 +869,6 @@ func TestDemystifiedSidecarStatus_PrimaryMissing(t *testing.T) {
 	assert.Equal(t, pluginsCore.PhasePermanentFailure, phaseInfo.Phase())
 }
 
-// TODO @hamersaw
 func TestDemystifiedSidecarStatus_PrimaryNotExistsYet(t *testing.T) {
 	res := &v1.Pod{
 		Spec: v1.PodSpec{


### PR DESCRIPTION
## Tracking issue
fixes https://github.com/flyteorg/flyte/issues/4332

## Describe your changes
If the primary container status is not found we check if the pod definition contains the containers name. In this scenario the container status has not yet been reported, but will be when it begins executing.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots
_NA_

## Note to reviewers
_NA_
