### PR TITLE
Use updated cronSchedule in CreateLaunchPlanModel

### DIFF
--- a/flyteadmin/pkg/manager/impl/testutils/mock_requests.go
+++ b/flyteadmin/pkg/manager/impl/testutils/mock_requests.go
@@ -164,11 +164,24 @@ func GetLaunchPlanRequest() admin.LaunchPlanCreateRequest {
 	}
 }
 
-func GetLaunchPlanRequestWithCronSchedule(testCronExpr string) admin.LaunchPlanCreateRequest {
+func GetLaunchPlanRequestWithDeprecatedCronSchedule(testCronExpr string) admin.LaunchPlanCreateRequest {
 	lpRequest := GetLaunchPlanRequest()
 	lpRequest.Spec.EntityMetadata = &admin.LaunchPlanMetadata{
 		Schedule: &admin.Schedule{
 			ScheduleExpression:  &admin.Schedule_CronExpression{CronExpression: testCronExpr},
+			KickoffTimeInputArg: "",
+		},
+	}
+	return lpRequest
+}
+
+func GetLaunchPlanRequestWithCronSchedule(testCronExpr string) admin.LaunchPlanCreateRequest {
+	lpRequest := GetLaunchPlanRequest()
+	lpRequest.Spec.EntityMetadata = &admin.LaunchPlanMetadata{
+		Schedule: &admin.Schedule{
+			ScheduleExpression: &admin.Schedule_CronSchedule{CronSchedule: &admin.CronSchedule{
+				Schedule: testCronExpr,
+			}},
 			KickoffTimeInputArg: "",
 		},
 	}

--- a/flyteadmin/pkg/manager/impl/validation/launch_plan_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/launch_plan_validator_test.go
@@ -294,7 +294,7 @@ func TestValidateSchedule_NoSchedule(t *testing.T) {
 }
 
 func TestValidateSchedule_ArgNotFixed(t *testing.T) {
-	request := testutils.GetLaunchPlanRequestWithCronSchedule("* * * * * *")
+	request := testutils.GetLaunchPlanRequestWithDeprecatedCronSchedule("* * * * * *")
 	inputMap := &core.ParameterMap{
 		Parameters: map[string]*core.Parameter{
 			"foo": {
@@ -313,7 +313,7 @@ func TestValidateSchedule_ArgNotFixed(t *testing.T) {
 }
 
 func TestValidateSchedule_KickoffTimeArgDoesNotExist(t *testing.T) {
-	request := testutils.GetLaunchPlanRequestWithCronSchedule("* * * * * *")
+	request := testutils.GetLaunchPlanRequestWithDeprecatedCronSchedule("* * * * * *")
 	inputMap := &core.ParameterMap{
 		Parameters: map[string]*core.Parameter{},
 	}
@@ -324,7 +324,7 @@ func TestValidateSchedule_KickoffTimeArgDoesNotExist(t *testing.T) {
 }
 
 func TestValidateSchedule_KickoffTimeArgPointsAtWrongType(t *testing.T) {
-	request := testutils.GetLaunchPlanRequestWithCronSchedule("* * * * * *")
+	request := testutils.GetLaunchPlanRequestWithDeprecatedCronSchedule("* * * * * *")
 	inputMap := &core.ParameterMap{
 		Parameters: map[string]*core.Parameter{
 			"foo": {
@@ -344,7 +344,7 @@ func TestValidateSchedule_KickoffTimeArgPointsAtWrongType(t *testing.T) {
 }
 
 func TestValidateSchedule_NoRequired(t *testing.T) {
-	request := testutils.GetLaunchPlanRequestWithCronSchedule("* * * * * *")
+	request := testutils.GetLaunchPlanRequestWithDeprecatedCronSchedule("* * * * * *")
 	inputMap := &core.ParameterMap{
 		Parameters: map[string]*core.Parameter{
 			"foo": {
@@ -363,7 +363,7 @@ func TestValidateSchedule_NoRequired(t *testing.T) {
 }
 
 func TestValidateSchedule_KickoffTimeBound(t *testing.T) {
-	request := testutils.GetLaunchPlanRequestWithCronSchedule("* * * * * *")
+	request := testutils.GetLaunchPlanRequestWithDeprecatedCronSchedule("* * * * * *")
 	inputMap := &core.ParameterMap{
 		Parameters: map[string]*core.Parameter{
 			"foo": {

--- a/flyteadmin/pkg/repositories/transformers/launch_plan.go
+++ b/flyteadmin/pkg/repositories/transformers/launch_plan.go
@@ -42,7 +42,7 @@ func CreateLaunchPlanModel(
 
 	scheduleType := models.LaunchPlanScheduleTypeNONE
 	if launchPlan.Spec.EntityMetadata != nil && launchPlan.Spec.EntityMetadata.Schedule != nil {
-		if launchPlan.Spec.EntityMetadata.Schedule.GetCronExpression() != "" {
+		if launchPlan.Spec.EntityMetadata.Schedule.GetCronExpression() != "" || launchPlan.Spec.EntityMetadata.Schedule.GetCronSchedule() != nil {
 			scheduleType = models.LaunchPlanScheduleTypeCRON
 		} else if launchPlan.Spec.EntityMetadata.Schedule.GetRate() != nil {
 			scheduleType = models.LaunchPlanScheduleTypeRATE

--- a/flyteadmin/pkg/repositories/transformers/launch_plan_test.go
+++ b/flyteadmin/pkg/repositories/transformers/launch_plan_test.go
@@ -84,7 +84,18 @@ func TestToLaunchPlanModel(t *testing.T) {
 }
 
 func TestToLaunchPlanModelWithCronSchedule(t *testing.T) {
-	lpRequest := testutils.GetLaunchPlanRequestWithCronSchedule("* * * * *")
+
+	t.Run("deprecated cron schedule", func(t *testing.T) {
+		lpRequest := testutils.GetLaunchPlanRequestWithDeprecatedCronSchedule("* * * * *")
+		testLaunchPlanWithCronInternal(t, lpRequest)
+	})
+	t.Run("cron schedule", func(t *testing.T) {
+		lpRequest := testutils.GetLaunchPlanRequestWithCronSchedule("* * * * *")
+		testLaunchPlanWithCronInternal(t, lpRequest)
+	})
+}
+
+func testLaunchPlanWithCronInternal(t *testing.T, lpRequest admin.LaunchPlanCreateRequest) {
 	lpRequest.Spec.DefaultInputs = expectedInputs
 	workflowID := uint(11)
 	launchPlanDigest := []byte("launch plan")


### PR DESCRIPTION
## Why are the changes needed?

Create schedule launchplan is using deprecated field to determine if schedule type is CRON and saving it in the DB
This causes the list launchplan with filter for CRON type schedule returns null 

This fixes the logic of saving all new scheduled launchplans.
We are not planning to support this for older scheduled launchplans and hence no migration script for it.


## How was this patch tested?

Tested this on an internal tenant by registering the latest version of the examples

*  flytectl register examples  --project flytesnacks  --domain development 
* flytectl update launchplan my_cron_scheduled_lp  --project flytesnacks --domain development --version v0.3.248   --activate
* flytectl update launchplan my_fixed_rate_lp   --project flytesnacks --domain development  --version v0.3.248   --activate

Verified the result  of https://dogfood.cloud-staging.union.ai/api/v1/launch_plans/flytesnacks/development?filters=ne(schedule_type,NONE)%2Beq(state,1)&limit=10000&sort_by.direction=ASCENDING&sort_by.key=name

returns exactly the two activated launchplans.

```
{
"launch_plans": [
{
"id": {
"resource_type": "LAUNCH_PLAN",
"project": "flytesnacks",
"domain": "development",
"name": "my_cron_scheduled_lp",
"version": "v0.3.248"
},
"spec": {
"workflow_id": {
"resource_type": "WORKFLOW",
"project": "flytesnacks",
"domain": "development",
"name": "productionizing.lp_schedules.date_formatter_wf",
"version": "v0.3.248"
},
"entity_metadata": {
"schedule": {
"cron_schedule": {
"schedule": "*/1 * * * *"
},
"kickoff_time_input_arg": "kickoff_time"
}
},
"default_inputs": {
"parameters": {
"kickoff_time": {
"var": {
"type": {
"simple": "DATETIME"
},
"description": "kickoff_time"
},
"required": true
}
}
},
"fixed_inputs": {},
"labels": {},
"annotations": {},
"raw_output_data_config": {}
},
"closure": {
"state": "ACTIVE",
"expected_inputs": {
"parameters": {
"kickoff_time": {
"var": {
"type": {
"simple": "DATETIME"
},
"description": "kickoff_time"
},
"required": true
}
}
},
"expected_outputs": {},
"created_at": "2023-12-13T05:42:29.102555Z",
"updated_at": "2023-12-13T05:42:29.102555Z"
}
},
{
"id": {
"resource_type": "LAUNCH_PLAN",
"project": "flytesnacks",
"domain": "development",
"name": "my_fixed_rate_lp",
"version": "v0.3.248"
},
"spec": {
"workflow_id": {
"resource_type": "WORKFLOW",
"project": "flytesnacks",
"domain": "development",
"name": "productionizing.lp_schedules.positive_wf",
"version": "v0.3.248"
},
"entity_metadata": {
"schedule": {
"rate": {
"value": 10
}
}
},
"default_inputs": {},
"fixed_inputs": {
"literals": {
"name": {
"scalar": {
"primitive": {
"string_value": "you"
}
}
}
}
},
"labels": {},
"annotations": {},
"raw_output_data_config": {}
},
"closure": {
"state": "ACTIVE",
"expected_inputs": {},
"expected_outputs": {},
"created_at": "2023-12-13T05:42:30.835996Z",
"updated_at": "2023-12-13T05:42:30.835996Z"
}
}
]
}
```

* flytectl update launchplan my_fixed_rate_lp   --project flytesnacks --domain development --version v0.3.248   --archive    
* flytectl update launchplan my_cron_scheduled_lp   --project flytesnacks --domain development --version v0.3.248   --archive 

Also verified after the above two steps of archive the following link returns no result  https://dogfood.cloud-staging.union.ai/api/v1/launch_plans/flytesnacks/development?filters=ne(schedule_type,NONE)%2Beq(state,1)&limit=10000&sort_by.direction=ASCENDING&sort_by.key=name


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
