### PR TITLE
Fix broken gpu resource override when using pod templates

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/container_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/container_helper.go
@@ -129,11 +129,24 @@ func adjustResourceRequirement(resourceName v1.ResourceName, resourceRequirement
 	resourceRequirements.Limits[resourceName] = resourceValue.Limit
 }
 
+// Convert GPU resource requirements named 'gpu' the recognized 'nvidia.com/gpu' identifier.
+func SanitizeGPUResourceRequirements(resources *v1.ResourceRequirements) {
+	gpuResourceName := config.GetK8sPluginConfig().GpuResourceName
+
+	if res, found := resources.Requests[resourceGPU]; found {
+		resources.Requests[gpuResourceName] = res
+		delete(resources.Requests, resourceGPU)
+	}
+
+	if res, found := resources.Limits[resourceGPU]; found {
+		resources.Limits[gpuResourceName] = res
+		delete(resources.Limits, resourceGPU)
+	}
+}
+
 // ApplyResourceOverrides handles resource resolution, allocation and validation. Primarily, it ensures that container
 // resources do not exceed defined platformResource limits and in the case of assignIfUnset, ensures that limits and
 // requests are sensibly set for resources of all types.
-// Furthermore, this function handles some clean-up such as converting GPU resources to the recognized Nvidia gpu
-// resource name and deleting unsupported Storage-type resources.
 func ApplyResourceOverrides(resources, platformResources v1.ResourceRequirements, assignIfUnset bool) v1.ResourceRequirements {
 	if len(resources.Requests) == 0 {
 		resources.Requests = make(v1.ResourceList)
@@ -166,19 +179,6 @@ func ApplyResourceOverrides(resources, platformResources v1.ResourceRequirements
 	_, gpuRequested := resources.Requests[gpuResourceName]
 	_, gpuLimited := resources.Limits[gpuResourceName]
 	if gpuRequested || gpuLimited {
-		shouldAdjustGPU = true
-	}
-
-	// Override GPU
-	if res, found := resources.Requests[resourceGPU]; found {
-		resources.Requests[gpuResourceName] = res
-		delete(resources.Requests, resourceGPU)
-		shouldAdjustGPU = true
-	}
-
-	if res, found := resources.Limits[resourceGPU]; found {
-		resources.Limits[gpuResourceName] = res
-		delete(resources.Limits, resourceGPU)
 		shouldAdjustGPU = true
 	}
 
@@ -306,6 +306,8 @@ func AddFlyteCustomizationsToContainer(ctx context.Context, parameters template.
 	if overrideResources == nil {
 		overrideResources = &v1.ResourceRequirements{}
 	}
+
+	SanitizeGPUResourceRequirements(&container.Resources)
 
 	logger.Infof(ctx, "ApplyResourceOverrides with Resources [%v], Platform Resources [%v] and Container"+
 		" Resources [%v] with mode [%v]", overrideResources, platformResources, container.Resources, mode)

--- a/flyteplugins/go/tasks/plugins/array/awsbatch/transformer.go
+++ b/flyteplugins/go/tasks/plugins/array/awsbatch/transformer.go
@@ -95,6 +95,8 @@ func FlyteTaskToBatchInput(ctx context.Context, tCtx pluginCore.TaskExecutionCon
 	if platformResources == nil {
 		platformResources = &v1.ResourceRequirements{}
 	}
+
+	flytek8s.SanitizeGPUResourceRequirements(res)
 	resources := flytek8s.ApplyResourceOverrides(*res, *platformResources, assignResources)
 
 	submitJobInput := &batch.SubmitJobInput{}


### PR DESCRIPTION
## Why are the changes needed?

```py
@task(
    requests=Resources(cpu="11", mem="11Gi", gpu="11"),
)
def foo():
    ...

@workflow
def test_wf():
    foo().with_overrides(requests=Resources(cpu="13", mem="13Gi", gpu="13"), limits=Resources(cpu="13", mem="13Gi", gpu="13"))
```

The resulting task pod - as expected - uses the following resources:

```yaml
resources:
  limits:
    cpu: "13"
    memory: 13Gi
    nvidia.com/gpu: "13"
  requests:
    cpu: "13"
    ephemeral-storage: 2Gi
    memory: 13Gi
    nvidia.com/gpu: "13"
```

If I now add `pod_template=PodTemplate(labels={"foo": "bar"})` to the task decorator, I would expect the same pod resources but the creation of the pod actually fails:

```
E0221 13:50:14.805583  427772 workers.go:103] error syncing 'development/f454d2131ec484221b70': failed at Node[n0]. RuntimeExecutionError: failed during plugin execution, caused by: failed to execute handle for plugin [container]: [Invalid] failed to create resource, caused by: Pod "f454d2131ec484221b70-n0-0" is invalid: spec.containers[0].resources.requests: Invalid value: "11": must be equal to nvidia.com/gpu limit
```

This PR fixes this.



## What changes were proposed in this pull request?

The bug happens as follows:

* When not using the pod template, [here](https://github.com/flyteorg/flyte/blob/22b0005b4d889fce7ac9f201e227f8654f3bbeac/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go#L275), from our example above, we create a container with `cpu: 11` , `memory: 11Gi`, and `nvidia.com/gpu: 11` (both for requests and limits).
* However, when using a pod template, [here](https://github.com/flyteorg/flyte/blob/22b0005b4d889fce7ac9f201e227f8654f3bbeac/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go#L293), we retrieve a pod spec from the task proto which sets `cpu: 11` , `memory: 11Gi`, and `gpu: 11` (not `nvidia.com/gpu`!) as requests and which doesn't have limits.  This pod spec was built on the flytekit side [here](https://github.com/flyteorg/flytekit/blob/d1d1bd911cacb36d732ecb57977ece7931076b50/flytekit/core/utils.py#L97).

In the latter case, when merging the container resources with the resource overrides [here](https://github.com/flyteorg/flyte/blob/22b0005b4d889fce7ac9f201e227f8654f3bbeac/flyteplugins/go/tasks/pluginmachinery/flytek8s/container_helper.go#L322), we end up with the following requests:

```yaml
cpu: 13
memory: 13Gi
nvidia.com/gpu: 13
gpu: 11  # This value should have been overridden but wasn't because of the wrong resource name
```

Finally, [here](https://github.com/flyteorg/flyte/blob/22b0005b4d889fce7ac9f201e227f8654f3bbeac/flyteplugins/go/tasks/pluginmachinery/flytek8s/container_helper.go#L173), we override `nvidia.com/gpu: 13` with the wrong value `11` and delete the `gpu` key from the resource requirements.

(The actual error message above states that the gpu request and limit are not the same. The root cause for this is what I described here.)

**Proposed fix:**

I propose to fix this by cleaning up the wrong gpu resource name *before* merging the resource overrides.

## How was this patch tested?

I ran propeller with my proposed change. The resource overriding in the example above works as expected, also when using the pod template.

**I will still adapt the tests**

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

