### PR TITLE
Create CODEOWNERS file and add docs team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Automatically request docs team for docs PR review
+/docs/          @neverett @ppiegaze
+


### PR DESCRIPTION
## Why are the changes needed?

To flag the docs team when there are docs PRs.

## What changes were proposed in this pull request?

Creates a CODEOWNERS file and adds docs team members (@neverett and @ppiegaze) as reviewers for files in the /docs directory.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.
