### PR TITLE
[Docs] add sandbox to local cluster resource path

### DIFF
--- a/docs/community/contribute.rst
+++ b/docs/community/contribute.rst
@@ -403,11 +403,11 @@ that integrates all Flyte components into a single binary.
    # We will now create a simple template that allows the automatic creation of required namespaces for projects.
    # For example, with Flyte's default project "flytesnacks", the controller will auto-create the following namespaces:
    # flytesnacks-staging, flytesnacks-development, and flytesnacks-production.
-   mkdir $HOME/.flyte/cluster-resource-templates/
+   mkdir $HOME/.flyte/sandbox/cluster-resource-templates/
    echo "apiVersion: v1
    kind: Namespace
    metadata:
-     name: '{{ namespace }}'" > $HOME/.flyte/cluster-resource-templates/namespace.yaml
+     name: '{{ namespace }}'" > $HOME/.flyte/sandbox/cluster-resource-templates/namespace.yaml
 
    # Step5: Running the single binary.
    # The POD_NAMESPACE environment variable is necessary for the webhook to function correctly. 


### PR DESCRIPTION
`flytectl` [looks](https://github.com/flyteorg/flytectl/blob/71fbaf4291393d7e120df868e68404494849842f/pkg/docker/docker_util.go#L31) at the `sandbox/` subdirectory to get configuration so let's add that to the docs.