### PR TITLE
Remove 'needs' from generate_flyte_manifest

### DIFF
--- a/.github/workflows/generate_flyte_manifest.yml
+++ b/.github/workflows/generate_flyte_manifest.yml
@@ -11,8 +11,6 @@ jobs:
   update-flyte-releases:
     name: Update Flyte components
     runs-on: ubuntu-latest
-    needs:
-      - generate-tags
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Describe your changes

The `needs` step was not removed from the `flyte_generate_manifest` gh workflow in https://github.com/flyteorg/flyte/pull/4304. This PR removes it.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Setup Process

<!-- Describe how you set up this PR's environment to help maintainers reproduce your results more easily -->

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->

## Related PRs

<!-- Add related pull requests for reviewers to check -->

