### PR TITLE
chore: handle empty or invalid secrets nicely

### DIFF
--- a/flyteadmin/auth/authzserver/provider.go
+++ b/flyteadmin/auth/authzserver/provider.go
@@ -205,10 +205,10 @@ func NewProvider(ctx context.Context, cfg config.AuthorizationServer, sm core.Se
 
 	// Try to load old key to validate tokens using it to support key rotation.
 	privateKeyPEM, err = sm.Get(ctx, cfg.OldTokenSigningRSAKeySecretName)
-	if privateKeyPEM == "" {
-		return Provider{}, fmt.Errorf("failed to read PKCS1PrivateKey. Error: empty value")
-	}
 	if err == nil {
+		if privateKeyPEM == "" {
+			return Provider{}, fmt.Errorf("failed to read PKCS1PrivateKey. Error: empty value")
+		}
 		block, _ = pem.Decode([]byte(privateKeyPEM))
 		if block == nil {
 			return Provider{}, fmt.Errorf("failed to decode PKCS1PrivateKey. Error: no PEM data found")

--- a/flyteadmin/auth/authzserver/provider.go
+++ b/flyteadmin/auth/authzserver/provider.go
@@ -147,6 +147,9 @@ func NewProvider(ctx context.Context, cfg config.AuthorizationServer, sm core.Se
 	if err != nil {
 		return Provider{}, fmt.Errorf("failed to read secretTokenHash file. Error: %w", err)
 	}
+	if tokenHashBase64 == "" {
+		return Provider{}, fmt.Errorf("failed to read secretTokenHash. Error: empty value")
+	}
 
 	secret, err := base64.RawStdEncoding.DecodeString(tokenHashBase64)
 	if err != nil {
@@ -158,8 +161,14 @@ func NewProvider(ctx context.Context, cfg config.AuthorizationServer, sm core.Se
 	if err != nil {
 		return Provider{}, fmt.Errorf("failed to read token signing RSA Key. Error: %w", err)
 	}
+	if privateKeyPEM == "" {
+		return Provider{}, fmt.Errorf("failed to read token signing RSA Key. Error: empty value")
+	}
 
 	block, _ := pem.Decode([]byte(privateKeyPEM))
+	if block == nil {
+		return Provider{}, fmt.Errorf("failed to decode token signing RSA Key. Error: no PEM data found")
+	}
 	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
 		return Provider{}, fmt.Errorf("failed to parse PKCS1PrivateKey. Error: %w", err)
@@ -196,8 +205,14 @@ func NewProvider(ctx context.Context, cfg config.AuthorizationServer, sm core.Se
 
 	// Try to load old key to validate tokens using it to support key rotation.
 	privateKeyPEM, err = sm.Get(ctx, cfg.OldTokenSigningRSAKeySecretName)
+	if privateKeyPEM == "" {
+		return Provider{}, fmt.Errorf("failed to read PKCS1PrivateKey. Error: empty value")
+	}
 	if err == nil {
 		block, _ = pem.Decode([]byte(privateKeyPEM))
+		if block == nil {
+			return Provider{}, fmt.Errorf("failed to decode PKCS1PrivateKey. Error: no PEM data found")
+		}
 		oldPrivateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 		if err != nil {
 			return Provider{}, fmt.Errorf("failed to parse PKCS1PrivateKey. Error: %w", err)

--- a/flyteadmin/auth/authzserver/provider_test.go
+++ b/flyteadmin/auth/authzserver/provider_test.go
@@ -45,7 +45,7 @@ func TestNewProvider(t *testing.T) {
 	newMockProvider(t)
 }
 
-func newInvalidMockProvider(t *testing.T, ctx context.Context, secrets auth.SecretsSet, sm *mocks.SecretManager, invalidFunc func() *mocks.SecretManager_Get, errorContains string) {
+func newInvalidMockProvider(ctx context.Context, t *testing.T, secrets auth.SecretsSet, sm *mocks.SecretManager, invalidFunc func() *mocks.SecretManager_Get, errorContains string) {
 
 	sm.OnGet(ctx, config.SecretNameClaimSymmetricKey).Return(base64.RawStdEncoding.EncodeToString(secrets.TokenHashKey), nil)
 	sm.OnGet(ctx, config.SecretNameCookieBlockKey).Return(base64.RawStdEncoding.EncodeToString(secrets.CookieBlockKey), nil)
@@ -75,7 +75,7 @@ func TestNewInvalidProviderSecretTokenHashBad(t *testing.T) {
 		sm.OnGet(ctx, config.SecretNameClaimSymmetricKey).Unset()
 		return sm.OnGet(ctx, config.SecretNameClaimSymmetricKey).Return("", fmt.Errorf("test error"))
 	}
-	newInvalidMockProvider(t, ctx, secrets, sm, invalidFunc, "failed to read secretTokenHash file. Error: test error")
+	newInvalidMockProvider(ctx, t, secrets, sm, invalidFunc, "failed to read secretTokenHash file. Error: test error")
 }
 
 func TestNewInvalidProviderSecretTokenHashEmpty(t *testing.T) {
@@ -89,7 +89,7 @@ func TestNewInvalidProviderSecretTokenHashEmpty(t *testing.T) {
 		sm.OnGet(ctx, config.SecretNameClaimSymmetricKey).Unset()
 		return sm.OnGet(ctx, config.SecretNameClaimSymmetricKey).Return("", nil)
 	}
-	newInvalidMockProvider(t, ctx, secrets, sm, invalidFunc, "failed to read secretTokenHash. Error: empty value")
+	newInvalidMockProvider(ctx, t, secrets, sm, invalidFunc, "failed to read secretTokenHash. Error: empty value")
 }
 
 func TestNewInvalidProviderTokenSigningRSAKeyBad(t *testing.T) {
@@ -103,7 +103,7 @@ func TestNewInvalidProviderTokenSigningRSAKeyBad(t *testing.T) {
 		sm.OnGet(ctx, config.SecretNameTokenSigningRSAKey).Unset()
 		return sm.OnGet(ctx, config.SecretNameTokenSigningRSAKey).Return("", fmt.Errorf("test error"))
 	}
-	newInvalidMockProvider(t, ctx, secrets, sm, invalidFunc, "failed to read token signing RSA Key. Error: test error")
+	newInvalidMockProvider(ctx, t, secrets, sm, invalidFunc, "failed to read token signing RSA Key. Error: test error")
 }
 
 func TestNewInvalidProviderTokenSigningRSAKeyEmpty(t *testing.T) {
@@ -117,7 +117,7 @@ func TestNewInvalidProviderTokenSigningRSAKeyEmpty(t *testing.T) {
 		sm.OnGet(ctx, config.SecretNameTokenSigningRSAKey).Unset()
 		return sm.OnGet(ctx, config.SecretNameTokenSigningRSAKey).Return("", nil)
 	}
-	newInvalidMockProvider(t, ctx, secrets, sm, invalidFunc, "failed to read token signing RSA Key. Error: empty value")
+	newInvalidMockProvider(ctx, t, secrets, sm, invalidFunc, "failed to read token signing RSA Key. Error: empty value")
 }
 
 func TestNewInvalidProviderTokenSigningRSAKeyNoPEMData(t *testing.T) {
@@ -131,7 +131,7 @@ func TestNewInvalidProviderTokenSigningRSAKeyNoPEMData(t *testing.T) {
 		sm.OnGet(ctx, config.SecretNameTokenSigningRSAKey).Unset()
 		return sm.OnGet(ctx, config.SecretNameTokenSigningRSAKey).Return("this is no PEM data", nil)
 	}
-	newInvalidMockProvider(t, ctx, secrets, sm, invalidFunc, "failed to decode token signing RSA Key. Error: no PEM data found")
+	newInvalidMockProvider(ctx, t, secrets, sm, invalidFunc, "failed to decode token signing RSA Key. Error: no PEM data found")
 }
 
 func TestNewInvalidProviderOldTokenSigningRSAKeyEmpty(t *testing.T) {
@@ -145,7 +145,7 @@ func TestNewInvalidProviderOldTokenSigningRSAKeyEmpty(t *testing.T) {
 		sm.OnGet(ctx, config.SecretNameOldTokenSigningRSAKey).Unset()
 		return sm.OnGet(ctx, config.SecretNameOldTokenSigningRSAKey).Return("", nil)
 	}
-	newInvalidMockProvider(t, ctx, secrets, sm, invalidFunc, "failed to read PKCS1PrivateKey. Error: empty value")
+	newInvalidMockProvider(ctx, t, secrets, sm, invalidFunc, "failed to read PKCS1PrivateKey. Error: empty value")
 }
 
 func TestNewInvalidProviderOldTokenSigningRSAKeyNoPEMData(t *testing.T) {
@@ -159,7 +159,7 @@ func TestNewInvalidProviderOldTokenSigningRSAKeyNoPEMData(t *testing.T) {
 		sm.OnGet(ctx, config.SecretNameOldTokenSigningRSAKey).Unset()
 		return sm.OnGet(ctx, config.SecretNameOldTokenSigningRSAKey).Return("this is no PEM data", nil)
 	}
-	newInvalidMockProvider(t, ctx, secrets, sm, invalidFunc, "failed to decode PKCS1PrivateKey. Error: no PEM data found")
+	newInvalidMockProvider(ctx, t, secrets, sm, invalidFunc, "failed to decode PKCS1PrivateKey. Error: no PEM data found")
 }
 
 func TestProvider_KeySet(t *testing.T) {

--- a/flyteadmin/auth/authzserver/provider_test.go
+++ b/flyteadmin/auth/authzserver/provider_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
-	"fmt"
 	"testing"
 	"time"
 
@@ -34,7 +33,7 @@ func newMockProvider(t testing.TB) (Provider, auth.SecretsSet) {
 	var buf bytes.Buffer
 	assert.NoError(t, pem.Encode(&buf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: privBytes}))
 	sm.OnGet(ctx, config.SecretNameTokenSigningRSAKey).Return(buf.String(), nil)
-	sm.OnGet(ctx, config.SecretNameOldTokenSigningRSAKey).Return("", fmt.Errorf("not found"))
+	sm.OnGet(ctx, config.SecretNameOldTokenSigningRSAKey).Return(buf.String(), nil)
 
 	p, err := NewProvider(ctx, config.DefaultConfig.AppAuth.SelfAuthServer, sm)
 	assert.NoError(t, err)
@@ -47,7 +46,7 @@ func TestNewProvider(t *testing.T) {
 
 func TestProvider_KeySet(t *testing.T) {
 	p, _ := newMockProvider(t)
-	assert.Equal(t, 1, p.KeySet().Len())
+	assert.Equal(t, 2, p.KeySet().Len())
 }
 
 func TestProvider_NewJWTSessionToken(t *testing.T) {
@@ -64,7 +63,7 @@ func TestProvider_NewJWTSessionToken(t *testing.T) {
 
 func TestProvider_PublicKeys(t *testing.T) {
 	p, _ := newMockProvider(t)
-	assert.Len(t, p.PublicKeys(), 1)
+	assert.Len(t, p.PublicKeys(), 2)
 }
 
 type CustomClaimsExample struct {
@@ -175,7 +174,7 @@ func TestProvider_ValidateAccessToken(t *testing.T) {
 		var buf bytes.Buffer
 		assert.NoError(t, pem.Encode(&buf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: privBytes}))
 		sm.OnGet(ctx, config.SecretNameTokenSigningRSAKey).Return(buf.String(), nil)
-		sm.OnGet(ctx, config.SecretNameOldTokenSigningRSAKey).Return("", fmt.Errorf("not found"))
+		sm.OnGet(ctx, config.SecretNameOldTokenSigningRSAKey).Return(buf.String(), nil)
 
 		p, err := NewProvider(ctx, config.DefaultConfig.AppAuth.SelfAuthServer, sm)
 		assert.NoError(t, err)


### PR DESCRIPTION
## Tracking issue

Closes #4800 

## Why are the changes needed?

So flyteadmin errors out nicely and with information about the error instead of with a stack trace, which is difficult to follow for people not used to code.

## What changes were proposed in this pull request?

I'm adding some missing error handling.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

Having both an empty and an invalid `PrivateKeyPEM` variable resulted in the stack trace below:
```
time="2024-01-31T13:19:12Z" level=info msg="Using config file: [/etc/flyte/config/flyteadmin_config.yaml]"
{"data":{"src":"service.go:71"},"message":"setting metrics keys to [project domain wf task phase tasktype runtime_type runtime_version app_name]","severity":"INFO","timestamp":"2024-01-31T13:19:12Z"}
{"data":{"src":"service.go:302"},"message":"Serving Flyte Admin Insecure","severity":"INFO","timestamp":"2024-01-31T13:19:12Z"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x205939c]

goroutine 1 [running]:
github.com/flyteorg/flyte/flyteadmin/auth/authzserver.NewProvider({_, _}, {{0x0, 0x0}, {0x1a3185c5000}, {0x34630b8a000}, {0x45d964b800}, {0xc000bfdd10, 0x13}, {0xc000bfdd28, ...}, ...}, ...)
	/go/src/github.com/flyteorg/flyteadmin/auth/authzserver/provider.go:163 +0x33c
github.com/flyteorg/flyte/flyteadmin/pkg/server.serveGatewayInsecure({0x31c9678?, 0xc00013a000}, 0x4871340?, 0xc000225680, 0xc0001d2600, 0xc000f55bc0?, 0xc000f55c28?, {0x31e5328, 0xc0013ee370})
	/go/src/github.com/flyteorg/flyteadmin/pkg/server/service.go:316 +0x1f2
github.com/flyteorg/flyte/flyteadmin/pkg/server.Serve({0x31c9678, 0xc00013a000}, 0x0?, 0x0?)
	/go/src/github.com/flyteorg/flyteadmin/pkg/server/service.go:62 +0x19f
github.com/flyteorg/flyte/flyteadmin/cmd/entrypoints.glob..func7(0x4882b60?, {0x2bbada5?, 0x2?, 0x2?})
	/go/src/github.com/flyteorg/flyteadmin/cmd/entrypoints/serve.go:44 +0x1f2
github.com/spf13/cobra.(*Command).execute(0x4882b60, {0xc0001a7c00, 0x2, 0x2})
	/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0x4883f80)
	/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/flyteorg/flyte/flyteadmin/cmd/entrypoints.Execute(0x60?)
	/go/src/github.com/flyteorg/flyteadmin/cmd/entrypoints/root.go:49 +0x3a
main.main()
	/go/src/github.com/flyteorg/flyteadmin/cmd/main.go:12 +0x85
```
This refers to these fields in the `flyteadmin_config.yaml` file:
* `.auth.appAuth.selfAuthServer.tokenSigningRSAKeySecretName`
* `.clusters.clusterConfigs[].auth.certPath`

Setting valid PEMs in both cases solved the issue. Values were read from files mounted in the pod from a Kubernetes `Secret`, so the actual fix was to correct the value in the `Secret`.

### Setup process

Set an empty environment variable or an invalid value in the `Secret`.


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

