### PR TITLE
Update repeated value filters with ValueNotIn support

### DIFF
--- a/docs/concepts/admin.rst
+++ b/docs/concepts/admin.rst
@@ -260,14 +260,15 @@ The fully supported set of filter functions are
 
 - contains  
 - gt (greater than) 
-- gte (greter than or equal to) 
+- gte (greater than or equal to)
 - lt (less than)  
 - lte (less than or equal to) 
 - eq (equal)  
 - ne (not equal)  
-- value_in (for repeated sets of values)  
+- value_in (value in repeated sets of values)
+- value_not_in (value not in repeated sets of values)
 
-"value_in" is a special case where multiple values are passed to the filter expression. For example:: 
+"value_in" and "value_not_in" are special cases where multiple values are passed to the filter expression. For example::
 
  value_in(phase, RUNNING;SUCCEEDED;FAILED)  
 

--- a/flyteadmin/pkg/common/filters.go
+++ b/flyteadmin/pkg/common/filters.go
@@ -29,6 +29,7 @@ const (
 	Equal
 	NotEqual
 	ValueIn
+	ValueNotIn
 )
 
 // String formats for various filter expression queries
@@ -43,6 +44,7 @@ const (
 	equalQuery              = "%s = ?"
 	notEqualQuery           = "%s <> ?"
 	valueInQuery            = "%s in (?)"
+	valueNotInQuery         = "%s not in (?)"
 )
 
 // Set of available filters which exclusively accept a single argument value.
