### PR TITLE
Docs/Clarify propeller scaling

### DIFF
--- a/docs/deployment/configuration/performance.rst
+++ b/docs/deployment/configuration/performance.rst
@@ -189,7 +189,7 @@ Manual scale-out
 ----------------
 FlytePropeller can be run manually per namespace. This is not a recommended solution as it is harder to deploy, but if your organization can deploy and maintain multiple copies of FlytePropeller, you can use this.
 
-Automatic scale-out
+Sharded scale-out
 -------------------
 FlytePropeller Manager is a new component introduced as part of `this RFC <https://github.com/flyteorg/flyte/blob/master/rfc/system/1483-flytepropeller-horizontal-scaling.md>`_ to facilitate horizontal scaling of FlytePropeller through sharding. Effectively, the Manager is responsible for maintaining liveness and proper configuration over a collection of FlytePropeller instances. This scheme uses k8s label selectors to deterministically assign FlyteWorkflow CRD responsibilities to FlytePropeller instances, effectively distributing processing load over the shards.
 
@@ -197,7 +197,7 @@ Deployment of FlytePropeller Manager requires k8s configuration updates includin
 
 Flyte provides a variety of Shard Strategies to configure how FlyteWorkflows are sharded among managed FlytePropeller instances. These include hash, which uses consistent hashing to load-balance evaluation over shards, and project / domain, which map the respective IDs to specific managed FlytePropeller instances. Below we include examples of helm configurations for each of the existing Shard Strategies.
 
-The Hash Shard Strategy, denoted by "type: hash" in the configuration below, uses consistent hashing to evenly distribute FlyteWorkflows over managed FlytePropeller instances. This configuration requires a "shard-count" variable which defines the number of managed FlytePropeller instances.
+The Hash Shard Strategy, denoted by "type: Hash" in the configuration below, uses consistent hashing to evenly distribute FlyteWorkflows over managed FlytePropeller instances. This configuration requires a "shard-count" variable which defines the number of managed FlytePropeller instances. You may change the shard count without impacting existing workflows. Note that changing the shard-count is a manual step, it is not auto-scaling.
 
 .. code-block:: yaml
 
@@ -208,7 +208,7 @@ The Hash Shard Strategy, denoted by "type: hash" in the configuration below, use
           # pod and scanning configuration redacted
           # ...
           shard:
-            type: hash     # use the "hash" shard strategy
+            type: Hash     # use the "hash" shard strategy
             shard-count: 4 # the total number of shards
  
 The Project and Domain Shard Strategies, denoted by "type: project" and "type: domain" respectively, use the FlyteWorkflow project and domain metadata to shard FlyteWorkflows. These Shard Strategies are configured using a "per-shard-mapping" option, which is a list of ID lists. Each element in the "per-shard-mapping" list defines a new shard and the ID list assigns responsibility for the specified IDs to that shard. A shard configured as a single wildcard ID (i.e. "*") is responsible for all IDs that are not covered by other shards. Only a single shard may be configured with a wildcard ID and on that shard their must be only one ID, namely the wildcard.


### PR DESCRIPTION
The enumer generated code needs the type to be `Hash` not `hash`.  Also clarify that it's not autoscaling in the traditional sense.