### PR TITLE
Fix ephemeral storage validation in the case of pod templates

### DIFF
--- a/flyteadmin/pkg/manager/impl/validation/task_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/task_validator.go
@@ -166,7 +166,12 @@ func isWholeNumber(quantity resource.Quantity) bool {
 func resourceListToQuantity(resources corev1.ResourceList) map[core.Resources_ResourceName]resource.Quantity {
 	var requestedToQuantity = make(map[core.Resources_ResourceName]resource.Quantity)
 	for name, quantity := range resources {
-		resourceName := core.Resources_ResourceName(core.Resources_ResourceName_value[strings.ToUpper(name.String())])
+		var resourceName = core.Resources_UNKNOWN
+		if name == "ephemeral-storage" {
+			resourceName = core.Resources_ResourceName(core.Resources_ResourceName_value["EPHEMERAL_STORAGE"])
+		} else {
+			resourceName = core.Resources_ResourceName(core.Resources_ResourceName_value[strings.ToUpper(name.String())])
+		}
 		requestedToQuantity[resourceName] = quantity
 	}
 	return requestedToQuantity

--- a/flyteadmin/pkg/manager/impl/validation/task_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/task_validator.go
@@ -169,8 +169,8 @@ func resourceListToQuantity(resources corev1.ResourceList) map[core.Resources_Re
 		// The name to refer to ephemeral storage defined in k8s (https://github.com/kubernetes/api/blob/05aa4bceed70af2652698a28fb144ee22b2dd2ba/core/v1/types.go#L5988)
 		// is different from the name defined in Flyte's proto (https://github.com/flyteorg/flyte/blob/fd42f65660069d9c164cda2de579d3a89cac5b0f/flyteidl/protos/flyteidl/core/tasks.proto#L25).
 		// This is a workaround to handle the conversion.
-		if name == "ephemeral-storage" {
-			name = "EPHEMERAL_STORAGE"
+		if name == corev1.ResourceEphemeralStorage {
+			name = corev1.ResourceName(core.Resources_EPHEMERAL_STORAGE.String())
 		}
 		resourceName := core.Resources_ResourceName(core.Resources_ResourceName_value[strings.ToUpper(name.String())])
 		requestedToQuantity[resourceName] = quantity

--- a/flyteadmin/pkg/manager/impl/validation/task_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/task_validator.go
@@ -166,12 +166,13 @@ func isWholeNumber(quantity resource.Quantity) bool {
 func resourceListToQuantity(resources corev1.ResourceList) map[core.Resources_ResourceName]resource.Quantity {
 	var requestedToQuantity = make(map[core.Resources_ResourceName]resource.Quantity)
 	for name, quantity := range resources {
-		var resourceName = core.Resources_UNKNOWN
+		// The name to refer to ephemeral storage defined in k8s (https://github.com/kubernetes/api/blob/05aa4bceed70af2652698a28fb144ee22b2dd2ba/core/v1/types.go#L5988)
+		// is different from the name defined in Flyte's proto (https://github.com/flyteorg/flyte/blob/fd42f65660069d9c164cda2de579d3a89cac5b0f/flyteidl/protos/flyteidl/core/tasks.proto#L25).
+		// This is a workaround to handle the conversion.
 		if name == "ephemeral-storage" {
-			resourceName = core.Resources_ResourceName(core.Resources_ResourceName_value["EPHEMERAL_STORAGE"])
-		} else {
-			resourceName = core.Resources_ResourceName(core.Resources_ResourceName_value[strings.ToUpper(name.String())])
+			name = "EPHEMERAL_STORAGE"
 		}
+		resourceName := core.Resources_ResourceName(core.Resources_ResourceName_value[strings.ToUpper(name.String())])
 		requestedToQuantity[resourceName] = quantity
 	}
 	return requestedToQuantity

--- a/flyteadmin/pkg/manager/impl/validation/task_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/task_validator_test.go
@@ -278,6 +278,11 @@ func TestResourceListToQuantity(t *testing.T) {
 	gpuQuantity := gpuResources[core.Resources_CPU]
 	val = gpuQuantity.Value()
 	assert.Equal(t, val, int64(2))
+
+	ephemeralStorageResources := resourceListToQuantity(corev1.ResourceList{corev1.ResourceEphemeralStorage: resource.MustParse("500Mi")})
+	ephemeralStorageQuantity := ephemeralStorageResources[core.Resources_EPHEMERAL_STORAGE]
+	val = ephemeralStorageQuantity.Value()
+	assert.Equal(t, val, int64(524288000))
 }
 
 func TestRequestedResourcesToQuantity(t *testing.T) {


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4965

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?
We have a slight mismatch between the constants used to refer to ephemeral storage between the k8s pod spec and Flyte's resource object. This is especially important during task resource validation, since in the case of pod templates the pod spec is provided as is, whereas in the case of regular tasks the flytekit sdk ensures that the correct value is used. 

## What changes were proposed in this pull request?
Special case the value "ephemeral-storage" during task resource validation only in the case of pod templates.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Unit tests and also ran on sandbox locally.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
