### PR TITLE
convert commit to string

### DIFF
--- a/docs/_ext/import_projects.py
+++ b/docs/_ext/import_projects.py
@@ -151,7 +151,7 @@ def import_projects(app: Sphinx, config: Config):
                 # If tags don't exist just use the current commit. This occurs
                 # when the git repo is a shallow clone.
                 tag_str = "dev"
-                commit = repo.head.commit
+                commit = str(repo.head.commit)[:7]
             else:
                 tag = tags[-1]
                 tag_str = str(tag)


### PR DESCRIPTION
Fix a minor issue: git commit object should be converted to string in `import_project` sphinx extension.