### PR TITLE
Fixing 100 kilobyte max error message size

### DIFF
--- a/flytepropeller/events/event_recorder.go
+++ b/flytepropeller/events/event_recorder.go
@@ -14,7 +14,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )
 
-const MaxErrorMessageLength = 104857600 //100KB
+const MaxErrorMessageLength = 102400 //100KB
 const truncationIndicator = "... <Message Truncated> ..."
 
 type recordingMetrics struct {


### PR DESCRIPTION
## Tracking issue
_NA_

## Why are the changes needed?
This `MaxErrorMessageLength` value is now used to truncate `ArrayNode` errors, since it was actually 100MB this resulted in potentially large FlyteWorkflow CRs.

## What changes were proposed in this pull request?
Correctly computing the 100KB to B conversion.

## How was this patch tested?
_NA_

### Setup process
_NA_

### Screenshots
_NA_

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
_NA_

## Docs link
_NA_