### PR TITLE
Flyte-core remove unnecessary ingress capability checks

### DIFF
--- a/charts/flyte-core/templates/common/ingress.yaml
+++ b/charts/flyte-core/templates/common/ingress.yaml
@@ -7,154 +7,90 @@
 - path: /flyteidl.service.SignalService
   pathType: ImplementationSpecific
   backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     service:
       name: flyteadmin
       port:
         number: {{ $grpcPort }}
-{{- else }}
-    serviceName: flyteadmin
-    servicePort: {{ $grpcPort }}
-{{- end }}
 - path: /flyteidl.service.SignalService/*
   pathType: ImplementationSpecific
   backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     service:
       name: flyteadmin
       port:
         number: {{ $grpcPort }}
-{{- else }}
-    serviceName: flyteadmin
-    servicePort: {{ $grpcPort }}
-{{- end }}
 - path: /flyteidl.service.AdminService
   pathType: ImplementationSpecific
   backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     service:
       name: flyteadmin
       port:
         number: {{ $grpcPort }}
-{{- else }}
-    serviceName: flyteadmin
-    servicePort: {{ $grpcPort }}
-{{- end }}
 - path: /flyteidl.service.AdminService/*
   pathType: ImplementationSpecific
   backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     service:
       name: flyteadmin
       port:
         number: {{ $grpcPort }}
-{{- else }}
-    serviceName: flyteadmin
-    servicePort: {{ $grpcPort }}
-{{- end }}
 - path: /flyteidl.service.DataProxyService
   pathType: ImplementationSpecific
   backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     service:
       name: flyteadmin
       port:
         number: {{ $grpcPort }}
-{{- else }}
-    serviceName: flyteadmin
-    servicePort: {{ $grpcPort }}
-{{- end }}
 - path: /flyteidl.service.DataProxyService/*
   pathType: ImplementationSpecific
   backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     service:
       name: flyteadmin
       port:
         number: {{ $grpcPort }}
-{{- else }}
-    serviceName: flyteadmin
-    servicePort: {{ $grpcPort }}
-{{- end }}
 - path: /flyteidl.service.AuthMetadataService
   pathType: ImplementationSpecific
   backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     service:
       name: flyteadmin
       port:
         number: {{ $grpcPort }}
-{{- else }}
-    serviceName: flyteadmin
-    servicePort: {{ $grpcPort }}
-{{- end }}
 - path: /flyteidl.service.AuthMetadataService/*
   pathType: ImplementationSpecific
   backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     service:
       name: flyteadmin
       port:
         number: {{ $grpcPort }}
-{{- else }}
-    serviceName: flyteadmin
-    servicePort: {{ $grpcPort }}
-{{- end }}
 - path: /flyteidl.service.IdentityService
   pathType: ImplementationSpecific
   backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     service:
       name: flyteadmin
       port:
         number: {{ $grpcPort }}
-{{- else }}
-    serviceName: flyteadmin
-    servicePort: {{ $grpcPort }}
-{{- end }}
 - path: /flyteidl.service.IdentityService/*
   pathType: ImplementationSpecific
   backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     service:
       name: flyteadmin
       port:
         number: {{ $grpcPort }}
-{{- else }}
-    serviceName: flyteadmin
-    servicePort: {{ $grpcPort }}
-{{- end }}
 - path: /grpc.health.v1.Health
   pathType: ImplementationSpecific
   backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     service:
       name: flyteadmin
       port:
         number: {{ $grpcPort }}
-{{- else }}
-    serviceName: flyteadmin
-    servicePort: {{ $grpcPort }}
-{{- end }}
 - path: /grpc.health.v1.Health/*
   pathType: ImplementationSpecific
   backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     service:
       name: flyteadmin
       port:
         number: {{ $grpcPort }}
-{{- else }}
-    serviceName: flyteadmin
-    servicePort: {{ $grpcPort }}
-{{- end }}
   {{- end }}
   {{- if .Values.common.ingress.enabled }}
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "flyte.name" . }}
@@ -171,288 +107,173 @@ spec:
           - path: /*
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: ssl-redirect
                 port:
                   name: use-annotation
-{{- else }}
-              serviceName: ssl-redirect
-              servicePort: use-annotation
-{{- end }}
           {{- end }}
           # This is useful only for frontend development
           {{- if .Values.common.ingress.webpackHMR }}
           - path: /__webpack_hmr
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteconsole
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteconsole
-              servicePort: 80
-{{- end }}
           {{- end }}
           # NOTE: If you change this, you must update the BASE_URL value in flyteconsole.yaml
           - path: /console
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteconsole
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteconsole
-              servicePort: 80
-{{- end }}
           - path: /console/*
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteconsole
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteconsole
-              servicePort: 80
-{{- end }}
           - path: /api
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /api/*
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /healthcheck
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /v1/*
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
 {{- if .Values.deployRedoc }}
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: redoc
                 port:
                   number: 87
-{{- else }}
-              serviceName: redoc
-              servicePort: 87
-{{- end }}
           # Port 87 in FlyteAdmin maps to the redoc container.
           - path: /openapi/*
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: redoc
                 port:
                   number: 87
-{{- else }}
-              serviceName: redoc
-              servicePort: 87
-{{- end }}
 {{- end }}
           - path: /.well-known
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /.well-known/*
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /login
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /login/*
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /logout
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /logout/*
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /callback
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /callback/*
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /me
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /config
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /config/*
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /oauth2
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           - path: /oauth2/*
             pathType: ImplementationSpecific
             backend:
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: flyteadmin
                 port:
                   number: 80
-{{- else }}
-              serviceName: flyteadmin
-              servicePort: 80
-{{- end }}
           {{- if not .Values.common.ingress.separateGrpcIngress }}
           {{- include "grpcRoutes" . | nindent 10 -}}
           {{- end }}
@@ -469,11 +290,7 @@ spec:
 # Certain ingress controllers like nginx cannot serve HTTP 1 and GRPC with a single ingress because GRPC can only
 # enabled on the ingress object, not on backend services (GRPC annotation is set on the ingress, not on the services).
 ---
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "flyte.name" . }}-grpc


### PR DESCRIPTION
## Tracking issue
_https://github.com/flyteorg/flyte/issues/<number>_

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?

 - Kubernetes 1.19 was released in August 2020 and it moved ingress out of beta

 - Kubernetes 1.22 removed the beta ingress type in August 2021 and went out of support in October 2022

 - As of March 2024, only Kubernetes 1.26 and later are supported

 - Therefore, there's no reason to make this check!
 - 
## What changes were proposed in this pull request?

Simplify ingress code

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
