### PR TITLE
Remove protoc_gen_swagger

### DIFF
--- a/flyteidl/pyproject.toml
+++ b/flyteidl/pyproject.toml
@@ -12,24 +12,8 @@ readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.8,<3.13"
 dependencies = [
     'googleapis-common-protos',
-    'protoc_gen_swagger',
     'protoc-gen-openapiv2',
     'protobuf>=4.21.1,<5.0.0',
-    # Packages in here should rarely be pinned. This is because these
-    # packages (at the specified version) are required for project
-    # consuming this library. By pinning to a specific version you are the
-    # number of projects that can consume this or forcing them to
-    # upgrade/downgrade any dependencies pinned here in their project.
-    #
-    # Generally packages listed here are pinned to a major version range.
-    #
-    # e.g.
-    # Python FooBar package for foobaring
-    # pyfoobar>=1.0, <2.0
-    #
-    # This will allow for any consuming projects to use this library as
-    # long as they have a version of pyfoobar equal to or greater than 1.x
-    # and less than 2.x installed.
 ]
 classifiers = [
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
We're fully moved to buf, this dependence is no longer needed (as it was replaced by `protoc-gen-openapiv2`).

## What changes were proposed in this pull request?



## How was this patch tested?
Tested in sandbox by generating an image that contained a version of flyteidl using the code in this PR and a doctored version of flytekit that didn't require flyteidl (so that I could install both at the same time without conflicts).

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
