### PR TITLE
Fix test get logs template uri test

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/k8s/client.go
+++ b/flyteplugins/go/tasks/pluginmachinery/k8s/client.go
@@ -69,7 +69,7 @@ func NewKubeClient(config *rest.Config, options Options) (core.KubeClient, error
 	if options.ClientOptions == nil {
 		options.ClientOptions = &client.Options{
 			HTTPClient: httpClient,
-			Mapper: mapper,
+			Mapper:     mapper,
 		}
 	}
 

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator_test.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	"fmt"
-  "os"
+	"os"
 	"testing"
 	"time"
 
@@ -25,7 +25,6 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	os.Exit(code)
 }
-
 
 func TestExtractCurrentCondition(t *testing.T) {
 	jobCreated := commonOp.JobCondition{

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+  "os"
 	"testing"
 	"time"
 
@@ -17,6 +18,14 @@ import (
 	pluginsCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core/mocks"
 )
+
+func TestMain(m *testing.M) {
+	// All tests should run assuming UTC timezone.
+	time.Local = time.UTC
+	code := m.Run()
+	os.Exit(code)
+}
+
 
 func TestExtractCurrentCondition(t *testing.T) {
 	jobCreated := commonOp.JobCondition{


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?

`TestGetLogsTemplateUri` would fail with error:
```
    common_operator_test.go:216:
                Error Trace:    /Users/eduardo/repos/flyte-copy/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator_test.go:216
                Error:          Not equal:
                                expected: "https://console.cloud.google.com/logs/query;query=resource.labels.pod_name=test-worker-0&timestamp>2022-01-01T12:00:00Z"
                                actual  : "https://console.cloud.google.com/logs/query;query=resource.labels.pod_name=test-worker-0&timestamp>2022-01-01T04:00:00-08:00"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -https://console.cloud.google.com/logs/query;query=resource.labels.pod_name=test-worker-0&timestamp>2022-01-01T12:00:00Z
                                +https://console.cloud.google.com/logs/query;query=resource.labels.pod_name=test-worker-0&timestamp>2022-01-01T04:00:00-08:00
                Test:           TestGetLogsTemplateUri
```

The reason being the discrepancy between local and CI environments, in the former (e.g. Macos) the local timezone would be set, whereas in CI (i.e. linux) the local timezone would be unset, which would default to UTC. This discrepancy would cause this test to always fail when run locally.

## What changes were proposed in this pull request?

Force the tests in this test suite to run on UTC using [TestMain](https://pkg.go.dev/testing#hdr-Main).

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
