### PR TITLE
Adding securityContext configuration to flyte-core charts

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -137,7 +137,7 @@ helm install gateway bitnami/contour -n flyte
 | datacatalog.priorityClassName | string | `""` | Sets priorityClassName for datacatalog pod(s). |
 | datacatalog.replicaCount | int | `1` | Replicas count for Datacatalog deployment |
 | datacatalog.resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Datacatalog deployment |
-| datacatalog.securityContext | object | `{"runAsNonRoot":true,"fsGroup":1001,"runAsUser":1001,"fsGroupChangePolicy":"OnRootMismatch","seLinuxOptions":{"type":"spc_t"}}` | Security context definition for Datacatalog pods |
+| datacatalog.securityContext | object | `{"fsGroup":1001,"fsGroupChangePolicy":"OnRootMismatch","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for datacatalog pod(s). |
 | datacatalog.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"type":"NodePort"}` | Service settings for Datacatalog |
 | datacatalog.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for Datacatalog |
 | datacatalog.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Datacatalog pods |
@@ -173,7 +173,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.replicaCount | int | `1` | Replicas count for Flyteadmin deployment |
 | flyteadmin.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flyteadmin deployment |
 | flyteadmin.secrets | object | `{}` |  |
-| flyteadmin.securityContext | object | `{"runAsNonRoot":true,"fsGroup":65534,"runAsUser":1001,"fsGroupChangePolicy":"Always","seLinuxOptions":{"type":"spc_t"}}` | Security context definition for Flyteadmin pods |
+| flyteadmin.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for flyteadmin pod(s). |
 | flyteadmin.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"loadBalancerSourceRanges":[],"type":"ClusterIP"}` | Service settings for Flyteadmin |
 | flyteadmin.serviceAccount | object | `{"alwaysCreate":false,"annotations":{},"clusterRole":{"apiGroups":["","flyte.lyft.com","rbac.authorization.k8s.io"],"resources":["configmaps","flyteworkflows","namespaces","pods","resourcequotas","roles","rolebindings","secrets","services","serviceaccounts","spark-role","limitranges"],"verbs":["*"]},"create":true,"createClusterRole":true,"imagePullSecrets":[]}` | Configuration for service accounts for FlyteAdmin |
 | flyteadmin.serviceAccount.alwaysCreate | bool | `false` | Should a service account always be created for flyteadmin even without an actual flyteadmin deployment running (e.g. for multi-cluster setups) |
@@ -209,7 +209,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteconsole.priorityClassName | string | `""` | Sets priorityClassName for flyte console pod(s). |
 | flyteconsole.replicaCount | int | `1` | Replicas count for Flyteconsole deployment |
 | flyteconsole.resources | object | `{"limits":{"cpu":"500m","memory":"250Mi"},"requests":{"cpu":"10m","memory":"50Mi"}}` | Default resources requests and limits for Flyteconsole deployment |
-| flyteconsole.securityContext | object | `{"runAsNonRoot":true,"runAsUser":1000,"fsGroupChangePolicy":"OnRootMismatch","seLinuxOptions":{"type":"spc_t"}}` | Security context definition for Flyteconsole pods |
+| flyteconsole.securityContext | object | `{"fsGroupChangePolicy":"OnRootMismatch","runAsNonRoot":true,"runAsUser":1000,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for flyteconsole pod(s). |
 | flyteconsole.service | object | `{"annotations":{},"type":"ClusterIP"}` | Service settings for Flyteconsole |
 | flyteconsole.tolerations | list | `[]` | tolerations for Flyteconsole deployment |
 | flytepropeller.additionalContainers | list | `[]` | Appends additional containers to the deployment spec. May include template values. |
@@ -233,7 +233,7 @@ helm install gateway bitnami/contour -n flyte
 | flytepropeller.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
 | flytepropeller.replicaCount | int | `1` | Replicas count for Flytepropeller deployment |
 | flytepropeller.resources | object | `{"limits":{"cpu":"200m","ephemeral-storage":"100Mi","memory":"200Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"100Mi"}}` | Default resources requests and limits for Flytepropeller deployment |
-| flytepropeller.securityContext | object | `{"fsGroup":65534,"runAsUser":1001,"fsGroupChangePolicy":"Always"}` | Security context definition for Flytepropeller pods |
+| flytepropeller.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsUser":1001}` | Sets securityContext for flytepropeller pod(s). |
 | flytepropeller.service | object | `{"enabled":false}` | Settings for flytepropeller service |
 | flytepropeller.service.enabled | bool | `false` | If enabled create the flytepropeller service |
 | flytepropeller.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for FlytePropeller |
@@ -263,7 +263,7 @@ helm install gateway bitnami/contour -n flyte
 | flytescheduler.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flytescheduler deployment |
 | flytescheduler.runPrecheck | bool | `true` | Whether to inject an init container which waits on flyteadmin |
 | flytescheduler.secrets | object | `{}` |  |
-| flytescheduler.securityContext | object | `{"runAsNonRoot":true,"fsGroup":65534,"runAsUser":1001,"fsGroupChangePolicy":"Always","seLinuxOptions":{"type":"spc_t"}}` | Security context definition for Flytescheduler pods |
+| flytescheduler.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for flytescheduler pod(s). |
 | flytescheduler.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for Flytescheduler |
 | flytescheduler.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Flytescheduler pods |
 | flytescheduler.serviceAccount.create | bool | `true` | Should a service account be created for Flytescheduler |
@@ -288,7 +288,7 @@ helm install gateway bitnami/contour -n flyte
 | storage.s3.secretKey | string | `""` | AWS IAM user secret access key to use for S3 bucket auth, only used if authType is set to accesskey |
 | storage.type | string | `"sandbox"` | Sets the storage type. Supported values are sandbox, s3, gcs and custom. |
 | webhook.enabled | bool | `true` | enable or disable secrets webhook |
-| webhook.securityContext | object | `{"runAsNonRoot":true,"fsGroup":65534,"runAsUser":1001,"fsGroupChangePolicy":"Always","seLinuxOptions":{"type":"spc_t"}}` | Security context definition for Flytescheduler pods |
+| webhook.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for webhook pod(s). |
 | webhook.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"type":"ClusterIP"}` | Service settings for the webhook |
 | webhook.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for the webhook |
 | webhook.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to the webhook |

--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -137,6 +137,7 @@ helm install gateway bitnami/contour -n flyte
 | datacatalog.priorityClassName | string | `""` | Sets priorityClassName for datacatalog pod(s). |
 | datacatalog.replicaCount | int | `1` | Replicas count for Datacatalog deployment |
 | datacatalog.resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Datacatalog deployment |
+| datacatalog.securityContext | object | `{"runAsNonRoot":true,"fsGroup":1001,"runAsUser":1001,"fsGroupChangePolicy":"OnRootMismatch","seLinuxOptions":{"type":"spc_t"}}` | Security context definition for Datacatalog pods |
 | datacatalog.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"type":"NodePort"}` | Service settings for Datacatalog |
 | datacatalog.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for Datacatalog |
 | datacatalog.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Datacatalog pods |
