### PR TITLE
Fix Id bigint conversation for not yet created table

### DIFF
--- a/flyteadmin/pkg/repositories/config/migrations.go
+++ b/flyteadmin/pkg/repositories/config/migrations.go
@@ -17,6 +17,7 @@ import (
 
 // TODO: add a way to get these list of tables directly from the gorm loaded models
 var (
+	// Tables are ordererd by creation. Migration code relies on this ordering.
 	tables = []string{"execution_events", "executions", "launch_plans", "named_entity_metadata",
 		"node_execution_events", "node_executions", "projects", "resources", "schedulable_entities",
 		"schedule_entities_snapshots", "task_executions", "tasks", "workflows", "description_entities"}
@@ -347,6 +348,7 @@ var LegacyMigrations = []*gormigrate.Migration{
 
 	// For any new table, Please use the following pattern due to a bug
 	// in the postgres gorm layer https://github.com/go-gorm/postgres/issues/65
+	// The 13th table in tables was created before this migration.
 	{
 		ID: "2022-01-11-id-to-bigint",
 		Migrate: func(tx *gorm.DB) error {
@@ -354,14 +356,14 @@ var LegacyMigrations = []*gormigrate.Migration{
 			if err != nil {
 				return err
 			}
-			return alterTableColumnType(db, "id", "bigint")
+			return alterTableColumnType(db, "id", "bigint", tables[:13])
 		},
 		Rollback: func(tx *gorm.DB) error {
 			db, err := tx.DB()
 			if err != nil {
 				return err
 			}
-			return alterTableColumnType(db, "id", "int")
+			return alterTableColumnType(db, "id", "int", tables[:13])
 		},
 	},
 
@@ -1225,7 +1227,7 @@ var ContinuedMigrations = []*gormigrate.Migration{
 var m = append(LegacyMigrations, NoopMigrations...)
 var Migrations = append(m, ContinuedMigrations...)
 
-func alterTableColumnType(db *sql.DB, columnName, columnType string) error {
+func alterTableColumnType(db *sql.DB, columnName, columnType string, tables []string) error {
 	var err error
 	for _, table := range tables {
 		if _, err = db.Exec(fmt.Sprintf(`ALTER TABLE IF EXISTS %s ALTER COLUMN "%s" TYPE %s`, table, columnName,

--- a/flyteadmin/pkg/repositories/config/migrations_test.go
+++ b/flyteadmin/pkg/repositories/config/migrations_test.go
@@ -20,7 +20,7 @@ func TestAlterTableColumnType(t *testing.T) {
 		`ALTER TABLE IF EXISTS execution_events ALTER COLUMN "id" TYPE bigint`)
 	assert.NoError(t, err)
 	tables = []string{"execution_events"}
-	_ = alterTableColumnType(db, "id", "bigint")
+	_ = alterTableColumnType(db, "id", "bigint", tables)
 	assert.True(t, query.Triggered)
 }
 


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3966

## Why are the changes needed?
This commit fixes a bug with migrations. The previous code was modifying a table (`description_entities`) that does not exists yet when the migration is ran in order. 

## What changes were proposed in this pull request?
Only modify id column of tables that exist already.

## How was this patch tested?
N/A

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [x] All commits are signed-off.

