### PR TITLE
Logger disable HTML escaping

### DIFF
--- a/flytestdlib/logger/logger.go
+++ b/flytestdlib/logger/logger.go
@@ -41,7 +41,8 @@ func onConfigUpdated(cfg Config) {
 	default:
 		if _, isJSON := logrus.StandardLogger().Formatter.(*logrus.JSONFormatter); !isJSON {
 			logrus.SetFormatter(&logrus.JSONFormatter{
-				DataKey: jsonDataKey,
+				DataKey:           jsonDataKey,
+				DisableHTMLEscape: true,
 				FieldMap: logrus.FieldMap{
 					logrus.FieldKeyTime: "ts",
 				},


### PR DESCRIPTION
## Why are the changes needed?

When logging, html characters are escaped (JSONFormatter default). This prevents copying logged urls into the browser without modifying first.

## What changes were proposed in this pull request?

This change sets logger's JSONFormatter to [disable HTML escaping](https://pkg.go.dev/github.com/sirupsen/logrus#JSONFormatter). While this may cause issues with HTML, this is a sane config for a logger where we don't intend to log HTML generally.

When logging with characters `&, <, >`
```
logger.Info(ctx, "foo&bar")
```

Before
```
{"json":{"src":"logger_test.go:619"},"level":"info","msg":"foo\u0026bar","ts":"2024-02-04T20:27:18-08:00"}
```

After
```
{"json":{"src":"logger_test.go:619"},"level":"info","msg":"foo&bar","ts":"2024-02-04T20:27:18-08:00"}
```

## How was this patch tested?

Added a unit test

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
