### PR TITLE
Cache console assets in single binary

### DIFF
--- a/cmd/single/console_dist.go
+++ b/cmd/single/console_dist.go
@@ -20,6 +20,7 @@ var consoleHandlers = map[string]handlerFunc{
 		consoleHandler.ServeHTTP(writer, request)
 	},
 	consoleRoot + "/": func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Cache-Control", "max-age=604800")  // 7 days
 		consoleHandler.ServeHTTP(writer, request)
 	},
 }


### PR DESCRIPTION
## Tracking issue
NA

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?
We recently noticed that flyteconsole assets were not being cached in single binary. This causes an unnecessary slowdown, as it forces the browser to always download all assets.


## What changes were proposed in this pull request?
This PR sets the [`Cache-Control` header](https://www.cloudflare.com/learning/cdn/glossary/what-is-cache-control/) to store the assets returned by single binary for 7 days.

## How was this patch tested?
```
❯ curl -I 'http://localhost:30080/console/assets/886-55c90ced75ee4d84c22e.chunk.js' --compressed
HTTP/1.1 200 OK
accept-ranges: bytes
cache-control: max-age=604800
content-length: 18796
content-type: text/javascript; charset=utf-8
date: Tue, 20 Feb 2024 00:49:09 GMT
x-envoy-upstream-service-time: 0
server: envoy
```

Notice the `Cache-control` header being set in the response. 

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
