### PR TITLE
add google site verification meta tag

### DIFF
--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -98,6 +98,7 @@
         }
       });
     </script>
+    <meta name="google-site-verification" content="bg8Zfs2n77qUXD_sAvcd7a1zc2N_SyDsYZvFHdJfS6A" />
   </head>
   <body>
     {% block body %}


### PR DESCRIPTION
## Why are the changes needed?

Adds a meta tag to verify site ownership so I can ask Google to [recrawl](https://developers.google.com/search/docs/crawling-indexing/ask-google-to-recrawl) docs.flyte.org and reindex updated docs URLs. (Currently searching for basic stuff, like "flyte task", returns docs at extremely outdated URLs that will break once we fully switch to the monodocs build.)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

