### PR TITLE
Add allowedAudience to flyte-core external auth deployment documentation

### DIFF
--- a/docs/deployment/configuration/auth_setup.rst
+++ b/docs/deployment/configuration/auth_setup.rst
@@ -565,7 +565,7 @@ Follow the steps in this section to configure `flyteadmin` to use an external au
                # 2. Optional: Set external auth server baseUrl if different from OpenId baseUrl.
                externalAuthServer:
                # Replace this with your deployment URL.  It will be used by flyteadmin to validate the token audience
-                 allowedAudience: [https://<your-flyte-deployment-URL>]
+                 allowedAudience: https://<your-flyte-deployment-URL>
                # baseUrl: https://<keycloak-url>/auth/realms/<keycloak-realm> # Uncomment for Keycloak and update with your installation host and realm name
                # baseUrl: https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize # Uncomment for Azure AD
                # For Okta, use the Issuer URI of the custom auth server:  

--- a/docs/deployment/configuration/auth_setup.rst
+++ b/docs/deployment/configuration/auth_setup.rst
@@ -564,6 +564,8 @@ Follow the steps in this section to configure `flyteadmin` to use an external au
 
                # 2. Optional: Set external auth server baseUrl if different from OpenId baseUrl.
                externalAuthServer:
+               # Replace this with your deployment URL.  It will be used by flyteadmin to validate the token audience
+                 allowedAudience: [https://<your-flyte-deployment-URL>]
                # baseUrl: https://<keycloak-url>/auth/realms/<keycloak-realm> # Uncomment for Keycloak and update with your installation host and realm name
                # baseUrl: https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize # Uncomment for Azure AD
                # For Okta, use the Issuer URI of the custom auth server:  


### PR DESCRIPTION
## Why are the changes needed?

This adds documentation to the auth config for flyte-core deployments with Okta.  In the case where flyteadmin is running in the same cluster as flytepropeller/flytescheduler, the authentication request from flytescheduler to flyteadmin is made using `http://flyteadmin:80`.  flyteadmin uses the domain in the request to validate the audience in the JWT returned by okta ([code reference](https://github.com/flyteorg/flyte/blob/cf7c638497224aa60912967df529182b4c41b5d5/flyteadmin/auth/handler_utils.go#L114)).   This causes a mismatch between the JWT audience and the expectedAudience when the auth request originates from flytescheduler within the same cluster.  The `allowedAudience` setting takes precedence over the URL extracted from the request, so setting this property in the values file fixes the issue.

## What changes were proposed in this pull request?
This is only a documentation change

## How was this patch tested?
Tested with the latest helm chart


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.


## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
