### PR TITLE
Correcting IsParent metadata in ArrayNode eventing

### DIFF
--- a/flyteadmin/pkg/repositories/transformers/node_execution.go
+++ b/flyteadmin/pkg/repositories/transformers/node_execution.go
@@ -284,7 +284,7 @@ func UpdateNodeExecutionModel(
 
 	// In the case of dynamic nodes reporting DYNAMIC_RUNNING, the IsParent and IsDynamic bits will be set for this event.
 	// Update the node execution metadata accordingly.
-	if request.Event.IsParent || request.Event.IsDynamic {
+	if request.Event.IsParent || request.Event.IsDynamic || request.Event.IsArray {
 		var nodeExecutionMetadata admin.NodeExecutionMetaData
 		if len(nodeExecutionModel.NodeExecutionMetadata) > 0 {
 			if err := proto.Unmarshal(nodeExecutionModel.NodeExecutionMetadata, &nodeExecutionMetadata); err != nil {

--- a/flytepropeller/pkg/controller/nodes/transformers.go
+++ b/flytepropeller/pkg/controller/nodes/transformers.go
@@ -178,8 +178,10 @@ func ToNodeExecutionEvent(nodeExecID *core.NodeExecutionIdentifier,
 	if node.GetKind() == v1alpha1.NodeKindWorkflow && node.GetWorkflowNode() != nil && node.GetWorkflowNode().GetSubWorkflowRef() != nil {
 		nev.IsParent = true
 	} else if node.GetKind() == v1alpha1.NodeKindArray {
-		nev.IsParent = true
 		nev.IsArray = true
+		if config.GetConfig().ArrayNodeEventVersion == 1 {
+			nev.IsParent = true
+		}
 	} else if dynamicNodePhase != v1alpha1.DynamicNodePhaseNone {
 		nev.IsDynamic = true
 		if nev.GetTaskNodeMetadata() != nil && nev.GetTaskNodeMetadata().DynamicWorkflow != nil {


### PR DESCRIPTION
## Tracking issue
_NA_

## Why are the changes needed?
If `IsParent` is set flyteconsole will continually attempt to retrieve child node executions. In the case of ArrayNode, child node executions are only populated with the eventing scheme == 1.

## What changes were proposed in this pull request?
Only setting `IsParent` on the node execution metadata if the array node event version is 1.

## How was this patch tested?
locally.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
_NA_

## Docs link
_NA_
