### PR TITLE
Modify how flytecopilot version is parsed from values file

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -105,8 +105,11 @@ jobs:
       - name: Get Latest Version of component
         id: set_version
         run: |
-          echo ::set-output name=version::$(yq eval '.${{ matrix.component }}.image.tag' charts/flyte-core/values.yaml)
-        shell: bash
+          if [ ${{ matrix.component }} = "flytecopilot" ]; then
+             echo ::set-output name=version::$(yq eval '.configmap.copilot.plugins.k8s.co-pilot.image' charts/flyte-core/values.yaml | cut -d ":" -f 2 )
+          else
+             echo ::set-output name=version::$(yq eval '.${{ matrix.component }}.image.tag' charts/flyte-core/values.yaml)
+          fi        shell: bash
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1


### PR DESCRIPTION
## Describe your changes

In https://github.com/flyteorg/flyte/pull/4304 we modified the way all version were fetched from the values file, however that's not correct in the case of flytecopilot.  In this PR we go back to the correct way of fetching the version of flytecopilot from the values file.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Setup Process

<!-- Describe how you set up this PR's environment to help maintainers reproduce your results more easily -->

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->

## Related PRs

<!-- Add related pull requests for reviewers to check -->

