### PR TITLE
propeller gc ttl comparison should allow 23

### DIFF
--- a/flytepropeller/pkg/controller/garbage_collector.go
+++ b/flytepropeller/pkg/controller/garbage_collector.go
@@ -169,7 +169,7 @@ func (g *GarbageCollector) StartGC(ctx context.Context) error {
 
 func NewGarbageCollector(cfg *config.Config, scope promutils.Scope, clk clock.WithTicker, namespaceClient corev1.NamespaceInterface, wfClient v1alpha1.FlyteworkflowV1alpha1Interface) (*GarbageCollector, error) {
 	ttl := 23
-	if cfg.MaxTTLInHours < 23 {
+	if cfg.MaxTTLInHours <= 23 {
 		ttl = cfg.MaxTTLInHours
 	} else {
 		logger.Warningf(context.TODO(), "defaulting max ttl for workflows to 23 hours, since configured duration is larger than 23 [%d]", cfg.MaxTTLInHours)


### PR DESCRIPTION
## Tracking issue
_NA_

## Why are the changes needed?
The GC TTL configuration defaults to 23 in propeller configuration, but the comparison logs a warning if the value is not less than 23 and then proceeds to reset to 23. The correct approach is to make the comparison allow 23.

## What changes were proposed in this pull request?
^^^

## How was this patch tested?
Locally.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
_NA_

## Docs link
_NA_
