### PR TITLE
Pin helmdocs to 1.12.0

### DIFF
--- a/script/generate_helm.sh
+++ b/script/generate_helm.sh
@@ -7,7 +7,7 @@ echo "Generating Helm"
 HELM_SKIP_INSTALL=${HELM_SKIP_INSTALL:-false}
 
 if [ "${HELM_SKIP_INSTALL}" != "true" ]; then
-    curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+	curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 fi
 
 helm version
@@ -15,7 +15,7 @@ helm version
 # All the values files to be built
 DEPLOYMENT_CORE=${1:-eks gcp}
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 HELM_CAPABILITIES="-a rbac.authorization.k8s.io/v1 -a networking.k8s.io/v1/Ingress -a apiextensions.k8s.io/v1/CustomResourceDefinition"
 
 helm dep update ${DIR}/../charts/flyte-deps/
@@ -24,49 +24,48 @@ helm dep update ${DIR}/../charts/flyte-binary/
 helm dep update ${DIR}/../charts/flyte-sandbox/
 helm dep update ${DIR}/../charts/flyte/
 
-helm template flyte -n flyte ${DIR}/../charts/flyte/ -f ${DIR}/../charts/flyte/values.yaml ${HELM_CAPABILITIES} --debug > ${DIR}/../deployment/sandbox/flyte_helm_generated.yaml
+helm template flyte -n flyte ${DIR}/../charts/flyte/ -f ${DIR}/../charts/flyte/values.yaml ${HELM_CAPABILITIES} --debug >${DIR}/../deployment/sandbox/flyte_helm_generated.yaml
 
 for deployment in ${DEPLOYMENT_CORE}; do
-    helm template flyte -n flyte ${DIR}/../charts/flyte-core/ -f ${DIR}/../charts/flyte-core/values.yaml -f ${DIR}/../charts/flyte-core/values-${deployment}.yaml ${HELM_CAPABILITIES} > ${DIR}/../deployment/${deployment}/flyte_helm_generated.yaml
-    helm template flyte -n flyte ${DIR}/../charts/flyte-core/ -f ${DIR}/../charts/flyte-core/values.yaml -f ${DIR}/../charts/flyte-core/values-${deployment}.yaml  -f ${DIR}/../charts/flyte-core/values-controlplane.yaml ${HELM_CAPABILITIES} > ${DIR}/../deployment/${deployment}/flyte_helm_controlplane_generated.yaml
-    helm template flyte -n flyte ${DIR}/../charts/flyte-core/ -f ${DIR}/../charts/flyte-core/values.yaml -f ${DIR}/../charts/flyte-core/values-${deployment}.yaml -f ${DIR}/../charts/flyte-core/values-dataplane.yaml ${HELM_CAPABILITIES} > ${DIR}/../deployment/${deployment}/flyte_helm_dataplane_generated.yaml
+	helm template flyte -n flyte ${DIR}/../charts/flyte-core/ -f ${DIR}/../charts/flyte-core/values.yaml -f ${DIR}/../charts/flyte-core/values-${deployment}.yaml ${HELM_CAPABILITIES} >${DIR}/../deployment/${deployment}/flyte_helm_generated.yaml
+	helm template flyte -n flyte ${DIR}/../charts/flyte-core/ -f ${DIR}/../charts/flyte-core/values.yaml -f ${DIR}/../charts/flyte-core/values-${deployment}.yaml -f ${DIR}/../charts/flyte-core/values-controlplane.yaml ${HELM_CAPABILITIES} >${DIR}/../deployment/${deployment}/flyte_helm_controlplane_generated.yaml
+	helm template flyte -n flyte ${DIR}/../charts/flyte-core/ -f ${DIR}/../charts/flyte-core/values.yaml -f ${DIR}/../charts/flyte-core/values-${deployment}.yaml -f ${DIR}/../charts/flyte-core/values-dataplane.yaml ${HELM_CAPABILITIES} >${DIR}/../deployment/${deployment}/flyte_helm_dataplane_generated.yaml
 done
 
 # Generate manifest AWS Scheduler
