### PR TITLE
Improve Agent Terminal Phase Error Message

### DIFF
--- a/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
@@ -184,9 +184,9 @@ func (p Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phase
 		}
 		return core.PhaseInfoSuccess(taskInfo), nil
 	case flyteIdl.TaskExecution_ABORTED:
-		return core.PhaseInfoFailure(pluginErrors.TaskFailedWithError, "failed to run the job with aborted phase", taskInfo), nil
+		return core.PhaseInfoFailure(pluginErrors.TaskFailedWithError, "failed to run the job with aborted phase"+resource.Message, taskInfo), nil
 	case flyteIdl.TaskExecution_FAILED:
-		return core.PhaseInfoFailure(pluginErrors.TaskFailedWithError, "failed to run the job", taskInfo), nil
+		return core.PhaseInfoFailure(pluginErrors.TaskFailedWithError, "failed to run the job"+resource.Message, taskInfo), nil
 	}
 
 	// The default phase is undefined.
@@ -201,9 +201,9 @@ func (p Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phase
 	case admin.State_RUNNING:
 		return core.PhaseInfoRunning(core.DefaultPhaseVersion, taskInfo), nil
 	case admin.State_PERMANENT_FAILURE:
-		return core.PhaseInfoFailure(pluginErrors.TaskFailedWithError, "failed to run the job", taskInfo), nil
+		return core.PhaseInfoFailure(pluginErrors.TaskFailedWithError, "failed to run the job"+resource.Message, taskInfo), nil
 	case admin.State_RETRYABLE_FAILURE:
-		return core.PhaseInfoRetryableFailure(pluginErrors.TaskFailedWithError, "failed to run the job", taskInfo), nil
+		return core.PhaseInfoRetryableFailure(pluginErrors.TaskFailedWithError, "failed to run the job"+resource.Message, taskInfo), nil
 	case admin.State_SUCCEEDED:
 		err = writeOutput(ctx, taskCtx, resource)
 		if err != nil {


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
When Agent Tasks fail, we want to help users to find the bug quickly, so that it will be easier for us to identify the error from the agent server or flytepropeller.

## What changes were proposed in this pull request?
add `resource.Message` in all Terminal Phase. (Except for Success)

## How was this patch tested?

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
