### PR TITLE
Add failure node example from flytesnacks #1328

### DIFF
--- a/docs/user_guide/development_lifecycle/failure_node.md
+++ b/docs/user_guide/development_lifecycle/failure_node.md
@@ -1,15 +1,15 @@
 (failure_node)=
-# Failure Node
+# Failure node
 
 ```{eval-rst}
  .. tags:: FailureNode, Intermediate
 ```
 
-The Failure Node feature enables you to designate a specific node to execute in the event of a failure within your workflow.
+The failure node feature enables you to designate a specific node to execute in the event of a failure within your workflow.
 
-For example, workflow involves creating a cluster at the beginning, followed by the execution of tasks, and concluding with the deletion of the cluster once all tasks are completed. However, if any task within the workflow encounters an error, flyte will abort the entire workflow and won’t delete the cluster. This poses a challenge if you still need to clean up the cluster even in a task failure.
+For example, a workflow involves creating a cluster at the beginning, followed by the execution of tasks, and concludes with the deletion of the cluster once all tasks are completed. However, if any task within the workflow encounters an error, flyte will abort the entire workflow and won’t delete the cluster. This poses a challenge if you still need to clean up the cluster even in a task failure.
 
-A failure node can be incorporated into the workflow to address this issue. This ensures that critical actions, such as deleting the cluster, are executed even in the event of failures occurring throughout the workflow execution.
+To address this issue, you can add a failure node into your workflow. This ensures that critical actions, such as deleting the cluster, are executed even in the event of failures occurring throughout the workflow execution:
 
 ```python
 from flytekit import WorkflowFailurePolicy, task, workflow
@@ -21,7 +21,7 @@ def create_cluster(name: str):
 
 ```
 
-Create a task that will fail during execution.
+Create a task that will fail during execution:
 
 ```python
 @task
@@ -35,7 +35,7 @@ def delete_cluster(name: str):
     print(f"Deleting cluster {name}")
 ```
 
-Create a task that will be executed if any of the tasks in the workflow fail.
+Create a task that will be executed if any of the tasks in the workflow fail:
 
 ```python
 @task
@@ -44,7 +44,7 @@ def clean_up(name: str):
 
 ```
 
-Specify the `on_failure` to a cleanup task. This task will be executed if any of the tasks in the workflow fail.
+Specify the `on_failure` to a cleanup task. This task will be executed if any of the tasks in the workflow fail:
 
 
 :::{note}
@@ -60,7 +60,7 @@ def subwf(name: str):
     c >> t >> d
 ```
 
-By setting the failure policy to `FAIL_AFTER_EXECUTABLE_NODES_COMPLETE` to ensure that the `wf1` is executed even if the subworkflow fails. In this case, both parent and child workflows will fail, resulting in the `clean_up` task being executed twice.
+By setting the failure policy to `FAIL_AFTER_EXECUTABLE_NODES_COMPLETE` to ensure that the `wf1` is executed even if the subworkflow fails. In this case, both parent and child workflows will fail, resulting in the `clean_up` task being executed twice:
 
 ```python
 @workflow(on_failure=clean_up, failure_policy=WorkflowFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE)
@@ -77,7 +77,7 @@ def clean_up_wf(name: str):
     return clean_up(name=name)
 ```
 
-You can also set the `on_failure` to a workflow. This workflow will be executed if any of the tasks in the workflow fail.
+You can also set the `on_failure` to a workflow. This workflow will be executed if any of the tasks in the workflow fail:
 
 ```python
 @workflow(on_failure=clean_up_wf)

--- a/docs/user_guide/development_lifecycle/failure_node.md
+++ b/docs/user_guide/development_lifecycle/failure_node.md
@@ -1,0 +1,89 @@
+(failure_node)=
+# Failure Node
+
+```{eval-rst}
+ .. tags:: FailureNode, Intermediate
+```
+
+The Failure Node feature enables you to designate a specific node to execute in the event of a failure within your workflow.
+
+For example, workflow involves creating a cluster at the beginning, followed by the execution of tasks, and concluding with the deletion of the cluster once all tasks are completed. However, if any task within the workflow encounters an error, flyte will abort the entire workflow and won’t delete the cluster. This poses a challenge if you still need to clean up the cluster even in a task failure.
+
+A failure node can be incorporated into the workflow to address this issue. This ensures that critical actions, such as deleting the cluster, are executed even in the event of failures occurring throughout the workflow execution.
+
+```{python}
+from flytekit import WorkflowFailurePolicy, task, workflow
+
+
+@task
+def create_cluster(name: str):
+    print(f"Creating cluster: {name}")
+
+```
+
+Create a task that will fail during execution.
+
+```{python}
+@task
+def t1(a: int, b: str):
+    print(f"{a} {b}")
+    raise ValueError("Fail!")
+
+
+@task
+def delete_cluster(name: str):
+    print(f"Deleting cluster {name}")
+```
+
+Create a task that will be executed if any of the tasks in the workflow fail.
+
+```{python}
+@task
+def clean_up(name: str):
+    print(f"Cleaning up cluster {name}")
+
+```
+
+Specify the `on_failure` to a cleanup task. This task will be executed if any of the tasks in the workflow fail.
+
+
+:::{note}
+The input of `clean_up` should be the exact same as the input of the workflow.
+:::
+
+```{python}
+@workflow(on_failure=clean_up)
+def subwf(name: str):
+    c = create_cluster(name=name)
+    t = t1(a=1, b="2")
+    d = delete_cluster(name=name)
+    c >> t >> d
+```
+
+By setting the failure policy to `FAIL_AFTER_EXECUTABLE_NODES_COMPLETE` to ensure that the `wf1` is executed even if the subworkflow fails. In this case, both parent and child workflows will fail, resulting in the `clean_up` task being executed twice.
+
+```{python}
+@workflow(on_failure=clean_up, failure_policy=WorkflowFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE)
+def wf1(name: str = "my_cluster"):
+    c = create_cluster(name=name)
+    subwf(name="another_cluster")
+    t = t1(a=1, b="2")
+    d = delete_cluster(name=name)
+    c >> t >> d
+
+
+@workflow
+def clean_up_wf(name: str):
+    return clean_up(name=name)
+```
+
+You can also set the `on_failure` to a workflow. This workflow will be executed if any of the tasks in the workflow fail.
+
+```{python}
+@workflow(on_failure=clean_up_wf)
+def wf2(name: str = "my_cluster"):
+    c = create_cluster(name=name)
+    t = t1(a=1, b="2")
+    d = delete_cluster(name=name)
+    c >> t >> d
+```

