### PR TITLE
Do not automatically close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,8 +12,11 @@ jobs:
     - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: "Hello 👋, This issue has been inactive for over 9 months. To help maintain a clean and focused backlog, we'll be marking this issue as stale and will close the issue if we detect no activity in the next 7 days. Thank you for your contribution and understanding! 🙏"
-        close-issue-message: "Hello 👋, This issue has been inactive for over 9 months and hasn't received any updates since it was marked as stale. We'll be closing this issue for now, but if you believe this issue is still relevant, please feel free to reopen it. Thank you for your contribution and understanding! 🙏"
+        stale-issue-message: >
+          Hello 👋, this issue has been inactive for over 9 months. To help maintain a clean and focused backlog, 
+          we'll be marking this issue as stale and will engage on it to decide if it is still applicable. 
+
+          Thank you for your contribution and understanding! 🙏
         stale-issue-label: "stale"
         exempt-issue-labels: "needs discussion,untriaged"  # Comma-separated list of labels.
         days-before-stale: 270

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,6 @@ jobs:
         stale-issue-label: "stale"
         exempt-issue-labels: "needs discussion,untriaged"  # Comma-separated list of labels.
         days-before-stale: 270
-        days-before-close: 7
+        days-before-close: -1
         ascending: true # https://github.com/actions/stale#ascending
         operations-per-run: 500


### PR DESCRIPTION
## Describe your changes

This PR disables prevents stalebot from closing issues automatically. We're going to implement a step where the core maintainers engage with stale issues instead.

As per the stalebot [docs](https://github.com/actions/stale#days-before-close), any negative number indicates that stalebot does not close issues/PRs.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
