### PR TITLE
CI workflow for helm charts and manifests

### DIFF
--- a/.github/workflows/validate-helm-charts.yaml
+++ b/.github/workflows/validate-helm-charts.yaml
@@ -36,6 +36,10 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Run chart-testing (lint)
+        if: steps.charts-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+
       - name: Create KinD cluster
         if: steps.charts-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1

--- a/.github/workflows/validate-helm-charts.yaml
+++ b/.github/workflows/validate-helm-charts.yaml
@@ -56,7 +56,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        k8s_versions: [ "1.29.2", "v1.28.7", "v1.27.11" ]
+        k8s_versions: [ "1.29.2", "1.28.7", "1.27.11" ]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/validate-helm-charts.yaml
+++ b/.github/workflows/validate-helm-charts.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint-and-test-charts:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -50,13 +50,13 @@ jobs:
   validate-manifests:
     needs:
       - lint-and-test-charts
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
     strategy:
       matrix:
-        k8s_versions: [ "1.29.2", "v1.28.7", "v1.27.11", "v1.26.14" ]
+        k8s_versions: [ "1.29.2", "v1.28.7", "v1.27.11" ]
 
     steps:
       - name: Checkout code
@@ -77,6 +77,5 @@ jobs:
           sudo mv kubeconform /usr/local/bin/kubeconform
 
       - name: Validate manifests
-        working-directory: deployment
         run: |
-          kubeconform -strict -summary -skip CustomResourceDefinition -kubernetes-version ${{ matrix.k8s_versions }} ./deployment ./manifests
+          kubeconform -strict -summary -skip CustomResourceDefinition -kubernetes-version ${{ matrix.k8s_versions }} ./deployment ./docker/sandbox-bundled/manifests

--- a/.github/workflows/validate-helm-charts.yaml
+++ b/.github/workflows/validate-helm-charts.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - deployment
+      - docker/sandbox-bundled/manifests
 
 jobs:
   lint-and-test-charts:

--- a/.github/workflows/validate-helm-charts.yaml
+++ b/.github/workflows/validate-helm-charts.yaml
@@ -78,4 +78,4 @@ jobs:
 
       - name: Validate manifests
         run: |
-          kubeconform -strict -summary -skip CustomResourceDefinition -kubernetes-version ${{ matrix.k8s_versions }} ./deployment ./docker/sandbox-bundled/manifests
+          kubeconform -strict -summary -skip CustomResourceDefinition -ignore-filename-pattern "deployment/stats/prometheus/*" -kubernetes-version ${{ matrix.k8s_versions }} ./deployment ./docker/sandbox-bundled/manifests

--- a/.github/workflows/validate-helm-charts.yaml
+++ b/.github/workflows/validate-helm-charts.yaml
@@ -2,7 +2,6 @@ name: Validate helm charts & manifests
 
 on:
   pull_request:
-  push:
     branches:
       - master
 

--- a/.github/workflows/validate-helm-charts.yaml
+++ b/.github/workflows/validate-helm-charts.yaml
@@ -1,0 +1,79 @@
+name: Validate helm charts & manifests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  lint-and-test-charts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          sparse-checkout: charts
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2
+
+      - name: Detect charts changed (list-changed)
+        id: charts-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create KinD cluster
+        if: steps.charts-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1
+
+      - name: Run chart-testing (install)
+        if: steps.charts-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+
+  validate-manifests:
+    needs:
+      - lint-and-test-charts
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        k8s_versions: [ "1.29.2", "v1.28.7", "v1.27.11", "v1.26.14" ]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            deployment
+            docker/sandbox-bundled/manifests
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install kubeconform
+        run: |
+          curl -L -o kubeconform.tar.gz https://github.com/yannh/kubeconform/releases/download/v0.6.4/kubeconform-linux-amd64.tar.gz
+          tar -zvxf kubeconform.tar.gz
+          chmod +x kubeconform
+          sudo mv kubeconform /usr/local/bin/kubeconform
+
+      - name: Validate manifests
+        working-directory: deployment
+        run: |
+          kubeconform -strict -summary -skip CustomResourceDefinition -kubernetes-version ${{ matrix.k8s_versions }} ./deployment ./manifests

--- a/.github/workflows/validate-helm-charts.yaml
+++ b/.github/workflows/validate-helm-charts.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint-and-test-charts:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
   validate-manifests:
     needs:
       - lint-and-test-charts
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Tracking issue
Closes #4973 

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?
We should be serious about changes to helm charts and manifests, The current CI doesn't ensure manifests are valid against to the schema for Kubernetes.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
1. Create a new gha workflow to test helm charts if them are changed, and validate generated manifests.
2. We can specify k8s versions that we want to ensure manifests are still valid for that k8s version. (avoiding some apiVersion of resource is deprecated but we don't notice that)

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
1. Install [nektos/act](https://github.com/nektos/act) to test actions locally
2. Create an json file called `event.json`, and copy & paste the following code into event.json
```json
{
  "repository": {
    "default_branch": "master"
  }
}
```
3. Run `act pull_request -W .github/workflows/validate-helm-charts.yaml --container-architecture linux/amd64 -e <path to event.json file>`

4. The workflow will start. You can change any charts to trigger steps after `Detect charts changed (list-changed)` in lint-and-test-charts job.

5. As for validate-manifests job, it will use `kubeconform` for validate manifests under deployments and docker/sandbox-bundled/manifests.

### Screenshots
<img width="1129" alt="截圖 2024-03-09 晚上8 20 21" src="https://github.com/flyteorg/flyte/assets/52355146/d173699b-256e-4ad2-a2fc-30e356636503">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
