### PR TITLE
Service Account for V1 Ray Jobs

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/ray/config.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/config.go
@@ -23,6 +23,7 @@ var (
 		DashboardHost:            "0.0.0.0",
 		EnableUsageStats:         false,
 		KubeRayCrdVersion:        "v1alpha1",
+		ServiceAccount:           "default",
 		Defaults: DefaultConfig{
 			HeadNode: NodeConfig{
 				StartParameters: map[string]string{
@@ -87,6 +88,7 @@ type Config struct {
 	Defaults             DefaultConfig                 `json:"defaults" pflag:"-,Default configuration for ray jobs"`
 	EnableUsageStats     bool                          `json:"enableUsageStats" pflag:",Enable usage stats for ray jobs. These stats are submitted to usage-stats.ray.io per https://docs.ray.io/en/latest/cluster/usage-stats.html"`
 	KubeRayCrdVersion    string                        `json:"kubeRayCrdVersion" pflag:",Version of the Ray CRD to use when creating RayClusters or RayJobs."`
+	ServiceAccount       string                        `json:"serviceAccount" pflag:",The k8s service account to run as"`
 }
 
 type DefaultConfig struct {

--- a/flyteplugins/go/tasks/plugins/k8s/ray/config_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/config_test.go
@@ -25,3 +25,13 @@ func TestLoadConfig(t *testing.T) {
 		assert.DeepEqual(t, config.RemoteClusterConfig, remoteConfig)
 	})
 }
+
+func TestLoadDefaultServiceAccountConfig(t *testing.T) {
+	rayConfig := GetConfig()
+	assert.Assert(t, rayConfig != nil)
+
+	t.Run("serviceAccount", func(t *testing.T) {
+		config := GetConfig()
+		assert.Equal(t, config.ServiceAccount, "default")
+	})
+}

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -114,6 +114,8 @@ func (rayJobResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsC
 		headNodeRayStartParams[DisableUsageStatsStartParameter] = DisableUsageStatsStartParameterVal
 	}
 
+	podSpec.ServiceAccountName = cfg.ServiceAccount
+
 	headPodSpec := podSpec.DeepCopy()
 
 	if cfg.KubeRayCrdVersion == "v1" {


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4797

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

Closes #4797

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?

Changes are needed to ensure that pods are running as the appropriate serviceAccount.

This enables these pods to pull images in private registries, and to further customize permissions per kubernetes environments.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

Change podSpecs to leverage a serviceAccount defined in the default config. Also ensure this is value can be modified.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

Through unit tests.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