@@ -58,7 +60,8 @@ var singleValueFilters = map[FilterExpression]bool{
 
 // Set of available filters which exclusively accept repeated argument values.
 var repeatedValueFilters = map[FilterExpression]bool{
-	ValueIn: true,
+	ValueIn:    true,
+	ValueNotIn: true,
 }
 
 const EqualExpression = "eq"
@@ -72,6 +75,19 @@ var filterNameMappings = map[string]FilterExpression{
 	EqualExpression: Equal,
 	"ne":            NotEqual,
 	"value_in":      ValueIn,
+	"value_not_in":  ValueNotIn,
+}
+
+var filterQueryMappings = map[FilterExpression]string{
+	Contains:           containsQuery,
+	GreaterThan:        greaterThanQuery,
+	GreaterThanOrEqual: greaterThanOrEqualQuery,
+	LessThan:           lessThanQuery,
+	LessThanOrEqual:    lessThanOrEqualQuery,
+	Equal:              equalQuery,
+	NotEqual:           notEqualQuery,
+	ValueIn:            valueInQuery,
+	ValueNotIn:         valueNotInQuery,
 }
 
 var executionIdentifierFields = map[string]bool{
@@ -108,6 +124,8 @@ func getFilterExpressionName(expression FilterExpression) string {
 		return "not equal"
 	case ValueIn:
 		return "value in"
+	case ValueNotIn:
+		return "value not in"
 	default:
 		return ""
 	}
@@ -166,9 +184,9 @@ func (f *inlineFilterImpl) GetField() string {
 
 func (f *inlineFilterImpl) getGormQueryExpr(formattedField string) (GormQueryExpr, error) {
 
-	// ValueIn is special because it uses repeating values.
-	if f.function == ValueIn {
-		queryStr := fmt.Sprintf(valueInQuery, formattedField)
+	// Filters that use repeated values
+	if _, ok := repeatedValueFilters[f.function]; ok {
+		queryStr := fmt.Sprintf(filterQueryMappings[f.function], formattedField)
 		return GormQueryExpr{
 			Query: queryStr,
 			Args:  f.repeatedValue,

--- a/flyteadmin/pkg/common/filters_test.go
+++ b/flyteadmin/pkg/common/filters_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,6 +84,14 @@ func TestNewRepeatedValueFilter(t *testing.T) {
 	assert.Equal(t, "projects.project in (?)", expression.Query)
 	assert.Equal(t, vals, expression.Args)
 
+	filter, err = NewRepeatedValueFilter(Workflow, ValueNotIn, "project", vals)
+	assert.NoError(t, err)
+
+	expression, err = filter.GetGormJoinTableQueryExpr("projects")
+	assert.NoError(t, err)
+	assert.Equal(t, "projects.project not in (?)", expression.Query)
+	assert.Equal(t, vals, expression.Args)
+
 	_, err = NewRepeatedValueFilter(Workflow, Equal, "domain", []string{"production", "qa"})
 	assert.EqualError(t, err, "invalid repeated value filter expression: equal")
 }
@@ -96,16 +105,6 @@ func TestGetGormJoinTableQueryExpr(t *testing.T) {
 	assert.Equal(t, "workflows.domain = ?", gormQueryExpr.Query)
 }
 
-var expectedQueriesForFilters = map[FilterExpression]string{
-	Contains:           "field LIKE ?",
-	GreaterThan:        "field > ?",
-	GreaterThanOrEqual: "field >= ?",
-	LessThan:           "field < ?",
-	LessThanOrEqual:    "field <= ?",
-	Equal:              "field = ?",
-	NotEqual:           "field <> ?",
-}
-
 var expectedArgsForFilters = map[FilterExpression]string{
 	Contains:           "%value%",
 	GreaterThan:        "value",
@@ -117,12 +116,13 @@ var expectedArgsForFilters = map[FilterExpression]string{
 }
 
 func TestQueryExpressions(t *testing.T) {
-	for expression, expectedQuery := range expectedQueriesForFilters {
+	for expression, _ := range singleValueFilters {
 		filter, err := NewSingleValueFilter(Workflow, expression, "field", "value")
 		assert.NoError(t, err)
 
 		gormQueryExpr, err := filter.GetGormQueryExpr()
 		assert.NoError(t, err)
+		expectedQuery := fmt.Sprintf(filterQueryMappings[expression], "field")
 		assert.Equal(t, expectedQuery, gormQueryExpr.Query)
 
 		expectedArg, ok := expectedArgsForFilters[expression]
@@ -130,14 +130,17 @@ func TestQueryExpressions(t *testing.T) {
 		assert.Equal(t, expectedArg, gormQueryExpr.Args)
 	}
 
-	// Also test the one repeated value filter
-	filter, err := NewRepeatedValueFilter(Workflow, ValueIn, "field", []string{"value"})
-	assert.NoError(t, err)
+	// Also test the repeated value filters
+	for expression, _ := range repeatedValueFilters {
+		filter, err := NewRepeatedValueFilter(Workflow, expression, "field", []string{"value"})
+		assert.NoError(t, err)
 
-	gormQueryExpr, err := filter.GetGormQueryExpr()
-	assert.NoError(t, err)
-	assert.Equal(t, "field in (?)", gormQueryExpr.Query)
-	assert.EqualValues(t, []string{"value"}, gormQueryExpr.Args)
+		gormQueryExpr, err := filter.GetGormQueryExpr()
+		assert.NoError(t, err)
+		expectedQuery := fmt.Sprintf(filterQueryMappings[expression], "field")
+		assert.Equal(t, expectedQuery, gormQueryExpr.Query)
+		assert.EqualValues(t, []string{"value"}, gormQueryExpr.Args)
+	}
 }
 
 func TestMapFilter(t *testing.T) {

--- a/flyteadmin/pkg/common/filters_test.go
+++ b/flyteadmin/pkg/common/filters_test.go
@@ -116,7 +116,7 @@ var expectedArgsForFilters = map[FilterExpression]string{
 }
 
 func TestQueryExpressions(t *testing.T) {
-	for expression, _ := range singleValueFilters {
+	for expression := range singleValueFilters {
 		filter, err := NewSingleValueFilter(Workflow, expression, "field", "value")
 		assert.NoError(t, err)
 
@@ -131,7 +131,7 @@ func TestQueryExpressions(t *testing.T) {
 	}
 
 	// Also test the repeated value filters
-	for expression, _ := range repeatedValueFilters {
+	for expression := range repeatedValueFilters {
 		filter, err := NewRepeatedValueFilter(Workflow, expression, "field", []string{"value"})
 		assert.NoError(t, err)
 


### PR DESCRIPTION
## Why are the changes needed?
We currently don't support value_not_in filter.

## What changes were proposed in this pull request?
Add value_not_in filter support.

## How was this patch tested?
- [X]  unit tests
- [X] end-to-end works

## Screenshots

<img width="948" alt="Screenshot 2024-03-26 at 9 33 01 AM" src="https://github.com/flyteorg/flyte/assets/114708546/c03dd579-0953-4779-a67b-50ac2060eb56">

<img width="1058" alt="Screenshot 2024-03-26 at 10 13 44 AM" src="https://github.com/flyteorg/flyte/assets/114708546/6d220293-82a7-4a7d-974f-1fd36945e7dd">
