### PR TITLE
Change retry error from RuntimeError to FlyteRecoverableException

### DIFF
--- a/docs/concepts/tasks.rst
+++ b/docs/concepts/tasks.rst
@@ -72,6 +72,7 @@ Inherent Features
 -----------------
 
 .. _fault-tolerance:
+
 Fault tolerance
 ^^^^^^^^^^^^^^^
 

--- a/docs/concepts/tasks.rst
+++ b/docs/concepts/tasks.rst
@@ -71,6 +71,7 @@ types in the system. Flyte has a set of defined, battle-tested task types. It al
 Inherent Features
 -----------------
 
+.. _fault-tolerance:
 Fault tolerance
 ^^^^^^^^^^^^^^^
 

--- a/docs/flyte_fundamentals/optimizing_tasks.md
+++ b/docs/flyte_fundamentals/optimizing_tasks.md
@@ -66,12 +66,13 @@ import random
 @task(retries=3)
 def compute_mean(data: List[float]) -> float:
     if random() < 0.05:
-        raise RuntimeError("Something bad happened 🔥")
+        raise FlyteRecoverableException("Something bad happened 🔥")
     return sum(data) / len(data)
 ```
 
 ```{note}
-Retries only take effect when running a task on a Flyte cluster.
+Retries only take effect when running a task on a Flyte cluster. 
+See {ref}`Fault Tolerance <fault-tolerance>` for details on the types of errors that will be retried.
 ```
 
 ## Timeouts


### PR DESCRIPTION
## Tracking issue
https://unionai.atlassian.net/browse/DOCS-385

## Why are the changes needed?

It turns out that all user exceptions are considered non-recoverable unless the exception is a subclass of FlyteRecoverableException ([Tasks - Flyte](https://docs.flyte.org/en/latest/concepts/tasks.html#fault-tolerance)). 

This means that the RuntimeError in the retry example [here](https://docs.flyte.org/en/latest/flyte_fundamentals/optimizing_tasks.html#retries) will not actually retry. 

We want to change the error in the example to one which will trigger a retry of the task if the decorator is used.

Slack convo: https://unionai.slack.com/archives/C06RE4ZR5QQ/p1711576283580859

## What changes were proposed in this pull request?

As only user exceptions that are subclasses of `FlyteRecoverableException` are compatible with retries, `FlyteRecoverableException` is used rather than a `RuntimeError`.

## How was this patch tested?

[This workflow](https://dogfood.cloud-staging.union.ai/console/projects/daniel/domains/development/workflows/workflows.retry_example.wf) was ran various times with `RuntimeError` (version CT3eWXJm_xOmb73ko1ww1w) and with `FlyteRecoverableException` (version d7nmtvMO6afNxNs4WFbTqA). With `RuntimeError` no retires were triggered, while with `FlyteRecoverableException` retries were triggered.

### Screenshots

<img width="1672" alt="image" src="https://github.com/flyteorg/flyte/assets/40698988/2f079abc-7d0f-4a71-b7df-04ca9dbf592c">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
