### PR TITLE
Fix broken link in "Mapping Python to Flyte types" table

### DIFF
--- a/docs/user_guide/data_types_and_io/index.md
+++ b/docs/user_guide/data_types_and_io/index.md
@@ -133,7 +133,7 @@ Here's a breakdown of these mappings:
       - Any
       - Custom transformers
       - The ``FlytePickle`` transformer is the default option, but you can also define custom transformers.
-        **For instructions on building custom type transformers, please refer to :ref:`this section <advanced_custom_types>`**.
+        For instructions on building custom type transformers, please refer to :ref:`this section <advanced_custom_types>`.
 ```
 
 ```{toctree}


### PR DESCRIPTION
## Why are the changes needed?

Fixes broken link in this table: https://docs.flyte.org/en/latest/user_guide/data_types_and_io/index.html#mapping-python-to-flyte-types

## What changes were proposed in this pull request?

Remove bold styling to fix link.

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Docs link

TK
