### PR TITLE
Fix the loop variable scheduler issue

### DIFF
--- a/flyteadmin/run.sh
+++ b/flyteadmin/run.sh
@@ -1,0 +1,2 @@
+dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec bin/flyteadmin serve -- --config  flyteadmin_config.yaml 
+#--server.kube-config ~/.kube/config

--- a/flyteadmin/run.sh
+++ b/flyteadmin/run.sh
@@ -1,2 +1,0 @@
-dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec bin/flyteadmin serve -- --config  flyteadmin_config.yaml 
-#--server.kube-config ~/.kube/config

--- a/flyteadmin/scheduler/core/gocron_scheduler.go
+++ b/flyteadmin/scheduler/core/gocron_scheduler.go
@@ -54,24 +54,24 @@ func (g *GoCronScheduler) GetTimedFuncWithSchedule() TimedFuncWithSchedule {
 func (g *GoCronScheduler) BootStrapSchedulesFromSnapShot(ctx context.Context, schedules []models.SchedulableEntity,
 	snapshot snapshoter.Snapshot) {
 	for _, s := range schedules {
-		s := s
+		schedule := s
 		if *s.Active {
 			funcRef := g.GetTimedFuncWithSchedule()
 			nameOfSchedule := identifier.GetScheduleName(ctx, s)
 			// Initialize the lastExectime as the updatedAt time
 			// Assumption here that schedule was activated and that the 0th execution of the schedule
 			// which will be used as a reference
-			lastExecTime := &s.UpdatedAt
+			lastExecTime := &schedule.UpdatedAt
 
 			fromSnapshot := snapshot.GetLastExecutionTime(nameOfSchedule)
 			// Use the latest time if available in the snapshot
-			if fromSnapshot != nil && fromSnapshot.After(s.UpdatedAt) {
+			if fromSnapshot != nil && fromSnapshot.After(schedule.UpdatedAt) {
 				lastExecTime = fromSnapshot
 			}
-			err := g.ScheduleJob(ctx, s, funcRef, lastExecTime)
+			err := g.ScheduleJob(ctx, schedule, funcRef, lastExecTime)
 			if err != nil {
 				g.metrics.JobScheduledFailedCounter.Inc()
-				logger.Errorf(ctx, "unable to register the schedule %+v due to %v", s, err)
+				logger.Errorf(ctx, "unable to register the schedule %+v due to %v", schedule, err)
 			}
 		}
 	}

--- a/flyteadmin/scheduler/core/gocron_scheduler.go
+++ b/flyteadmin/scheduler/core/gocron_scheduler.go
@@ -54,6 +54,8 @@ func (g *GoCronScheduler) GetTimedFuncWithSchedule() TimedFuncWithSchedule {
 func (g *GoCronScheduler) BootStrapSchedulesFromSnapShot(ctx context.Context, schedules []models.SchedulableEntity,
 	snapshot snapshoter.Snapshot) {
 	for _, s := range schedules {
+		// Copy the object to save to a new pointer since the pointer is saved later
+		// Issue due to https://github.com/golang/go/discussions/56010
 		schedule := s
 		if *s.Active {
 			funcRef := g.GetTimedFuncWithSchedule()

--- a/flyteadmin/scheduler/core/gocron_scheduler.go
+++ b/flyteadmin/scheduler/core/gocron_scheduler.go
@@ -54,6 +54,7 @@ func (g *GoCronScheduler) GetTimedFuncWithSchedule() TimedFuncWithSchedule {
 func (g *GoCronScheduler) BootStrapSchedulesFromSnapShot(ctx context.Context, schedules []models.SchedulableEntity,
 	snapshot snapshoter.Snapshot) {
 	for _, s := range schedules {
+		s := s
 		if *s.Active {
 			funcRef := g.GetTimedFuncWithSchedule()
 			nameOfSchedule := identifier.GetScheduleName(ctx, s)

--- a/flyteadmin/scheduler/core/gocron_scheduler_test.go
+++ b/flyteadmin/scheduler/core/gocron_scheduler_test.go
@@ -378,12 +378,12 @@ func TestGoCronScheduler_BootStrapSchedulesFromSnapShot(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g.BootStrapSchedulesFromSnapShot(context.Background(), tt.schedules, tt.snapshoter)
 			g.jobStore.Range(func(key, value interface{}) bool {
-				jobId := key.(string)
+				jobID := key.(string)
 				job := value.(*GoCronJob)
 				if !*job.schedule.Active {
 					return true
 				}
-				assert.Equal(t, job.catchupFromTime, tt.expectedCatchUpTimes[jobId])
+				assert.Equal(t, job.catchupFromTime, tt.expectedCatchUpTimes[jobID])
 				return true
 			})
 			for _, schedule := range tt.schedules {

--- a/flyteadmin/scheduler/core/gocron_scheduler_test.go
+++ b/flyteadmin/scheduler/core/gocron_scheduler_test.go
@@ -296,3 +296,99 @@ func TestCatchUpAllSchedule(t *testing.T) {
 	catchupSuccess := g.CatchupAll(ctx, toTime)
 	assert.True(t, catchupSuccess)
 }
+
+func TestGoCronScheduler_BootStrapSchedulesFromSnapShot(t *testing.T) {
+	g := setupWithSchedules(t, "testing", []models.SchedulableEntity{}, true)
+	True := true
+	False := false
+	scheduleActive1 := models.SchedulableEntity{
+		BaseModel: adminModels.BaseModel{
+			UpdatedAt: time.Date(1000, time.October, 19, 10, 0, 0, 0, time.UTC),
+		},
+		SchedulableEntityKey: models.SchedulableEntityKey{
+			Project: "project",
+			Domain:  "domain",
+			Name:    "schedule_active_1",
+			Version: "version1",
+		},
+		CronExpression: "0 19 * * *",
+		Active:         &True,
+	}
+	scheduleActive2 := models.SchedulableEntity{
+		BaseModel: adminModels.BaseModel{
+			UpdatedAt: time.Date(2000, time.November, 19, 10, 0, 0, 0, time.UTC),
+		},
+		SchedulableEntityKey: models.SchedulableEntityKey{
+			Project: "project",
+			Domain:  "domain",
+			Name:    "schedule_active_2",
+			Version: "version1",
+		},
+		CronExpression: "0 19 * * *",
+		Active:         &True,
+	}
+	scheduleInactive := models.SchedulableEntity{
+		BaseModel: adminModels.BaseModel{
+			UpdatedAt: time.Date(3000, time.December, 19, 10, 0, 0, 0, time.UTC),
+		},
+		SchedulableEntityKey: models.SchedulableEntityKey{
+			Project: "project",
+			Domain:  "domain",
+			Name:    "cron3",
+			Version: "version1",
+		},
+		CronExpression: "0 19 * * *",
+		Active:         &False,
+	}
+
+	schedule1SnapshotTime := time.Date(5000, time.December, 19, 10, 0, 0, 0, time.UTC)
+	schedule2SnapshotTime := time.Date(6000, time.December, 19, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name                 string
+		schedules            []models.SchedulableEntity
+		snapshoter           snapshoter.Snapshot
+		expectedCatchUpTimes map[string]*time.Time
+	}{
+		{
+			name:                 "two active",
+			schedules:            []models.SchedulableEntity{scheduleActive1, scheduleActive2},
+			snapshoter:           &snapshoter.SnapshotV1{},
+			expectedCatchUpTimes: map[string]*time.Time{"11407394263542327059": &scheduleActive1.UpdatedAt, "1420107156943834850": &scheduleActive2.UpdatedAt},
+		},
+		{
+			name:                 "two active one inactive",
+			schedules:            []models.SchedulableEntity{scheduleActive1, scheduleActive2, scheduleInactive},
+			snapshoter:           &snapshoter.SnapshotV1{},
+			expectedCatchUpTimes: map[string]*time.Time{"11407394263542327059": &scheduleActive1.UpdatedAt, "1420107156943834850": &scheduleActive2.UpdatedAt},
+		},
+		{
+			name:      "two active one inactive with snapshot populated",
+			schedules: []models.SchedulableEntity{scheduleActive1, scheduleActive2, scheduleInactive},
+			snapshoter: &snapshoter.SnapshotV1{
+				LastTimes: map[string]*time.Time{
+					"11407394263542327059": &schedule1SnapshotTime,
+					"1420107156943834850":  &schedule2SnapshotTime,
+				},
+			},
+			expectedCatchUpTimes: map[string]*time.Time{"11407394263542327059": &schedule1SnapshotTime, "1420107156943834850": &schedule2SnapshotTime},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g.BootStrapSchedulesFromSnapShot(context.Background(), tt.schedules, tt.snapshoter)
+			g.jobStore.Range(func(key, value interface{}) bool {
+				jobId := key.(string)
+				job := value.(*GoCronJob)
+				if !*job.schedule.Active {
+					return true
+				}
+				assert.Equal(t, job.catchupFromTime, tt.expectedCatchUpTimes[jobId])
+				return true
+			})
+			for _, schedule := range tt.schedules {
+				g.DeScheduleJob(context.TODO(), schedule)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4285

## Describe your changes

All kudos to @leonlnj who discovered this bug in Gojek production deployment and helped debug this nasty loop variable issue which caused unnecessary production issue where schedules ran with incorrect times

Overall the issue that was observed was when Gojek redeployed there scheduler, scheduler ran its regular catchup routine to recover from the missed schedule time during the redeploy and found schedules it needed to trigger.
This is well tested behavior in the fleet and we never encountered any issues with it.

But in case of Gojek, it mysteriously ran the schedules which shouldn't have been run and also ran with incorrect catcup from time.

There is much detail in the attached issue. 
To summarize, 
* The lastExecTime for each active schedule is computed using its updatedAt timestamp and whats stored in the lastsnapshot for that schedule
* If the schedule is available in the snapshot and has timestamp greater than the updatedAt timestamp then we use that timestamp or else we assume schedule was updated recently and hence we should use that for catching up 
* Now consider the case where schedules dont have a snapshot and they will all use updatedAt timestamp, 
* What was happening though was the lastExecTime which was pointer to loop variable s.UpdatedAt , when the loop variable moved to next schedule, the lastExecTime being pointer used the new schedules UpdatedAt
* So essentially this value will eventually have last schedules UpdatedAt timestamp and in gojek's case it was a new schedule and this schedule's updatedAt timestamp was used as lastExecTime for knowing the catupFromTime for the schedule
* All the active schedules started then firing using the last scheudes updateAt timestamp


The unit test written by Gojek team nicely capture this behavior.
Have updated those tests with assertions and added the loop variable fix.


There is ongoing open golang issue to fix the gotcha which many go developers have complained or ran into https://github.com/golang/go/discussions/56010

Hopefully they fix that soon






## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.


