### PR TITLE
Fix: Sanitize user identity before injecting into task pod as K8s label

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/k8s/task_exec_context.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/task_exec_context.go
@@ -61,8 +61,8 @@ func newTaskExecutionMetadata(tCtx pluginsCore.TaskExecutionMetadata, taskTmpl *
 
 	id := tCtx.GetSecurityContext().RunAs.ExecutionIdentity
 	if len(id) > 0 {
-		sanitizedId := k8sUtils.SanitizeLabelValue(id)
-		injectLabels[executionIdentityVariable] = sanitizedId
+		sanitizedID := k8sUtils.SanitizeLabelValue(id)
+		injectLabels[executionIdentityVariable] = sanitizedID
 	}
 
 	return TaskExecutionMetadata{

--- a/flytepropeller/pkg/controller/nodes/task/k8s/task_exec_context.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/task_exec_context.go
@@ -5,6 +5,7 @@ import (
 	pluginsCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils/secrets"
+	k8sUtils "github.com/flyteorg/flyte/flytepropeller/pkg/utils"
 )
 
 const executionIdentityVariable = "execution-identity"
@@ -60,7 +61,8 @@ func newTaskExecutionMetadata(tCtx pluginsCore.TaskExecutionMetadata, taskTmpl *
 
 	id := tCtx.GetSecurityContext().RunAs.ExecutionIdentity
 	if len(id) > 0 {
-		injectLabels[executionIdentityVariable] = id
+		sanitizedId := k8sUtils.SanitizeLabelValue(id)
+		injectLabels[executionIdentityVariable] = sanitizedId
 	}
 
 	return TaskExecutionMetadata{


### PR DESCRIPTION
## Why are the changes needed?

@ByronHsu recently implemented middleware to inject the user identity into the flyte workflow's ExecutionSpec: https://github.com/flyteorg/flyteadmin/pull/549 and in https://github.com/flyteorg/flyte/pull/4637 I injected the user identity into task pods as a label.

For IdPs like Okta, the execution identity is an email address which is not a valid Kubernetes label, causing the creation of the pod to fail.

## What changes were proposed in this pull request?

In this PR I add sanitation to the execution identity before injecting it as a label.

## How was this patch tested?

* Ran flytepropeller with this change and ensured that pods can be created when the execution identity is an email address
* Added a unit test that would have caught this

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