@@ -172,6 +173,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.replicaCount | int | `1` | Replicas count for Flyteadmin deployment |
 | flyteadmin.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flyteadmin deployment |
 | flyteadmin.secrets | object | `{}` |  |
+| flyteadmin.securityContext | object | `{"runAsNonRoot":true,"fsGroup":65534,"runAsUser":1001,"fsGroupChangePolicy":"Always","seLinuxOptions":{"type":"spc_t"}}` | Security context definition for Flyteadmin pods |
 | flyteadmin.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"loadBalancerSourceRanges":[],"type":"ClusterIP"}` | Service settings for Flyteadmin |
 | flyteadmin.serviceAccount | object | `{"alwaysCreate":false,"annotations":{},"clusterRole":{"apiGroups":["","flyte.lyft.com","rbac.authorization.k8s.io"],"resources":["configmaps","flyteworkflows","namespaces","pods","resourcequotas","roles","rolebindings","secrets","services","serviceaccounts","spark-role","limitranges"],"verbs":["*"]},"create":true,"createClusterRole":true,"imagePullSecrets":[]}` | Configuration for service accounts for FlyteAdmin |
 | flyteadmin.serviceAccount.alwaysCreate | bool | `false` | Should a service account always be created for flyteadmin even without an actual flyteadmin deployment running (e.g. for multi-cluster setups) |
@@ -207,6 +209,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteconsole.priorityClassName | string | `""` | Sets priorityClassName for flyte console pod(s). |
 | flyteconsole.replicaCount | int | `1` | Replicas count for Flyteconsole deployment |
 | flyteconsole.resources | object | `{"limits":{"cpu":"500m","memory":"250Mi"},"requests":{"cpu":"10m","memory":"50Mi"}}` | Default resources requests and limits for Flyteconsole deployment |
+| flyteconsole.securityContext | object | `{"runAsNonRoot":true,"runAsUser":1000,"fsGroupChangePolicy":"OnRootMismatch","seLinuxOptions":{"type":"spc_t"}}` | Security context definition for Flyteconsole pods |
 | flyteconsole.service | object | `{"annotations":{},"type":"ClusterIP"}` | Service settings for Flyteconsole |
 | flyteconsole.tolerations | list | `[]` | tolerations for Flyteconsole deployment |
 | flytepropeller.additionalContainers | list | `[]` | Appends additional containers to the deployment spec. May include template values. |
@@ -230,6 +233,7 @@ helm install gateway bitnami/contour -n flyte
 | flytepropeller.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
 | flytepropeller.replicaCount | int | `1` | Replicas count for Flytepropeller deployment |
 | flytepropeller.resources | object | `{"limits":{"cpu":"200m","ephemeral-storage":"100Mi","memory":"200Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"100Mi"}}` | Default resources requests and limits for Flytepropeller deployment |
+| flytepropeller.securityContext | object | `{"fsGroup":65534,"runAsUser":1001,"fsGroupChangePolicy":"Always"}` | Security context definition for Flytepropeller pods |
 | flytepropeller.service | object | `{"enabled":false}` | Settings for flytepropeller service |
 | flytepropeller.service.enabled | bool | `false` | If enabled create the flytepropeller service |
 | flytepropeller.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for FlytePropeller |
@@ -259,6 +263,7 @@ helm install gateway bitnami/contour -n flyte
 | flytescheduler.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flytescheduler deployment |
 | flytescheduler.runPrecheck | bool | `true` | Whether to inject an init container which waits on flyteadmin |
 | flytescheduler.secrets | object | `{}` |  |
+| flytescheduler.securityContext | object | `{"runAsNonRoot":true,"fsGroup":65534,"runAsUser":1001,"fsGroupChangePolicy":"Always","seLinuxOptions":{"type":"spc_t"}}` | Security context definition for Flytescheduler pods |
 | flytescheduler.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for Flytescheduler |
 | flytescheduler.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Flytescheduler pods |
 | flytescheduler.serviceAccount.create | bool | `true` | Should a service account be created for Flytescheduler |
@@ -280,9 +285,11 @@ helm install gateway bitnami/contour -n flyte
 | storage.s3 | object | `{"accessKey":"","authType":"iam","region":"us-east-1","secretKey":""}` | settings for storage type s3 |
 | storage.s3.accessKey | string | `""` | AWS IAM user access key ID to use for S3 bucket auth, only used if authType is set to accesskey |
 | storage.s3.authType | string | `"iam"` | type of authentication to use for S3 buckets, can either be iam or accesskey |
+| storage.s3.endpoint | string | `nil` | endpoint to use for S3 buckets, if not AWS public |
 | storage.s3.secretKey | string | `""` | AWS IAM user secret access key to use for S3 bucket auth, only used if authType is set to accesskey |
 | storage.type | string | `"sandbox"` | Sets the storage type. Supported values are sandbox, s3, gcs and custom. |
 | webhook.enabled | bool | `true` | enable or disable secrets webhook |
+| webhook.securityContext | object | `{"runAsNonRoot":true,"fsGroup":65534,"runAsUser":1001,"fsGroupChangePolicy":"Always","seLinuxOptions":{"type":"spc_t"}}` | Security context definition for Flytescheduler pods |
 | webhook.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"type":"ClusterIP"}` | Service settings for the webhook |
 | webhook.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for the webhook |
 | webhook.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to the webhook |

--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -285,7 +285,6 @@ helm install gateway bitnami/contour -n flyte
 | storage.s3 | object | `{"accessKey":"","authType":"iam","region":"us-east-1","secretKey":""}` | settings for storage type s3 |
 | storage.s3.accessKey | string | `""` | AWS IAM user access key ID to use for S3 bucket auth, only used if authType is set to accesskey |
 | storage.s3.authType | string | `"iam"` | type of authentication to use for S3 buckets, can either be iam or accesskey |
-| storage.s3.endpoint | string | `nil` | endpoint to use for S3 buckets, if not AWS public |
 | storage.s3.secretKey | string | `""` | AWS IAM user secret access key to use for S3 bucket auth, only used if authType is set to accesskey |
 | storage.type | string | `"sandbox"` | Sets the storage type. Supported values are sandbox, s3, gcs and custom. |
 | webhook.enabled | bool | `true` | enable or disable secrets webhook |

--- a/charts/flyte-core/templates/_helpers.tpl
+++ b/charts/flyte-core/templates/_helpers.tpl
@@ -220,6 +220,9 @@ storage:
   connection:
     auth-type: {{ .Values.storage.s3.authType }}
     region: {{ .Values.storage.s3.region }}
+    {{- if .Values.storage.s3.endpoint }}
+    endpoint: {{ .Values.storage.s3.endpoint }}
+    {{- end }}
     {{- if eq .Values.storage.s3.authType "accesskey" }}
     access-key: {{ .Values.storage.s3.accessKey }}
     secret-key: {{ .Values.storage.s3.secretKey }}

--- a/charts/flyte-core/templates/_helpers.tpl
+++ b/charts/flyte-core/templates/_helpers.tpl
@@ -220,9 +220,6 @@ storage:
   connection:
     auth-type: {{ .Values.storage.s3.authType }}
     region: {{ .Values.storage.s3.region }}
-    {{- if .Values.storage.s3.endpoint }}
-    endpoint: {{ .Values.storage.s3.endpoint }}
-    {{- end }}
     {{- if eq .Values.storage.s3.authType "accesskey" }}
     access-key: {{ .Values.storage.s3.accessKey }}
     secret-key: {{ .Values.storage.s3.secretKey }}

--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -18,13 +18,9 @@ spec:
         {{- end }}
       labels: {{ include "flyteadmin.podLabels" . | nindent 8 }}
     spec:
-      securityContext:
-        runAsNonRoot: true
-        fsGroup: 65534
-        runAsUser: 1001
-        fsGroupChangePolicy: "Always"
-        seLinuxOptions:
-          type: spc_t
+      {{- with .Values.flyteadmin.securityContext }}
+      securityContext: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       {{- if .Values.flyteadmin.priorityClassName }}
       priorityClassName: {{ .Values.flyteadmin.priorityClassName }}
       {{- end }}

--- a/charts/flyte-core/templates/console/deployment.yaml
+++ b/charts/flyte-core/templates/console/deployment.yaml
@@ -22,12 +22,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        fsGroupChangePolicy: "OnRootMismatch"
-        seLinuxOptions:
-          type: spc_t
+      {{- with .Values.flyteconsole.securityContext }}
+      securityContext: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       {{- if .Values.flyteconsole.priorityClassName }}
       priorityClassName: {{ .Values.flyteconsole.priorityClassName }}
       {{- end }}

--- a/charts/flyte-core/templates/datacatalog/deployment.yaml
+++ b/charts/flyte-core/templates/datacatalog/deployment.yaml
@@ -18,13 +18,9 @@ spec:
         {{- end }}
       labels: {{ include "datacatalog.podLabels" . | nindent 8 }}
     spec:
-      securityContext:
-        runAsNonRoot: true
-        fsGroup: 1001
-        runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
-        seLinuxOptions:
-          type: spc_t
+      {{- with .Values.datacatalog.securityContext }}
+      securityContext: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       {{- if .Values.datacatalog.priorityClassName }}
       priorityClassName: {{ .Values.datacatalog.priorityClassName }}
       {{- end }}

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -19,13 +19,9 @@ spec:
         {{- end }}
       labels: {{ include "flytescheduler.podLabels" . | nindent 8 }}
     spec:
-      securityContext:
-        runAsNonRoot: true
-        fsGroup: 65534
-        runAsUser: 1001
-        fsGroupChangePolicy: "Always"
-        seLinuxOptions:
-          type: spc_t
+      {{- with .Values.flytescheduler.securityContext }}
+      securityContext: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       {{- if .Values.flytescheduler.priorityClassName }}
       priorityClassName: {{ .Values.flytescheduler.priorityClassName }}
       {{- end }}

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -31,10 +31,9 @@ spec:
       labels: {{ include "flytepropeller.podLabels" . | nindent 8 }}
       {{- end }}
     spec:
-      securityContext:
-        fsGroup: 65534
-        runAsUser: 1001
-        fsGroupChangePolicy: "Always"
+      {{- with .Values.flytepropeller.securityContext }}
+      securityContext: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       {{- if .Values.flytepropeller.priorityClassName }}
       priorityClassName: {{ .Values.flytepropeller.priorityClassName }}
       {{- end }}

--- a/charts/flyte-core/templates/propeller/manager.yaml
+++ b/charts/flyte-core/templates/propeller/manager.yaml
@@ -15,10 +15,9 @@ template:
     labels: {{ include "flytepropeller.labels" . | nindent 6 }}
       app: {{ index .Values.configmap.core.manager "pod-application" }}
   spec:
-    securityContext:
-      fsGroup: 65534
-      runAsUser: 1001
-      fsGroupChangePolicy: "Always"
+    {{- with .Values.flytepropeller.securityContext }}
+    securityContext: {{ tpl (toYaml .) $ | nindent 8 }}
+    {{- end }}
     {{- if .Values.flytepropeller.priorityClassName }}
     priorityClassName: {{ .Values.flytepropeller.priorityClassName }}
     {{- end }}

--- a/charts/flyte-core/templates/propeller/webhook.yaml
+++ b/charts/flyte-core/templates/propeller/webhook.yaml
@@ -35,13 +35,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      securityContext:
-        fsGroup: 65534
-        runAsNonRoot: true
-        runAsUser: 1001
-        fsGroupChangePolicy: "Always"
-        seLinuxOptions:
-          type: spc_t
+      {{- with .Values.webhook.securityContext }}
+      securityContext: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "flyte-pod-webhook.name" . }}
 {{- if .Values.webhook.enabled }}
       initContainers:

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -111,6 +111,14 @@ flyteadmin:
   extraArgs: {}
   # -- Sets priorityClassName for flyteadmin pod(s).
   priorityClassName: ""
+  # -- Sets securityContext for flyteadmin pod(s).
+  securityContext:
+    runAsNonRoot: true
+    fsGroup: 65534
+    runAsUser: 1001
+    fsGroupChangePolicy: "Always"
+    seLinuxOptions:
+      type: spc_t
 
   # -- Settings for flyteadmin service monitor
   serviceMonitor:
@@ -179,6 +187,14 @@ flytescheduler:
   additionalContainers: []
   # -- Sets priorityClassName for flyte scheduler pod(s).
   priorityClassName: ""
+  # -- Sets securityContext for flytescheduler pod(s).
+  securityContext:
+    runAsNonRoot: true
+    fsGroup: 65534
+    runAsUser: 1001
+    fsGroupChangePolicy: "Always"
+    seLinuxOptions:
+      type: spc_t
 
 #
 # DATACATALOG SETTINGS
@@ -242,6 +258,14 @@ datacatalog:
   extraArgs: {}
   # -- Sets priorityClassName for datacatalog pod(s).
   priorityClassName: ""
+  # -- Sets securityContext for datacatalog pod(s).
+  securityContext:
+    runAsNonRoot: true
+    fsGroup: 1001
+    runAsUser: 1001
+    fsGroupChangePolicy: "OnRootMismatch"
+    seLinuxOptions:
+      type: spc_t
 
 #
 # FLYTE_AGENT SETTINGS
@@ -320,6 +344,11 @@ flytepropeller:
   clusterName: ""
   # -- Sets priorityClassName for propeller pod(s).
   priorityClassName: ""
+  # -- Sets securityContext for flytepropeller pod(s).
+  securityContext:
+    fsGroup: 65534
+    runAsUser: 1001
+    fsGroupChangePolicy: "Always"
 
   # -- Settings for flytepropeller service
   service:
@@ -382,6 +411,13 @@ flyteconsole:
   priorityClassName: ""
    # -- ImagePullSecrets to assign to the Flyteconsole deployment
   imagePullSecrets: []
+  # -- Sets securityContext for flyteconsole pod(s).
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroupChangePolicy: "OnRootMismatch"
+    seLinuxOptions:
+      type: spc_t
 
 # It will enable the redoc route in ingress
 deployRedoc: false
@@ -419,6 +455,14 @@ webhook:
     annotations:
       projectcontour.io/upstream-protocol.h2c: grpc
     type: ClusterIP
+  # -- Sets securityContext for webhook pod(s).
+  securityContext:
+    fsGroup: 65534
+    runAsNonRoot: true
+    runAsUser: 1001
+    fsGroupChangePolicy: "Always"
+    seLinuxOptions:
+      type: spc_t
 
 # ------------------------------------------------
 #

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -856,11 +856,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -1107,10 +1107,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
+      securityContext: 
+        fsGroupChangePolicy: OnRootMismatch
         runAsNonRoot: true
         runAsUser: 1000
-        fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
       containers:
@@ -1174,11 +1174,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -1276,10 +1276,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
       priorityClassName: system-cluster-critical
       containers:
       - command:
@@ -1353,11 +1353,11 @@ spec:
       annotations:
         configChecksum: "799320510466012ad23a7380ea4ac9ff51fd8ed6e56d9c543179b6bb6a9bcf1"
     spec:
-      securityContext:
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
         runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       serviceAccountName: flyte-pod-webhook

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -562,11 +562,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -813,10 +813,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
+      securityContext: 
+        fsGroupChangePolicy: OnRootMismatch
         runAsNonRoot: true
         runAsUser: 1000
-        fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
       containers:
@@ -880,11 +880,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -982,11 +982,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       initContainers:

--- a/deployment/eks/flyte_helm_dataplane_generated.yaml
+++ b/deployment/eks/flyte_helm_dataplane_generated.yaml
@@ -434,10 +434,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
       priorityClassName: system-cluster-critical
       containers:
       - command:
@@ -511,11 +511,11 @@ spec:
       annotations:
         configChecksum: "799320510466012ad23a7380ea4ac9ff51fd8ed6e56d9c543179b6bb6a9bcf1"
     spec:
-      securityContext:
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
         runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       serviceAccountName: flyte-pod-webhook

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -887,11 +887,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -1138,10 +1138,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
+      securityContext: 
+        fsGroupChangePolicy: OnRootMismatch
         runAsNonRoot: true
         runAsUser: 1000
-        fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
       containers:
@@ -1205,11 +1205,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -1307,11 +1307,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -1406,10 +1406,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
       priorityClassName: system-cluster-critical
       containers:
       - command:
@@ -1483,11 +1483,11 @@ spec:
       annotations:
         configChecksum: "799320510466012ad23a7380ea4ac9ff51fd8ed6e56d9c543179b6bb6a9bcf1"
     spec:
-      securityContext:
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
         runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       serviceAccountName: flyte-pod-webhook

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -577,11 +577,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -828,10 +828,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
+      securityContext: 
+        fsGroupChangePolicy: OnRootMismatch
         runAsNonRoot: true
         runAsUser: 1000
-        fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
       containers:
@@ -895,11 +895,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -997,11 +997,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       initContainers:

--- a/deployment/gcp/flyte_helm_dataplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_dataplane_generated.yaml
@@ -442,10 +442,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
       containers:
       - command:
         - flytepropeller
@@ -518,11 +518,11 @@ spec:
       annotations:
         configChecksum: "574080d58e672acb923d48388a0746a10a55b3a0397c836d204910e0ead139c"
     spec:
-      securityContext:
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
         runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       serviceAccountName: flyte-pod-webhook

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -910,11 +910,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -1161,10 +1161,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
+      securityContext: 
+        fsGroupChangePolicy: OnRootMismatch
         runAsNonRoot: true
         runAsUser: 1000
-        fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
       containers:
@@ -1228,11 +1228,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -1330,11 +1330,11 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -1429,10 +1429,10 @@ spec:
         helm.sh/chart: flyte-core-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
       containers:
       - command:
         - flytepropeller
@@ -1505,11 +1505,11 @@ spec:
       annotations:
         configChecksum: "574080d58e672acb923d48388a0746a10a55b3a0397c836d204910e0ead139c"
     spec:
-      securityContext:
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
         runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       serviceAccountName: flyte-pod-webhook

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -6693,11 +6693,11 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -6928,10 +6928,10 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
+      securityContext: 
+        fsGroupChangePolicy: OnRootMismatch
         runAsNonRoot: true
         runAsUser: 1000
-        fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
       containers:
@@ -6993,11 +6993,11 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -7084,11 +7084,11 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
-        runAsNonRoot: true
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       initContainers:
@@ -7179,10 +7179,10 @@ spec:
         helm.sh/chart: flyte-v0.1.10
         app.kubernetes.io/managed-by: Helm
     spec:
-      securityContext:
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
       containers:
       - command:
         - flytepropeller
@@ -7248,11 +7248,11 @@ spec:
       annotations:
         configChecksum: "05780b9daf69f0afaee7339e2948131e9b02b38496e68543370bf267e8ef708"
     spec:
-      securityContext:
+      securityContext: 
         fsGroup: 65534
+        fsGroupChangePolicy: Always
         runAsNonRoot: true
         runAsUser: 1001
-        fsGroupChangePolicy: "Always"
         seLinuxOptions:
           type: spc_t
       serviceAccountName: flyte-pod-webhook


### PR DESCRIPTION
## Tracking issue

Closes #4893 

## Why are the changes needed?

Without chart modifications, we are unable to deploy the flyte-core chart into OpenShift environments or other k8s environments that do not allow specification of user IDs.

## What changes were proposed in this pull request?

Adds ability to override securityContext in Helm chart deployment for flyteadmin, flyteconsole, datacatalog, flytepropeller, and flytescheduler.

## How was this patch tested?

Deployed in an on-prem environment.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
