### PR TITLE
Verify unbounded inputs for all scheduled launch plan types

### DIFF
--- a/flyteadmin/pkg/manager/impl/validation/launch_plan_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/launch_plan_validator.go
@@ -66,7 +66,7 @@ func ValidateLaunchPlan(ctx context.Context,
 
 func validateSchedule(request admin.LaunchPlanCreateRequest, expectedInputs *core.ParameterMap) error {
 	schedule := request.GetSpec().GetEntityMetadata().GetSchedule()
-	if schedule.GetCronExpression() != "" || schedule.GetRate() != nil {
+	if schedule.GetCronExpression() != "" || schedule.GetRate() != nil || schedule.GetCronSchedule() != nil {
 		for key, value := range expectedInputs.Parameters {
 			if value.GetRequired() && key != schedule.GetKickoffTimeInputArg() {
 				return errors.NewFlyteAdminErrorf(

--- a/flyteadmin/pkg/manager/impl/validation/launch_plan_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/launch_plan_validator_test.go
@@ -297,22 +297,60 @@ func TestValidateSchedule_NoSchedule(t *testing.T) {
 }
 
 func TestValidateSchedule_ArgNotFixed(t *testing.T) {
-	request := testutils.GetLaunchPlanRequestWithDeprecatedCronSchedule("* * * * * *")
-	inputMap := &core.ParameterMap{
-		Parameters: map[string]*core.Parameter{
-			"foo": {
-				Var: &core.Variable{
-					Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRING}},
-				},
-				Behavior: &core.Parameter_Required{
-					Required: true,
+	t.Run("with deprecated cron expression", func(t *testing.T) {
+		request := testutils.GetLaunchPlanRequestWithDeprecatedCronSchedule("* * * * * *")
+		inputMap := &core.ParameterMap{
+			Parameters: map[string]*core.Parameter{
+				"foo": {
+					Var: &core.Variable{
+						Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRING}},
+					},
+					Behavior: &core.Parameter_Required{
+						Required: true,
+					},
 				},
 			},
-		},
-	}
+		}
 
-	err := validateSchedule(request, inputMap)
-	assert.NotNil(t, err)
+		err := validateSchedule(request, inputMap)
+		assert.NotNil(t, err)
+	})
+	t.Run("with rate", func(t *testing.T) {
+		request := testutils.GetLaunchPlanRequestWithFixedRateSchedule(2, admin.FixedRateUnit_HOUR)
+		inputMap := &core.ParameterMap{
+			Parameters: map[string]*core.Parameter{
+				"foo": {
+					Var: &core.Variable{
+						Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRING}},
+					},
+					Behavior: &core.Parameter_Required{
+						Required: true,
+					},
+				},
+			},
+		}
+
+		err := validateSchedule(request, inputMap)
+		assert.NotNil(t, err)
+	})
+	t.Run("with cron schedule", func(t *testing.T) {
+		request := testutils.GetLaunchPlanRequestWithCronSchedule("* * * * * *")
+		inputMap := &core.ParameterMap{
+			Parameters: map[string]*core.Parameter{
+				"foo": {
+					Var: &core.Variable{
+						Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRING}},
+					},
+					Behavior: &core.Parameter_Required{
+						Required: true,
+					},
+				},
+			},
+		}
+
+		err := validateSchedule(request, inputMap)
+		assert.NotNil(t, err)
+	})
 }
 
 func TestValidateSchedule_KickoffTimeArgDoesNotExist(t *testing.T) {

--- a/flyteadmin/pkg/manager/impl/validation/launch_plan_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/launch_plan_validator_test.go
@@ -297,56 +297,32 @@ func TestValidateSchedule_NoSchedule(t *testing.T) {
 }
 
 func TestValidateSchedule_ArgNotFixed(t *testing.T) {
-	t.Run("with deprecated cron expression", func(t *testing.T) {
-		request := testutils.GetLaunchPlanRequestWithDeprecatedCronSchedule("* * * * * *")
-		inputMap := &core.ParameterMap{
-			Parameters: map[string]*core.Parameter{
-				"foo": {
-					Var: &core.Variable{
-						Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRING}},
-					},
-					Behavior: &core.Parameter_Required{
-						Required: true,
-					},
+	inputMap := &core.ParameterMap{
+		Parameters: map[string]*core.Parameter{
+			"foo": {
+				Var: &core.Variable{
+					Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRING}},
+				},
+				Behavior: &core.Parameter_Required{
+					Required: true,
 				},
 			},
-		}
+		},
+	}
+	t.Run("with deprecated cron expression", func(t *testing.T) {
+		request := testutils.GetLaunchPlanRequestWithDeprecatedCronSchedule("* * * * * *")
 
 		err := validateSchedule(request, inputMap)
 		assert.NotNil(t, err)
 	})
 	t.Run("with rate", func(t *testing.T) {
 		request := testutils.GetLaunchPlanRequestWithFixedRateSchedule(2, admin.FixedRateUnit_HOUR)
-		inputMap := &core.ParameterMap{
-			Parameters: map[string]*core.Parameter{
-				"foo": {
-					Var: &core.Variable{
-						Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRING}},
-					},
-					Behavior: &core.Parameter_Required{
-						Required: true,
-					},
-				},
-			},
-		}
-
+		
 		err := validateSchedule(request, inputMap)
 		assert.NotNil(t, err)
 	})
 	t.Run("with cron schedule", func(t *testing.T) {
 		request := testutils.GetLaunchPlanRequestWithCronSchedule("* * * * * *")
-		inputMap := &core.ParameterMap{
-			Parameters: map[string]*core.Parameter{
-				"foo": {
-					Var: &core.Variable{
-						Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRING}},
-					},
-					Behavior: &core.Parameter_Required{
-						Required: true,
-					},
-				},
-			},
-		}
 
 		err := validateSchedule(request, inputMap)
 		assert.NotNil(t, err)


### PR DESCRIPTION
## Tracking issue
closes https://github.com/flyteorg/flyte/issues/4866

## Why are the changes needed?
See tracking issue, launch plan registration and validation should catch unbounded inputs before schedule invocation

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
