### PR TITLE
monodocs - gracefully handle case when external repo doesn't contain tags: use current commit

### DIFF
--- a/docs/_ext/import_projects.py
+++ b/docs/_ext/import_projects.py
@@ -26,6 +26,7 @@ class ImportProjectsConfig:
     flytekit_api_dir: str
     source_regex_mapping: dict = field(default_factory=dict)
     list_table_toc: List[str] = field(default_factory=list)
+    dev_build: bool = False
 
 
 @dataclass
@@ -127,27 +128,28 @@ def import_projects(app: Sphinx, config: Config):
     if not hasattr(config, "html_context"):
         config.html_context = {}
 
-    show_repo_tags = False
+    show_repo_tags = not import_projects_config.dev_build
     for project in projects:
         if project.local:
             local_dir = srcdir / project.source
             try:
                 repo = Repo(local_dir)
-                show_repo_tags = True
             except git.InvalidGitRepositoryError:
                 repo = None
         else:
             local_dir = srcdir / import_projects_config.clone_dir / project.dest
             shutil.rmtree(local_dir, ignore_errors=True)
             repo = Repo.clone_from(project.source, local_dir)
-            show_repo_tags = True
 
         local_docs_path = local_dir / project.docs_path
         dest_docs_dir = srcdir / project.dest
 
-        # use the latest git tag when building docs
-        if repo:
+        # don't checkout/show latest tag on dev builds
+        if repo and show_repo_tags:
+            # use the latest git tag when building docs
             tags = sorted(repo.tags, key=lambda t: t.commit.committed_datetime)
+            if not tags:
+                raise RuntimeError(f"No tags found for {project.name}")
             tag = tags[-1]
             update_html_context(project, str(tag), str(tag.commit)[:7], config)
             repo.git.checkout(str(tag))

--- a/docs/_ext/import_projects.py
+++ b/docs/_ext/import_projects.py
@@ -149,7 +149,7 @@ def import_projects(app: Sphinx, config: Config):
             tags = sorted(repo.tags, key=lambda t: t.commit.committed_datetime)
             if not tags:
                 # If tags don't exist just use the current commit. This occurs
-                # when the git repo fetch depth is 0.
+                # when the git repo is a shallow clone.
                 tag_str = "dev"
                 commit = repo.head.commit
             else:

--- a/docs/_ext/import_projects.py
+++ b/docs/_ext/import_projects.py
@@ -150,7 +150,7 @@ def import_projects(app: Sphinx, config: Config):
             if not tags:
                 # If tags don't exist just use the current commit. This occurs
                 # when the git repo fetch depth is 0.
-                tag = None
+                tag_str = "dev"
                 commit = repo.head.commit
             else:
                 tag = tags[-1]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -337,7 +337,6 @@ import_projects_config = {
         "flytesnacks/tutorials",
         "flytesnacks/integrations",
     ],
-    "dev_build": bool(int(os.environ.get("DOCS_DEV_BUILD", 0))),
 }
 
 # Define these environment variables to use local copies of the projects. This

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -337,6 +337,7 @@ import_projects_config = {
         "flytesnacks/tutorials",
         "flytesnacks/integrations",
     ],
+    "dev_build": bool(int(os.environ.get("DOCS_DEV_BUILD", 0))),
 }
 
 # Define these environment variables to use local copies of the projects. This


### PR DESCRIPTION
This PR elegantly handles the case when an external repo (flytekit, flytesnacks, flytectl) does not have tags due to a cloning a copy of the repo with a depth of 0. This fixes a docs build issue caused by the fact that github actions `checkout` will fetch the latest commit (since `fetch-depth: 0` by default), see: https://github.com/flyteorg/flytesnacks/actions/runs/7204216790/job/19625299915?pr=1315