### PR TITLE
Bump version of goreleaser gh action to v5

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -177,7 +177,7 @@ jobs:
           git stash
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
           args: release --rm-dist --release-notes=CHANGELOG/CHANGELOG-${{ github.event.inputs.version }}.md


### PR DESCRIPTION
## Describe your changes

We introduced a way to skip certain tags in https://github.com/flyteorg/flyte/pull/4497 but in order to use that we need a newer version of goreleaser/goreleaser-action@v5

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Setup Process

<!-- Describe how you set up this PR's environment to help maintainers reproduce your results more easily -->

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->

## Related PRs

<!-- Add related pull requests for reviewers to check -->

