### PR TITLE
Fix npm publish of flyteidl package

### DIFF
--- a/.github/workflows/flyteidl-release.yml
+++ b/.github/workflows/flyteidl-release.yml
@@ -33,6 +33,7 @@ jobs:
       run:
         working-directory: flyteidl
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: "12.x"


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Since we moved to the monorepo we haven't published a flyteidl npm package (from versions [1.10.0 onwards](https://github.com/flyteorg/flyte/actions/workflows/flyteidl-release.yml)). 

This PR fixes it (by ensuring that it's functionally the same as the [original code in the flyteidl repo](https://github.com/flyteorg/flyteidl/blob/master/.github/workflows/npmpublish.yaml#L11)).

## What changes were proposed in this pull request?
Checkout the code before running the script to publish the new version.

## How was this patch tested?


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
