### PR TITLE
 Clarify that only pandas is needed for StructuredDataset

### DIFF
--- a/docs/user_guide/data_types_and_io/structureddataset.md
+++ b/docs/user_guide/data_types_and_io/structureddataset.md
@@ -39,9 +39,22 @@ It offers the following benefits:
   (not only at compile time, but also runtime since type information is carried along in the literal),
    store third-party schema definitions, and potentially in the future, render sample data, provide summary statistics, etc.
 
+## Usage
+
+To use the `StructuredDataset` type, import `pandas` and define a task that returns a Pandas Dataframe.
+Flytekit will detect the Pandas DataFrame return signature and convert the interface for the task to
+the {py:class}`StructuredDataset` type.
+
+## Example
+
 This example demonstrates how to work with a structured dataset using Flyte entities.
 
-To begin, import the necessary dependencies.
+```{note}
+To use the `StructuredDataset` type, you only need to import `pandas`.
+The other imports specified below are only necessary for this specific example.
+```
+
+To begin, import the dependencies for the example:
 
 ```{code-cell}
 import os
@@ -67,8 +80,6 @@ from typing_extensions import Annotated
 +++ {"lines_to_next_cell": 0}
 
 Define a task that returns a Pandas DataFrame.
-Flytekit will detect the Pandas dataframe return signature and
-convert the interface for the task to the new {py:class}`StructuredDataset` type.
 
 ```{code-cell}
 @task


### PR DESCRIPTION
## Why are the changes needed?

Now that [the user guide has been moved from flytesnacks to flyte](https://github.com/flyteorg/flyte/pull/4887), the changes from [this flytesnacks PR](https://github.com/flyteorg/flytesnacks/pull/1516) need to be applied over here instead.

## What changes were proposed in this pull request?

Update StructuredDataset page to clarify that pandas is the only dependency required to use StructuredDatasets.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Docs link

TBD
