### PR TITLE
Small formatting fixes for Databrick agents docs

### DIFF
--- a/docs/deployment/agents/index.md
+++ b/docs/deployment/agents/index.md
@@ -16,7 +16,7 @@ Discover the process of setting up Agents for Flyte.
   - Guide to setting up the MMCloud agent.
 * - {ref}`Sensor Agent <deployment-agent-setup-sensor>`
   - Guide to setting up the Sensor agent.
-* - {ref} `Databricks Agent <deployment-agent-setup-databricks>`
+* - {ref}`Databricks Agent <deployment-agent-setup-databricks>`
   - Guide to setting up the Databricks agent.
 ```
 

--- a/docs/deployment/agents/mmcloud.rst
+++ b/docs/deployment/agents/mmcloud.rst
@@ -118,4 +118,4 @@ Wait for the upgrade to complete. You can check the status of the deployment pod
 
   kubectl get pods -n flyte
 
-  For MMCloud plugin on the Flyte cluster, please refer to `Memory Machine Cloud Plugin Example <https://docs.flyte.org/en/latest/flytesnacks/examples/mmcloud_plugin/index.html>`_
+For MMCloud plugin on the Flyte cluster, please refer to `Memory Machine Cloud Plugin Example <https://docs.flyte.org/en/latest/flytesnacks/examples/mmcloud_plugin/index.html>`_


### PR DESCRIPTION
## Why are the changes needed?

I introduced a few small formatting issues in #4008; this PR fixes them.

## What changes were proposed in this pull request?

* Agents index page - fix link to Databricks Agent doc
* MMCloud Agent page - fix formatting of last line 

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

#4751 

## Docs link

https://flyte--4758.org.readthedocs.build/en/4758/deployment/agents/index.html

https://flyte--4758.org.readthedocs.build/en/4758/deployment/agents/mmcloud.html#upgrade-the-deployment