### PR TITLE
Add opentelemetry BlobstoreClientTracer to flyteadmin (#57)

### DIFF
--- a/flyteadmin/cmd/entrypoints/serve.go
+++ b/flyteadmin/cmd/entrypoints/serve.go
@@ -34,7 +34,7 @@ var serveCmd = &cobra.Command{
 		server.SetMetricKeys(cfg.ApplicationConfiguration().GetTopLevelConfig())
 
 		// register otel tracer providers
-		for _, serviceName := range []string{otelutils.AdminGormTracer, otelutils.AdminServerTracer} {
+		for _, serviceName := range []string{otelutils.AdminGormTracer, otelutils.AdminServerTracer, otelutils.BlobstoreClientTracer} {
 			if err := otelutils.RegisterTracerProvider(serviceName, otelutils.GetConfig()); err != nil {
 				logger.Errorf(ctx, "Failed to create otel tracer provider. %v", err)
 				return err


### PR DESCRIPTION
## Why are the changes needed?

Flyteadmin writes to blobstores, but it lacks tracing to analyze performance.

## What changes were proposed in this pull request?

Adds blobstore tracing to flyteadmin. This is already used by propeller.

## How was this patch tested?

Ran locally with tracing enabled and verified blobstore spans were included.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.
