### PR TITLE
Support Databricks WebAPI 2.1 version and Support `existing_cluster_id` and `new_cluster` options to create a Job

### DIFF
--- a/flyteplugins/go/tasks/plugins/webapi/databricks/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/databricks/plugin.go
@@ -236,6 +236,11 @@ func (p Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phase
 			}
 			return pluginsCore.PhaseInfoFailure(string(rune(statusCode)), message, taskInfo), nil
 		}
+
+		if lifeCycleState == "PENDING" {
+			return core.PhaseInfoInitializing(time.Now(), core.DefaultPhaseVersion, message, taskInfo), nil
+		}
+
 		return core.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion, taskInfo), nil
 	case http.StatusBadRequest:
 		fallthrough
@@ -283,7 +288,7 @@ func buildRequest(
 	var err error
 	if isCancel {
 		databricksURL += "/cancel"
-		data = []byte(fmt.Sprintf("{ run_id: %v }", runID))
+		data = []byte(fmt.Sprintf("{ \"run_id\": %v }", runID))
 	} else if method == post {
 		databricksURL += "/submit"
 		mJSON, err := json.Marshal(databricksJob)

--- a/flyteplugins/go/tasks/plugins/webapi/databricks/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/databricks/plugin.go
@@ -29,7 +29,7 @@ const (
 	ErrSystem       errors.ErrorCode = "System"
 	post            string           = "POST"
 	get             string           = "GET"
-	databricksAPI   string           = "/api/2.0/jobs/runs"
+	databricksAPI   string           = "/api/2.1/jobs/runs"
 	newCluster      string           = "new_cluster"
 	dockerImage     string           = "docker_image"
 	sparkConfig     string           = "spark_conf"
@@ -114,10 +114,15 @@ func (p Plugin) Create(ctx context.Context, taskCtx webapi.TaskExecutionContextR
 		return nil, nil, fmt.Errorf("failed to unmarshal databricksJob: %v: %v", sparkJob.DatabricksConf, err)
 	}
 
-	if _, ok := databricksJob[newCluster]; ok {
-		databricksJob[newCluster].(map[string]interface{})[dockerImage] = map[string]string{url: container.Image}
-		if len(sparkJob.SparkConf) != 0 {
-			databricksJob[newCluster].(map[string]interface{})[sparkConfig] = sparkJob.SparkConf
+	// If "existing_cluster_id" is in databricks_job, then we don't need to set "new_cluster"
+	// Refer the docs here: https://docs.databricks.com/en/workflows/jobs/jobs-2.0-api.html#request-structure
+	if clusterConfig, ok := databricksJob[newCluster].(map[string]interface{}); ok {
+		if dockerConfig, ok := clusterConfig[dockerImage].(map[string]interface{}); !ok || dockerConfig[url] == nil {
+			clusterConfig[dockerImage] = map[string]string{url: container.Image}
+		}
+
+		if clusterConfig[sparkConfig] == nil && len(sparkJob.SparkConf) != 0 {
+			clusterConfig[sparkConfig] = sparkJob.SparkConf
 		}
 	}
 	databricksJob[sparkPythonTask] = map[string]interface{}{pythonFile: p.cfg.EntrypointFile, parameters: modifiedArgs}
@@ -222,7 +227,7 @@ func (p Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phase
 	case http.StatusAccepted:
 		return core.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion, taskInfo), nil
 	case http.StatusOK:
-		if lifeCycleState == "TERMINATED" || lifeCycleState == "SKIPPED" || lifeCycleState == "INTERNAL_ERROR" {
+		if lifeCycleState == "TERMINATED" || lifeCycleState == "TERMINATING" || lifeCycleState == "INTERNAL_ERROR" {
 			if resultState == "SUCCESS" {
 				if err := writeOutput(ctx, taskCtx); err != nil {
 					pluginsCore.PhaseInfoFailure(string(rune(statusCode)), "failed to write output", taskInfo)

--- a/flyteplugins/go/tasks/plugins/webapi/databricks/plugin_test.go
+++ b/flyteplugins/go/tasks/plugins/webapi/databricks/plugin_test.go
@@ -67,7 +67,7 @@ func TestBuildRequest(t *testing.T) {
 	token := "test-token"
 	runID := "019e70eb"
 	databricksEndpoint := ""
-	databricksURL := "https://" + testInstance + "/api/2.0/jobs/runs"
+	databricksURL := "https://" + testInstance + "/api/2.1/jobs/runs"
 	t.Run("build http request for submitting a databricks job", func(t *testing.T) {
 		req, err := buildRequest(post, nil, databricksEndpoint, testInstance, token, runID, false)
 		header := http.Header{}


### PR DESCRIPTION
# TL;DR
- Fix `Delete` function, post request `data` format error
- Add `Message` in TaskInfo when `Pending` State
- Fix the bug in `lifeCycleState`. (`SKIPPED` doesn't have `resultState`, but `TERMINATING` does)
![image](https://github.com/flyteorg/flyte/assets/76461262/b761fac3-5ac8-4c5e-897f-08dbf9cd3910)

https://docs.databricks.com/en/workflows/jobs/jobs-2.0-api.html#runresultstate

- Currently, we only support Databricks API 2.0 and only the `new_cluster` key in the Databricks config.
However, some users want to use Databricks API 2.1 and want to use `existing_cluster_id` in the databricks config.
Here's the screenshot from the official documentation.
![image](https://github.com/flyteorg/flytekit/assets/76461262/fd03e906-e918-4a5c-8c3c-0482af434325)
you can find the difference between `existing_cluster_id` and `new_cluster`

https://docs.databricks.com/en/workflows/jobs/jobs-2.0-api.html#request-structure

## Type
 - [X] Bug Fix
 - [x] Feature
 - [x] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Config yaml in dev mode
```yaml
tasks:
  task-plugins:
    enabled-plugins:
      - container
      - sidecar
      - K8S-ARRAY
      - databricks
    default-for-task-types:
      spark: databricks
      custom_task: agent-service
      container: container
      container_array: K8S-ARRAY

plugins:
  databricks:
    entrypointFile: dbfs:///FileStore/tables/entrypoint.py
    databricksInstance: <YOUR WORKSPACE ID>.gcp.databricks.com```
```

Example Code
```python
import datetime
import os
import random

import flytekit
from flytekit import Secret, task, workflow
from flytekitplugins.spark import Databricks, Spark

@task(
    task_config=Databricks(
        # this configuration is applied to the spark cluster
        spark_conf={
            "spark.driver.memory": "1000M",
            "spark.executor.memory": "1000M",
            "spark.executor.cores": "1",
            "spark.executor.instances": "2",
            "spark.driver.cores": "1",
        },
        executor_path="/databricks/python3/bin/python",
        applications_path="dbfs:/entrypoint.py",
        databricks_conf={
            "run_name": "flytekit databricks plugin example",
            "new_cluster": {
                "spark_version": "12.2.x-scala2.12",
                "node_type_id": "n2-highmem-4",
                "num_workers": 1,
                "docker_image": {"url": "<docker-image-url>"},
                "spark_conf": {
                    "spark.driver.memory": "1000M",
                    "spark.executor.memory": "1000M",
                    "spark.executor.cores": "1",
                    "spark.executor.instances": "2",
                    "spark.driver.cores": "1",
                },
            },
        },
        databricks_instance=os.environ["DATABRICKS_HOST"],
    ),
)
def hello_spark(partitions: int) -> float:
    print("Starting Spark with Partitions: {}".format(partitions))

    n = 100000 * partitions
    sess = flytekit.current_context().spark_session
    count = (
        sess.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)
    )
    pi_val = 4.0 * count / n
    print("Pi val is :{}".format(pi_val))
    return pi_val


def f(_):
    x = random.random() * 2 - 1
    y = random.random() * 2 - 1
    return 1 if x**2 + y**2 <= 1 else 0


@task(cache_version="1")
def print_every_time(value_to_print: float, date_triggered: datetime.datetime) -> int:
    print("My printed value: {} @ {}".format(value_to_print, date_triggered))
    return 1


@workflow
def my_databricks_job(
    triggered_date: datetime.datetime = datetime.datetime.now(),
) -> float:
    """
    Using the workflow is still as any other workflow. As image is a property of the task, the workflow does not care
    about how the image is configured.
    """
    pi = hello_spark(partitions=50)
    print_every_time(value_to_print=pi, date_triggered=triggered_date)
    return pi


if __name__ == "__main__":
    print(f"Running {__file__} main...")
    print(
        f"Running To run a Spark job on Databricks platform(triggered_date=datetime.datetime.now()){my_databricks_job(triggered_date=datetime.datetime.now())}"
    )

```
Test it
```
pyflyte register spark_example.py --version API-V2
```


## Screenshots
### Delete Function correct
Note: I terminated it after triggering it for 24 seconds.
The job terminated at 27 seconds.
![image](https://github.com/flyteorg/flyte/assets/76461262/a5ac00fa-194b-40ef-a36c-0314a2810176)
![image](https://github.com/flyteorg/flyte/assets/76461262/85afe447-c833-48bf-82aa-29b4e213a0f2)


### Add Message in TaskInfo when `Pending` State 

![image](https://github.com/flyteorg/flyte/assets/76461262/e29fdd49-35ed-475b-8fba-19a16187f97e)


### Create a job.
Note: I print the log in `databricks/plugin.go`

![image](https://github.com/flyteorg/flyte/assets/76461262/62fbae33-8d7d-471b-9033-457147bafac1)

![image](https://github.com/flyteorg/flyte/assets/76461262/8eaf6a89-f678-4604-bc89-08b7376c0ddb)



## Tracking Issue
https://github.com/flyteorg/flyte/issues/3936
https://github.com/flyteorg/flyte/issues/4362

## Related PRs
https://github.com/flyteorg/flytekit/pull/1935
