### PR TITLE
fix: mount flyte-secret-auth secret conditionally

### DIFF
--- a/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
@@ -66,9 +66,11 @@ spec:
             secretName: cluster-credentials
         {{- end }}
         {{- if .Values.cluster_resource_manager.config.cluster_resources.standaloneDeployment }}
+        {{- if .Values.secrets.adminOauthClientCredentials.enabled }}
         - name: auth
           secret:
             secretName: flyte-secret-auth
+        {{- end }}
         {{- end }}
       {{- with .Values.cluster_resource_manager.nodeSelector }}
       nodeSelector: {{ tpl (toYaml .) $ | nindent 8 }}

--- a/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
@@ -38,8 +38,10 @@ spec:
           {{- if not .Values.cluster_resource_manager.config.cluster_resources.standaloneDeployment  }}
           {{- include "databaseSecret.volumeMount" . | nindent 10 }}
           {{- else }}
+          {{- if .Values.secrets.adminOauthClientCredentials.enabled }}
           - name: auth
             mountPath: /etc/secrets/
+          {{- end }}
           {{- end }}
           - mountPath: /etc/flyte/clusterresource/templates
             name: resource-templates

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -91,9 +91,11 @@ spec:
       - configMap:
           name: flyte-scheduler-config
         name: config-volume
+      {{- if .Values.secrets.adminOauthClientCredentials.enabled }}
       - name: auth
         secret:
           secretName: flyte-secret-auth
+      {{- end }}
       {{- with .Values.flytescheduler.additionalVolumes -}}
       {{ tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -76,8 +76,10 @@ spec:
         volumeMounts: {{- include "databaseSecret.volumeMount" . | nindent 8 }}
         - mountPath: /etc/flyte/config
           name: config-volume
+        {{- if .Values.secrets.adminOauthClientCredentials.enabled }}
         - name: auth
           mountPath: /etc/secrets/
+        {{- end }}
         {{- with .Values.flytescheduler.additionalVolumeMounts -}}
         {{ tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -98,9 +98,11 @@ spec:
       - configMap:
           name: flyte-propeller-config
         name: config-volume
+      {{- if .Values.secrets.adminOauthClientCredentials.enabled }}
       - name: auth
         secret:
           secretName: flyte-secret-auth
+      {{- end }}
       {{- with .Values.flytepropeller.additionalVolumes -}}
       {{ tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -82,8 +82,10 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /etc/flyte/config
+        {{- if .Values.secrets.adminOauthClientCredentials.enabled }}
         - name: auth
           mountPath: /etc/secrets/
+        {{- end }}
         {{- with .Values.flytepropeller.additionalVolumeMounts -}}
         {{ tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/charts/flyte-core/templates/propeller/manager.yaml
+++ b/charts/flyte-core/templates/propeller/manager.yaml
@@ -53,9 +53,11 @@ template:
     - configMap:
         name: flyte-propeller-config
       name: config-volume
+    {{- if .Values.secrets.adminOauthClientCredentials.enabled }}
     - name: auth
       secret:
         secretName: flyte-secret-auth
+    {{- end }}
     {{- with .Values.flytepropeller.nodeSelector }}
     nodeSelector: {{ tpl (toYaml .) $ | nindent 6 }}
     {{- end }}

--- a/charts/flyte-core/templates/propeller/manager.yaml
+++ b/charts/flyte-core/templates/propeller/manager.yaml
@@ -43,8 +43,10 @@ template:
       volumeMounts:
         - name: config-volume
           mountPath: /etc/flyte/config
+        {{- if .Values.secrets.adminOauthClientCredentials.enabled }}
         - name: auth
           mountPath: /etc/secrets/
+        {{- end }}
       {{- if .Values.flytepropeller.terminationMessagePolicy }}
       terminationMessagePolicy: "{{ .Values.flytepropeller.terminationMessagePolicy }}"
       {{- end }}


### PR DESCRIPTION
## Tracking issue
Closes #4908

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

If .Values.secrets.adminOauthClientCredentials.enabled is false in flyte-core chart, some deployments will mount flyte-secret-auth secret even though the secret isn't created.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

Add conditional brach volume and volumeMount to make creation of secret and volume mount are consistent

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Can test it locally via `helm template charts/flyte-core`

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