-helm template flyte -n flyte ${DIR}/../charts/flyte-core/ -f ${DIR}/../charts/flyte-core/values.yaml -f ${DIR}/../charts/flyte-core/values-eks.yaml -f ${DIR}/../charts/flyte-core/values-eks-override.yaml ${HELM_CAPABILITIES} --debug > ${DIR}/../deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+helm template flyte -n flyte ${DIR}/../charts/flyte-core/ -f ${DIR}/../charts/flyte-core/values.yaml -f ${DIR}/../charts/flyte-core/values-eks.yaml -f ${DIR}/../charts/flyte-core/values-eks-override.yaml ${HELM_CAPABILITIES} --debug >${DIR}/../deployment/eks/flyte_aws_scheduler_helm_generated.yaml
 
 # Generate manifest deps chart
-helm template flyte -n flyte ${DIR}/../charts/flyte-deps/ ${HELM_CAPABILITIES} --debug > ${DIR}/../deployment/sandbox/flyte_sandbox_deps_helm_generated.yaml
+helm template flyte -n flyte ${DIR}/../charts/flyte-deps/ ${HELM_CAPABILITIES} --debug >${DIR}/../deployment/sandbox/flyte_sandbox_deps_helm_generated.yaml
 
 # Generate manifest single binary chart
-helm template flyte -n flyte ${DIR}/../charts/flyte-binary/ ${HELM_CAPABILITIES} --debug > ${DIR}/../deployment/sandbox-binary/flyte_sandbox_binary_helm_generated.yaml
+helm template flyte -n flyte ${DIR}/../charts/flyte-binary/ ${HELM_CAPABILITIES} --debug >${DIR}/../deployment/sandbox-binary/flyte_sandbox_binary_helm_generated.yaml
 
 # Generate manifest flyte agent
-helm template flyte -n flyte ${DIR}/../charts/flyteagent/ ${HELM_CAPABILITIES} --debug > ${DIR}/../deployment/agent/flyte_agent_helm_generated.yaml
-
+helm template flyte -n flyte ${DIR}/../charts/flyteagent/ ${HELM_CAPABILITIES} --debug >${DIR}/../deployment/agent/flyte_agent_helm_generated.yaml
 
 echo "Generating helm docs"
-if  command -v helm-docs &> /dev/null
-then
-    rm $(which helm-docs)
+if command -v helm-docs &>/dev/null; then
+	rm $(which helm-docs)
 fi
 
-GO111MODULE=on go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+# TODO: (https://github.com/flyteorg/flyte/issues/4994) Unpin when moving past go 1.21
+GO111MODULE=on go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.12.0
 
 ${GOPATH:-~/go}/bin/helm-docs -c ${DIR}/../charts/
 
 # This section is used by GitHub workflow to ensure that the generation step was run
 if [ -n "$DELTA_CHECK" ]; then
-  DIRTY=$(git status --porcelain)
-  if [ -n "$DIRTY" ]; then
-    echo "FAILED: helm code updated without committing generated code."
-    echo "Ensure make helm has run and all changes are committed."
-    DIFF=$(git diff)
-    echo "diff detected: $DIFF"
-    DIFF=$(git diff --name-only)
-    echo "files different: $DIFF"
-    exit 1
-  else
-    echo "SUCCESS: Generated code is up to date."
-  fi
+	DIRTY=$(git status --porcelain)
+	if [ -n "$DIRTY" ]; then
+		echo "FAILED: helm code updated without committing generated code."
+		echo "Ensure make helm has run and all changes are committed."
+		DIFF=$(git diff)
+		echo "diff detected: $DIFF"
+		DIFF=$(git diff --name-only)
+		echo "files different: $DIFF"
+		exit 1
+	else
+		echo "SUCCESS: Generated code is up to date."
+	fi
 fi


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4950

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?
`make helm` expects to run on go 1.21, but `github.com/norwoodj/helm-docs/cmd/helm-docs` recently published a new version where they use go 1.22.

## What changes were proposed in this pull request?
Pin github.com/norwoodj/helm-docs/cmd/helm-docs to 1.12.0.

## How was this patch tested?
Made a change to `flyte-binary` chart and successfully ran `make helm`.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
