### PR TITLE
[BUG] subworkflow timeout propagation

### DIFF
--- a/flytepropeller/pkg/controller/nodes/executor.go
+++ b/flytepropeller/pkg/controller/nodes/executor.go
@@ -1341,7 +1341,7 @@ func (c *nodeExecutor) HandleNode(ctx context.Context, dag executors.DAGStructur
 
 	if currentPhase == v1alpha1.NodePhaseTimingOut {
 		logger.Debugf(ctx, "node timing out")
-		if err := c.Abort(ctx, h, nCtx, "node timed out", true); err != nil {
+		if err := c.Abort(ctx, h, nCtx, "node timed out", false); err != nil {
 			return interfaces.NodeStatusUndefined, err
 		}
 

--- a/flytepropeller/pkg/controller/nodes/executor.go
+++ b/flytepropeller/pkg/controller/nodes/executor.go
@@ -1341,7 +1341,7 @@ func (c *nodeExecutor) HandleNode(ctx context.Context, dag executors.DAGStructur
 
 	if currentPhase == v1alpha1.NodePhaseTimingOut {
 		logger.Debugf(ctx, "node timing out")
-		if err := c.Abort(ctx, h, nCtx, "node timed out", false); err != nil {
+		if err := c.Abort(ctx, h, nCtx, "node timed out", true); err != nil {
 			return interfaces.NodeStatusUndefined, err
 		}
 

--- a/flytepropeller/pkg/controller/nodes/subworkflow/subworkflow.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/subworkflow.go
@@ -88,6 +88,26 @@ func (s *subworkflowHandler) handleSubWorkflow(ctx context.Context, nCtx interfa
 		return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRunning(nil)), nil
 	}
 
+	// TODO clean this up
+	if state.HasTimedOut() {
+		workflowNodeState := handler.WorkflowNodeState{
+			Phase: v1alpha1.WorkflowNodePhaseFailing,
+			Error: &core.ExecutionError{
+				Kind:    core.ExecutionError_USER,
+				Code:    "Timeout",
+				Message: "Timeout in node"},
+		}
+
+		err = nCtx.NodeStateWriter().PutWorkflowNodeState(workflowNodeState)
+
+		if err != nil {
+			logger.Warnf(ctx, "failed to store failing subworkflow state with err: [%v]", err)
+			return handler.UnknownTransition, err
+		}
+
+		return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRunning(nil)), nil
+	}
+
 	if state.IsComplete() {
 		// If the WF interface has outputs, validate that the outputs file was written.
 		var oInfo *handler.OutputInfo

--- a/flytepropeller/pkg/controller/nodes/subworkflow/subworkflow.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/subworkflow.go
@@ -88,18 +88,17 @@ func (s *subworkflowHandler) handleSubWorkflow(ctx context.Context, nCtx interfa
 		return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRunning(nil)), nil
 	}
 
-	// TODO clean this up
 	if state.HasTimedOut() {
 		workflowNodeState := handler.WorkflowNodeState{
 			Phase: v1alpha1.WorkflowNodePhaseFailing,
 			Error: &core.ExecutionError{
 				Kind:    core.ExecutionError_USER,
 				Code:    "Timeout",
-				Message: "Timeout in node"},
+				Message: "Timeout in node",
+			},
 		}
 
 		err = nCtx.NodeStateWriter().PutWorkflowNodeState(workflowNodeState)
-
 		if err != nil {
 			logger.Warnf(ctx, "failed to store failing subworkflow state with err: [%v]", err)
 			return handler.UnknownTransition, err

--- a/flytepropeller/pkg/controller/nodes/transformers.go
+++ b/flytepropeller/pkg/controller/nodes/transformers.go
@@ -69,6 +69,8 @@ func ToNodeExecEventPhase(p handler.EPhase) core.NodeExecution_Phase {
 		return core.NodeExecution_FAILED
 	case handler.EPhaseRecovered:
 		return core.NodeExecution_RECOVERED
+	case handler.EPhaseTimedout:
+		return core.NodeExecution_TIMED_OUT
 	default:
 		return core.NodeExecution_UNDEFINED
 	}


### PR DESCRIPTION
## Tracking issue
_https://github.com/flyteorg/flyte/issues/4087_
_https://github.com/flyteorg/flyte/issues/4765_

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?

- When a subworkflow's task fails due to reaching node-active-deadline, the workflow does not fail. The workflow continues to run after the timed out task gets aborted and getting set to "UNKNOWN" state

- When a task time's out due to reaching node-active-deadline, the task's status gets set to "UNKNOWN"

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

- Have subworkflows handle TimedOut state 

- Transform EPhaseTimedout -> NodeExecution_TIMED_OUT when creating node execution events

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

Ran a couple workflows. Would be a decent effort to add unit testing - can add if needed.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->


### Setup process

Test subworkflow timeout propagation (will hit node-active-deadline on retry)

```
@task(
    timeout=timedelta(seconds=10),
    retries=1,
)
def demo_task():
    time.sleep(3000)



@task
def demo_task_1():
    time.sleep(3000)


@workflow
def subworkflow():
    demo_task()
    demo_task_1()


@workflow
def demo_workflow():
    subworkflow()
```

To isolate test to persisting aborted node on TimeOut:

Set node-active-deadline to small value in Flyte config:

```
propeller:
    node-config:
        default-deadlines:
            node-active-deadline: 10s
```
```
@task(
   retries=1,
)
def demo_task():
   time.sleep(3000)


@workflow
def demo_workflow():
   demo_task()
```

### Screenshots

![image](https://github.com/flyteorg/flyte/assets/37558497/6a540a6b-440c-4154-af68-7b853b30c7fe)


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
