### PR TITLE
Fixing caching on maptasks when using partials

### DIFF
--- a/flyteplugins/go/tasks/plugins/array/catalog.go
+++ b/flyteplugins/go/tasks/plugins/array/catalog.go
@@ -74,20 +74,16 @@ func DetermineDiscoverability(ctx context.Context, tCtx core.TaskExecutionContex
 			return state, errors.Errorf(errors.MetadataAccessFailed, "Could not read inputs and therefore failed to determine array job size")
 		}
 
+		// identify and validate the size of the array job
 		size := -1
 		var literalCollection *idlCore.LiteralCollection
-		literals := make([][]*idlCore.Literal, 0)
-		discoveredInputNames := make([]string, 0)
-		for inputName, literal := range inputs.Literals {
+		for _, literal := range inputs.Literals {
 			if literalCollection = literal.GetCollection(); literalCollection != nil {
 				// validate length of input list
 				if size != -1 && size != len(literalCollection.Literals) {
 					state = state.SetPhase(arrayCore.PhasePermanentFailure, 0).SetReason("all maptask input lists must be the same length")
 					return state, nil
 				}
-
-				literals = append(literals, literalCollection.Literals)
-				discoveredInputNames = append(discoveredInputNames, inputName)
 
 				size = len(literalCollection.Literals)
 			}
@@ -110,7 +106,7 @@ func DetermineDiscoverability(ctx context.Context, tCtx core.TaskExecutionContex
 		arrayJobSize = int64(size)
 
 		// build input readers
-		inputReaders = ConstructStaticInputReaders(tCtx.InputReader(), literals, discoveredInputNames)
+		inputReaders = ConstructStaticInputReaders(tCtx.InputReader(), inputs.Literals, size)
 	}
 
 	if arrayJobSize > maxArrayJobSize {
@@ -246,18 +242,7 @@ func WriteToDiscovery(ctx context.Context, tCtx core.TaskExecutionContext, state
 			return state, externalResources, errors.Errorf(errors.MetadataAccessFailed, "Could not read inputs and therefore failed to determine array job size")
 		}
 
-		var literalCollection *idlCore.LiteralCollection
-		literals := make([][]*idlCore.Literal, 0)
-		discoveredInputNames := make([]string, 0)
-		for inputName, literal := range inputs.Literals {
-			if literalCollection = literal.GetCollection(); literalCollection != nil {
-				literals = append(literals, literalCollection.Literals)
-				discoveredInputNames = append(discoveredInputNames, inputName)
-			}
-		}
-
-		// build input readers
-		inputReaders = ConstructStaticInputReaders(tCtx.InputReader(), literals, discoveredInputNames)
+		inputReaders = ConstructStaticInputReaders(tCtx.InputReader(), inputs.Literals, arrayJobSize)
 	}
 
 	// output reader
@@ -476,16 +461,19 @@ func ConstructCatalogReaderWorkItems(ctx context.Context, taskReader core.TaskRe
 
 // ConstructStaticInputReaders constructs input readers that comply with the io.InputReader interface but have their
 // inputs already populated.
-func ConstructStaticInputReaders(inputPaths io.InputFilePaths, inputs [][]*idlCore.Literal, inputNames []string) []io.InputReader {
-	inputReaders := make([]io.InputReader, 0, len(inputs))
-	if len(inputs) == 0 {
-		return inputReaders
-	}
+func ConstructStaticInputReaders(inputPaths io.InputFilePaths, inputLiterals map[string]*idlCore.Literal, arrayJobSize int) []io.InputReader {
+	var literalCollection *idlCore.LiteralCollection
 
-	for i := 0; i < len(inputs[0]); i++ {
+	inputReaders := make([]io.InputReader, 0, arrayJobSize)
+	for i := 0; i < arrayJobSize; i++ {
 		literals := make(map[string]*idlCore.Literal)
-		for j := 0; j < len(inputNames); j++ {
-			literals[inputNames[j]] = inputs[j][i]
+		for inputName, inputLiteral := range inputLiterals {
+			if literalCollection = inputLiteral.GetCollection(); literalCollection != nil {
+				// if literal is a collection then we need to retreive the specific literal for this subtask index
+				literals[inputName] = literalCollection.Literals[i]
+			} else {
+				literals[inputName] = inputLiteral
+			}
 		}
 
 		inputReaders = append(inputReaders, NewStaticInputReader(inputPaths, &idlCore.LiteralMap{Literals: literals}))

--- a/flytepropeller/pkg/controller/nodes/array/node_execution_context.go
+++ b/flytepropeller/pkg/controller/nodes/array/node_execution_context.go
@@ -36,6 +36,8 @@ func constructLiteralMap(ctx context.Context, inputReader io.InputReader, index 
 	for name, literal := range inputs.Literals {
 		if literalCollection := literal.GetCollection(); literalCollection != nil {
 			literals[name] = literalCollection.Literals[index]
+		} else {
+			literals[name] = literal
 		}
 	}
 


### PR DESCRIPTION
## Tracking issue
fixes https://github.com/flyteorg/flyte/issues/4330

## Describe your changes
Adding the partial input literals to the static input readers so that they are included in cache key computation.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots
_NA_

## Note to reviewers
_NA_