### PR TITLE
Add flyin plugin to monodocs integrations page

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -102,6 +102,8 @@ the Flyte task that use the respective plugin.
   - Execute queries using AWS Athena
 * - {doc}`AWS Batch <flytesnacks/examples/aws_batch_plugin/index>`
   - Running tasks and workflows on AWS batch service
+* - {doc}`Flyte Interactive <flytesnacks/examples/flyin_plugin/index>`
+  - Execute tasks using Flyte Interactive to debug.
 * - {doc}`Hive <flytesnacks/examples/hive_plugin/index>`
   - Run Hive jobs in your workflows.
 * - {doc}`MMCloud <flytesnacks/examples/mmcloud_plugin/index>`
@@ -210,4 +212,5 @@ flytesnacks/examples/snowflake_plugin/index
 flytesnacks/examples/databricks_plugin/index
 flytesnacks/examples/bigquery_plugin/index
 flytesnacks/examples/airflow_plugin/index
+flytesnacks/examples/flyin_plugin/index
 ```


### PR DESCRIPTION
## Why are the changes needed?

Currently, https://github.com/flyteorg/flytesnacks/pull/1314 is failing the monodocs build step because it adds a new plugin page that has not been added to the integrations TOC.

## What changes were proposed in this pull request?

Adds the flyin plugin index link to the integrations docs config page.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flytesnacks/pull/1314

## Docs link

TBD
