### PR TITLE
add mux option for application/json

### DIFF
--- a/flyteadmin/pkg/server/service.go
+++ b/flyteadmin/pkg/server/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"google.golang.org/protobuf/encoding/protojson"
 	"net"
 	"net/http"
 	"strings"
@@ -201,6 +202,11 @@ func newHTTPServer(ctx context.Context, pluginRegistry *plugins.Registry, cfg *c
 	var gwmuxOptions = make([]runtime.ServeMuxOption, 0)
 	// This option means that http requests are served with protobufs, instead of json. We always want this.
 	gwmuxOptions = append(gwmuxOptions, runtime.WithMarshalerOption("application/octet-stream", &runtime.ProtoMarshaller{}))
+	gwmuxOptions = append(gwmuxOptions, runtime.WithMarshalerOption("application/json", &runtime.JSONPb{
+		MarshalOptions: protojson.MarshalOptions{
+			UseProtoNames: true,
+		},
+	}))
 
 	// This option sets subject in the user info response
 	gwmuxOptions = append(gwmuxOptions, runtime.WithForwardResponseOption(auth.GetUserInfoForwardResponseHandler()))

--- a/flyteadmin/pkg/server/service.go
+++ b/flyteadmin/pkg/server/service.go
@@ -202,6 +202,12 @@ func newHTTPServer(ctx context.Context, pluginRegistry *plugins.Registry, cfg *c
 	var gwmuxOptions = make([]runtime.ServeMuxOption, 0)
 	// This option means that http requests are served with protobufs, instead of json. We always want this.
 	gwmuxOptions = append(gwmuxOptions, runtime.WithMarshalerOption("application/octet-stream", &runtime.ProtoMarshaller{}))
+	// grpc-gateway v2 switched the marshaller used to encode JSON messages in 2.5.0. This changed the
+	// default encoding from snake_case (the v1 behavior) to lowerCamelCase, which is the case recommended
+	// by protobuf. However the protobuf docs do mention that JSON printers may provide a way to use
+	// the proto names as field names instead. This option in grpc-gateway v2 does just that,
+	// by setting a custom marshaler. We are enabling this narrowly however, by applying it only for
+	// the application/json content type.
 	gwmuxOptions = append(gwmuxOptions, runtime.WithMarshalerOption("application/json", &runtime.JSONPb{
 		MarshalOptions: protojson.MarshalOptions{
 			UseProtoNames: true,

--- a/flyteadmin/pkg/server/service.go
+++ b/flyteadmin/pkg/server/service.go
@@ -205,6 +205,8 @@ func newHTTPServer(ctx context.Context, pluginRegistry *plugins.Registry, cfg *c
 	gwmuxOptions = append(gwmuxOptions, runtime.WithMarshalerOption("application/json", &runtime.JSONPb{
 		MarshalOptions: protojson.MarshalOptions{
 			UseProtoNames: true,
+			EmitUnpopulated: true,
+			EmitDefaultValues: true,
 		},
 	}))
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?

grpc-gateway v2 switched the marshaller used to encode JSON messages in 2.5.0. This changed the default encoding from using snake_case to the recommended by protobuf (i.e. use lowerCamelCase).

The protobuf [docs](https://protobuf.dev/programming-guides/proto3/#json-options) mention that JSON printers may provide a way to use the proto names as field names instead. This option is exposed in [grpc-gateway](https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/customizing_your_gateway/#using-proto-names-in-json) and it involves setting a custom marshaler. 

## What changes were proposed in this pull request?

This PR adds this custom marshaler to the `runtime.NewServeMux` call (see the [grpc gateway guide](https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/customizing_your_gateway/#using-proto-names-in-json)).  This marshaler, with this option, will return the name of the field in the .proto file.  (It does not rely on any of the tags in the generated go struct.)

This should be a fairly targeted change.  When looking at the network calls (using Chrome) made when you navigate to one of the flyte `/api/v1...` endpoints, the request accepts a number of headers, one of which is `*/*`.  It does _not_ appear that this accept header triggers the new servemux marshaler.  To trigger this marshaler, the `H 'Accept: application/json'` header must be passed.  The new marshaler will not be hit by the frontend since it by default uses `application/octet-stream` at least for the flyte components (though haytham says this is not the case for cloud idl services).

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
