### PR TITLE
[Docs] update outdated link to on-prem tutorial

### DIFF
--- a/docs/deployment/deployment/cloud_simple.rst
+++ b/docs/deployment/deployment/cloud_simple.rst
@@ -120,7 +120,7 @@ Flyte in on-premises infrastructure
 ***********************************
 
 Sometimes, it's also helpful to be able to set up a Flyte environment in an on-premises Kubernetes environment or even on a laptop for testing and development purposes.
-Check out `this community-maintained tutorial <https://github.com/davidmirror-ops/flyte-the-hard-way/blob/main/docs/on-premises/001-configure-local-k8s.md>`__ to learn how to setup the required dependencies and deploy the `flyte-binary` chart to a local Kubernetes cluster.
+Check out `this community-maintained tutorial <https://github.com/davidmirror-ops/flyte-the-hard-way/blob/main/docs/on-premises/single-node/001-configure-single-node-k8s.md>`__ to learn how to setup the required dependencies and deploy the `flyte-binary` chart to a local Kubernetes cluster.
 
 
 *************


### PR DESCRIPTION
## Tracking issue
[_https://github.com/flyteorg/flyte/issues/<number>_](https://github.com/flyteorg/flyte/issues/4865)
Closes #4865 

## Why are the changes needed?

The link in the docs that points to the "hard way" tutorial for on-prem deployment is out of date

## What changes were proposed in this pull request?

Updating the link. The link is found here, under this header: https://docs.flyte.org/en/latest/deployment/deployment/cloud_simple.html#flyte-in-on-premises-infrastructure

## How was this patch tested?

The link that is being changed to is working, it just added the `single-node` folder

### Screenshots
Old link
<img width="827" alt="image" src="https://github.com/flyteorg/flyte/assets/26172355/5e35395d-12d1-47b2-98de-9690c611e9d6">

New link
<img width="1059" alt="image" src="https://github.com/flyteorg/flyte/assets/26172355/f10e4dba-02a5-415d-8cc4-848c1975c53f">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Docs link

https://docs.flyte.org/en/latest/deployment/deployment/cloud_simple.html#flyte-in-on-premises-infrastructure