--- a/docs/user_guide/development_lifecycle/failure_node.md
+++ b/docs/user_guide/development_lifecycle/failure_node.md
@@ -11,7 +11,7 @@ For example, workflow involves creating a cluster at the beginning, followed by 
 
 A failure node can be incorporated into the workflow to address this issue. This ensures that critical actions, such as deleting the cluster, are executed even in the event of failures occurring throughout the workflow execution.
 
-```{python}
+```python
 from flytekit import WorkflowFailurePolicy, task, workflow
 
 
@@ -23,7 +23,7 @@ def create_cluster(name: str):
 
 Create a task that will fail during execution.
 
-```{python}
+```python
 @task
 def t1(a: int, b: str):
     print(f"{a} {b}")
@@ -37,7 +37,7 @@ def delete_cluster(name: str):
 
 Create a task that will be executed if any of the tasks in the workflow fail.
 
-```{python}
+```python
 @task
 def clean_up(name: str):
     print(f"Cleaning up cluster {name}")
@@ -51,7 +51,7 @@ Specify the `on_failure` to a cleanup task. This task will be executed if any of
 The input of `clean_up` should be the exact same as the input of the workflow.
 :::
 
-```{python}
+```python
 @workflow(on_failure=clean_up)
 def subwf(name: str):
     c = create_cluster(name=name)
@@ -62,7 +62,7 @@ def subwf(name: str):
 
 By setting the failure policy to `FAIL_AFTER_EXECUTABLE_NODES_COMPLETE` to ensure that the `wf1` is executed even if the subworkflow fails. In this case, both parent and child workflows will fail, resulting in the `clean_up` task being executed twice.
 
-```{python}
+```python
 @workflow(on_failure=clean_up, failure_policy=WorkflowFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE)
 def wf1(name: str = "my_cluster"):
     c = create_cluster(name=name)
@@ -79,7 +79,7 @@ def clean_up_wf(name: str):
 
 You can also set the `on_failure` to a workflow. This workflow will be executed if any of the tasks in the workflow fail.
 
-```{python}
+```python
 @workflow(on_failure=clean_up_wf)
 def wf2(name: str = "my_cluster"):
     c = create_cluster(name=name)

--- a/docs/user_guide/development_lifecycle/index.md
+++ b/docs/user_guide/development_lifecycle/index.md
@@ -1,19 +1,23 @@
-# Development Lifecycle
+# Development lifecycle
 
 In this section, you will discover Flyte's features that aid in local workflow development.
 You will gain an understanding of concepts like caching, the Flyte remote API, Agents, Decks and more.
 
-```{auto-examples-toc}
-agent_service
+```{toctree}
+:maxdepth: -1
+:name: development_lifecycle_toc
+:hidden:
+
+agents
 private_images
-task_cache
-task_cache_serialize
+caching
+cache_serializing
 decks
 failure_node
-register_project
-remote_task
-remote_workflow
-remote_launchplan
+creating_a_new_project
+running_tasks
+running_workflows
+running_launch_plans
 inspecting_executions
-debugging_workflows_tasks
+debugging_executions
 ```

--- a/docs/user_guide/development_lifecycle/index.md
+++ b/docs/user_guide/development_lifecycle/index.md
@@ -1,22 +1,19 @@
-# Development lifecycle
+# Development Lifecycle
 
 In this section, you will discover Flyte's features that aid in local workflow development.
 You will gain an understanding of concepts like caching, the Flyte remote API, Agents, Decks and more.
 
-```{toctree}
-:maxdepth: -1
-:name: development_lifecycle_toc
-:hidden:
-
-agents
+```{auto-examples-toc}
+agent_service
 private_images
-caching
-cache_serializing
+task_cache
+task_cache_serialize
 decks
-creating_a_new_project
-running_tasks
-running_workflows
-running_launch_plans
+failure_node
+register_project
+remote_task
+remote_workflow
+remote_launchplan
 inspecting_executions
-debugging_executions
+debugging_workflows_tasks
 ```


### PR DESCRIPTION

## Why are the changes needed?

Adds failure node example from https://github.com/flyteorg/flytesnacks/pull/1328 since user guide docs now live in this repo.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flytesnacks/pull/1328

## Docs link

TBD
