### PR TITLE
Re-add link to hosted sandbox

### DIFF
--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -3,6 +3,22 @@
 
 In this guide, you will create and run a Flyte workflow in a local Python environment to generate the output "Hello, world!"
 
+````{dropdown} Try Flyte in your browser
+:title: text-muted
+:animate: fade-in-slide-down
+
+```{link-button} https://sandbox.union.ai/
+---
+classes: try-hosted-flyte btn-warning btn-block
+text: Hosted Flyte sandbox
+---
+```
+```{div} text-muted
+*Courtesy of [Union.ai](https://www.union.ai/)*
+```
+````
+
+
 ## Prerequisites
 
 * [Install Python 3.8x or higher](https://www.python.org/downloads/)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Re-adds the link to the hosted sandbox so users can try Flyte in the browser.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Docs link

https://flyte--4856.org.readthedocs.build/en/4856/quickstart_guide.html
