### PR TITLE
Update order of cluster resources config to work with both uctl and flytectl

### DIFF
--- a/rsts/deployment/configuration/general.rst
+++ b/rsts/deployment/configuration/general.rst
@@ -105,11 +105,12 @@ Define an attributes file, ``cra.yaml``:
 
 .. code-block:: yaml
 
+    domain: development
+    project: flyteexamples
     attributes:
         projectQuotaCpu: "1000"
         projectQuotaMemory: 5Ti
-    domain: development
-    project: flyteexamples
+
 
 To ensure that the overrides reflect in the Kubernetes namespace
 ``flyteexamples-development`` (that is, the namespace has a resource quota of

--- a/rsts/deployment/configuration/general.rst
+++ b/rsts/deployment/configuration/general.rst
@@ -111,7 +111,6 @@ Define an attributes file, ``cra.yaml``:
         projectQuotaCpu: "1000"
         projectQuotaMemory: 5Ti
 
-
 To ensure that the overrides reflect in the Kubernetes namespace
 ``flyteexamples-development`` (that is, the namespace has a resource quota of
 1000 CPU cores and 5TB of memory) when the admin fills in cluster resource


### PR DESCRIPTION

## Tracking issue

Closes #4372 

## Describe your changes

Updates the cluster resources config to work with both `uctl` and `flytectl`.

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots

Not applicable

## Note to reviewers

None
