### PR TITLE
Fix webhook typo, add podLabels, add podEnv to flyte-core Helm chart

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -60,13 +60,14 @@ helm install gateway bitnami/contour -n flyte
 | cloud_events.eventsPublisher.eventTypes[0] | string | `"all"` |  |
 | cloud_events.eventsPublisher.topicName | string | `"arn:aws:sns:us-east-2:123456:123-my-topic"` |  |
 | cloud_events.type | string | `"aws"` |  |
-| cluster_resource_manager | object | `{"config":{"cluster_resources":{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}},"enabled":true,"podAnnotations":{},"service_account_name":"flyteadmin","standaloneDeployment":false,"templates":[{"key":"aa_namespace","value":"apiVersion: v1\nkind: Namespace\nmetadata:\n  name: {{ namespace }}\nspec:\n  finalizers:\n  - kubernetes\n"},{"key":"ab_project_resource_quota","value":"apiVersion: v1\nkind: ResourceQuota\nmetadata:\n  name: project-quota\n  namespace: {{ namespace }}\nspec:\n  hard:\n    limits.cpu: {{ projectQuotaCpu }}\n    limits.memory: {{ projectQuotaMemory }}\n"}]}` | Configuration for the Cluster resource manager component. This is an optional component, that enables automatic cluster configuration. This is useful to set default quotas, manage namespaces etc that map to a project/domain |
+| cluster_resource_manager | object | `{"config":{"cluster_resources":{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}},"enabled":true,"podAnnotations":{},"podLabels":{},"service_account_name":"flyteadmin","standaloneDeployment":false,"templates":[{"key":"aa_namespace","value":"apiVersion: v1\nkind: Namespace\nmetadata:\n  name: {{ namespace }}\nspec:\n  finalizers:\n  - kubernetes\n"},{"key":"ab_project_resource_quota","value":"apiVersion: v1\nkind: ResourceQuota\nmetadata:\n  name: project-quota\n  namespace: {{ namespace }}\nspec:\n  hard:\n    limits.cpu: {{ projectQuotaCpu }}\n    limits.memory: {{ projectQuotaMemory }}\n"}]}` | Configuration for the Cluster resource manager component. This is an optional component, that enables automatic cluster configuration. This is useful to set default quotas, manage namespaces etc that map to a project/domain |
 | cluster_resource_manager.config | object | `{"cluster_resources":{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}}` | Configmap for ClusterResource parameters |
 | cluster_resource_manager.config.cluster_resources | object | `{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}` | ClusterResource parameters Refer to the [structure](https://pkg.go.dev/github.com/lyft/flyteadmin@v0.3.37/pkg/runtime/interfaces#ClusterResourceConfig) to customize. |
 | cluster_resource_manager.config.cluster_resources.refreshInterval | string | `"5m"` | How frequently to run the sync process |
 | cluster_resource_manager.config.cluster_resources.standaloneDeployment | bool | `false` | Starts the cluster resource manager in standalone mode with requisite auth credentials to call flyteadmin service endpoints |
 | cluster_resource_manager.enabled | bool | `true` | Enables the Cluster resource manager component |
 | cluster_resource_manager.podAnnotations | object | `{}` | Annotations for ClusterResource pods |
+| cluster_resource_manager.podLabels | object | `{}` | Labels for ClusterResource pods |
 | cluster_resource_manager.service_account_name | string | `"flyteadmin"` | Service account name to run with |
 | cluster_resource_manager.templates | list | `[{"key":"aa_namespace","value":"apiVersion: v1\nkind: Namespace\nmetadata:\n  name: {{ namespace }}\nspec:\n  finalizers:\n  - kubernetes\n"},{"key":"ab_project_resource_quota","value":"apiVersion: v1\nkind: ResourceQuota\nmetadata:\n  name: project-quota\n  namespace: {{ namespace }}\nspec:\n  hard:\n    limits.cpu: {{ projectQuotaCpu }}\n    limits.memory: {{ projectQuotaMemory }}\n"}]` | Resource templates that should be applied |
 | cluster_resource_manager.templates[0] | object | `{"key":"aa_namespace","value":"apiVersion: v1\nkind: Namespace\nmetadata:\n  name: {{ namespace }}\nspec:\n  finalizers:\n  - kubernetes\n"}` | Template for namespaces resources |
@@ -128,6 +129,7 @@ helm install gateway bitnami/contour -n flyte
 | datacatalog.image.tag | string | `"v1.10.7-b1"` | Docker image tag |
 | datacatalog.nodeSelector | object | `{}` | nodeSelector for Datacatalog deployment |
 | datacatalog.podAnnotations | object | `{}` | Annotations for Datacatalog pods |
+| datacatalog.podLabels | object | `{}` | Labels for Datacatalog pods |
 | datacatalog.priorityClassName | string | `""` | Sets priorityClassName for datacatalog pod(s). |
 | datacatalog.replicaCount | int | `1` | Replicas count for Datacatalog deployment |
 | datacatalog.resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Datacatalog deployment |
@@ -161,6 +163,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.initialProjects | list | `["flytesnacks","flytetester","flyteexamples"]` | Initial projects to create |
 | flyteadmin.nodeSelector | object | `{}` | nodeSelector for Flyteadmin deployment |
 | flyteadmin.podAnnotations | object | `{}` | Annotations for Flyteadmin pods |
+| flyteadmin.podLabels | object | `{}` | Labels for Flyteadmin pods |
 | flyteadmin.priorityClassName | string | `""` | Sets priorityClassName for flyteadmin pod(s). |
 | flyteadmin.replicaCount | int | `1` | Replicas count for Flyteadmin deployment |
 | flyteadmin.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flyteadmin deployment |
@@ -192,6 +195,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteconsole.image.tag | string | `"v1.10.2"` |  |
 | flyteconsole.nodeSelector | object | `{}` | nodeSelector for Flyteconsole deployment |
 | flyteconsole.podAnnotations | object | `{}` | Annotations for Flyteconsole pods |
+| flyteconsole.podLabels | object | `{}` | Labels for Flyteconsole pods |
 | flyteconsole.priorityClassName | string | `""` | Sets priorityClassName for flyte console pod(s). |
 | flyteconsole.replicaCount | int | `1` | Replicas count for Flyteconsole deployment |
 | flyteconsole.resources | object | `{"limits":{"cpu":"500m","memory":"250Mi"},"requests":{"cpu":"10m","memory":"50Mi"}}` | Default resources requests and limits for Flyteconsole deployment |
@@ -213,6 +217,7 @@ helm install gateway bitnami/contour -n flyte
 | flytepropeller.manager | bool | `false` |  |
 | flytepropeller.nodeSelector | object | `{}` | nodeSelector for Flytepropeller deployment |
 | flytepropeller.podAnnotations | object | `{}` | Annotations for Flytepropeller pods |
+| flytepropeller.podLabels | object | `{}` | Labels for Flytepropeller pods |
 | flytepropeller.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
 | flytepropeller.replicaCount | int | `1` | Replicas count for Flytepropeller deployment |
 | flytepropeller.resources | object | `{"limits":{"cpu":"200m","ephemeral-storage":"100Mi","memory":"200Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"100Mi"}}` | Default resources requests and limits for Flytepropeller deployment |
@@ -239,6 +244,7 @@ helm install gateway bitnami/contour -n flyte
 | flytescheduler.image.tag | string | `"v1.10.7-b1"` | Docker image tag |
 | flytescheduler.nodeSelector | object | `{}` | nodeSelector for Flytescheduler deployment |
 | flytescheduler.podAnnotations | object | `{}` | Annotations for Flytescheduler pods |
+| flytescheduler.podLabels | object | `{}` | Labels for Flytescheduler pods |
 | flytescheduler.priorityClassName | string | `""` | Sets priorityClassName for flyte scheduler pod(s). |
 | flytescheduler.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flytescheduler deployment |
 | flytescheduler.runPrecheck | bool | `true` | Whether to inject an init container which waits on flyteadmin |

--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -60,13 +60,14 @@ helm install gateway bitnami/contour -n flyte
 | cloud_events.eventsPublisher.eventTypes[0] | string | `"all"` |  |
 | cloud_events.eventsPublisher.topicName | string | `"arn:aws:sns:us-east-2:123456:123-my-topic"` |  |
 | cloud_events.type | string | `"aws"` |  |
-| cluster_resource_manager | object | `{"config":{"cluster_resources":{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}},"enabled":true,"podAnnotations":{},"podLabels":{},"service_account_name":"flyteadmin","standaloneDeployment":false,"templates":[{"key":"aa_namespace","value":"apiVersion: v1\nkind: Namespace\nmetadata:\n  name: {{ namespace }}\nspec:\n  finalizers:\n  - kubernetes\n"},{"key":"ab_project_resource_quota","value":"apiVersion: v1\nkind: ResourceQuota\nmetadata:\n  name: project-quota\n  namespace: {{ namespace }}\nspec:\n  hard:\n    limits.cpu: {{ projectQuotaCpu }}\n    limits.memory: {{ projectQuotaMemory }}\n"}]}` | Configuration for the Cluster resource manager component. This is an optional component, that enables automatic cluster configuration. This is useful to set default quotas, manage namespaces etc that map to a project/domain |
+| cluster_resource_manager | object | `{"config":{"cluster_resources":{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}},"enabled":true,"podAnnotations":{},"podEnv":{},"podLabels":{},"service_account_name":"flyteadmin","standaloneDeployment":false,"templates":[{"key":"aa_namespace","value":"apiVersion: v1\nkind: Namespace\nmetadata:\n  name: {{ namespace }}\nspec:\n  finalizers:\n  - kubernetes\n"},{"key":"ab_project_resource_quota","value":"apiVersion: v1\nkind: ResourceQuota\nmetadata:\n  name: project-quota\n  namespace: {{ namespace }}\nspec:\n  hard:\n    limits.cpu: {{ projectQuotaCpu }}\n    limits.memory: {{ projectQuotaMemory }}\n"}]}` | Configuration for the Cluster resource manager component. This is an optional component, that enables automatic cluster configuration. This is useful to set default quotas, manage namespaces etc that map to a project/domain |
 | cluster_resource_manager.config | object | `{"cluster_resources":{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}}` | Configmap for ClusterResource parameters |
 | cluster_resource_manager.config.cluster_resources | object | `{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}` | ClusterResource parameters Refer to the [structure](https://pkg.go.dev/github.com/lyft/flyteadmin@v0.3.37/pkg/runtime/interfaces#ClusterResourceConfig) to customize. |
 | cluster_resource_manager.config.cluster_resources.refreshInterval | string | `"5m"` | How frequently to run the sync process |
 | cluster_resource_manager.config.cluster_resources.standaloneDeployment | bool | `false` | Starts the cluster resource manager in standalone mode with requisite auth credentials to call flyteadmin service endpoints |
 | cluster_resource_manager.enabled | bool | `true` | Enables the Cluster resource manager component |
 | cluster_resource_manager.podAnnotations | object | `{}` | Annotations for ClusterResource pods |
+| cluster_resource_manager.podEnv | object | `{}` | Additional ClusterResource container environment variables |
 | cluster_resource_manager.podLabels | object | `{}` | Labels for ClusterResource pods |
 | cluster_resource_manager.service_account_name | string | `"flyteadmin"` | Service account name to run with |
 | cluster_resource_manager.templates | list | `[{"key":"aa_namespace","value":"apiVersion: v1\nkind: Namespace\nmetadata:\n  name: {{ namespace }}\nspec:\n  finalizers:\n  - kubernetes\n"},{"key":"ab_project_resource_quota","value":"apiVersion: v1\nkind: ResourceQuota\nmetadata:\n  name: project-quota\n  namespace: {{ namespace }}\nspec:\n  hard:\n    limits.cpu: {{ projectQuotaCpu }}\n    limits.memory: {{ projectQuotaMemory }}\n"}]` | Resource templates that should be applied |
@@ -129,6 +130,7 @@ helm install gateway bitnami/contour -n flyte
 | datacatalog.image.tag | string | `"v1.10.7-b1"` | Docker image tag |
 | datacatalog.nodeSelector | object | `{}` | nodeSelector for Datacatalog deployment |
 | datacatalog.podAnnotations | object | `{}` | Annotations for Datacatalog pods |
+| datacatalog.podEnv | object | `{}` | Additional Datacatalog container environment variables |
 | datacatalog.podLabels | object | `{}` | Labels for Datacatalog pods |
 | datacatalog.priorityClassName | string | `""` | Sets priorityClassName for datacatalog pod(s). |
 | datacatalog.replicaCount | int | `1` | Replicas count for Datacatalog deployment |
@@ -195,6 +197,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteconsole.image.tag | string | `"v1.10.2"` |  |
 | flyteconsole.nodeSelector | object | `{}` | nodeSelector for Flyteconsole deployment |
 | flyteconsole.podAnnotations | object | `{}` | Annotations for Flyteconsole pods |
+| flyteconsole.podEnv | object | `{}` | Additional Flyteconsole container environment variables |
 | flyteconsole.podLabels | object | `{}` | Labels for Flyteconsole pods |
 | flyteconsole.priorityClassName | string | `""` | Sets priorityClassName for flyte console pod(s). |
 | flyteconsole.replicaCount | int | `1` | Replicas count for Flyteconsole deployment |
@@ -217,6 +220,7 @@ helm install gateway bitnami/contour -n flyte
 | flytepropeller.manager | bool | `false` |  |
 | flytepropeller.nodeSelector | object | `{}` | nodeSelector for Flytepropeller deployment |
 | flytepropeller.podAnnotations | object | `{}` | Annotations for Flytepropeller pods |
+| flytepropeller.podEnv | object | `{}` | Additional Flytepropeller container environment variables |
 | flytepropeller.podLabels | object | `{}` | Labels for Flytepropeller pods |
 | flytepropeller.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
 | flytepropeller.replicaCount | int | `1` | Replicas count for Flytepropeller deployment |
@@ -244,6 +248,7 @@ helm install gateway bitnami/contour -n flyte
 | flytescheduler.image.tag | string | `"v1.10.7-b1"` | Docker image tag |
 | flytescheduler.nodeSelector | object | `{}` | nodeSelector for Flytescheduler deployment |
 | flytescheduler.podAnnotations | object | `{}` | Annotations for Flytescheduler pods |
+| flytescheduler.podEnv | object | `{}` | Additional Flytescheduler container environment variables |
 | flytescheduler.podLabels | object | `{}` | Labels for Flytescheduler pods |
 | flytescheduler.priorityClassName | string | `""` | Sets priorityClassName for flyte scheduler pod(s). |
 | flytescheduler.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flytescheduler deployment |

--- a/charts/flyte-core/templates/_helpers.tpl
+++ b/charts/flyte-core/templates/_helpers.tpl
@@ -28,6 +28,13 @@ helm.sh/chart: {{ include "flyte.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
+{{- define "flyteadmin.podLabels" -}}
+{{ include "flyteadmin.labels" . }}
+{{- with .Values.flyteadmin.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
 {{- define "flytescheduler.name" -}}
 flytescheduler
 {{- end -}}
@@ -42,6 +49,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "flytescheduler.selectorLabels" . }}
 helm.sh/chart: {{ include "flyte.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "flytescheduler.podLabels" -}}
+{{ include "flytescheduler.labels" . }}
+{{- with .Values.flytescheduler.podLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 
 {{- define "flyteclusterresourcesync.name" -}}
@@ -59,6 +73,13 @@ helm.sh/chart: {{ include "flyte.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
+{{- define "flyteclusterresourcesync.podLabels" -}}
+{{ include "flyteclusterresourcesync.labels" . }}
+{{- with .Values.cluster_resource_manager.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
 {{- define "datacatalog.name" -}}
 datacatalog
 {{- end -}}
@@ -72,6 +93,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "datacatalog.selectorLabels" . }}
 helm.sh/chart: {{ include "flyte.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "datacatalog.podLabels" -}}
+{{ include "datacatalog.labels" . }}
+{{- with .Values.datacatalog.podLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 
 {{- define "flyteagent.name" -}}
@@ -89,6 +117,13 @@ helm.sh/chart: {{ include "flyte.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
+{{- define "flyteagent.podLabels" -}}
+{{ include "flyteagent.labels" . }}
+{{- with .Values.flyteagent.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
 {{- define "flytepropeller.name" -}}
 flytepropeller
 {{- end -}}
@@ -104,6 +139,13 @@ helm.sh/chart: {{ include "flyte.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
+{{- define "flytepropeller.podLabels" -}}
+{{ include "flytepropeller.labels" . }}
+{{- with .Values.flytepropeller.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
 {{- define "flytepropeller-manager.name" -}}
 flytepropeller-manager
 {{- end -}}
@@ -117,6 +159,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "flytepropeller-manager.selectorLabels" . }}
 helm.sh/chart: {{ include "flyte.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "flytepropeller-manager.podLabels" -}}
+{{ include "flytepropeller-manager.labels" . }}
+{{- with .Values.flytepropeller.podLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 
 {{- define "flyte-pod-webhook.name" -}}
@@ -137,6 +186,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "flyteconsole.selectorLabels" . }}
 helm.sh/chart: {{ include "flyte.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "flyteconsole.podLabels" -}}
+{{ include "flyteconsole.labels" . }}
+{{- with .Values.flyteconsole.podLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 
 # Optional blocks for secret mount

--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         {{- with .Values.flyteadmin.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      labels: {{ include "flyteadmin.labels" . | nindent 8 }}
+      labels: {{ include "flyteadmin.podLabels" . | nindent 8 }}
     spec:
       securityContext:
         fsGroup: 65534

--- a/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
@@ -25,6 +25,12 @@ spec:
             - {{ .Values.flyteadmin.configPath }}
             - clusterresource
             - run
+          {{- if .Values.cluster_resource_manager.podEnv }}
+          env:
+            {{- with .Values.cluster_resource_manager.podEnv }}
+            {{- toYaml . | nindent 10 }}
+            {{- end }}
+          {{- end }}
           image: "{{ .Values.flyteadmin.image.repository }}:{{ .Values.flyteadmin.image.tag }}"
           imagePullPolicy: "{{ .Values.flyteadmin.image.pullPolicy }}"
           name: sync-cluster-resources

--- a/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         {{- with .Values.cluster_resource_manager.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      labels: {{ include "flyteclusterresourcesync.labels" . | nindent 8 }}
+      labels: {{ include "flyteclusterresourcesync.podLabels" . | nindent 8 }}
     spec:
       containers:
         - command:

--- a/charts/flyte-core/templates/console/deployment.yaml
+++ b/charts/flyte-core/templates/console/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         {{- with .Values.flyteconsole.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      labels: {{ include "flyteconsole.labels" . | nindent 8 }}
+      labels: {{ include "flyteconsole.podLabels" . | nindent 8 }}
     spec:
       securityContext:
         runAsUser: 1000

--- a/charts/flyte-core/templates/console/deployment.yaml
+++ b/charts/flyte-core/templates/console/deployment.yaml
@@ -33,12 +33,17 @@ spec:
             name: flyte-console-config
         ports:
         - containerPort: 8080
-        {{- if .Values.flyteconsole.ga.enabled }}
         env:
+        {{- if .Values.flyteconsole.ga.enabled }}
         - name: ENABLE_GA
           value: "{{ .Values.flyteconsole.ga.enabled }}"
         - name: GA_TRACKING_ID
           value: "{{ .Values.flyteconsole.ga.tracking_id }}"
+        {{- end }}
+        {{- if .Values.flyteconsole.podEnv -}}
+        {{- with .Values.flyteconsole.podEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- end }}
         resources: {{ toYaml .Values.flyteconsole.resources | nindent 10 }}
         volumeMounts:

--- a/charts/flyte-core/templates/datacatalog/deployment.yaml
+++ b/charts/flyte-core/templates/datacatalog/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         {{- with .Values.datacatalog.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      labels: {{ include "datacatalog.labels" . | nindent 8 }}
+      labels: {{ include "datacatalog.podLabels" . | nindent 8 }}
     spec:
       securityContext:
         fsGroup: 1001

--- a/charts/flyte-core/templates/datacatalog/deployment.yaml
+++ b/charts/flyte-core/templates/datacatalog/deployment.yaml
@@ -47,6 +47,12 @@ spec:
         {{- with .Values.datacatalog.extraArgs }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
+        {{- if .Values.datacatalog.podEnv }}
+        env:
+          {{- with .Values.datacatalog.podEnv }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+        {{- end }}
         image: "{{ .Values.datacatalog.image.repository }}:{{ .Values.datacatalog.image.tag }}"
         imagePullPolicy: "{{ .Values.datacatalog.image.pullPolicy }}"
         name: datacatalog

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -48,6 +48,12 @@ spec:
         - run
         - --config
         - {{ .Values.flytescheduler.configPath }}
+        {{- if .Values.flytescheduler.podEnv }}
+        env:
+          {{- with .Values.flytescheduler.podEnv -}}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+        {{- end }}
         image: "{{ .Values.flytescheduler.image.repository }}:{{ .Values.flytescheduler.image.tag }}"
         imagePullPolicy: "{{ .Values.flytescheduler.image.pullPolicy }}"
         name: flytescheduler

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         {{- with .Values.flytescheduler.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      labels: {{ include "flytescheduler.labels" . | nindent 8 }}
+      labels: {{ include "flytescheduler.podLabels" . | nindent 8 }}
     spec:
       securityContext:
         fsGroup: 65534

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -26,9 +26,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- if .Values.flytepropeller.manager }}
-      labels: {{ include "flytepropeller-manager.labels" . | nindent 8 }}
+      labels: {{ include "flytepropeller-manager.podLabels" . | nindent 8 }}
       {{- else }}
-      labels: {{ include "flytepropeller.labels" . | nindent 8 }}
+      labels: {{ include "flytepropeller.podLabels" . | nindent 8 }}
       {{- end }}
     spec:
       securityContext:

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -65,6 +65,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.flytepropeller.podEnv -}}
+        {{- with .Values.flytepropeller.podEnv -}}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
         image: "{{ .Values.flytepropeller.image.repository }}:{{ .Values.flytepropeller.image.tag }}"
         imagePullPolicy: "{{ .Values.flytepropeller.image.pullPolicy }}"
         {{- if .Values.flytepropeller.manager }}

--- a/charts/flyte-core/templates/propeller/webhook.yaml
+++ b/charts/flyte-core/templates/propeller/webhook.yaml
@@ -84,6 +84,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+        {{- if .Values.flytepropeller.podEnv -}}
+        {{- with .Values.flytepropeller.podEnv -}}
+        {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/flyte/config

--- a/charts/flyte-core/templates/propeller/webhook.yaml
+++ b/charts/flyte-core/templates/propeller/webhook.yaml
@@ -26,6 +26,9 @@ spec:
         app: {{ template "flyte-pod-webhook.name" . }}
         app.kubernetes.io/name: {{ template "flyte-pod-webhook.name" . }}
         app.kubernetes.io/version: {{ .Values.flytepropeller.image.tag }}
+        {{- with .Values.flytepropeller.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         configChecksum: {{ include (print .Template.BasePath "/propeller/configmap.yaml") . | sha256sum | trunc 63 | quote }}
         {{- with .Values.flytepropeller.podAnnotations }}

--- a/charts/flyte-core/templates/propeller/webhook.yaml
+++ b/charts/flyte-core/templates/propeller/webhook.yaml
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/version: {{ .Values.flytepropeller.image.tag }}
       annotations:
         configChecksum: {{ include (print .Template.BasePath "/propeller/configmap.yaml") . | sha256sum | trunc 63 | quote }}
-        {{- with .Values.flyteadmin.podAnnotations }}
+        {{- with .Values.flytepropeller.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -60,7 +60,7 @@ spec:
                 fieldPath: metadata.namespace
         volumeMounts:
           - name: config-volume
-            mountPath: /etc/flyte/config      
+            mountPath: /etc/flyte/config
 {{- end }}
       containers:
         - name: webhook

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -92,6 +92,8 @@ flyteadmin:
         - '*'
   # -- Annotations for Flyteadmin pods
   podAnnotations: {}
+  # -- Labels for Flyteadmin pods
+  podLabels: {}
   # -- nodeSelector for Flyteadmin deployment
   nodeSelector: {}
   # -- tolerations for Flyteadmin deployment
@@ -158,6 +160,8 @@ flytescheduler:
     imagePullSecrets: []
   # -- Annotations for Flytescheduler pods
   podAnnotations: {}
+  # -- Labels for Flytescheduler pods
+  podLabels: {}
   # -- nodeSelector for Flytescheduler deployment
   nodeSelector: {}
   # -- tolerations for Flytescheduler deployment
@@ -216,6 +220,8 @@ datacatalog:
     imagePullSecrets: []
   # -- Annotations for Datacatalog pods
   podAnnotations: {}
+  # -- Labels for Datacatalog pods
+  podLabels: {}
   # -- nodeSelector for Datacatalog deployment
   nodeSelector: {}
   # -- tolerations for Datacatalog deployment
@@ -282,6 +288,8 @@ flytepropeller:
     imagePullSecrets: []
   # -- Annotations for Flytepropeller pods
   podAnnotations: {}
+  # -- Labels for Flytepropeller pods
+  podLabels: {}
   # -- nodeSelector for Flytepropeller deployment
   nodeSelector: {}
   # -- tolerations for Flytepropeller deployment
@@ -344,6 +352,8 @@ flyteconsole:
     type: ClusterIP
   # -- Annotations for Flyteconsole pods
   podAnnotations: {}
+  # -- Labels for Flyteconsole pods
+  podLabels: {}
   # -- nodeSelector for Flyteconsole deployment
   nodeSelector: {}
   # -- tolerations for Flyteconsole deployment
@@ -824,6 +834,8 @@ cluster_resource_manager:
   service_account_name: flyteadmin
   # -- Annotations for ClusterResource pods
   podAnnotations: {}
+  # -- Labels for ClusterResource pods
+  podLabels: {}
   # -- Configmap for ClusterResource parameters
   config:
     # -- ClusterResource parameters

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -160,6 +160,8 @@ flytescheduler:
     imagePullSecrets: []
   # -- Annotations for Flytescheduler pods
   podAnnotations: {}
+  # -- Additional Flytescheduler container environment variables
+  podEnv: {}
   # -- Labels for Flytescheduler pods
   podLabels: {}
   # -- nodeSelector for Flytescheduler deployment
@@ -220,6 +222,8 @@ datacatalog:
     imagePullSecrets: []
   # -- Annotations for Datacatalog pods
   podAnnotations: {}
+  # -- Additional Datacatalog container environment variables
+  podEnv: {}
   # -- Labels for Datacatalog pods
   podLabels: {}
   # -- nodeSelector for Datacatalog deployment
@@ -288,6 +292,8 @@ flytepropeller:
     imagePullSecrets: []
   # -- Annotations for Flytepropeller pods
   podAnnotations: {}
+  # -- Additional Flytepropeller container environment variables
+  podEnv: {}
   # -- Labels for Flytepropeller pods
   podLabels: {}
   # -- nodeSelector for Flytepropeller deployment
@@ -352,6 +358,8 @@ flyteconsole:
     type: ClusterIP
   # -- Annotations for Flyteconsole pods
   podAnnotations: {}
+  # -- Additional Flyteconsole container environment variables
+  podEnv: {}
   # -- Labels for Flyteconsole pods
   podLabels: {}
   # -- nodeSelector for Flyteconsole deployment
@@ -581,7 +589,7 @@ configmap:
       eventVersion: 2
       testing:
         host: http://flyteadmin
-      
+
     # -- Authentication configuration
     auth:
       authorizedUris:
@@ -834,6 +842,8 @@ cluster_resource_manager:
   service_account_name: flyteadmin
   # -- Annotations for ClusterResource pods
   podAnnotations: {}
+  # -- Additional ClusterResource container environment variables
+  podEnv: {}
   # -- Labels for ClusterResource pods
   podLabels: {}
   # -- Configmap for ClusterResource parameters

--- a/charts/flyteagent/README.md
+++ b/charts/flyteagent/README.md
@@ -24,6 +24,7 @@ A Helm chart for Flyte agent
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | nodeSelector for flyteagent deployment |
 | podAnnotations | object | `{}` | Annotations for flyteagent pods |
+| podLabels | object | `{}` | Labels for flyteagent pods |
 | ports.containerPort | int | `8000` |  |
 | ports.name | string | `"agent-grpc"` |  |
 | priorityClassName | string | `""` | Sets priorityClassName for datacatalog pod(s). |

--- a/charts/flyteagent/README.md
+++ b/charts/flyteagent/README.md
@@ -24,6 +24,7 @@ A Helm chart for Flyte agent
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | nodeSelector for flyteagent deployment |
 | podAnnotations | object | `{}` | Annotations for flyteagent pods |
+| podEnv | object | `{}` | Additional flyteagent pod container environment variables |
 | podLabels | object | `{}` | Labels for flyteagent pods |
 | ports.containerPort | int | `8000` |  |
 | ports.name | string | `"agent-grpc"` |  |

--- a/charts/flyteagent/templates/_helpers.tpl
+++ b/charts/flyteagent/templates/_helpers.tpl
@@ -28,6 +28,13 @@ helm.sh/chart: {{ include "flyte.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
+{{- define "flyteagent.podLabels" -}}
+{{ include "flyteagent.labels" . }}
+{{- with .Values.podLabels }}
+{{- toYaml . }}
+{{- end }}
+{{- end -}}
+
 # Optional blocks for secret mount
 
 {{- define "agentSecret.volume" -}}

--- a/charts/flyteagent/templates/agent/deployment.yaml
+++ b/charts/flyteagent/templates/agent/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      labels: {{ include "flyteagent.labels" . | nindent 8 }}
+      labels: {{ include "flyteagent.podLabels" . | nindent 8 }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/charts/flyteagent/templates/agent/deployment.yaml
+++ b/charts/flyteagent/templates/agent/deployment.yaml
@@ -23,6 +23,12 @@ spec:
       - command:
         - pyflyte
         - serve
+        {{- if .Values.podEnv }}
+        env:
+        {{- with .Values.podEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         name: flyteagent

--- a/charts/flyteagent/values.yaml
+++ b/charts/flyteagent/values.yaml
@@ -56,6 +56,8 @@ serviceAccount:
   imagePullSecrets: []
 # -- Annotations for flyteagent pods
 podAnnotations: {}
+# -- Labels for flyteagent pods
+podLabels: {}
 # -- nodeSelector for flyteagent deployment
 nodeSelector: {}
 # -- tolerations for flyteagent deployment

--- a/charts/flyteagent/values.yaml
+++ b/charts/flyteagent/values.yaml
@@ -56,6 +56,8 @@ serviceAccount:
   imagePullSecrets: []
 # -- Annotations for flyteagent pods
 podAnnotations: {}
+# -- Additional flyteagent pod container environment variables
+podEnv: {}
 # -- Labels for flyteagent pods
 podLabels: {}
 # -- nodeSelector for flyteagent deployment

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -1094,6 +1094,7 @@ spec:
             name: flyte-console-config
         ports:
         - containerPort: 8080
+        env:
         resources: 
           limits:
             cpu: 250m

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -800,6 +800,7 @@ spec:
             name: flyte-console-config
         ports:
         - containerPort: 8080
+        env:
         resources: 
           limits:
             cpu: 250m

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -1125,6 +1125,7 @@ spec:
             name: flyte-console-config
         ports:
         - containerPort: 8080
+        env:
         resources: 
           limits:
             cpu: 250m

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -815,6 +815,7 @@ spec:
             name: flyte-console-config
         ports:
         - containerPort: 8080
+        env:
         resources: 
           limits:
             cpu: 250m

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -1148,6 +1148,7 @@ spec:
             name: flyte-console-config
         ports:
         - containerPort: 8080
+        env:
         resources: 
           limits:
             cpu: 250m


### PR DESCRIPTION
## Tracking issue
_https://github.com/flyteorg/flyte/issues/<number>_

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?

Hopefully this isn't too controversial a change. To deploy in our environments, we've standardized on the use of `podAnnotations`, `podLabels` and `podEnv` helm values. Globally, this allows for setting values across all deployment, statefulset and daemonset resources.


## What changes were proposed in this pull request?

Flyte already has `podAnnotations`, but not `podLabels` or `podEnv`. This PR adds both to `flyte-core`.

Of not, `flyteadmin` has a `env: []` value set already, but it's the only one. I didn't want to break anything so left it as-is. Ideally I think  that would become `podEnv: {}` and would render in the same way as the other charts.


## How was this patch tested?

`make helm` was used locally to generate charts / docs. I set values explicitly in the `values.yaml` to verify correct rendering

i.e.

```helm
podEnv:
  - name: TEST
    value: value
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
