### PR TITLE
Fix Kubeflow TF Operator `GetTaskPhase` Bug

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow.go
@@ -217,7 +217,7 @@ func (tensorflowOperatorResourceHandler) BuildResource(ctx context.Context, task
 	return job, nil
 }
 
-func getReplicaCount(specs map[commonOp.ReplicaType]*commonOp.ReplicaSpec, replicaType commonOp.ReplicaType) *int32 {
+func getReplicasCount(specs map[commonOp.ReplicaType]*commonOp.ReplicaSpec, replicaType commonOp.ReplicaType) *int32 {
 	if spec, ok := specs[replicaType]; ok && spec.Replicas != nil {
 		return spec.Replicas
 	}
@@ -231,10 +231,10 @@ func getReplicaCount(specs map[commonOp.ReplicaType]*commonOp.ReplicaSpec, repli
 func (tensorflowOperatorResourceHandler) GetTaskPhase(_ context.Context, pluginContext k8s.PluginContext, resource client.Object) (pluginsCore.PhaseInfo, error) {
 	app := resource.(*kubeflowv1.TFJob)
 
-	workersCount := getReplicaCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeWorker)
-	psReplicasCount := getReplicaCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypePS)
-	chiefCount := getReplicaCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeChief)
-	evaluatorReplicasCount := getReplicaCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeEval)
+	workersCount := getReplicasCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeWorker)
+	psReplicasCount := getReplicasCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypePS)
+	chiefCount := getReplicasCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeChief)
+	evaluatorReplicasCount := getReplicasCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeEval)
 
 	taskLogs, err := common.GetLogs(pluginContext, common.TensorflowTaskType, app.ObjectMeta, false,
 		*workersCount, *psReplicasCount, *chiefCount, *evaluatorReplicasCount)

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow.go
@@ -217,7 +217,7 @@ func (tensorflowOperatorResourceHandler) BuildResource(ctx context.Context, task
 	return job, nil
 }
 
-func getReplicasCount(specs map[commonOp.ReplicaType]*commonOp.ReplicaSpec, replicaType commonOp.ReplicaType) *int32 {
+func getReplicaCount(specs map[commonOp.ReplicaType]*commonOp.ReplicaSpec, replicaType commonOp.ReplicaType) *int32 {
 	if spec, ok := specs[replicaType]; ok && spec.Replicas != nil {
 		return spec.Replicas
 	}
@@ -231,10 +231,10 @@ func getReplicasCount(specs map[commonOp.ReplicaType]*commonOp.ReplicaSpec, repl
 func (tensorflowOperatorResourceHandler) GetTaskPhase(_ context.Context, pluginContext k8s.PluginContext, resource client.Object) (pluginsCore.PhaseInfo, error) {
 	app := resource.(*kubeflowv1.TFJob)
 
-	workersCount := getReplicasCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeWorker)
-	psReplicasCount := getReplicasCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypePS)
-	chiefCount := getReplicasCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeChief)
-	evaluatorReplicasCount := getReplicasCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeEval)
+	workersCount := getReplicaCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeWorker)
+	psReplicasCount := getReplicaCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypePS)
+	chiefCount := getReplicaCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeChief)
+	evaluatorReplicasCount := getReplicaCount(app.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeEval)
 
 	taskLogs, err := common.GetLogs(pluginContext, common.TensorflowTaskType, app.ObjectMeta, false,
 		*workersCount, *psReplicasCount, *chiefCount, *evaluatorReplicasCount)

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow_test.go
@@ -295,6 +295,22 @@ func dummyTensorFlowJobResource(tensorflowResourceHandler tensorflowOperatorReso
 	}
 }
 
+func TestGetReplicaCount(t *testing.T) {
+	tensorflowResourceHandler := tensorflowOperatorResourceHandler{}
+	tfObj := dummyTensorFlowCustomObj(1, 0, 0, 0)
+	taskTemplate := dummyTensorFlowTaskTemplate("the job", tfObj)
+	resource, err := tensorflowResourceHandler.BuildResource(context.TODO(), dummyTensorFlowTaskContext(taskTemplate, resourceRequirements, nil))
+	assert.NoError(t, err)
+	assert.NotNil(t, resource)
+	tensorflowJob, ok := resource.(*kubeflowv1.TFJob)
+	assert.True(t, ok)
+
+	assert.NotNil(t, getReplicaCount(tensorflowJob.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeWorker))
+	assert.NotNil(t, getReplicaCount(tensorflowJob.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypePS))
+	assert.NotNil(t, getReplicaCount(tensorflowJob.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeChief))
+	assert.NotNil(t, getReplicaCount(tensorflowJob.Spec.TFReplicaSpecs, kubeflowv1.TFJobReplicaTypeEval))
+}
+
 func TestBuildResourceTensorFlow(t *testing.T) {
 	tensorflowResourceHandler := tensorflowOperatorResourceHandler{}
 

--- a/flyteplugins/go/tasks/plugins/webapi/athena/plugin_test.go
+++ b/flyteplugins/go/tasks/plugins/webapi/athena/plugin_test.go
@@ -23,7 +23,6 @@ func TestCreateTaskInfo(t *testing.T) {
 	assert.Equal(t, taskInfo.ExternalResources[0].ExternalID, "query_id")
 }
 
-
 func TestCreateTaskInfoGovAWS(t *testing.T) {
 	taskInfo := createTaskInfo("query_id", awsSdk.Config{
 		Region: "us-gov-east-1",


### PR DESCRIPTION
## Describe your changes
- Add a function `getReplicasCount` to give replica pointer with default value.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Setup Process
```python
image_spec = ImageSpec(
            packages=["flytekit",
                    "flytekitplugins-kftensorflow",
                    "tensorflow"],
            registry="localhost:30000")

# build-essential git
task_config = TfJob(
    worker=Worker(replicas=1),
    chief=Chief(replicas=0),
    ps=PS(replicas=0),
    evaluator=Evaluator(replicas=0),
)

@task(
    task_config=task_config,
    cache=True,
    requests=Resources(cpu="1"),
    cache_version="1",
    container_image=image_spec,
)
def my_tensorflow_task(x: int = 10, y: str = "abc") -> int:
    return x


if __name__ == "__main__":
    print(my_tensorflow_task(x=10, y="hello"))
```

## Screenshots

![image](https://github.com/flyteorg/flyte/assets/76461262/64cd922e-2b98-405f-9e21-725007fb444b)
![image](https://github.com/flyteorg/flyte/assets/76461262/1829d876-7dad-46e2-b701-af154742c126)


