### PR TITLE
Return InvalidArgument for workflow compilation failures in CreateWorkflow

### DIFF
--- a/flyteadmin/cmd/entrypoints/serve.go
+++ b/flyteadmin/cmd/entrypoints/serve.go
@@ -35,7 +35,7 @@ var serveCmd = &cobra.Command{
 
 		// register otel tracer providers
 		for _, serviceName := range []string{otelutils.AdminGormTracer, otelutils.AdminServerTracer} {
-			if err := otelutils.RegisterTracerProvider(serviceName, otelutils.GetConfig()) ; err != nil {
+			if err := otelutils.RegisterTracerProvider(serviceName, otelutils.GetConfig()); err != nil {
 				logger.Errorf(ctx, "Failed to create otel tracer provider. %v", err)
 				return err
 			}

--- a/flyteadmin/pkg/manager/impl/workflow_manager.go
+++ b/flyteadmin/pkg/manager/impl/workflow_manager.go
@@ -146,7 +146,7 @@ func (w *WorkflowManager) CreateWorkflow(
 	workflowClosure, err := w.getCompiledWorkflow(ctx, finalizedRequest)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to compile workflow with err: %v", err)
-		return nil, errors.NewFlyteAdminErrorf(codes.Internal,
+		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument,
 			"failed to compile workflow for [%+v] with err %v", request.Id, err)
 	}
 	err = validation.ValidateCompiledWorkflow(

--- a/flyteadmin/pkg/manager/impl/workflow_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/workflow_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"google.golang.org/grpc/status"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -243,10 +244,13 @@ func TestCreateWorkflow_CompileWorkflowError(t *testing.T) {
 		getMockWorkflowConfigProvider(), mockCompiler, getMockStorage(), storagePrefix, mockScope.NewTestScope())
 	request := testutils.GetWorkflowRequest()
 	response, err := workflowManager.CreateWorkflow(context.Background(), request)
+	assert.Nil(t, response)
+	s, ok := status.FromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, s.Code())
 	assert.EqualError(t, err, fmt.Sprintf(
 		"failed to compile workflow for [resource_type:WORKFLOW project:\"project\" domain:\"domain\" "+
 			"name:\"name\" version:\"version\" ] with err %v", expectedErr.Error()))
-	assert.Nil(t, response)
 }
 
 func TestCreateWorkflow_DatabaseError(t *testing.T) {

--- a/flyteadmin/pkg/manager/impl/workflow_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/workflow_manager_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"google.golang.org/grpc/status"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/flyteorg/flyte/flyteadmin/pkg/common"
 	commonMocks "github.com/flyteorg/flyte/flyteadmin/pkg/common/mocks"


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4565


## Why are the changes needed?
Invalid workflow specs passed to CreateWorkflow calls currently return Internal grpc status response codes and are erroneously treated as server rather than user errors.

As far as I could tell, the [compiler](https://github.com/flyteorg/flyte/blob/d03a0bc1c0e8f8a5fa0d83407df3a87827359079/flytepropeller/pkg/compiler/workflow_compiler.go) propagates compiler errors that only surface due to invalid workflow definitions

## What changes were proposed in this pull request?
Updates workflow compilation handling to return a more accurate response code.

## How was this patch tested?
Added unit tests.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
