### PR TITLE
Reduce maptask transitions between WaitingForResources and CheckingSubtaskExecutions

### DIFF
--- a/flyteplugins/go/tasks/plugins/array/k8s/executor.go
+++ b/flyteplugins/go/tasks/plugins/array/k8s/executor.go
@@ -103,15 +103,15 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 	case arrayCore.PhasePreLaunch:
 		nextState = pluginState.SetPhase(arrayCore.PhaseLaunch, version+1).SetReason("Nothing to do in PreLaunch phase.")
 
-	case arrayCore.PhaseWaitingForResources:
-		fallthrough
-
 	case arrayCore.PhaseLaunch:
 		// In order to maintain backwards compatibility with the state transitions
 		// in the aws batch plugin. Forward to PhaseCheckingSubTasksExecutions where the launching
 		// is actually occurring.
 		nextState = pluginState.SetPhase(arrayCore.PhaseCheckingSubTaskExecutions, version+1).SetReason("Nothing to do in Launch phase.")
 		err = nil
+
+	case arrayCore.PhaseWaitingForResources:
+		fallthrough
 
 	case arrayCore.PhaseCheckingSubTaskExecutions:
 		nextState, externalResources, err = LaunchAndCheckSubTasksState(ctx, tCtx, e.kubeClient, pluginConfig,

--- a/flyteplugins/go/tasks/plugins/array/k8s/management.go
+++ b/flyteplugins/go/tasks/plugins/array/k8s/management.go
@@ -316,7 +316,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 			version++
 		}
 
-		newState = newState.SetPhase(phase, version).SetReason("Task is still running")
+		newState = newState.SetPhase(arrayCore.PhaseCheckingSubTaskExecutions, version).SetReason("Task is still running")
 	} else {
 		newState = newState.SetPhase(phase, version+1)
 	}

--- a/flyteplugins/go/tasks/plugins/array/k8s/management.go
+++ b/flyteplugins/go/tasks/plugins/array/k8s/management.go
@@ -306,7 +306,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 	}
 
 	_, version := currentState.GetPhase()
-	if phase == arrayCore.PhaseCheckingSubTaskExecutions {
+	if phase == arrayCore.PhaseCheckingSubTaskExecutions || phase == arrayCore.PhaseWaitingForResources {
 		newSubTaskPhaseHash, err := newState.GetArrayStatus().HashCode()
 		if err != nil {
 			return currentState, externalResources, err

--- a/flyteplugins/go/tasks/plugins/array/k8s/management_test.go
+++ b/flyteplugins/go/tasks/plugins/array/k8s/management_test.go
@@ -300,7 +300,7 @@ func TestCheckSubTasksState(t *testing.T) {
 		// validate results
 		assert.Nil(t, err)
 		p, _ := newState.GetPhase()
-		assert.Equal(t, arrayCore.PhaseWaitingForResources.String(), p.String())
+		assert.Equal(t, arrayCore.PhaseCheckingSubTaskExecutions.String(), p.String())
 		resourceManager.AssertNumberOfCalls(t, "AllocateResource", subtaskCount)
 		for _, subtaskPhaseIndex := range newState.GetArrayStatus().Detailed.GetItems() {
 			assert.Equal(t, core.PhaseWaitingForResources, core.Phases[subtaskPhaseIndex])


### PR DESCRIPTION
## Tracking issue
_NA_

## Why are the changes needed?
In maptask, if any subtasks are in the `PhaseWaitingForResources` phase then the entire maptask task [transitions to that phase](https://github.com/flyteorg/flyte/blob/master/flyteplugins/go/tasks/plugins/array/core/state.go#L276-L279). The issue is that the `k8s-array` plugin uses a transition through `PhaseLaunch` to get back to `PhaseCheckingSubtaskExecutions` [here](https://github.com/flyteorg/flyte/blob/master/flyteplugins/go/tasks/plugins/array/k8s/executor.go#L106-L114). This causes events to be sent to flyteadmin to satisfy the phase update. With [this commit](https://github.com/flyteorg/flyte/commit/67e65c7a5f6f0dc394186f7a1010565af1754ff0) flyteadmin began processing phase reason updates in batches, which causes all reason updates to persist in a timeline. The continual transition between `PhaseWaitingForResources` and `PhaseCheckingSubtaskExecutions` causes a large amount of duplicated reasons in the time series.

## What changes were proposed in this pull request?
This PR proposed to treat `PhaseWaitingForResources` and `PhaseCheckingSubtaskExecutions` the same so that events are only sent when subtask phases are updated rather than duplicate transitions between these maptask phases.

## How was this patch tested?
Locally.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
_NA_

## Docs link
_NA_
