### PR TITLE
Replaced deprecated bitnami/bitnami-shell image with bitnami/os-shell

### DIFF
--- a/docker/sandbox-bundled/images/manifest.txt
+++ b/docker/sandbox-bundled/images/manifest.txt
@@ -1,4 +1,4 @@
-docker.io/bitnami/bitnami-shell:sandbox=bitnami/bitnami-shell:11-debian-11-r76
+docker.io/bitnami/os-shell:sandbox=bitnami/os-shell:11-debian-11
 docker.io/bitnami/minio:sandbox=bitnami/minio:2023.1.25-debian-11-r0
 docker.io/bitnami/postgresql:sandbox=bitnami/postgresql:15.1.0-debian-11-r20
 docker.io/envoyproxy/envoy:sandbox=envoyproxy/envoy:v1.23-latest

--- a/docker/sandbox-bundled/manifests/complete-agent.yaml
+++ b/docker/sandbox-bundled/manifests/complete-agent.yaml
@@ -1653,7 +1653,7 @@ spec:
         - -ec
         - |
           chown -R 1001:1001 /data
-        image: docker.io/bitnami/bitnami-shell:sandbox
+        image: docker.io/bitnami/os-shell:sandbox
         imagePullPolicy: Never
         name: volume-permissions
         resources:
@@ -1909,7 +1909,7 @@ spec:
           chmod 700 /bitnami/postgresql/data
           find /bitnami/postgresql -mindepth 1 -maxdepth 1 -not -name "conf" -not -name ".snapshot" -not -name "lost+found" | \
             xargs -r chown -R 1001:1001
-        image: docker.io/bitnami/bitnami-shell:sandbox
+        image: docker.io/bitnami/os-shell:sandbox
         imagePullPolicy: Never
         name: init-chmod-data
         resources:

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -1601,7 +1601,7 @@ spec:
         - -ec
         - |
           chown -R 1001:1001 /data
-        image: docker.io/bitnami/bitnami-shell:sandbox
+        image: docker.io/bitnami/os-shell:sandbox
         imagePullPolicy: Never
         name: volume-permissions
         resources:
@@ -1794,7 +1794,7 @@ spec:
           chmod 700 /bitnami/postgresql/data
           find /bitnami/postgresql -mindepth 1 -maxdepth 1 -not -name "conf" -not -name ".snapshot" -not -name "lost+found" | \
             xargs -r chown -R 1001:1001
-        image: docker.io/bitnami/bitnami-shell:sandbox
+        image: docker.io/bitnami/os-shell:sandbox
         imagePullPolicy: Never
         name: init-chmod-data
         resources:

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -1175,7 +1175,7 @@ spec:
         - -ec
         - |
           chown -R 1001:1001 /data
-        image: docker.io/bitnami/bitnami-shell:sandbox
+        image: docker.io/bitnami/os-shell:sandbox
         imagePullPolicy: Never
         name: volume-permissions
         resources:
@@ -1368,7 +1368,7 @@ spec:
           chmod 700 /bitnami/postgresql/data
           find /bitnami/postgresql -mindepth 1 -maxdepth 1 -not -name "conf" -not -name ".snapshot" -not -name "lost+found" | \
             xargs -r chown -R 1001:1001
-        image: docker.io/bitnami/bitnami-shell:sandbox
+        image: docker.io/bitnami/os-shell:sandbox
         imagePullPolicy: Never
         name: init-chmod-data
         resources:


### PR DESCRIPTION
## Why are the changes needed?

Docker repository `bitnami/bitnami-shell` has been deprecated for a while and was removed recently. Single binary builds fail due to that ([failed workflow example](https://github.com/flyteorg/flyte/actions/runs/7871419560/job/21474991056)). `bitnami/os-shell` is a [direct replacement](https://hub.docker.com/search?q=bitnami-shell).

## What changes were proposed in this pull request?

This change updates deprecated image references with the new one.

## How was this patch tested?

Singe binary workflow was executed successfully with these changes applied.

### Setup process

N/A.

### Screenshots

N/A.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.
