### PR TITLE
Writing zero length inputs

### DIFF
--- a/flytepropeller/pkg/controller/nodes/executor.go
+++ b/flytepropeller/pkg/controller/nodes/executor.go
@@ -753,7 +753,7 @@ func (c *nodeExecutor) preExecute(ctx context.Context, dag executors.DAGStructur
 				return handler.PhaseInfoFailure(core.ExecutionError_SYSTEM, "BindingResolutionFailure", err.Error(), nil), nil
 			}
 
-			if nodeInputs != nil && len(nodeInputs.Literals) > 0 {
+			if nodeInputs != nil {
 				inputsFile := v1alpha1.GetInputsFile(dataDir)
 				if err := c.store.WriteProtobuf(ctx, inputsFile, storage.Options{}, nodeInputs); err != nil {
 					c.metrics.InputsWriteFailure.Inc(ctx)


### PR DESCRIPTION
## Tracking issue
_NA_

## Why are the changes needed?
Flytes templating and flytekit both rely on this zero length file to indicate there are no inputs.

## What changes were proposed in this pull request?
This PR re-introduces writing a zero length input file if the node has no inputs.

## How was this patch tested?
Flytesnacks workflows.

### Setup process
_NA_

### Screenshots
_NA_

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
- [this PR](https://github.com/flyteorg/flyte/pull/4535) introduced the issue.

## Docs link
_NA_
