### PR TITLE
[Docs] Remove broken link from Understand How Flyte Handles Data page (for new monodocs site) (second attempt)

### DIFF
--- a/docs/concepts/data_management.rst
+++ b/docs/concepts/data_management.rst
@@ -168,7 +168,7 @@ Between Tasks
 Bringing in Your Own Datastores for Raw Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Flytekit has a pluggable `data persistence layer.
+Flytekit has a pluggable data persistence layer.
 This is driven by PROTOCOL.
 For example, it is theoretically possible to use S3 ``s3://`` for metadata and GCS ``gcs://`` for raw data. It is also possible to create your own protocol ``my_fs://``, to change how data is stored and accessed.
 But for Metadata, the data should be accessible to Flyte control plane.

--- a/docs/concepts/data_management.rst
+++ b/docs/concepts/data_management.rst
@@ -168,7 +168,7 @@ Between Tasks
 Bringing in Your Own Datastores for Raw Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Flytekit has a pluggable `data persistence layer <https://docs.flyte.org/projects/flytekit/en/latest/data.extend.html>`__.
+Flytekit has a pluggable `data persistence layer.
 This is driven by PROTOCOL.
 For example, it is theoretically possible to use S3 ``s3://`` for metadata and GCS ``gcs://`` for raw data. It is also possible to create your own protocol ``my_fs://``, to change how data is stored and accessed.
 But for Metadata, the data should be accessible to Flyte control plane.


### PR DESCRIPTION
## Tracking issue

Re-applies the change in https://github.com/flyteorg/flyte/pull/4518. I opened this new PR for this change since I was unable to fast forward or rebase the branch in https://github.com/flyteorg/flyte/pull/4547

## Why are the changes needed?

The change in #4518 was made after the monodocs branch was created, so we need to bring that change over now that the monodocs PR has been merged.

## What changes were proposed in this pull request?

Removes broken link from "[Bringing in Your Own Datastores for Raw Data](https://docs.flyte.org/en/latest/concepts/data_management.html#bringing-in-your-own-datastores-for-raw-data)" section of  "[Understand How Flyte Handles Data](https://docs.flyte.org/en/latest/concepts/data_management.html)" docs page.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

#4518 
#4547 

## Docs link

https://flyte--4757.org.readthedocs.build/en/4757/concepts/data_management.html#bringing-in-your-own-datastores-for-raw-data
