### PR TITLE
Fix execution phase

### DIFF
--- a/flyteadmin/pkg/manager/impl/execution_manager.go
+++ b/flyteadmin/pkg/manager/impl/execution_manager.go
@@ -617,7 +617,6 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 		TaskID:              taskModel.ID,
 		WorkflowID:          workflowModel.ID,
 		// The execution is not considered running until the propeller sends a specific event saying so.
-		Phase:                 core.WorkflowExecution_UNDEFINED,
 		CreatedAt:             m._clock.Now(),
 		Notifications:         notificationsSettings,
 		WorkflowIdentifier:    workflow.Id,
@@ -1006,7 +1005,6 @@ func (m *ExecutionManager) launchExecutionAndPrepareModel(
 		LaunchPlanID:        launchPlanModel.ID,
 		WorkflowID:          launchPlanModel.WorkflowID,
 		// The execution is not considered running until the propeller sends a specific event saying so.
-		Phase:                 core.WorkflowExecution_UNDEFINED,
 		CreatedAt:             m._clock.Now(),
 		Notifications:         notificationsSettings,
 		WorkflowIdentifier:    workflow.Id,

--- a/flyteadmin/pkg/repositories/transformers/execution.go
+++ b/flyteadmin/pkg/repositories/transformers/execution.go
@@ -34,7 +34,6 @@ type CreateExecutionModelInput struct {
 	LaunchPlanID          uint
 	WorkflowID            uint
 	TaskID                uint
-	Phase                 core.WorkflowExecution_Phase
 	CreatedAt             time.Time
 	Notifications         []*admin.Notification
 	WorkflowIdentifier    *core.Identifier
@@ -76,7 +75,7 @@ func CreateExecutionModel(input CreateExecutionModelInput) (*models.Execution, e
 	}
 	createdAt := timestamppb.New(input.CreatedAt)
 	closure := admin.ExecutionClosure{
-		Phase:         input.Phase,
+		Phase:         core.WorkflowExecution_UNDEFINED,
 		CreatedAt:     createdAt,
 		UpdatedAt:     createdAt,
 		Notifications: input.Notifications,
@@ -86,9 +85,6 @@ func CreateExecutionModel(input CreateExecutionModelInput) (*models.Execution, e
 			Principal:  requestSpec.Metadata.Principal,
 			OccurredAt: createdAt,
 		},
-	}
-	if input.Phase == core.WorkflowExecution_RUNNING {
-		closure.StartedAt = createdAt
 	}
 	if input.Error != nil {
 		closure.Phase = core.WorkflowExecution_FAILED

--- a/flyteadmin/pkg/repositories/transformers/execution.go
+++ b/flyteadmin/pkg/repositories/transformers/execution.go
@@ -128,7 +128,7 @@ func CreateExecutionModel(input CreateExecutionModelInput) (*models.Execution, e
 			Name:    input.WorkflowExecutionID.Name,
 		},
 		Spec:                  spec,
-		Phase:                 input.Phase.String(),
+		Phase:                 closure.Phase.String(),
 		Closure:               closureBytes,
 		WorkflowID:            input.WorkflowID,
 		ExecutionCreatedAt:    &input.CreatedAt,

--- a/flyteadmin/pkg/repositories/transformers/execution.go
+++ b/flyteadmin/pkg/repositories/transformers/execution.go
@@ -75,7 +75,6 @@ func CreateExecutionModel(input CreateExecutionModelInput) (*models.Execution, e
 	}
 	createdAt := timestamppb.New(input.CreatedAt)
 	closure := admin.ExecutionClosure{
-		Phase:         core.WorkflowExecution_UNDEFINED,
 		CreatedAt:     createdAt,
 		UpdatedAt:     createdAt,
 		Notifications: input.Notifications,

--- a/flyteadmin/pkg/repositories/transformers/execution_test.go
+++ b/flyteadmin/pkg/repositories/transformers/execution_test.go
@@ -184,7 +184,6 @@ func TestCreateExecutionModel(t *testing.T) {
 				},
 			},
 			CreatedAt:  expectedCreatedAt,
-			StartedAt:  expectedCreatedAt,
 			UpdatedAt:  expectedCreatedAt,
 			WorkflowId: workflowIdentifier,
 			StateChangeDetails: &admin.ExecutionStateChangeDetails{
@@ -251,7 +250,6 @@ func TestCreateExecutionModel(t *testing.T) {
 				},
 			},
 			CreatedAt:  expectedCreatedAt,
-			StartedAt:  expectedCreatedAt,
 			UpdatedAt:  expectedCreatedAt,
 			WorkflowId: workflowIdentifier,
 			StateChangeDetails: &admin.ExecutionStateChangeDetails{
@@ -318,7 +316,6 @@ func TestCreateExecutionModel(t *testing.T) {
 				},
 			},
 			CreatedAt:  expectedCreatedAt,
-			StartedAt:  expectedCreatedAt,
 			UpdatedAt:  expectedCreatedAt,
 			WorkflowId: workflowIdentifier,
 			StateChangeDetails: &admin.ExecutionStateChangeDetails{

--- a/flyteadmin/pkg/repositories/transformers/execution_test.go
+++ b/flyteadmin/pkg/repositories/transformers/execution_test.go
@@ -71,7 +71,7 @@ func TestCreateExecutionModel(t *testing.T) {
 		},
 	}
 	namespace := "ns"
-	t.Run("running", func(t *testing.T) {
+	t.Run("successful execution", func(t *testing.T) {
 		execution, err := CreateExecutionModel(CreateExecutionModelInput{
 			WorkflowExecutionID: core.WorkflowExecutionIdentifier{
 				Project: "project",
@@ -81,7 +81,6 @@ func TestCreateExecutionModel(t *testing.T) {
 			RequestSpec:           execRequest.Spec,
 			LaunchPlanID:          lpID,
 			WorkflowID:            wfID,
-			Phase:                 core.WorkflowExecution_RUNNING,
 			CreatedAt:             createdAt,
 			WorkflowIdentifier:    workflowIdentifier,
 			ParentNodeExecutionID: nodeID,
@@ -103,6 +102,7 @@ func TestCreateExecutionModel(t *testing.T) {
 		assert.Equal(t, nodeID, execution.ParentNodeExecutionID)
 		assert.Equal(t, sourceID, execution.SourceExecutionID)
 		assert.Equal(t, "launch_plan", execution.LaunchEntity)
+		assert.Equal(t, execution.Phase, core.WorkflowExecution_UNDEFINED.String())
 		expectedSpec := execRequest.Spec
 		expectedSpec.Metadata.Principal = principal
 		expectedSpec.Metadata.SystemMetadata = &admin.SystemMetadata{
@@ -116,9 +116,8 @@ func TestCreateExecutionModel(t *testing.T) {
 
 		expectedCreatedAt, _ := ptypes.TimestampProto(createdAt)
 		expectedClosure, _ := proto.Marshal(&admin.ExecutionClosure{
-			Phase:      core.WorkflowExecution_RUNNING,
+			Phase:      core.WorkflowExecution_UNDEFINED,
 			CreatedAt:  expectedCreatedAt,
-			StartedAt:  expectedCreatedAt,
 			UpdatedAt:  expectedCreatedAt,
 			WorkflowId: workflowIdentifier,
 			StateChangeDetails: &admin.ExecutionStateChangeDetails{
@@ -140,7 +139,6 @@ func TestCreateExecutionModel(t *testing.T) {
 			RequestSpec:           execRequest.Spec,
 			LaunchPlanID:          lpID,
 			WorkflowID:            wfID,
-			Phase:                 core.WorkflowExecution_RUNNING,
 			CreatedAt:             createdAt,
 			WorkflowIdentifier:    workflowIdentifier,
 			ParentNodeExecutionID: nodeID,
@@ -163,7 +161,7 @@ func TestCreateExecutionModel(t *testing.T) {
 		assert.Equal(t, nodeID, execution.ParentNodeExecutionID)
 		assert.Equal(t, sourceID, execution.SourceExecutionID)
 		assert.Equal(t, "launch_plan", execution.LaunchEntity)
-		assert.Equal(t, execution.Phase, core.WorkflowExecution_FAILED.String())
+		assert.Equal(t, core.WorkflowExecution_FAILED.String(), execution.Phase)
 		expectedSpec := execRequest.Spec
 		expectedSpec.Metadata.Principal = principal
 		expectedSpec.Metadata.SystemMetadata = &admin.SystemMetadata{
@@ -208,7 +206,6 @@ func TestCreateExecutionModel(t *testing.T) {
 			RequestSpec:           execRequest.Spec,
 			LaunchPlanID:          lpID,
 			WorkflowID:            wfID,
-			Phase:                 core.WorkflowExecution_RUNNING,
 			CreatedAt:             createdAt,
 			WorkflowIdentifier:    workflowIdentifier,
 			ParentNodeExecutionID: nodeID,
@@ -231,6 +228,7 @@ func TestCreateExecutionModel(t *testing.T) {
 		assert.Equal(t, nodeID, execution.ParentNodeExecutionID)
 		assert.Equal(t, sourceID, execution.SourceExecutionID)
 		assert.Equal(t, "launch_plan", execution.LaunchEntity)
+		assert.Equal(t, core.WorkflowExecution_FAILED.String(), execution.Phase)
 		expectedSpec := execRequest.Spec
 		expectedSpec.Metadata.Principal = principal
 		expectedSpec.Metadata.SystemMetadata = &admin.SystemMetadata{
@@ -275,7 +273,6 @@ func TestCreateExecutionModel(t *testing.T) {
 			RequestSpec:           execRequest.Spec,
 			LaunchPlanID:          lpID,
 			WorkflowID:            wfID,
-			Phase:                 core.WorkflowExecution_RUNNING,
 			CreatedAt:             createdAt,
 			WorkflowIdentifier:    workflowIdentifier,
 			ParentNodeExecutionID: nodeID,
@@ -298,6 +295,7 @@ func TestCreateExecutionModel(t *testing.T) {
 		assert.Equal(t, nodeID, execution.ParentNodeExecutionID)
 		assert.Equal(t, sourceID, execution.SourceExecutionID)
 		assert.Equal(t, "launch_plan", execution.LaunchEntity)
+		assert.Equal(t, core.WorkflowExecution_FAILED.String(), execution.Phase)
 		expectedSpec := execRequest.Spec
 		expectedSpec.Metadata.Principal = principal
 		expectedSpec.Metadata.SystemMetadata = &admin.SystemMetadata{

--- a/flyteadmin/pkg/repositories/transformers/execution_test.go
+++ b/flyteadmin/pkg/repositories/transformers/execution_test.go
@@ -163,6 +163,7 @@ func TestCreateExecutionModel(t *testing.T) {
 		assert.Equal(t, nodeID, execution.ParentNodeExecutionID)
 		assert.Equal(t, sourceID, execution.SourceExecutionID)
 		assert.Equal(t, "launch_plan", execution.LaunchEntity)
+		assert.Equal(t, execution.Phase, core.WorkflowExecution_FAILED.String())
 		expectedSpec := execRequest.Spec
 		expectedSpec.Metadata.Principal = principal
 		expectedSpec.Metadata.SystemMetadata = &admin.SystemMetadata{


### PR DESCRIPTION
## Why are the changes needed?
The execution phase should be FAILED because of the error in input pass to `CreateExecutionModel()`. However, we only update the phase in closure but not in `execution.phase`.

As a follow up, we don't even need `Phase` in the `CreateExecutionModelInput`

## What changes were proposed in this pull request?
1. Fix the bug
2. Add assertion in test.
3. Clean up redundant phase in `CreateExecutionModelInput{`