### PR TITLE
Tune sandbox readiness checks to ensure that sandbox is fully accessi…

### DIFF
--- a/charts/flyte-binary/templates/deployment.yaml
+++ b/charts/flyte-binary/templates/deployment.yaml
@@ -193,6 +193,7 @@ spec:
             httpGet:
               path: /healthcheck
               port: http
+            initialDelaySeconds: 30
           {{- end }}
           readinessProbe:
           {{- if .Values.deployment.readinessProbe }}

--- a/charts/flyte-sandbox/templates/proxy/deployment.yaml
+++ b/charts/flyte-sandbox/templates/proxy/deployment.yaml
@@ -25,6 +25,13 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/envoy
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: http
       volumes:
         - name: config
           configMap:

--- a/deployment/sandbox-binary/flyte_sandbox_binary_helm_generated.yaml
+++ b/deployment/sandbox-binary/flyte_sandbox_binary_helm_generated.yaml
@@ -417,6 +417,7 @@ spec:
             httpGet:
               path: /healthcheck
               port: http
+            initialDelaySeconds: 30
           readinessProbe:
             httpGet:
               path: /healthcheck

--- a/docker/sandbox-bundled/manifests/complete-agent.yaml
+++ b/docker/sandbox-bundled/manifests/complete-agent.yaml
@@ -816,7 +816,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: SWRqSVZmendLdVJvamVGRQ==
+  haSharedSecret: UzFydXlGcGwyM3FJYWpTdw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1273,6 +1273,7 @@ spec:
           httpGet:
             path: /healthcheck
             port: http
+          initialDelaySeconds: 30
         name: flyte
         ports:
         - containerPort: 8088
@@ -1409,7 +1410,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 4e6248034c039b0bc65cf110d26fccc9d88b8a2d49855a0ecba0443f972ca3c3
+        checksum/secret: 12acfc99559b7ddf909a9c66f3645153d66e96bc8dd1a7c1e2ff5af865d51827
       labels:
         app: docker-registry
         release: flyte-sandbox
@@ -1697,10 +1698,17 @@ spec:
       containers:
       - image: envoyproxy/envoy:sandbox
         imagePullPolicy: Never
+        livenessProbe:
+          initialDelaySeconds: 30
+          tcpSocket:
+            port: http
         name: proxy
         ports:
         - containerPort: 8000
           name: http
+        readinessProbe:
+          tcpSocket:
+            port: http
         volumeMounts:
         - mountPath: /etc/envoy
           name: config
@@ -1744,7 +1752,7 @@ spec:
           value: minio
         - name: FLYTE_AWS_SECRET_ACCESS_KEY
           value: miniostorage
-        image: ghcr.io/flyteorg/flyteagent:1.9.1
+        image: ghcr.io/flyteorg/flyteagent:1.10.0
         imagePullPolicy: IfNotPresent
         name: flyteagent
         ports:

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -805,7 +805,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: UUREcXo3a1VGNnlyc1RCWg==
+  haSharedSecret: Y2dKT2xJeEhXaWUyZUcwMg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1230,6 +1230,7 @@ spec:
           httpGet:
             path: /healthcheck
             port: http
+          initialDelaySeconds: 30
         name: flyte
         ports:
         - containerPort: 8088
@@ -1366,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: cfe2089fc583f69d068c3b3d56e875082a5d926c70b00b32f094d587df7396a5
+        checksum/secret: 9a48d62cb53f25eaefca010e49af275334df350c757deb72a31fca6dcb2cdb95
       labels:
         app: docker-registry
         release: flyte-sandbox
@@ -1654,10 +1655,17 @@ spec:
       containers:
       - image: envoyproxy/envoy:sandbox
         imagePullPolicy: Never
+        livenessProbe:
+          initialDelaySeconds: 30
+          tcpSocket:
+            port: http
         name: proxy
         ports:
         - containerPort: 8000
           name: http
+        readinessProbe:
+          tcpSocket:
+            port: http
         volumeMounts:
         - mountPath: /etc/envoy
           name: config

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: VjRtTTRpSW94OU9rUVFZTQ==
+  haSharedSecret: OFd1Q2o4V28zVk1lV0lOcA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -933,7 +933,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 8b25114d47a69e875e3841dace0b87abfda7a16f6833a5cf76b4570092f3a1cd
+        checksum/secret: 83de0933db4333daa08a690fbbf752532361f657be692a243b79daa7dc1fef1c
       labels:
         app: docker-registry
         release: flyte-sandbox
@@ -1221,10 +1221,17 @@ spec:
       containers:
       - image: envoyproxy/envoy:sandbox
         imagePullPolicy: Never
+        livenessProbe:
+          initialDelaySeconds: 30
+          tcpSocket:
+            port: http
         name: proxy
         ports:
         - containerPort: 8000
           name: http
+        readinessProbe:
+          tcpSocket:
+            port: http
         volumeMounts:
         - mountPath: /etc/envoy
           name: config


### PR DESCRIPTION
…ble when marked as ready

## Describe your changes
The envoy proxy on `sandbox-bundled` was missing a healthcheck, and was incorrectly marked as ready before the listening port was even open. This causes CI to occasionally fail if using operations that depend on a ready sandbox state.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
