### PR TITLE
Fix RunPluginEndToEndTest util

### DIFF
--- a/flyteplugins/tests/end_to_end.go
+++ b/flyteplugins/tests/end_to_end.go
@@ -82,7 +82,6 @@ func RunPluginEndToEndTest(t *testing.T, executor pluginCore.Plugin, template *i
 	outputWriter.OnGetOutputPath().Return(basePrefix + "/outputs.pb")
 	outputWriter.OnGetCheckpointPrefix().Return("/checkpoint")
 	outputWriter.OnGetPreviousCheckpointsPrefix().Return("/prev")
-	outputWriter.OnPutMatch(mock.Anything, mock.Anything).Return(nil)
 
 	outputWriter.OnPutMatch(mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		or := args.Get(1).(io.OutputReader)


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/4343
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Describe your changes

Remove duplicated mock without `Run` that produces that the output file is not saved to the inmemory store.

```
time="2023-11-01T10:34:44+01:00" level=error msg="Failed to read from the raw store [fake://bucket/prefix/2g6/outputs.pb] Error: file does not exist"
        	Error:      	Received unexpected error:
        	            	file does not exist
        	            	path:fake://bucket/prefix/2g6/outputs.pb
        	            	github.com/flyteorg/flyte/flytestdlib/storage.DefaultProtobufStore.ReadProtobuf
        	            		/Users/andresg/go/pkg/mod/github.com/flyteorg/flyte/flytestdlib@v1.10.0/storage/protobuf_store.go:39
        	            	github.com/flyteorg/flyte/flyteplugins/tests.RunPluginEndToEndTest
        	            		/Users/andresg/go/pkg/mod/github.com/flyteorg/flyte/flyteplugins@v1.10.0/tests/end_to_end.go:261
....
```

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
