### PR TITLE
Add the smaller scoped branch

### DIFF
--- a/.github/workflows/flyteidl-buf-publish.yml
+++ b/.github/workflows/flyteidl-buf-publish.yml
@@ -3,6 +3,7 @@ name: Publish flyteidl Buf Package
 on:
   push:
     branches:
+      - artifacts-shell
       - artifacts
       - master
     paths:


### PR DESCRIPTION
For working with artifact branch, we're stripping out the service for now. The necessary OSS changes are in a new branch, which we want to buf on push.