### PR TITLE
using Abort phase and cleaning up best-effort

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/core/phase.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/phase.go
@@ -36,6 +36,8 @@ const (
 	PhasePermanentFailure
 	// Indicates the task is waiting for the cache to be populated so it can reuse results
 	PhaseWaitingForCache
+	// Indicate the task has been aborted
+	PhaseAborted
 )
 
 var Phases = []Phase{
@@ -49,11 +51,12 @@ var Phases = []Phase{
 	PhaseRetryableFailure,
 	PhasePermanentFailure,
 	PhaseWaitingForCache,
+	PhaseAborted,
 }
 
 // Returns true if the given phase is failure, retryable failure or success
 func (p Phase) IsTerminal() bool {
-	return p.IsFailure() || p.IsSuccess()
+	return p.IsFailure() || p.IsSuccess() || p.IsAborted()
 }
 
 func (p Phase) IsFailure() bool {
@@ -62,6 +65,10 @@ func (p Phase) IsFailure() bool {
 
 func (p Phase) IsSuccess() bool {
 	return p == PhaseSuccess
+}
+
+func (p Phase) IsAborted() bool {
+	return p == PhaseAborted
 }
 
 func (p Phase) IsWaitingForResources() bool {
@@ -82,8 +89,6 @@ type ExternalResource struct {
 	RetryAttempt uint32
 	// Phase (if exists) associated with the external resource
 	Phase Phase
-	// Indicates if external resource is a subtask getting aborted
-	IsAbortedSubtask bool
 }
 
 type ReasonInfo struct {

--- a/flyteplugins/go/tasks/plugins/array/core/state.go
+++ b/flyteplugins/go/tasks/plugins/array/core/state.go
@@ -226,9 +226,9 @@ func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idl
 
 	case PhasePermanentFailure:
 		if state.GetExecutionErr() != nil {
-			phaseInfo = core.PhaseInfoFailureWithCleanup(core.PhasePermanentFailure.String(), state.GetExecutionErr().Message, nowTaskInfo)
+			phaseInfo = core.PhaseInfoFailed(core.PhasePermanentFailure, state.GetExecutionErr(), nowTaskInfo)
 		} else {
-			phaseInfo = core.PhaseInfoSystemFailureWithCleanup(ErrorK8sArrayGeneric, state.GetReason(), nowTaskInfo)
+			phaseInfo = core.PhaseInfoSystemFailure(ErrorK8sArrayGeneric, state.GetReason(), nowTaskInfo)
 		}
 	default:
 		return phaseInfo, fmt.Errorf("failed to map custom state phase to core phase. State Phase [%v]", p)

--- a/flyteplugins/go/tasks/plugins/array/k8s/executor.go
+++ b/flyteplugins/go/tasks/plugins/array/k8s/executor.go
@@ -168,7 +168,8 @@ func (e Executor) Finalize(ctx context.Context, tCtx core.TaskExecutionContext) 
 		return errors.Wrapf(errors.CorruptedPluginState, err, "Failed to read unmarshal custom state")
 	}
 
-	return TerminateSubTasksOnAbort(ctx, tCtx, e.kubeClient, GetConfig(), finalizeSubtask, pluginState)
+	_, _, err := TerminateSubTasks(ctx, tCtx, e.kubeClient, GetConfig(), finalizeSubtask, pluginState)
+	return err
 }
 
 func (e Executor) Start(ctx context.Context) error {

--- a/flytepropeller/pkg/controller/nodes/task/transformer.go
+++ b/flytepropeller/pkg/controller/nodes/task/transformer.go
@@ -44,6 +44,8 @@ func ToTaskEventPhase(p pluginCore.Phase) core.TaskExecution_Phase {
 		return core.TaskExecution_FAILED
 	case pluginCore.PhaseRetryableFailure:
 		return core.TaskExecution_FAILED
+	case pluginCore.PhaseAborted:
+		return core.TaskExecution_ABORTED
 	case pluginCore.PhaseNotReady:
 		fallthrough
 	case pluginCore.PhaseUndefined:
@@ -118,9 +120,6 @@ func ToTaskExecutionEvent(input ToTaskExecutionEventInputs) (*event.TaskExecutio
 		metadata.ExternalResources = make([]*event.ExternalResourceInfo, len(externalResources))
 		for idx, e := range input.Info.Info().ExternalResources {
 			phase := ToTaskEventPhase(e.Phase)
-			if e.IsAbortedSubtask {
-				phase = core.TaskExecution_ABORTED
-			}
 			metadata.ExternalResources[idx] = &event.ExternalResourceInfo{
 				ExternalId:   e.ExternalID,
 				CacheStatus:  e.CacheStatus,


### PR DESCRIPTION
Updating to:
- enable use of the `Abort` phase directly in `ExternalResourceInfo` rather than a bool flag
- Remove failing w/ cleanup, because we only need to attempt abort once. While the workflow is running this happens with the `AbortSubTask` `ArrayNodePhase` and otherwise this is attempted during `Abort`
- Removed eventing as `Abort` during finalize. This function is used to handle finalizer cleanup and resource deletion (if requested), so tasks should not be phase transitioned.