### PR TITLE
manually create flytekit/_version.py file in docs build

### DIFF
--- a/docs/_ext/import_projects.py
+++ b/docs/_ext/import_projects.py
@@ -33,6 +33,11 @@ class Project:
 
 
 def update_sys_path_for_flytekit(import_project_config: ImportProjectsConfig):
+    # create flytekit/_version.py file manually
+    with open(f"{import_project_config.flytekit_api_dir}/flytekit/_version.py", "w") as f:
+        f.write(f'__version__ = "dev"')
+
+
     # add flytekit to python path
     flytekit_dir = os.path.abspath(import_project_config.flytekit_api_dir)
     flytekit_src_dir = os.path.abspath(os.path.join(flytekit_dir, "flytekit"))


### PR DESCRIPTION
This PR fixes a breakage in the monodocs build introduced by https://github.com/flyteorg/flytekit/commit/f0d4f1357a770b66dc8344ab97b8b41d19eca9df, where a `_version.py` file is being created in the package build process.