### PR TITLE
docs(sandbox): Add guide for running newest flyteconsole in flyte sandbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,3 +117,7 @@ go-tidy:
 lint-helm-charts:
 	# This pressuposes that you have act installed
 	act pull_request -W .github/workflows/validate-helm-charts.yaml --container-architecture linux/amd64 -e charts/event.json
+
+.PHONY: clean
+clean: ## Remove the HTML files related to the Flyteconsole.
+	rm -rf cmd/single/dist

--- a/docs/community/contribute.rst
+++ b/docs/community/contribute.rst
@@ -396,6 +396,7 @@ that integrates all Flyte components into a single binary.
    # Step2: Build a single binary that bundles all the Flyte components.
    # The version of each component/library used to build the single binary are defined in `go.mod`.
    sudo apt-get -y install jq # You may need to install jq
+   make clean # (Optional) Run this only if you want to run the newest version of flyteconsole
    go mod tidy
    make compile
 


### PR DESCRIPTION
## Why are the changes needed?
Clarify instructions and add make target to rebuild single-binary flyte console dependency. There is currently no guide about how to run the  newest flyteconsole in flyte demo sandbox.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

Update the docs and add a new Makefile target `clean`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
