### PR TITLE
use javascript to open new tab for external links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,9 @@ install-conda-lock:
 
 .PHONY: conda-lock
 conda-lock: install-conda-lock
-	conda-lock -f monodocs-environment.yaml --without-cuda --lockfile monodocs-environment.lock.yaml
+	conda-lock -f monodocs-environment.yaml --without-cuda \
+		--lockfile monodocs-environment.lock.yaml \
+		--platform=osx-64 --platform=osx-arm64 --platform=linux-64
 
 .PHONY: stats
 stats:

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -1,0 +1,11 @@
+// Add event listener for DOMContentLoaded event
+window.addEventListener("DOMContentLoaded", function() {
+    // Select all <a> elements with class "external"
+    var externalLinks = document.querySelectorAll("a.external");
+
+    // Loop through each <a> element with class "external"
+    externalLinks.forEach(function(link) {
+        // Set the target attribute to "_blank"
+        link.setAttribute("target", "_blank");
+    });
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,6 @@ extensions = [
     # custom extensions
     "auto_examples",
     "import_projects",
-    "sphinx_new_tab_link"
 ]
 
 source_suffix = {
@@ -188,6 +187,7 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 html_css_files = ["custom.css", "flyte.css", "algolia.css"]
+html_js_files = ["custom.js"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/monodocs-environment.lock.yaml
+++ b/monodocs-environment.lock.yaml
@@ -13,13 +13,15 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 32d4de5273d85a0237eda3bf606d0faaff506dac029d80b303bdf7ed5245ad2a
+    linux-64: c4ea2742c1d9704007aa9e822229cb0555a2f0da58b375bb5a1bdb05c82a5542
     osx-arm64: e58daa2c17c4401600ecf9a4e1039741eb1d186d902acfad0e7f254968ee3732
+    osx-64: 99fdb22e3d6a1054e7f3e655d0550e0b9dff6adc206fb5b5c5219d371468faf8
   channels:
   - url: conda-forge
     used_env_vars: []
   platforms:
   - linux-64
+  - osx-64
   - osx-arm64
   sources:
   - monodocs-environment.yaml
@@ -63,6 +65,18 @@ package:
 - name: absl-py
   version: 2.1.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 035d1d58677c13ec93122d9eb6b8803b
+    sha256: 6c84575fe0c3a860c7b6a52cb36dc548c838503c8da0f950a63a64c29b443937
+  category: main
+  optional: false
+- name: absl-py
+  version: 2.1.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -91,13 +105,29 @@ package:
 - name: adal
   version: 1.2.7
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    requests: '>=2.0.0'
+    pyjwt: '>=1.0.0'
+    cryptography: '>=1.1.0'
+    python-dateutil: '>=2.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/adal-1.2.7-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 1a0f134d22bad81e93f1e130b35afb35
+    sha256: 3631c3713355d8fa81a77489dbc803b5004ea3be7e02b4ac9c16391f67dc57d5
+  category: main
+  optional: false
+- name: adal
+  version: 1.2.7
+  manager: conda
   platform: osx-arm64
   dependencies:
-    cryptography: '>=1.1.0'
-    pyjwt: '>=1.0.0'
     python: '>=3.6'
-    python-dateutil: '>=2.1.0'
     requests: '>=2.0.0'
+    pyjwt: '>=1.0.0'
+    cryptography: '>=1.1.0'
+    python-dateutil: '>=2.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/adal-1.2.7-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 1a0f134d22bad81e93f1e130b35afb35
@@ -125,15 +155,33 @@ package:
 - name: adlfs
   version: 2024.2.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    azure-identity: ''
+    python: '>=3.8'
+    azure-datalake-store: '>=0.0.46,<0.1'
+    aiohttp: '>=3.7.0'
+    fsspec: '>=2023.12.0'
+    azure-storage-blob: '>=12.12.0'
+    azure-core: '>=1.23.1,<2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/adlfs-2024.2.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 4dfa76ae23a7c27f4ccaf64945b71871
+    sha256: b9ae4843b862ee69a1bfdcbb4604db817dd4f220d598fcbe64987c700b4e4cf4
+  category: main
+  optional: false
+- name: adlfs
+  version: 2024.2.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    aiohttp: '>=3.7.0'
-    azure-core: '>=1.23.1,<2.0.0'
-    azure-datalake-store: '>=0.0.46,<0.1'
     azure-identity: ''
-    azure-storage-blob: '>=12.12.0'
-    fsspec: '>=2023.12.0'
     python: '>=3.8'
+    azure-datalake-store: '>=0.0.46,<0.1'
+    aiohttp: '>=3.7.0'
+    fsspec: '>=2023.12.0'
+    azure-storage-blob: '>=12.12.0'
+    azure-core: '>=1.23.1,<2.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/adlfs-2024.2.0-pyhd8ed1ab_1.conda
   hash:
     md5: 4dfa76ae23a7c27f4ccaf64945b71871
@@ -159,13 +207,29 @@ package:
 - name: aiobotocore
   version: 2.12.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    aiohttp: '>=3.7.4.post0,<4.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.34.41,<1.34.52'
     python: '>=3.8'
     wrapt: '>=1.10.10,<2.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    aiohttp: '>=3.7.4.post0,<4.0.0'
+    botocore: '>=1.34.41,<1.34.52'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 045560daef58c75a759c2638fbdb5c6a
+    sha256: e7d43681c7c2957b535aac2b3ad90013bcb39ed5514cea3cec52302f624d457a
+  category: main
+  optional: false
+- name: aiobotocore
+  version: 2.12.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+    wrapt: '>=1.10.10,<2.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    aiohttp: '>=3.7.4.post0,<4.0.0'
+    botocore: '>=1.34.41,<1.34.52'
   url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.12.1-pyhd8ed1ab_0.conda
   hash:
     md5: 045560daef58c75a759c2638fbdb5c6a
@@ -190,6 +254,25 @@ package:
   hash:
     md5: 437936123de28b9bf81d35b943170c4f
     sha256: 0fcc6c976dc7dd7592cfd584cacbc121190513ddeff9d7ab386ef67146808c0c
+  category: main
+  optional: false
+- name: aiohttp
+  version: 3.9.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aiosignal: '>=1.1.2'
+    async-timeout: '>=4.0,<5.0'
+    attrs: '>=17.3.0'
+    frozenlist: '>=1.1.1'
+    multidict: '>=4.5,<7.0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    yarl: '>=1.0,<2.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.9.3-py39ha09f3b3_1.conda
+  hash:
+    md5: 9898a8146b20e891e62171f2aabd7893
+    sha256: fbc33a785294fb4f90cf6b97b880bbe2d5331976863279e5f6869c759bf88219
   category: main
   optional: false
 - name: aiohttp
@@ -227,6 +310,19 @@ package:
 - name: aioitertools
   version: 0.11.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 59c40397276a286241c65faec5e1be3c
+    sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
+  category: main
+  optional: false
+- name: aioitertools
+  version: 0.11.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
@@ -253,10 +349,23 @@ package:
 - name: aiosignal
   version: 1.3.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    frozenlist: '>=1.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: d1e1eb7e21a9e2c74279d87dafb68156
+    sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
+  category: main
+  optional: false
+- name: aiosignal
+  version: 1.3.1
+  manager: conda
   platform: osx-arm64
   dependencies:
-    frozenlist: '>=1.1.0'
     python: '>=3.7'
+    frozenlist: '>=1.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: d1e1eb7e21a9e2c74279d87dafb68156
@@ -278,6 +387,18 @@ package:
 - name: alabaster
   version: 0.7.16
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.16-pyhd8ed1ab_0.conda
+  hash:
+    md5: def531a3ac77b7fb8c21d17bb5d0badb
+    sha256: fd39ad2fabec1569bbb0dfdae34ab6ce7de6ec09dcec8638f83dad0373594069
+  category: main
+  optional: false
+- name: alabaster
+  version: 0.7.16
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9'
@@ -307,6 +428,23 @@ package:
 - name: alembic
   version: 1.13.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    importlib-metadata: ''
+    importlib_resources: ''
+    mako: ''
+    python: '>=3.8'
+    sqlalchemy: '>=1.3.0'
+    typing-extensions: '>=4'
+  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.13.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 7b7b0062b0de9f3f71502d31215fcbbb
+    sha256: e4bc9aa5a6e866461274826bb750407a407fed9207a5adb70bf727f6addd7fe6
+  category: main
+  optional: false
+- name: alembic
+  version: 1.13.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     importlib-metadata: ''
@@ -321,6 +459,18 @@ package:
     sha256: e4bc9aa5a6e866461274826bb750407a407fed9207a5adb70bf727f6addd7fe6
   category: main
   optional: false
+- name: alsa-lib
+  version: 1.2.11
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.11-hd590300_1.conda
+  hash:
+    md5: 0bb492cca54017ea314b809b1ee3a176
+    sha256: 0e2b75b9834a6e520b13db516f7cf5c9cea8f0bbc9157c978444173dacb98fec
+  category: main
+  optional: false
 - name: altair
   version: 4.2.2
   manager: conda
@@ -342,15 +492,33 @@ package:
 - name: altair
   version: 4.2.2
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    entrypoints: ''
     jinja2: ''
+    toolz: ''
+    entrypoints: ''
+    python: '>=3.7'
+    pandas: '>=0.18'
     jsonschema: '>=3.0'
     numpy: '>=0.18'
-    pandas: '>=0.18'
-    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/altair-4.2.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: afca9c6a93335c55bbc84072011e86dc
+    sha256: 5b36be4717e05b7c1f016d3534b7fe316381260ac2367a7815ff96fb88273deb
+  category: main
+  optional: false
+- name: altair
+  version: 4.2.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    jinja2: ''
     toolz: ''
+    entrypoints: ''
+    python: '>=3.7'
+    pandas: '>=0.18'
+    jsonschema: '>=3.0'
+    numpy: '>=0.18'
   url: https://conda.anaconda.org/conda-forge/noarch/altair-4.2.2-pyhd8ed1ab_0.conda
   hash:
     md5: afca9c6a93335c55bbc84072011e86dc
@@ -373,10 +541,23 @@ package:
 - name: ansiwrap
   version: 0.8.4
   manager: conda
+  platform: osx-64
+  dependencies:
+    textwrap3: ''
+    python: <3.12.0a0
+  url: https://conda.anaconda.org/conda-forge/noarch/ansiwrap-0.8.4-py_0.tar.bz2
+  hash:
+    md5: f09557e2a7cbd2470a2ab6353000cebd
+    sha256: 34e2445a78857c7418ab738b3a3c88f3226923676c3c185688dd570a6f9129a4
+  category: main
+  optional: false
+- name: ansiwrap
+  version: 0.8.4
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: <3.12.0a0
     textwrap3: ''
+    python: <3.12.0a0
   url: https://conda.anaconda.org/conda-forge/noarch/ansiwrap-0.8.4-py_0.tar.bz2
   hash:
     md5: f09557e2a7cbd2470a2ab6353000cebd
@@ -402,13 +583,29 @@ package:
 - name: anyio
   version: 4.3.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    exceptiongroup: '>=1.0.2'
-    idna: '>=2.8'
     python: '>=3.8'
     sniffio: '>=1.1'
     typing_extensions: '>=4.1'
+    idna: '>=2.8'
+    exceptiongroup: '>=1.0.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: ac95aa8ed65adfdde51132595c79aade
+    sha256: 86aca4a31c09f9b4dbdb332cd9a6a7dbab62ca734d3f832651c0ab59c6a7f52e
+  category: main
+  optional: false
+- name: anyio
+  version: 4.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+    sniffio: '>=1.1'
+    typing_extensions: '>=4.1'
+    idna: '>=2.8'
+    exceptiongroup: '>=1.0.2'
   url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: ac95aa8ed65adfdde51132595c79aade
@@ -430,6 +627,18 @@ package:
 - name: aplus
   version: 0.11.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/aplus-0.11.0-py_1.tar.bz2
+  hash:
+    md5: 7785bb1ae3202fb550f23699c6f89121
+    sha256: 7f2734233106b9ccfcf0bcd916cfdd39b59dcedf1a8832e6b1ec0048b6bc1ba2
+  category: main
+  optional: false
+- name: aplus
+  version: 0.11.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
@@ -437,6 +646,18 @@ package:
   hash:
     md5: 7785bb1ae3202fb550f23699c6f89121
     sha256: 7f2734233106b9ccfcf0bcd916cfdd39b59dcedf1a8832e6b1ec0048b6bc1ba2
+  category: main
+  optional: false
+- name: appnope
+  version: 0.1.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: cc4834a9ee7cc49ce8d25177c47b10d8
+    sha256: 45ae2d41f4a4dcf8707633d3d7ae376fc62f0c09b1d063c3049c3f6f8c911670
   category: main
   optional: false
 - name: appnope
@@ -468,11 +689,25 @@ package:
 - name: argon2-cffi
   version: 23.1.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    typing-extensions: ''
     argon2-cffi-bindings: ''
     python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+    sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
+  category: main
+  optional: false
+- name: argon2-cffi
+  version: 23.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     typing-extensions: ''
+    argon2-cffi-bindings: ''
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 3afef1f55a1366b4d3b6a0d92e2235e4
@@ -492,6 +727,20 @@ package:
   hash:
     md5: 6a04738e75f877b68552fc19cb045233
     sha256: 63c6f462a18e655e6c5fe4e433ac94100bca1a076e5bb5382c2479ac7a42fd54
+  category: main
+  optional: false
+- name: argon2-cffi-bindings
+  version: 21.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cffi: '>=1.0.1'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py39hdc70f33_4.conda
+  hash:
+    md5: 3a0f682e6fdf53ff630c22cdd90ac0c1
+    sha256: 47eb7e5826557364e7f71f3cb57d98486572c6af9bc4b1a9cb6c164504c09d92
   category: main
   optional: false
 - name: argon2-cffi-bindings
@@ -525,6 +774,20 @@ package:
 - name: arrow
   version: 1.3.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    python-dateutil: '>=2.7.0'
+    types-python-dateutil: '>=2.8.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: b77d8c2313158e6e461ca0efb1c2c508
+    sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  category: main
+  optional: false
+- name: arrow
+  version: 1.3.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
@@ -540,6 +803,18 @@ package:
   version: 1.5.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/asn1crypto-1.5.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: f3f2ab3ce28979a24d1a988ba211eb9b
+    sha256: 1354731d0eb1b406b66b3cb3d6ab74d7cbe9c0ec1d30b9e5afa366d4539e4687
+  category: main
+  optional: false
+- name: asn1crypto
+  version: 1.5.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/asn1crypto-1.5.1-pyhd8ed1ab_0.tar.bz2
@@ -577,6 +852,20 @@ package:
 - name: astroid
   version: 3.1.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    typing-extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/astroid-3.1.0-py39h6e9494a_0.conda
+  hash:
+    md5: a6ecd75c6b8076b53152f11bb41ce9ca
+    sha256: b2bc5c7d074578beb2234a1a993ab1ba2983b41289c82e2a347fc66969646491
+  category: main
+  optional: false
+- name: astroid
+  version: 3.1.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -604,6 +893,19 @@ package:
 - name: asttokens
   version: 2.4.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+    six: '>=1.12.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5f25798dcefd8252ce5f9dc494d5f571
+    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+  category: main
+  optional: false
+- name: asttokens
+  version: 2.4.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -630,6 +932,19 @@ package:
 - name: astunparse
   version: 1.6.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    six: '>=1.6.1,<2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/astunparse-1.6.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 000b6f68a0bfaba800ced7500c11780f
+    sha256: e5173d1ed038038e24c0623f0219dc587ee8663cf7efa737e7075128edbc6c60
+  category: main
+  optional: false
+- name: astunparse
+  version: 1.6.3
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
@@ -656,6 +971,19 @@ package:
 - name: async-lru
   version: 2.0.4
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    typing_extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+    sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
+  category: main
+  optional: false
+- name: async-lru
+  version: 2.0.4
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
@@ -670,6 +998,19 @@ package:
   version: 4.0.3
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    typing-extensions: '>=3.6.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3ce482ec3066e6d809dbbb1d1679f215
+    sha256: bd8b698e7f037a9c6107216646f1191f4f7a7fc6da6c34d1a6d4c211bcca8979
+  category: main
+  optional: false
+- name: async-timeout
+  version: 4.0.3
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
     typing-extensions: '>=3.6.5'
@@ -709,6 +1050,19 @@ package:
 - name: atk-1.0
   version: 2.38.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=14.0.4'
+    libglib: '>=2.74.1,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/atk-1.0-2.38.0-h1d18e73_1.tar.bz2
+  hash:
+    md5: 5a538295f97a484ee332aacc131718b5
+    sha256: 7af1f86cfc85b1e57547e2a81c069095545ff6a52f3f8e15184df954dce446dd
+  category: main
+  optional: false
+- name: atk-1.0
+  version: 2.38.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=14.0.4'
@@ -719,10 +1073,34 @@ package:
     sha256: d40f103467fd2fa426072691919fd135a4fed4a2b03cd12256ff0fee37a98249
   category: main
   optional: false
+- name: attr
+  version: 2.5.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
+  hash:
+    md5: d9c69a24ad678ffce24c6543a0176b00
+    sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
+  category: main
+  optional: false
 - name: attrs
   version: 23.2.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+  hash:
+    md5: 5e4c0743c70186509d1412e03c2d8dfa
+    sha256: 77c7d03bdb243a048fff398cedc74327b7dc79169ebe3b4c8448b0331ea55fea
+  category: main
+  optional: false
+- name: attrs
+  version: 23.2.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
@@ -763,6 +1141,22 @@ package:
 - name: aws-c-auth
   version: 0.7.11
   manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-http: '>=0.8.0,<0.8.1.0a0'
+    aws-c-io: '>=0.14.0,<0.14.1.0a0'
+    aws-c-sdkutils: '>=0.1.13,<0.1.14.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.11-h94c8779_1.conda
+  hash:
+    md5: 0c504fbf22cf8560e4cbe1a68d71bace
+    sha256: 2aa423f5c64c4df7a8a2d9b4f7fa915c4a7d6e01a018f04fbf4c4bd9b699ea50
+  category: main
+  optional: false
+- name: aws-c-auth
+  version: 0.7.11
+  manager: conda
   platform: osx-arm64
   dependencies:
     aws-c-cal: '>=0.6.9,<0.6.10.0a0'
@@ -793,6 +1187,18 @@ package:
 - name: aws-c-cal
   version: 0.6.9
   manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.9-he75d6b7_3.conda
+  hash:
+    md5: 56bca8b8f924ba21b26b9a0a158b93be
+    sha256: 772a3d9864658df5097c866633f14a78d88f21509157b09f9f8d6d0c04f09166
+  category: main
+  optional: false
+- name: aws-c-cal
+  version: 0.6.9
+  manager: conda
   platform: osx-arm64
   dependencies:
     aws-c-common: '>=0.9.12,<0.9.13.0a0'
@@ -812,6 +1218,17 @@ package:
   hash:
     md5: 7dbb94ffb9df66406f3101625807cac1
     sha256: 22e7c9438f2fe3c46a1747efcaae4ab3a078714ff8992a6ec3c213f50b9d6704
+  category: main
+  optional: false
+- name: aws-c-common
+  version: 0.9.12
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.12-h10d778d_0.conda
+  hash:
+    md5: d04b9a72861e43eb78e0c133056e1655
+    sha256: 21171720a36e233246ce9fa602b124b2fb4fffe97b906fa58bf7603d1af93789
   category: main
   optional: false
 - name: aws-c-common
@@ -841,6 +1258,18 @@ package:
 - name: aws-c-compression
   version: 0.2.17
   manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-h45babc2_8.conda
+  hash:
+    md5: 3b63d41977e0e390e42446372f5f1b03
+    sha256: 19d3fb58b89ad3c1a2693ea81f98bca51843c7cdec7afaebc96b5013d73b2a91
+  category: main
+  optional: false
+- name: aws-c-compression
+  version: 0.2.17
+  manager: conda
   platform: osx-arm64
   dependencies:
     aws-c-common: '>=0.9.12,<0.9.13.0a0'
@@ -864,6 +1293,21 @@ package:
   hash:
     md5: 5a16088be732d54b50c134203f712d24
     sha256: a7cb50ccb2779d2934cae3a4fcc3d032a4525b63a464d6bd23957650381d633e
+  category: main
+  optional: false
+- name: aws-c-event-stream
+  version: 0.4.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-io: '>=0.14.0,<0.14.1.0a0'
+    aws-checksums: '>=0.1.17,<0.1.18.0a0'
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.1-h3600a39_2.conda
+  hash:
+    md5: d15584e342a31e978262627e6fd4063b
+    sha256: ef306832c033c46ab4b434ebf6e0a53a0f1a5023d6dbd6d31b90c2deea997a6c
   category: main
   optional: false
 - name: aws-c-event-stream
@@ -900,6 +1344,21 @@ package:
 - name: aws-c-http
   version: 0.8.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-compression: '>=0.2.17,<0.2.18.0a0'
+    aws-c-io: '>=0.14.0,<0.14.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.0-h19e0e28_2.conda
+  hash:
+    md5: 0714dff2eee274db27ad65d82b61374d
+    sha256: f6de21c9ade6ac83b418a5277025b9a0ec55fdcb9c34f8cf3a595122b9b5e43f
+  category: main
+  optional: false
+- name: aws-c-http
+  version: 0.8.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     aws-c-cal: '>=0.6.9,<0.6.10.0a0'
@@ -930,6 +1389,19 @@ package:
 - name: aws-c-io
   version: 0.14.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.0-h49ca7b5_1.conda
+  hash:
+    md5: f276e1df52ac6d261e5fa7e85d8cb02f
+    sha256: 27d102f01cc662f703ecc7cff9350526587e6fc57347ddc6d3df8db569b2e19b
+  category: main
+  optional: false
+- name: aws-c-io
+  version: 0.14.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     aws-c-cal: '>=0.6.9,<0.6.10.0a0'
@@ -941,7 +1413,7 @@ package:
   category: main
   optional: false
 - name: aws-c-mqtt
-  version: 0.10.1
+  version: 0.10.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -949,10 +1421,24 @@ package:
     aws-c-http: '>=0.8.0,<0.8.1.0a0'
     aws-c-io: '>=0.14.0,<0.14.1.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.1-h2b97f5f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.0-h2b97f5f_3.conda
   hash:
-    md5: 4cba7afc0f74a7cce3159c0bceb607c3
-    sha256: 8edcb09a2d93c24320f517f837a0e46e98749b72dc7c9d55ce1fa0c4fa5db116
+    md5: fd57022ff2e0bd1dcaf5399ad16763b0
+    sha256: 2cd60ece1706c84b50be9ccca101a711d1905a3c38395c4ff1f9b5d1a689d207
+  category: main
+  optional: false
+- name: aws-c-mqtt
+  version: 0.10.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-http: '>=0.8.0,<0.8.1.0a0'
+    aws-c-io: '>=0.14.0,<0.14.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.1-h947eb33_0.conda
+  hash:
+    md5: 572658337a20c3a1e6ecf59f610be930
+    sha256: 0f9a6de491c1c61ed1635a2814d6be52f041f2bf393c04a85a1da13ee862c90b
   category: main
   optional: false
 - name: aws-c-mqtt
@@ -991,6 +1477,23 @@ package:
 - name: aws-c-s3
   version: 0.4.9
   manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-auth: '>=0.7.11,<0.7.12.0a0'
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-http: '>=0.8.0,<0.8.1.0a0'
+    aws-c-io: '>=0.14.0,<0.14.1.0a0'
+    aws-checksums: '>=0.1.17,<0.1.18.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.4.9-hee0ca28_0.conda
+  hash:
+    md5: b3d80d5c3ff89a4e04799caf71e8ec41
+    sha256: 4d85b122da9250ad318922e09e63f2ed9efb2c394c9c5e38bcdc38a534f6db1a
+  category: main
+  optional: false
+- name: aws-c-s3
+  version: 0.4.9
+  manager: conda
   platform: osx-arm64
   dependencies:
     aws-c-auth: '>=0.7.11,<0.7.12.0a0'
@@ -1021,6 +1524,18 @@ package:
 - name: aws-c-sdkutils
   version: 0.1.13
   manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.13-h45babc2_1.conda
+  hash:
+    md5: 4fd7f6b8225feb707d401eb18bfc0b2a
+    sha256: f780e3d3de1a4111b63ee7fad24046e2618c4086fcbdebca5cb75469fc7abfda
+  category: main
+  optional: false
+- name: aws-c-sdkutils
+  version: 0.1.13
+  manager: conda
   platform: osx-arm64
   dependencies:
     aws-c-common: '>=0.9.12,<0.9.13.0a0'
@@ -1046,6 +1561,18 @@ package:
 - name: aws-checksums
   version: 0.1.17
   manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-h45babc2_7.conda
+  hash:
+    md5: 356e6abc54e4a2e26027d179ddad29ce
+    sha256: 9f6e240ce66f3d120b6bc7d6ac9f3625c039a2f0b4132479ccc9798d08200e8f
+  category: main
+  optional: false
+- name: aws-checksums
+  version: 0.1.17
+  manager: conda
   platform: osx-arm64
   dependencies:
     aws-c-common: '>=0.9.12,<0.9.13.0a0'
@@ -1066,15 +1593,36 @@ package:
     aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
     aws-c-http: '>=0.8.0,<0.8.1.0a0'
     aws-c-io: '>=0.14.0,<0.14.1.0a0'
-    aws-c-mqtt: '>=0.10.1,<0.10.2.0a0'
+    aws-c-mqtt: '>=0.10.0,<0.10.1.0a0'
     aws-c-s3: '>=0.4.9,<0.4.10.0a0'
     aws-c-sdkutils: '>=0.1.13,<0.1.14.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.0-h04327c0_8.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.0-hc5c3545_8.conda
   hash:
-    md5: 8d2aeb8c24b47ad3ff87166957b216fd
-    sha256: 4bdef70ff6362d8a3350b4c4181d078e7b1f654a249d63294e9ab1c5a9ca72c7
+    md5: 504eb8e5c22244f9f2427c2313ac629a
+    sha256: a81784ae987c6cddb65fd28dfcea48bbe9dcfb82b08b9d1add7faa92cfb72b42
+  category: main
+  optional: false
+- name: aws-crt-cpp
+  version: 0.26.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-auth: '>=0.7.11,<0.7.12.0a0'
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
+    aws-c-http: '>=0.8.0,<0.8.1.0a0'
+    aws-c-io: '>=0.14.0,<0.14.1.0a0'
+    aws-c-mqtt: '>=0.10.1,<0.10.2.0a0'
+    aws-c-s3: '>=0.4.9,<0.4.10.0a0'
+    aws-c-sdkutils: '>=0.1.13,<0.1.14.0a0'
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.0-he4637c3_8.conda
+  hash:
+    md5: 47d83636ee8f3876199ad1c3bf32a5b3
+    sha256: 1eaea1b9e4ce6e39ffbdc9533e5f738d01b88b3219cb6a583d8a270a923abaec
   category: main
   optional: false
 - name: aws-crt-cpp
@@ -1121,6 +1669,25 @@ package:
 - name: aws-sdk-cpp
   version: 1.11.210
   manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
+    aws-checksums: '>=0.1.17,<0.1.18.0a0'
+    aws-crt-cpp: '>=0.26.0,<0.26.1.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=15'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.210-hf51409f_10.conda
+  hash:
+    md5: 10d6bd28caf5b216b9042d3fd891fab4
+    sha256: fd4ff9b0422d104bde364fb0dc27f85eb64adce03fc866315120493e9409a64a
+  category: main
+  optional: false
+- name: aws-sdk-cpp
+  version: 1.11.210
+  manager: conda
   platform: osx-arm64
   dependencies:
     aws-c-common: '>=0.9.12,<0.9.13.0a0'
@@ -1155,11 +1722,26 @@ package:
 - name: azure-core
   version: 1.30.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    six: '>=1.11.0'
+    requests: '>=2.21.0'
+    typing-extensions: '>=4.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.30.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 690b51eb2dbc703e8f9ba2f7ce298363
+    sha256: c70bef5f28ee9efead58f5a4992e2b1dc120c66d24e4c9678356c123e031553f
+  category: main
+  optional: false
+- name: azure-core
+  version: 1.30.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-    requests: '>=2.21.0'
     six: '>=1.11.0'
+    requests: '>=2.21.0'
     typing-extensions: '>=4.6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.30.1-pyhd8ed1ab_0.conda
   hash:
@@ -1180,6 +1762,20 @@ package:
   hash:
     md5: c05a913b8203d14b4a91c54d57b52282
     sha256: 8740ccf0a22b13ddc7e6b0b577398fc3ec82aa8e020428aa13d69cf4c02bd0b6
+  category: main
+  optional: false
+- name: azure-core-cpp
+  version: 1.10.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=15'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.10.3-hbb1e571_1.conda
+  hash:
+    md5: 9c258c44761c173f7b21b4375a459496
+    sha256: 9dd27a9a321ec113cd52f7e2cee268c44e31b7ce1963d34d9623d2119215652e
   category: main
   optional: false
 - name: azure-core-cpp
@@ -1214,12 +1810,27 @@ package:
 - name: azure-datalake-store
   version: 0.0.51
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+    cffi: ''
+    requests: '>=2.20.0'
+    adal: '>=0.4.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-datalake-store-0.0.51-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 0a6d240a3a8198dce8508a5409b4737e
+    sha256: 8ba71f78851d238d8dc9f469f88b2f5619c7f6f5d009a96bcbd8bd595ed85273
+  category: main
+  optional: false
+- name: azure-datalake-store
+  version: 0.0.51
+  manager: conda
   platform: osx-arm64
   dependencies:
-    adal: '>=0.4.2'
-    cffi: ''
     python: ''
+    cffi: ''
     requests: '>=2.20.0'
+    adal: '>=0.4.2'
   url: https://conda.anaconda.org/conda-forge/noarch/azure-datalake-store-0.0.51-pyh9f0ad1d_0.tar.bz2
   hash:
     md5: 0a6d240a3a8198dce8508a5409b4737e
@@ -1245,13 +1856,29 @@ package:
 - name: azure-identity
   version: 1.15.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    cryptography: '>=2.5'
+    azure-core: <2.0.0,>=1.23.0
+    msal_extensions: <2.0.0,>=0.3.0
+    msal: <2.0.0,>=1.24.0
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-identity-1.15.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: d1ef208ae2a355e5bb9cdce337644ce9
+    sha256: a7a80ce603b0b2af0670e676b0ce96cc3fddd7c59f8f2c4d5767f5cfda7a74e9
+  category: main
+  optional: false
+- name: azure-identity
+  version: 1.15.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    azure-core: <2.0.0,>=1.23.0
-    cryptography: '>=2.5'
-    msal: <2.0.0,>=1.24.0
-    msal_extensions: <2.0.0,>=0.3.0
     python: '>=3.7'
+    cryptography: '>=2.5'
+    azure-core: <2.0.0,>=1.23.0
+    msal_extensions: <2.0.0,>=0.3.0
+    msal: <2.0.0,>=1.24.0
   url: https://conda.anaconda.org/conda-forge/noarch/azure-identity-1.15.0-pyhd8ed1ab_0.conda
   hash:
     md5: d1ef208ae2a355e5bb9cdce337644ce9
@@ -1277,13 +1904,29 @@ package:
 - name: azure-storage-blob
   version: 12.19.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    azure-core: <2.0.0,>=1.28.0
-    cryptography: '>=2.1.4'
-    isodate: '>=0.6.1'
     python: '>=3.7'
     typing-extensions: '>=4.3.0'
+    cryptography: '>=2.1.4'
+    isodate: '>=0.6.1'
+    azure-core: <2.0.0,>=1.28.0
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-storage-blob-12.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 57fdaf60fb362bb31c685b0f5e2b1f3a
+    sha256: fe43dcceec8cea87f1c5fcf3c155fb0e5c0c1a9d3656112ec4da232c053edaca
+  category: main
+  optional: false
+- name: azure-storage-blob
+  version: 12.19.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+    typing-extensions: '>=4.3.0'
+    cryptography: '>=2.1.4'
+    isodate: '>=0.6.1'
+    azure-core: <2.0.0,>=1.28.0
   url: https://conda.anaconda.org/conda-forge/noarch/azure-storage-blob-12.19.1-pyhd8ed1ab_0.conda
   hash:
     md5: 57fdaf60fb362bb31c685b0f5e2b1f3a
@@ -1303,6 +1946,21 @@ package:
   hash:
     md5: 64eec459779f01803594f5272cdde23c
     sha256: ea323e7028590b1877af92b76bc3cda52db5a1d90b8321ec91b9db0689f07fb3
+  category: main
+  optional: false
+- name: azure-storage-blobs-cpp
+  version: 12.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    azure-core-cpp: '>=1.10.3,<1.10.4.0a0'
+    azure-storage-common-cpp: '>=12.5.0,<12.5.1.0a0'
+    libcxx: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.10.0-he51d815_0.conda
+  hash:
+    md5: 49b100390f08fbbf2219b4e220f79983
+    sha256: 2b20c7884bebc511a7433802a81b7fc95a9aae957a760779a1699f087ffdf018
   category: main
   optional: false
 - name: azure-storage-blobs-cpp
@@ -1339,6 +1997,22 @@ package:
 - name: azure-storage-common-cpp
   version: 12.5.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    azure-core-cpp: '>=1.10.3,<1.10.4.0a0'
+    libcxx: '>=16.0.6'
+    libxml2: '>=2.12.1,<3.0.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.5.0-hf4badfb_2.conda
+  hash:
+    md5: 277020b2f0245d1d5a0a3bb0e921c069
+    sha256: b9336e9cbbf7a26f5cfab7dca2aec8037549efe8c8d6022e07b38f8840bbc608
+  category: main
+  optional: false
+- name: azure-storage-common-cpp
+  version: 12.5.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=10.9'
@@ -1369,11 +2043,25 @@ package:
 - name: babel
   version: 2.14.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    setuptools: ''
+    pytz: ''
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9669586875baeced8fc30c0826c3270e
+    sha256: 8584e3da58e92b72641c89ff9b98c51f0d5dbe76e527867804cbdf03ac91d8e6
+  category: main
+  optional: false
+- name: babel
+  version: 2.14.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    pytz: ''
     setuptools: ''
+    pytz: ''
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
   hash:
     md5: 9669586875baeced8fc30c0826c3270e
@@ -1392,6 +2080,19 @@ package:
   hash:
     md5: 171d33a4f1694713e0646dbc98e7f7cf
     sha256: 72c5a63962463b0d7c7c95db33266c8dbcdd72cd8ae9ca81d42f253f9d80cdf3
+  category: main
+  optional: false
+- name: bcrypt
+  version: 4.1.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/bcrypt-4.1.2-py39h3f9c672_0.conda
+  hash:
+    md5: e323c9439e1c508bd341839aac2972ce
+    sha256: cd1fa9468e71bd3d62c7c68833ac788d3bb51090993480ac606016bc99af2928
   category: main
   optional: false
 - name: bcrypt
@@ -1423,6 +2124,19 @@ package:
 - name: beautifulsoup4
   version: 4.12.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    soupsieve: '>=1.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+  hash:
+    md5: 332493000404d8411859539a5a630865
+    sha256: 7b05b2d0669029326c623b9df7a29fa49d1982a9e7e31b2fea34b4c9a4a72317
+  category: main
+  optional: false
+- name: beautifulsoup4
+  version: 4.12.3
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
@@ -1449,10 +2163,23 @@ package:
 - name: binaryornot
   version: 0.4.4
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+    chardet: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/binaryornot-0.4.4-py_1.tar.bz2
+  hash:
+    md5: a556fa60840fcb9dd739d186bfd252f7
+    sha256: 8f65c16a9f85285e1f704a26d4c5ced25f46544f5cc20dc8a4aebd7796f8011a
+  category: main
+  optional: false
+- name: binaryornot
+  version: 0.4.4
+  manager: conda
   platform: osx-arm64
   dependencies:
-    chardet: ''
     python: ''
+    chardet: ''
   url: https://conda.anaconda.org/conda-forge/noarch/binaryornot-0.4.4-py_1.tar.bz2
   hash:
     md5: a556fa60840fcb9dd739d186bfd252f7
@@ -1460,7 +2187,7 @@ package:
   category: main
   optional: false
 - name: black
-  version: 24.2.0
+  version: 24.3.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -1473,14 +2200,34 @@ package:
     python_abi: 3.9.*
     tomli: '>=1.1.0'
     typing_extensions: '>=4.0.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/black-24.2.0-py39hf3d152e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/black-24.3.0-py39hf3d152e_0.conda
   hash:
-    md5: 8060f38a7e9ced7e0ff82adfa5c01b65
-    sha256: 71539f1f61a9a3c0ceceae79ed7460e901bf0294599dbcd170496e8671e5d3b8
+    md5: 831bcbaf689b20fc85bf87eab3b5ee29
+    sha256: 7a4d9a43600c24ac29845689e24465b6c15819ad53d35e7120197aaf0badd1bb
   category: main
   optional: false
 - name: black
-  version: 24.2.0
+  version: 24.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    click: '>=8.0.0'
+    mypy_extensions: '>=0.4.3'
+    packaging: '>=22.0'
+    pathspec: '>=0.9'
+    platformdirs: '>=2'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    tomli: '>=1.1.0'
+    typing_extensions: '>=4.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/black-24.3.0-py39h6e9494a_0.conda
+  hash:
+    md5: d1fd38166a4edfc6b81ca209ac7393d2
+    sha256: 03d2486854754203540352e2ff94d9ddc4a25674c450f2a3cacaa682faf23b90
+  category: main
+  optional: false
+- name: black
+  version: 24.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1493,10 +2240,10 @@ package:
     python_abi: 3.9.*
     tomli: '>=1.1.0'
     typing_extensions: '>=4.0.1'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.2.0-py39h2804cbe_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.3.0-py39h2804cbe_0.conda
   hash:
-    md5: ea3b2d9d3b5d32361056e8c0eed7153c
-    sha256: 07397f3989ee6c50538f9c98b8b5ab7256ded48bfebe513c7c831945f0689364
+    md5: c86e0fc313a494cc855e80c02959fbff
+    sha256: 8e14d423a9613ad2763949d9ecc8c0e740a46dfac2dba7307f2c6790796c7f49
   category: main
   optional: false
 - name: blake3
@@ -1512,6 +2259,20 @@ package:
   hash:
     md5: cb2f0e7c51a8b55641034e52be530714
     sha256: 7a5db684002e9e01c7387ba19a1e7954d9ef9f91656d3cd9f4cdf5250f0a1d5c
+  category: main
+  optional: false
+- name: blake3
+  version: 0.3.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    numpy: ''
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/blake3-0.3.3-py39hf33989b_2.conda
+  hash:
+    md5: 00f9bcdfe7f207893d57fbf3a0d55cef
+    sha256: c8072db21e0e7b167b451cf2456c3482ad3409314b229104b1fdbab35af073a7
   category: main
   optional: false
 - name: blake3
@@ -1547,13 +2308,29 @@ package:
 - name: bleach
   version: 6.1.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    setuptools: ''
+    packaging: ''
+    webencodings: ''
+    python: '>=3.6'
+    six: '>=1.9.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
+    sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
+  category: main
+  optional: false
+- name: bleach
+  version: 6.1.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
-    python: '>=3.6'
     setuptools: ''
-    six: '>=1.9.0'
+    packaging: ''
     webencodings: ''
+    python: '>=3.6'
+    six: '>=1.9.0'
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
@@ -1564,6 +2341,18 @@ package:
   version: 1.7.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 550da20b2c2e38be9cc44bb819fda5d5
+    sha256: c8d72c2af4f57898dfd5e4c62ae67f7fea1490a37c8b6855460a170d61591177
+  category: main
+  optional: false
+- name: blinker
+  version: 1.7.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
@@ -1599,6 +2388,22 @@ package:
   hash:
     md5: 009521b7ed97cca25f8f997f9e745976
     sha256: e2b15b017775d1bda8edbb1bc48e545e45364edefa4d926732fc5488cc600731
+  category: main
+  optional: false
+- name: blosc
+  version: 1.21.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    snappy: '>=1.1.10,<2.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.5-heccf04b_0.conda
+  hash:
+    md5: 3003fa6dd18769db1a616982dcee5b40
+    sha256: db629047f1721d5a6e3bd41b07c1a3bacd0dee70f4063b61db2aa46f19a0b8b4
   category: main
   optional: false
 - name: blosc
@@ -1641,18 +2446,39 @@ package:
 - name: bokeh
   version: 3.4.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    contourpy: '>=1.2'
-    jinja2: '>=2.9'
+    python: '>=3.9'
     numpy: '>=1.16'
-    packaging: '>=16.8'
+    pyyaml: '>=3.10'
     pandas: '>=1.2'
     pillow: '>=7.1.0'
-    python: '>=3.9'
-    pyyaml: '>=3.10'
+    packaging: '>=16.8'
+    jinja2: '>=2.9'
     tornado: '>=6.2'
     xyzservices: '>=2021.09.1'
+    contourpy: '>=1.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: eebbbfdb7eb885ddc751c790c3d0ad64
+    sha256: a980687100456202425af0936185ef95c53309044e271daa60d2eeb009410f73
+  category: main
+  optional: false
+- name: bokeh
+  version: 3.4.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    numpy: '>=1.16'
+    pyyaml: '>=3.10'
+    pandas: '>=1.2'
+    pillow: '>=7.1.0'
+    packaging: '>=16.8'
+    jinja2: '>=2.9'
+    tornado: '>=6.2'
+    xyzservices: '>=2021.09.1'
+    contourpy: '>=1.2'
   url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: eebbbfdb7eb885ddc751c790c3d0ad64
@@ -1677,11 +2503,26 @@ package:
 - name: botocore
   version: 1.34.51
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.8'
     python-dateutil: '>=2.1,<3.0.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    urllib3: '>=1.25.4,<1.27'
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.51-pyge38_1234567_0.conda
+  hash:
+    md5: 79fc60a0a40d6254f67da7ce274c30a8
+    sha256: b264cf2547f0730a4c3efaa771533be790a76b35e3dd5f0c19cc7f7a6aad6151
+  category: main
+  optional: false
+- name: botocore
+  version: 1.34.51
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+    python-dateutil: '>=2.1,<3.0.0'
+    jmespath: '>=0.7.1,<2.0.0'
     urllib3: '>=1.25.4,<1.27'
   url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.51-pyge38_1234567_0.conda
   hash:
@@ -1705,10 +2546,23 @@ package:
 - name: branca
   version: 0.7.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    jinja2: '>=3'
+  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 35fa1bfd27c4d4c3cd46501a9ca7bd78
+    sha256: 4053ce4389a524e226eea020e2e507335e908a45d324b4f48d4b4407b17c88e3
+  category: main
+  optional: false
+- name: branca
+  version: 0.7.1
+  manager: conda
   platform: osx-arm64
   dependencies:
-    jinja2: '>=3'
     python: '>=3.7'
+    jinja2: '>=3'
   url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.1-pyhd8ed1ab_0.conda
   hash:
     md5: 35fa1bfd27c4d4c3cd46501a9ca7bd78
@@ -1728,6 +2582,20 @@ package:
   hash:
     md5: f27a24d46e3ea7b70a1f98e50c62508f
     sha256: f2d918d351edd06c55a6c2d84b488fe392f85ea018ff227daac07db22b408f6b
+  category: main
+  optional: false
+- name: brotli
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    brotli-bin: 1.1.0
+    libbrotlidec: 1.1.0
+    libbrotlienc: 1.1.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: 9272dd3b19c4e8212f8542cefd5c3d67
+    sha256: 4bf66d450be5d3f9ebe029b50f818d088b1ef9666b1f19e90c85479c77bbdcde
   category: main
   optional: false
 - name: brotli
@@ -1761,6 +2629,19 @@ package:
 - name: brotli-bin
   version: 1.1.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libbrotlidec: 1.1.0
+    libbrotlienc: 1.1.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: ece565c215adcc47fc1db4e651ee094b
+    sha256: 7ca3cfb4c5df314ed481301335387ab2b2ee651e2c74fbb15bacc795c664a5f1
+  category: main
+  optional: false
+- name: brotli-bin
+  version: 1.1.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libbrotlidec: 1.1.0
@@ -1784,6 +2665,20 @@ package:
   hash:
     md5: c48418c8b35f1d59ae9ae1174812b40a
     sha256: e22afb19527a93da24c1108c3e91532811f9c3df64a9473989faf332c98af082
+  category: main
+  optional: false
+- name: brotli-python
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py39h840bb9f_1.conda
+  hash:
+    md5: bf1edb07835e15685718843f7e71bab1
+    sha256: e19de8f5d9e1fe650b49eff6b0111eebd3b98368b5ae82733b90ec0abea5062a
   category: main
   optional: false
 - name: brotli-python
@@ -1815,6 +2710,17 @@ package:
 - name: bzip2
   version: 1.0.8
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
+  hash:
+    md5: 6097a6ca9ada32699b5fc4312dd6ef18
+    sha256: 61fb2b488928a54d9472113e1280b468a309561caa54f33825a3593da390b242
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
@@ -1824,26 +2730,37 @@ package:
   category: main
   optional: false
 - name: c-ares
-  version: 1.27.0
+  version: 1.28.1
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.27.0-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.28.1-hd590300_0.conda
   hash:
-    md5: f6afff0e9ee08d2f1b897881a4f38cdb
-    sha256: 2a5866b19d28cb963fab291a62ff1c884291b9d6f59de14643e52f103e255749
+    md5: dcde58ff9a1f30b0037a2315d1846d1f
+    sha256: cb25063f3342149c7924b21544109696197a9d774f1407567477d4f3026bf38a
   category: main
   optional: false
 - name: c-ares
-  version: 1.27.0
+  version: 1.28.1
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.28.1-h10d778d_0.conda
+  hash:
+    md5: d5eb7992227254c0e9a0ce71151f0079
+    sha256: fccd7ad7e3dfa6b19352705b33eb738c4c55f79f398e106e6cf03bab9415595a
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.28.1
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.27.0-h93a5062_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.28.1-h93a5062_0.conda
   hash:
-    md5: d3579ba506791b1f8f8a16cfc2885326
-    sha256: a168e53ee462980cd78b324e055afdd00080ded378ca974969a0917eb4ae1ccb
+    md5: 04f776a6139f7eafc2f38668570eb7db
+    sha256: 2fc553d7a75e912efbdd6b82cd7916cc9cb2773e6cd873b77e02d631dd7be698
   category: main
   optional: false
 - name: ca-certificates
@@ -1855,6 +2772,17 @@ package:
   hash:
     md5: 2f4327a1cbe7f022401b236e915a5fef
     sha256: 91d81bfecdbb142c15066df70cc952590ae8991670198f92c66b62019b251aeb
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2024.2.2
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
+  hash:
+    md5: f2eacee8c33c43692f1ccfd33d0f50b1
+    sha256: 54a794aedbb4796afeabdf54287b06b1d27f7b13b3814520925f4c2c80f58ca9
   category: main
   optional: false
 - name: ca-certificates
@@ -1883,6 +2811,18 @@ package:
 - name: cached-property
   version: 1.5.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    cached_property: '>=1.5.2,<1.5.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  hash:
+    md5: 9b347a7ec10940d3f7941ff6c460b551
+    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  category: main
+  optional: false
+- name: cached-property
+  version: 1.5.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     cached_property: '>=1.5.2,<1.5.3.0a0'
@@ -1907,6 +2847,18 @@ package:
 - name: cached_property
   version: 1.5.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  hash:
+    md5: 576d629e47797577ab0f1b351297ef4a
+    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  category: main
+  optional: false
+- name: cached_property
+  version: 1.5.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
@@ -1920,6 +2872,18 @@ package:
   version: 5.3.3
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.3.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: cd4c26c702a9bcdc70ff05b609ddacbe
+    sha256: 561b860cba68da76cab8c6504bb5bfb4756ecb2ec9f124d0c17e76caad4f6dfd
+  category: main
+  optional: false
+- name: cachetools
+  version: 5.3.3
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.3.3-pyhd8ed1ab_0.conda
@@ -1971,6 +2935,28 @@ package:
 - name: cairo
   version: 1.18.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    icu: '>=73.2,<74.0a0'
+    libcxx: '>=16.0.6'
+    libglib: '>=2.78.0,<3.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    pixman: '>=0.42.2,<1.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
+  hash:
+    md5: 13f830b1bf46018f7062d1b798d53eca
+    sha256: f8d1142cf244eadcbc44e8ca2266aa61a05b6cda5571f9b745ba32c7ebbfdfba
+  category: main
+  optional: false
+- name: cairo
+  version: 1.18.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=10.9'
@@ -1994,6 +2980,18 @@ package:
   version: 2024.2.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.2.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0876280e409658fc6f9e75d035960333
+    sha256: f1faca020f988696e6b6ee47c82524c7806380b37cfdd1def32f92c326caca54
+  category: main
+  optional: false
+- name: certifi
+  version: 2024.2.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.2.2-pyhd8ed1ab_0.conda
@@ -2033,6 +3031,21 @@ package:
 - name: cffi
   version: 1.16.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libffi: '>=3.4,<4.0a0'
+    pycparser: ''
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py39h18ef598_0.conda
+  hash:
+    md5: c31ac48f93f773fd27e99f113cfffb98
+    sha256: 26f365b87864cac155aa966a979d8cb17195032c05b61041d3d0dabd43ba0c0b
+  category: main
+  optional: false
+- name: cffi
+  version: 1.16.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libffi: '>=3.4,<4.0a0'
@@ -2049,6 +3062,18 @@ package:
   version: 3.3.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: ebb5f5f7dc4f1a3780ef7ea7738db08c
+    sha256: fbc03537a27ef756162c49b1d0608bf7ab12fa5e38ceb8563d6f4859e835ac5c
+  category: main
+  optional: false
+- name: cfgv
+  version: 3.3.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
@@ -2089,6 +3114,22 @@ package:
 - name: cfitsio
   version: 4.3.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libcurl: '>=8.4.0,<9.0a0'
+    libgfortran: 5.*
+    libgfortran5: '>=13.2.0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.3.1-h60fb419_0.conda
+  hash:
+    md5: 03ab895afe3804b527c12193a9612cac
+    sha256: 5bd157478529ff4d05b8e8654de0580609177252eb11ecf5201b831effeeb2ec
+  category: main
+  optional: false
+- name: cfitsio
+  version: 4.3.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
@@ -2113,6 +3154,19 @@ package:
   hash:
     md5: 514bcdeaf82679b99ac629cb6f2860f1
     sha256: 1733218d1da1ce2f1e9a0d28b6e9c62fe32c3b86c5bd7a0cdceb2f3a4b03cfa9
+  category: main
+  optional: false
+- name: chardet
+  version: 5.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/chardet-5.2.0-py39h6e9494a_1.conda
+  hash:
+    md5: ad452e3e1b22c65052c17219c7a868e6
+    sha256: 3af30427ac7a2f32f12ebc948beb29f9990005249172ed9803186945dea7920f
   category: main
   optional: false
 - name: chardet
@@ -2143,6 +3197,18 @@ package:
 - name: charset-normalizer
   version: 3.3.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7f4a9e3fcff3f6356ae99244a014da6a
+    sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+  category: main
+  optional: false
+- name: charset-normalizer
+  version: 3.3.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -2168,6 +3234,19 @@ package:
 - name: click
   version: 8.1.7
   manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  hash:
+    md5: f3ad426304898027fc619827ff428eca
+    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  category: main
+  optional: false
+- name: click
+  version: 8.1.7
+  manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
@@ -2194,10 +3273,23 @@ package:
 - name: click-plugins
   version: 1.1.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+    click: '>=3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+  hash:
+    md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
+    sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+  category: main
+  optional: false
+- name: click-plugins
+  version: 1.1.1
+  manager: conda
   platform: osx-arm64
   dependencies:
-    click: '>=3.0'
     python: ''
+    click: '>=3.0'
   url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
   hash:
     md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
@@ -2220,10 +3312,23 @@ package:
 - name: cligj
   version: 0.7.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: <4.0
+    click: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+  hash:
+    md5: a29b7c141d6b2de4bb67788a5f107734
+    sha256: 97bd58f0cfcff56a0bcda101e26f7d936625599325beba3e3a1fa512dd7fc174
+  category: main
+  optional: false
+- name: cligj
+  version: 0.7.2
+  manager: conda
   platform: osx-arm64
   dependencies:
-    click: '>=4.0'
     python: <4.0
+    click: '>=4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
   hash:
     md5: a29b7c141d6b2de4bb67788a5f107734
@@ -2245,6 +3350,18 @@ package:
 - name: cloudpickle
   version: 2.2.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-2.2.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: b325bfc4cff7d7f8a868f1f7ecc4ed16
+    sha256: f0c2fd0e842899a05ddd7b147fb26424adf58be0e8e54e5bc68b8f7e67d05dcd
+  category: main
+  optional: false
+- name: cloudpickle
+  version: 2.2.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
@@ -2269,6 +3386,18 @@ package:
 - name: codespell
   version: 2.2.6
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/codespell-2.2.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: a206349b7bb7475ae580f987cb425bdd
+    sha256: b49d5482fbdeeb610275f6e7def3ee1409e6f2305b0eae4d37e23ada8b01e989
+  category: main
+  optional: false
+- name: codespell
+  version: 2.2.6
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
@@ -2293,6 +3422,18 @@ package:
 - name: colorama
   version: 0.4.6
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 3faab06a954c2a04039983f2c4a50d99
+    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  category: main
+  optional: false
+- name: colorama
+  version: 0.4.6
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -2318,6 +3459,19 @@ package:
 - name: comm
   version: 0.2.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 948d84721b578d426294e17a02e24cbb
+    sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+  category: main
+  optional: false
+- name: comm
+  version: 0.2.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
@@ -2344,10 +3498,23 @@ package:
 - name: commonmark
   version: 0.9.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+    future: '>=0.14.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/commonmark-0.9.1-py_0.tar.bz2
+  hash:
+    md5: 6aa0173c14befcd577ded130cf6f22f5
+    sha256: 10577f82bafd5d37f0c3f2122272d0dc1f2d133655c2bdd1a3cd5f910d0bd4c5
+  category: main
+  optional: false
+- name: commonmark
+  version: 0.9.1
+  manager: conda
   platform: osx-arm64
   dependencies:
-    future: '>=0.14.0'
     python: ''
+    future: '>=0.14.0'
   url: https://conda.anaconda.org/conda-forge/noarch/commonmark-0.9.1-py_0.tar.bz2
   hash:
     md5: 6aa0173c14befcd577ded130cf6f22f5
@@ -2358,6 +3525,18 @@ package:
   version: 6.0.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/configparser-6.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2a24e68637e51e2adf001e9d0af848b1
+    sha256: e01107b458dd21f1915dcd9901f5ecc7d918a8157d9a9802020286ed83f9847e
+  category: main
+  optional: false
+- name: configparser
+  version: 6.0.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/configparser-6.0.1-pyhd8ed1ab_0.conda
@@ -2392,6 +3571,22 @@ package:
   hash:
     md5: ed71ad3e30eb03da363fb797419cce98
     sha256: 7a85421667d97132c5d23575da63c2da850775c81832607e56bfd881c9750f3a
+  category: main
+  optional: false
+- name: contourpy
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    numpy: '>=1.20,<2'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.2.0-py39h6be1789_0.conda
+  hash:
+    md5: f612db80986ecdc867662b9dc4e46f11
+    sha256: cd0808189a10f45b41ef8eee2f373ae870673b0fe49d17ecee4e401445f17ea6
   category: main
   optional: false
 - name: contourpy
@@ -2433,17 +3628,37 @@ package:
 - name: cookiecutter
   version: 2.6.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    rich: ''
     arrow: ''
-    binaryornot: '>=0.4.4'
-    click: '>=7.0,<9.0.0'
-    jinja2: '>=2.7,<4.0.0'
     python: '>=3.7'
-    python-slugify: '>=4.0.0'
     pyyaml: '>=5.3.1'
     requests: '>=2.23.0'
+    python-slugify: '>=4.0.0'
+    binaryornot: '>=0.4.4'
+    jinja2: '>=2.7,<4.0.0'
+    click: '>=7.0,<9.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cookiecutter-2.6.0-pyhca7485f_0.conda
+  hash:
+    md5: d6260b53b9db90017321af0b45cc00da
+    sha256: 5bed5805127757a4f03231eb7fe971cfe3c3411eeef036e670c41bfd8a42d91d
+  category: main
+  optional: false
+- name: cookiecutter
+  version: 2.6.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     rich: ''
+    arrow: ''
+    python: '>=3.7'
+    pyyaml: '>=5.3.1'
+    requests: '>=2.23.0'
+    python-slugify: '>=4.0.0'
+    binaryornot: '>=0.4.4'
+    jinja2: '>=2.7,<4.0.0'
+    click: '>=7.0,<9.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/cookiecutter-2.6.0-pyhca7485f_0.conda
   hash:
     md5: d6260b53b9db90017321af0b45cc00da
@@ -2451,31 +3666,45 @@ package:
   category: main
   optional: false
 - name: croniter
-  version: 2.0.2
+  version: 2.0.3
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
     python-dateutil: ''
     pytz: '>2021.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/croniter-2.0.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/croniter-2.0.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 81e82a2922ee960cc5e324b0102174d0
-    sha256: e235c57e6070f5d2b161f7b496d00cb9e75796c5234cf62aff9e04258302940e
+    md5: e78f1f7d43de7213744075a90881c789
+    sha256: eeed424fd485c23b19db8df76cbd21987af4190036292f5b7372745e8ad9f216
   category: main
   optional: false
 - name: croniter
-  version: 2.0.2
+  version: 2.0.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python-dateutil: ''
+    python: '>=3.7'
+    pytz: '>2021.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/croniter-2.0.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: e78f1f7d43de7213744075a90881c789
+    sha256: eeed424fd485c23b19db8df76cbd21987af4190036292f5b7372745e8ad9f216
+  category: main
+  optional: false
+- name: croniter
+  version: 2.0.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     python-dateutil: ''
+    python: '>=3.7'
     pytz: '>2021.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/croniter-2.0.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/croniter-2.0.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 81e82a2922ee960cc5e324b0102174d0
-    sha256: e235c57e6070f5d2b161f7b496d00cb9e75796c5234cf62aff9e04258302940e
+    md5: e78f1f7d43de7213744075a90881c789
+    sha256: eeed424fd485c23b19db8df76cbd21987af4190036292f5b7372745e8ad9f216
   category: main
   optional: false
 - name: cryptography
@@ -2497,6 +3726,22 @@ package:
 - name: cryptography
   version: 42.0.5
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.12'
+    cffi: '>=1.12'
+    openssl: '>=3.2.1,<4.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/cryptography-42.0.5-py39h915638b_0.conda
+  hash:
+    md5: ca39a462c79476c4237b8abbe82e5584
+    sha256: 798d6f7b12397ea3bbf1e298a7bad6dc82af0bccf8f4b4acc2917e99bcc877a5
+  category: main
+  optional: false
+- name: cryptography
+  version: 42.0.5
+  manager: conda
   platform: osx-arm64
   dependencies:
     cffi: '>=1.12'
@@ -2509,52 +3754,61 @@ package:
     sha256: 4ce400c11245a79feb9fea93e8179379c48af6e755347f3c91181c5fd54423e9
   category: main
   optional: false
+- name: cuda-cudart
+  version: 12.4.99
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cuda-cudart_linux-64: 12.4.99
+    cuda-version: '>=12.4,<12.5.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-12.4.99-hd3aeb46_0.conda
+  hash:
+    md5: 4d229c1bd27b08f176d35dd2b6fa3e43
+    sha256: a98f120b8578e9d5dc6997e49caca972147d22e69760c432ca24b1f16208e5b0
+  category: main
+  optional: false
+- name: cuda-cudart_linux-64
+  version: 12.4.99
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cuda-version: '>=12.4,<12.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-12.4.99-h59595ed_0.conda
+  hash:
+    md5: 2c184d2ca9f4e01b501103b42b895016
+    sha256: dc8734b59e2765fdcf8c7765193af2fc5e8120ca1a47b9b2c13eb8789c20a781
+  category: main
+  optional: false
 - name: cuda-version
-  version: '11.8'
+  version: '12.4'
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/cuda-version-11.8-h70ddcb2_3.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cuda-version-12.4-h3060b56_3.conda
   hash:
-    md5: 670f0e1593b8c1d84f57ad5fe5256799
-    sha256: 53e0ffc14ea2f2b8c12320fd2aa38b01112763eba851336ff5953b436ae61259
-  category: main
-  optional: false
-- name: cudatoolkit
-  version: 11.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cudatoolkit-11.8.0-h4ba93d1_13.conda
-  hash:
-    md5: eb43f5f1f16e2fad2eba22219c3e499b
-    sha256: 1797bacaf5350f272413c7f50787c01aef0e8eb955df0f0db144b10be2819752
-  category: main
-  optional: false
-- name: cudnn
-  version: 8.9.7.29
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cuda-version: '>=11.0,<12.0a0'
-    cudatoolkit: 11.*
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cudnn-8.9.7.29-hbc23b4c_3.conda
-  hash:
-    md5: 4a2d5fab2871d95544de4e1752948d0f
-    sha256: c553234d447d9938556f067aba7a4686c8e5427e03e740e67199da3782cc420c
+    md5: c9a3fe8b957176e1a8452c6f3431b0d8
+    sha256: 571d32fbd0dc8df6e85c14d1757549927e272af9c70b935d7e3a553ab0b0b4da
   category: main
   optional: false
 - name: cycler
   version: 0.12.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5cd86562580f274031ede6aa6aa24441
+    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+  category: main
+  optional: false
+- name: cycler
+  version: 0.12.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
@@ -2593,6 +3847,20 @@ package:
 - name: cytoolz
   version: 0.12.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    toolz: '>=0.10.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-0.12.3-py39ha09f3b3_0.conda
+  hash:
+    md5: 069c271e8e59773b433717998f1ffd4e
+    sha256: 7871cef868636cc21c710a931c359bd1af79fe198d2b3aaaa6256cbbc0300570
+  category: main
+  optional: false
+- name: cytoolz
+  version: 0.12.3
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -2605,15 +3873,15 @@ package:
   category: main
   optional: false
 - name: dask
-  version: 2024.3.0
+  version: 2024.3.1
   manager: conda
   platform: linux-64
   dependencies:
     bokeh: '>=2.4.2,!=3.0.*'
     cytoolz: '>=0.11.0'
-    dask-core: '>=2024.3.0,<2024.3.1.0a0'
+    dask-core: '>=2024.3.1,<2024.3.2.0a0'
     dask-expr: '>=1.0,<1.1'
-    distributed: '>=2024.3.0,<2024.3.1.0a0'
+    distributed: '>=2024.3.1,<2024.3.2.0a0'
     jinja2: '>=2.10.3'
     lz4: '>=4.3.2'
     numpy: '>=1.21'
@@ -2621,37 +3889,60 @@ package:
     pyarrow: '>=7.0'
     pyarrow-hotfix: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.3.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 271447895d7d7f1bd28a74e6afc51be3
-    sha256: 666cd081c8a33164aa2f20177cd2e3c952746936390f38558898269cf80cf8ed
+    md5: e3f23f17022881c62e75ddbab7a61f9e
+    sha256: ee6ba90fab615bd224d58e1c8f6d049e42a044dcd66ee465e516d85282d08336
   category: main
   optional: false
 - name: dask
-  version: 2024.3.0
+  version: 2024.3.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    bokeh: '>=2.4.2,!=3.0.*'
-    cytoolz: '>=0.11.0'
-    dask-core: '>=2024.3.0,<2024.3.1.0a0'
-    dask-expr: '>=1.0,<1.1'
-    distributed: '>=2024.3.0,<2024.3.1.0a0'
-    jinja2: '>=2.10.3'
-    lz4: '>=4.3.2'
+    pyarrow-hotfix: ''
+    python: '>=3.9'
     numpy: '>=1.21'
     pandas: '>=1.3'
+    jinja2: '>=2.10.3'
     pyarrow: '>=7.0'
+    lz4: '>=4.3.2'
+    cytoolz: '>=0.11.0'
+    bokeh: '>=2.4.2,!=3.0.*'
+    dask-expr: '>=1.0,<1.1'
+    dask-core: '>=2024.3.1,<2024.3.2.0a0'
+    distributed: '>=2024.3.1,<2024.3.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: e3f23f17022881c62e75ddbab7a61f9e
+    sha256: ee6ba90fab615bd224d58e1c8f6d049e42a044dcd66ee465e516d85282d08336
+  category: main
+  optional: false
+- name: dask
+  version: 2024.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     pyarrow-hotfix: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.3.0-pyhd8ed1ab_1.conda
+    numpy: '>=1.21'
+    pandas: '>=1.3'
+    jinja2: '>=2.10.3'
+    pyarrow: '>=7.0'
+    lz4: '>=4.3.2'
+    cytoolz: '>=0.11.0'
+    bokeh: '>=2.4.2,!=3.0.*'
+    dask-expr: '>=1.0,<1.1'
+    dask-core: '>=2024.3.1,<2024.3.2.0a0'
+    distributed: '>=2024.3.1,<2024.3.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 271447895d7d7f1bd28a74e6afc51be3
-    sha256: 666cd081c8a33164aa2f20177cd2e3c952746936390f38558898269cf80cf8ed
+    md5: e3f23f17022881c62e75ddbab7a61f9e
+    sha256: ee6ba90fab615bd224d58e1c8f6d049e42a044dcd66ee465e516d85282d08336
   category: main
   optional: false
 - name: dask-core
-  version: 2024.3.0
+  version: 2024.3.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -2664,60 +3955,95 @@ package:
     python: '>=3.9'
     pyyaml: '>=5.3.1'
     toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b6c573c271bf4c062873d7f3df97c3ba
-    sha256: b7c1514f0be3b447305440bad0d7cc5842f521d46b01788e1d9bbdbf623bc76a
+    md5: 52dd56ce3afa6a52c2f3d3116875ff32
+    sha256: 396607b11601c89331d6934ded9f9765a9aa8485fee19ea8d466c631bee3ba61
   category: main
   optional: false
 - name: dask-core
-  version: 2024.3.0
+  version: 2024.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    packaging: '>=20.0'
+    pyyaml: '>=5.3.1'
+    cloudpickle: '>=1.5.0'
+    toolz: '>=0.10.0'
+    partd: '>=1.2.0'
+    click: '>=8.1'
+    importlib_metadata: '>=4.13.0'
+    fsspec: '>=2021.09.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 52dd56ce3afa6a52c2f3d3116875ff32
+    sha256: 396607b11601c89331d6934ded9f9765a9aa8485fee19ea8d466c631bee3ba61
+  category: main
+  optional: false
+- name: dask-core
+  version: 2024.3.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    click: '>=8.1'
-    cloudpickle: '>=1.5.0'
-    fsspec: '>=2021.09.0'
-    importlib_metadata: '>=4.13.0'
-    packaging: '>=20.0'
-    partd: '>=1.2.0'
     python: '>=3.9'
+    packaging: '>=20.0'
     pyyaml: '>=5.3.1'
+    cloudpickle: '>=1.5.0'
     toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.3.0-pyhd8ed1ab_0.conda
+    partd: '>=1.2.0'
+    click: '>=8.1'
+    importlib_metadata: '>=4.13.0'
+    fsspec: '>=2021.09.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b6c573c271bf4c062873d7f3df97c3ba
-    sha256: b7c1514f0be3b447305440bad0d7cc5842f521d46b01788e1d9bbdbf623bc76a
+    md5: 52dd56ce3afa6a52c2f3d3116875ff32
+    sha256: 396607b11601c89331d6934ded9f9765a9aa8485fee19ea8d466c631bee3ba61
   category: main
   optional: false
 - name: dask-expr
-  version: 1.0.2
+  version: 1.0.5
   manager: conda
   platform: linux-64
   dependencies:
-    dask-core: 2024.3.0
+    dask-core: 2024.3.1
     pandas: '>=2'
     pyarrow: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.0.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.0.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 55fad7bd4735ae915926b7c14aed1d97
-    sha256: 7d09a3b8499b3fb3f035977809959e212de669c4a4a0619e728e9f52a7bbc97b
+    md5: d1e973e2e617f806194f4e664c2d3d33
+    sha256: fb83d89b4303c620bc1d7ff968db15622548110d74f0d2d8f9cc5fd180830e61
   category: main
   optional: false
 - name: dask-expr
-  version: 1.0.2
+  version: 1.0.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pyarrow: ''
+    python: '>=3.9'
+    pandas: '>=2'
+    dask-core: 2024.3.1
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: d1e973e2e617f806194f4e664c2d3d33
+    sha256: fb83d89b4303c620bc1d7ff968db15622548110d74f0d2d8f9cc5fd180830e61
+  category: main
+  optional: false
+- name: dask-expr
+  version: 1.0.5
   manager: conda
   platform: osx-arm64
   dependencies:
-    dask-core: 2024.3.0
-    pandas: '>=2'
     pyarrow: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.0.2-pyhd8ed1ab_0.conda
+    pandas: '>=2'
+    dask-core: 2024.3.1
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.0.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 55fad7bd4735ae915926b7c14aed1d97
-    sha256: 7d09a3b8499b3fb3f035977809959e212de669c4a4a0619e728e9f52a7bbc97b
+    md5: d1e973e2e617f806194f4e664c2d3d33
+    sha256: fb83d89b4303c620bc1d7ff968db15622548110d74f0d2d8f9cc5fd180830e61
   category: main
   optional: false
 - name: databricks-cli
@@ -2743,16 +4069,36 @@ package:
 - name: databricks-cli
   version: 0.18.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    python: '>=3.7'
     click: '>=7.0'
+    six: '>=1.10.0'
+    pyjwt: '>=1.7.0'
+    tabulate: '>=0.7.7'
+    requests: '>=2.17.3'
     configparser: '>=0.3.5'
     oauthlib: '>=3.1.0'
-    pyjwt: '>=1.7.0'
+    urllib3: '>=1.26.7,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/databricks-cli-0.18.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5036bba5b1dd105148a5bab9ff4b0620
+    sha256: 6ac45a54c2d7e14195d413bbe372f4636d00bc6ce76ffc0c737fb9c7d80a32eb
+  category: main
+  optional: false
+- name: databricks-cli
+  version: 0.18.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     python: '>=3.7'
-    requests: '>=2.17.3'
+    click: '>=7.0'
     six: '>=1.10.0'
+    pyjwt: '>=1.7.0'
     tabulate: '>=0.7.7'
+    requests: '>=2.17.3'
+    configparser: '>=0.3.5'
+    oauthlib: '>=3.1.0'
     urllib3: '>=1.26.7,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/databricks-cli-0.18.0-pyhd8ed1ab_0.conda
   hash:
@@ -2779,13 +4125,29 @@ package:
 - name: dataclasses-json
   version: 0.5.7
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    python: '>=3.6'
+    typing_inspect: '>=0.4.0'
     marshmallow: '>=3.3.0,<4.0.0'
     marshmallow-enum: '>=1.5.1,<2.0.0'
-    python: '>=3.6'
     stringcase: 1.2.0,<2.0.0
+  url: https://conda.anaconda.org/conda-forge/noarch/dataclasses-json-0.5.7-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 460d0446b90718c6b535bfe807eab1cd
+    sha256: 8775cfe2a7583f724c1b424088f988eb480f242b9a09823e92f4af9df3c190de
+  category: main
+  optional: false
+- name: dataclasses-json
+  version: 0.5.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
     typing_inspect: '>=0.4.0'
+    marshmallow: '>=3.3.0,<4.0.0'
+    marshmallow-enum: '>=1.5.1,<2.0.0'
+    stringcase: 1.2.0,<2.0.0
   url: https://conda.anaconda.org/conda-forge/noarch/dataclasses-json-0.5.7-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 460d0446b90718c6b535bfe807eab1cd
@@ -2793,57 +4155,81 @@ package:
   category: main
   optional: false
 - name: datasets
-  version: 2.18.0
+  version: 2.14.4
   manager: conda
   platform: linux-64
   dependencies:
     aiohttp: ''
-    dill: '>=0.3.0,<0.3.9'
-    filelock: ''
-    fsspec: '>=2023.1.0,<=2024.2.0'
-    huggingface_hub: '>=0.19.4'
+    dill: '>=0.3.0,<0.3.8'
+    fsspec: '>=2021.11.1'
+    huggingface_hub: '>=0.14.0,<1.0.0'
+    importlib-metadata: ''
     multiprocess: ''
     numpy: '>=1.17'
     packaging: ''
     pandas: ''
-    pyarrow: '>=12.0.0'
-    pyarrow-hotfix: ''
+    pyarrow: '>=8.0.0'
     python: '>=3.8.0'
     python-xxhash: ''
     pyyaml: '>=5.1'
     requests: '>=2.19.0'
     tqdm: '>=4.62.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.18.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.14.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 3482c9b417757df305ff4e3a7e4b7c10
-    sha256: 2d792e6f8ecd3ac02921e13f0d5013f412c61d39bcbb8fad4a1f42d6cf6e7a53
+    md5: 3e087f072ce03c43a9b60522f5d0ca2f
+    sha256: 7e09bd083a609138b780fcc4535924cb96814d2c908a36d4c64a2ba9ee3efe7f
   category: main
   optional: false
 - name: datasets
-  version: 2.18.0
+  version: 2.14.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pandas: ''
+    packaging: ''
+    importlib-metadata: ''
+    aiohttp: ''
+    python-xxhash: ''
+    multiprocess: ''
+    pyyaml: '>=5.1'
+    numpy: '>=1.17'
+    pyarrow: '>=8.0.0'
+    requests: '>=2.19.0'
+    python: '>=3.8.0'
+    tqdm: '>=4.62.1'
+    fsspec: '>=2021.11.1'
+    dill: '>=0.3.0,<0.3.8'
+    huggingface_hub: '>=0.14.0,<1.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.14.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3e087f072ce03c43a9b60522f5d0ca2f
+    sha256: 7e09bd083a609138b780fcc4535924cb96814d2c908a36d4c64a2ba9ee3efe7f
+  category: main
+  optional: false
+- name: datasets
+  version: 2.14.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    aiohttp: ''
-    dill: '>=0.3.0,<0.3.9'
-    filelock: ''
-    fsspec: '>=2023.1.0,<=2024.2.0'
-    huggingface_hub: '>=0.19.4'
-    multiprocess: ''
-    numpy: '>=1.17'
-    packaging: ''
     pandas: ''
-    pyarrow: '>=12.0.0'
-    pyarrow-hotfix: ''
-    python: '>=3.8.0'
+    packaging: ''
+    importlib-metadata: ''
+    aiohttp: ''
     python-xxhash: ''
+    multiprocess: ''
     pyyaml: '>=5.1'
+    numpy: '>=1.17'
+    pyarrow: '>=8.0.0'
     requests: '>=2.19.0'
+    python: '>=3.8.0'
     tqdm: '>=4.62.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.18.0-pyhd8ed1ab_0.conda
+    fsspec: '>=2021.11.1'
+    dill: '>=0.3.0,<0.3.8'
+    huggingface_hub: '>=0.14.0,<1.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.14.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 3482c9b417757df305ff4e3a7e4b7c10
-    sha256: 2d792e6f8ecd3ac02921e13f0d5013f412c61d39bcbb8fad4a1f42d6cf6e7a53
+    md5: 3e087f072ce03c43a9b60522f5d0ca2f
+    sha256: 7e09bd083a609138b780fcc4535924cb96814d2c908a36d4c64a2ba9ee3efe7f
   category: main
   optional: false
 - name: db-dtypes
@@ -2865,13 +4251,29 @@ package:
 - name: db-dtypes
   version: 1.2.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    pandas: '>=0.24.2'
+    packaging: '>=17.0'
+    pyarrow: '>=3.0.0'
+    numpy: '>=1.16.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/db-dtypes-1.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: d7dbb7a600bb820b5b7874b3a2a87990
+    sha256: f96091a81a3dbef3ef27e9860dd220c4f87ed6b1791b56f0096b7054c4130d7a
+  category: main
+  optional: false
+- name: db-dtypes
+  version: 1.2.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    numpy: '>=1.16.6'
-    packaging: '>=17.0'
-    pandas: '>=0.24.2'
-    pyarrow: '>=3.0.0'
     python: '>=3.7'
+    pandas: '>=0.24.2'
+    packaging: '>=17.0'
+    pyarrow: '>=3.0.0'
+    numpy: '>=1.16.6'
   url: https://conda.anaconda.org/conda-forge/noarch/db-dtypes-1.2.0-pyhd8ed1ab_0.conda
   hash:
     md5: d7dbb7a600bb820b5b7874b3a2a87990
@@ -2910,6 +4312,20 @@ package:
 - name: debugpy
   version: 1.8.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.1-py39hd253f6c_0.conda
+  hash:
+    md5: 328dc0de8a70c8f8de65d37a6b289220
+    sha256: 9c45fffa6c2c4494b267e371d6c55cd0f8c7703e89b167263f4906a7339339b7
+  category: main
+  optional: false
+- name: debugpy
+  version: 1.8.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=16'
@@ -2936,6 +4352,18 @@ package:
 - name: decorator
   version: 5.1.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 43afe5ab04e35e17ba28649471dd7364
+    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  category: main
+  optional: false
+- name: decorator
+  version: 5.1.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -2960,6 +4388,18 @@ package:
 - name: defusedxml
   version: 0.7.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 961b3a227b437d82ad7054484cfa71b2
+    sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  category: main
+  optional: false
+- name: defusedxml
+  version: 0.7.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
@@ -2970,33 +4410,57 @@ package:
   category: main
   optional: false
 - name: dill
-  version: 0.3.8
+  version: 0.3.7
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 78745f157d56877a2c6e7b386f66f3e2
-    sha256: 482b5b566ca559119b504c53df12b08f3962a5ef8e48061d62fd58a47f8f2ec4
+    md5: 5e4f3466526c52bc9af2d2353a1460bd
+    sha256: 4ff20c6be028be2825235631c45d9e4a75bca1de65f8840c02dfb28ea0137c45
   category: main
   optional: false
 - name: dill
-  version: 0.3.8
+  version: 0.3.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.7-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5e4f3466526c52bc9af2d2353a1460bd
+    sha256: 4ff20c6be028be2825235631c45d9e4a75bca1de65f8840c02dfb28ea0137c45
+  category: main
+  optional: false
+- name: dill
+  version: 0.3.7
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 78745f157d56877a2c6e7b386f66f3e2
-    sha256: 482b5b566ca559119b504c53df12b08f3962a5ef8e48061d62fd58a47f8f2ec4
+    md5: 5e4f3466526c52bc9af2d2353a1460bd
+    sha256: 4ff20c6be028be2825235631c45d9e4a75bca1de65f8840c02dfb28ea0137c45
   category: main
   optional: false
 - name: diskcache
   version: 5.6.3
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4c33109f652b5d8c995ab243436c9370
+    sha256: 2547a3aa97f0862e55d9d4bbef457b087d35f4bff05766c8169c82719bc61e17
+  category: main
+  optional: false
+- name: diskcache
+  version: 5.6.3
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_0.conda
@@ -3032,6 +4496,18 @@ package:
 - name: distlib
   version: 0.3.8
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: 2.7|>=3.6
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: db16c66b759a64dc5183d69cc3745a52
+    sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
+  category: main
+  optional: false
+- name: distlib
+  version: 0.3.8
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: 2.7|>=3.6
@@ -3042,14 +4518,14 @@ package:
   category: main
   optional: false
 - name: distributed
-  version: 2024.3.0
+  version: 2024.3.1
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=8.0'
     cloudpickle: '>=1.5.0'
     cytoolz: '>=0.10.1'
-    dask-core: '>=2024.3.0,<2024.3.1.0a0'
+    dask-core: '>=2024.3.1,<2024.3.2.0a0'
     jinja2: '>=2.10.3'
     locket: '>=1.0.0'
     msgpack-python: '>=1.0.0'
@@ -3063,44 +4539,84 @@ package:
     tornado: '>=6.0.4'
     urllib3: '>=1.24.3'
     zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: e4736ce580a5b289f7412f14ae8df42a
-    sha256: d13ee04cb06fa760b7b1fab4ce3b1d4bef37013daafb49aad6d28cb7c7dae906
+    md5: b0ad5ef44595ef37c3008fc04ecd2abf
+    sha256: f587da3ff040968fecac7f424b88c5bc5fe16fe92fe08643fb5be8318d05c275
   category: main
   optional: false
 - name: distributed
-  version: 2024.3.0
+  version: 2024.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    packaging: '>=20.0'
+    pyyaml: '>=5.3.1'
+    cloudpickle: '>=1.5.0'
+    click: '>=8.0'
+    msgpack-python: '>=1.0.0'
+    urllib3: '>=1.24.3'
+    toolz: '>=0.10.0'
+    jinja2: '>=2.10.3'
+    tblib: '>=1.6.0'
+    locket: '>=1.0.0'
+    tornado: '>=6.0.4'
+    sortedcontainers: '>=2.0.5'
+    cytoolz: '>=0.10.1'
+    psutil: '>=5.7.2'
+    zict: '>=3.0.0'
+    dask-core: '>=2024.3.1,<2024.3.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: b0ad5ef44595ef37c3008fc04ecd2abf
+    sha256: f587da3ff040968fecac7f424b88c5bc5fe16fe92fe08643fb5be8318d05c275
+  category: main
+  optional: false
+- name: distributed
+  version: 2024.3.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    click: '>=8.0'
-    cloudpickle: '>=1.5.0'
-    cytoolz: '>=0.10.1'
-    dask-core: '>=2024.3.0,<2024.3.1.0a0'
-    jinja2: '>=2.10.3'
-    locket: '>=1.0.0'
-    msgpack-python: '>=1.0.0'
-    packaging: '>=20.0'
-    psutil: '>=5.7.2'
     python: '>=3.9'
+    packaging: '>=20.0'
     pyyaml: '>=5.3.1'
-    sortedcontainers: '>=2.0.5'
-    tblib: '>=1.6.0'
-    toolz: '>=0.10.0'
-    tornado: '>=6.0.4'
+    cloudpickle: '>=1.5.0'
+    click: '>=8.0'
+    msgpack-python: '>=1.0.0'
     urllib3: '>=1.24.3'
+    toolz: '>=0.10.0'
+    jinja2: '>=2.10.3'
+    tblib: '>=1.6.0'
+    locket: '>=1.0.0'
+    tornado: '>=6.0.4'
+    sortedcontainers: '>=2.0.5'
+    cytoolz: '>=0.10.1'
+    psutil: '>=5.7.2'
     zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.3.0-pyhd8ed1ab_0.conda
+    dask-core: '>=2024.3.1,<2024.3.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: e4736ce580a5b289f7412f14ae8df42a
-    sha256: d13ee04cb06fa760b7b1fab4ce3b1d4bef37013daafb49aad6d28cb7c7dae906
+    md5: b0ad5ef44595ef37c3008fc04ecd2abf
+    sha256: f587da3ff040968fecac7f424b88c5bc5fe16fe92fe08643fb5be8318d05c275
   category: main
   optional: false
 - name: distro
   version: 1.9.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: bbdb409974cd6cb30071b1d978302726
+    sha256: ae1c13d709c8001331b5b9345e4bcd77e9ae712d25f7958b2ebcbe0b068731b7
+  category: main
+  optional: false
+- name: distro
+  version: 1.9.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_0.conda
@@ -3142,15 +4658,33 @@ package:
 - name: docker-py
   version: 6.1.3
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    packaging: '>=14.0'
-    paramiko: '>=2.4.3'
-    python: '>=3.7'
     pywin32-on-windows: ''
+    python: '>=3.7'
     requests: '>=2.26.0'
     urllib3: '>=1.26.0'
+    packaging: '>=14.0'
     websocket-client: '>=0.32.0'
+    paramiko: '>=2.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-6.1.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: c95d23d8bae7e21491868cc7772d7c73
+    sha256: 7c3031602e92fd7682302ef98a45bdf7374d48a849cdd3900b7c68a32d162177
+  category: main
+  optional: false
+- name: docker-py
+  version: 6.1.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pywin32-on-windows: ''
+    python: '>=3.7'
+    requests: '>=2.26.0'
+    urllib3: '>=1.26.0'
+    packaging: '>=14.0'
+    websocket-client: '>=0.32.0'
+    paramiko: '>=2.4.3'
   url: https://conda.anaconda.org/conda-forge/noarch/docker-py-6.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: c95d23d8bae7e21491868cc7772d7c73
@@ -3161,6 +4695,18 @@ package:
   version: '0.16'
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.16-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1541834779ec03de593eb3c35f393632
+    sha256: da4fcb232504392344a2ddae6863cbbbbf2a876ddd6d00c8f1dfcdefc29f7f2a
+  category: main
+  optional: false
+- name: docstring_parser
+  version: '0.16'
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.16-pyhd8ed1ab_0.conda
@@ -3197,6 +4743,19 @@ package:
 - name: docutils
   version: 0.17.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.17.1-py39h6e9494a_4.conda
+  hash:
+    md5: 2075bada3661d0a7fb762b4f84f7c06a
+    sha256: de75694b8d0c0e244aa6f3a50d3915311410a51bfb4e8074e8bc61152b63396d
+  category: main
+  optional: false
+- name: docutils
+  version: 0.17.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -3222,6 +4781,18 @@ package:
 - name: entrypoints
   version: '0.4'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 3cf04868fee0a029769bd41f4b2fbf2d
+    sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+  category: main
+  optional: false
+- name: entrypoints
+  version: '0.4'
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
@@ -3246,6 +4817,18 @@ package:
 - name: exceptiongroup
   version: 1.2.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
+  hash:
+    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
+    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
+  category: main
+  optional: false
+- name: exceptiongroup
+  version: 1.2.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -3259,6 +4842,18 @@ package:
   version: 2.0.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: e16be50e378d8a4533b989035b196ab8
+    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
+  category: main
+  optional: false
+- name: executing
+  version: 2.0.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=2.7'
   url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
@@ -3295,6 +4890,18 @@ package:
 - name: expat
   version: 2.6.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    libexpat: 2.6.2
+  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
+  hash:
+    md5: dc0882915da2ec74696ad87aa2350f27
+    sha256: 0fd1befb18d9d937358a90d5b8f97ac2402761e9d4295779cbad9d7adfb47976
+  category: main
+  optional: false
+- name: expat
+  version: 2.6.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     libexpat: 2.6.2
@@ -3322,6 +4929,20 @@ package:
 - name: fastavro
   version: 1.9.4
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    pytz: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/fastavro-1.9.4-py39ha09f3b3_0.conda
+  hash:
+    md5: 824ffedb4e9e643043ebf0ee4f885587
+    sha256: e360caf1086152665d06e383981f1bdfdc33c5e390ae45cf6046a9cee2bd2506
+  category: main
+  optional: false
+- name: fastavro
+  version: 1.9.4
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -3334,27 +4955,39 @@ package:
   category: main
   optional: false
 - name: filelock
-  version: 3.13.1
+  version: 3.13.3
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 0c1729b74a8152fde6a38ba0a2ab9f45
-    sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
+    md5: ff15f46b0d34308f4d40c1c51df07592
+    sha256: 3bb2b4b8b97160ee7d2ed40b9dbc78555932274e82ef314c8a400a1d17aa4626
   category: main
   optional: false
 - name: filelock
-  version: 3.13.1
+  version: 3.13.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: ff15f46b0d34308f4d40c1c51df07592
+    sha256: 3bb2b4b8b97160ee7d2ed40b9dbc78555932274e82ef314c8a400a1d17aa4626
+  category: main
+  optional: false
+- name: filelock
+  version: 3.13.3
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 0c1729b74a8152fde6a38ba0a2ab9f45
-    sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
+    md5: ff15f46b0d34308f4d40c1c51df07592
+    sha256: 3bb2b4b8b97160ee7d2ed40b9dbc78555932274e82ef314c8a400a1d17aa4626
   category: main
   optional: false
 - name: fiona
@@ -3381,6 +5014,31 @@ package:
   hash:
     md5: 37555ce3fc10c4edc5b5a063bc6449aa
     sha256: 89e29d589bd8f749471a7286cfd275f6b27c37bdf7b87a2f81bac24c025018d3
+  category: main
+  optional: false
+- name: fiona
+  version: 1.9.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    attrs: '>=19.2.0'
+    certifi: ''
+    click: '>=8.0,<9.dev0'
+    click-plugins: '>=1.0'
+    cligj: '>=0.5'
+    gdal: ''
+    importlib-metadata: ''
+    libcxx: '>=16'
+    libgdal: '>=3.8.4,<3.9.0a0'
+    numpy: '>=1.22.4,<2.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    shapely: ''
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/fiona-1.9.6-py39h0f5ad13_0.conda
+  hash:
+    md5: 0d4dc7f0a01bec071b0e7b5925405dc7
+    sha256: 00d0672d38b04db3a45ef03de94472135423bd5b20ef9855292adcec5f1a2992
   category: main
   optional: false
 - name: fiona
@@ -3429,14 +5087,32 @@ package:
 - name: flask
   version: 2.3.3
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    blinker: '>=1.6.2'
+    python: '>=3.8'
     click: '>=8.1.3'
+    jinja2: '>=3.1.2'
     importlib-metadata: '>=3.6.0'
     itsdangerous: '>=2.1.2'
-    jinja2: '>=3.1.2'
+    blinker: '>=1.6.2'
+    werkzeug: '>=2.3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9b0d29067484a8dfacfae85b8fba81bc
+    sha256: 4f84ffdc5471236e8225db86c7508426b46aa2c3802d58ca40b3c3e174533b39
+  category: main
+  optional: false
+- name: flask
+  version: 2.3.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     python: '>=3.8'
+    click: '>=8.1.3'
+    jinja2: '>=3.1.2'
+    importlib-metadata: '>=3.6.0'
+    itsdangerous: '>=2.1.2'
+    blinker: '>=1.6.2'
     werkzeug: '>=2.3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
   hash:
@@ -3455,6 +5131,18 @@ package:
   hash:
     md5: 913a1c6fd00b66f33392a129e835ceca
     sha256: 898446f402c14da0e74cd2062e78ebcfbc531e08a8207f4df36dd596d30ccb70
+  category: main
+  optional: false
+- name: flatbuffers
+  version: 23.5.26
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+  url: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-23.5.26-he965462_1.conda
+  hash:
+    md5: 76123c120b7b701941234d774e18c7c0
+    sha256: 4b1c90079e7bb323dd22f13b9bc014da7f0105b29323efb9097b0610997c9e04
   category: main
   optional: false
 - name: flatbuffers
@@ -3487,12 +5175,27 @@ package:
 - name: flyteidl
   version: 1.11.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    googleapis-common-protos: ''
+    protoc-gen-openapiv2: ''
+    python: '>=3.8'
+    protobuf: '>=4.21.1,<5.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/flyteidl-1.11.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 131db08709c41ff9dcb9d9a9d0b1b06c
+    sha256: 20bdb20e0cecfc3ac3c55a435f5be794f87497984fc8a25ae1c9378e8f11fa5d
+  category: main
+  optional: false
+- name: flyteidl
+  version: 1.11.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     googleapis-common-protos: ''
-    protobuf: '>=4.21.1,<5.0.0'
     protoc-gen-openapiv2: ''
     python: '>=3.8'
+    protobuf: '>=4.21.1,<5.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/flyteidl-1.11.0-pyhd8ed1ab_0.conda
   hash:
     md5: 131db08709c41ff9dcb9d9a9d0b1b06c
@@ -3551,46 +5254,95 @@ package:
 - name: flytekit
   version: 1.11.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    adlfs: '>=2023.3.0'
-    click: '>=6.6,<9.0'
-    cloudpickle: '>=2.0.0'
-    cookiecutter: '>=1.7.3'
-    croniter: '>=0.3.20,<4.0.0'
-    dataclasses-json: '>=0.5.2,<0.5.12'
-    diskcache: '>=5.2.1'
-    docker-py: '>=4.0.0,<7.0.0'
-    docstring_parser: '>=0.9.0'
-    flyteidl: '>=1.11.0b1'
-    fsspec: '>=2023.3.0'
-    gcsfs: '>=2023.3.0'
-    googleapis-common-protos: '>=1.57'
-    grpcio: ''
-    grpcio-status: ''
+    typing-extensions: ''
     importlib-metadata: ''
-    isodate: ''
+    rich: ''
     joblib: ''
-    jsonpickle: ''
-    keyring: '>=18.0.1'
-    markdown-it-py: ''
-    marshmallow-enum: ''
-    marshmallow-jsonschema: '>=0.12.0'
-    mashumaro: '>=3.9.1'
-    protobuf: '!=4.25.0'
     pyarrow: ''
     pygments: ''
-    python: '>=3.8,<3.12'
-    python-json-logger: '>=2.0.0'
-    pytimeparse: '>=1.1.8,<2.0.0'
-    pyyaml: '!=6.0.0,!=5.4.0,!=5.4.1'
-    requests: '>=2.18.4,<3.0.0'
-    rich: ''
+    jsonpickle: ''
+    grpcio: ''
     rich-click: ''
-    s3fs: '>=2023.3.0'
+    markdown-it-py: ''
+    isodate: ''
+    grpcio-status: ''
+    marshmallow-enum: ''
+    python: '>=3.8,<3.12'
+    diskcache: '>=5.2.1'
+    python-json-logger: '>=2.0.0'
+    cloudpickle: '>=2.0.0'
+    fsspec: '>=2023.3.0'
+    cookiecutter: '>=1.7.3'
+    gcsfs: '>=2023.3.0'
+    croniter: '>=0.3.20,<4.0.0'
+    docstring_parser: '>=0.9.0'
+    keyring: '>=18.0.1'
+    marshmallow-jsonschema: '>=0.12.0'
+    pytimeparse: '>=1.1.8,<2.0.0'
+    requests: '>=2.18.4,<3.0.0'
     statsd: '>=3.0.0,<4.0.0'
-    typing-extensions: ''
     urllib3: '>=1.22,<2.0.0'
+    click: '>=6.6,<9.0'
+    googleapis-common-protos: '>=1.57'
+    docker-py: '>=4.0.0,<7.0.0'
+    pyyaml: '!=6.0.0,!=5.4.0,!=5.4.1'
+    dataclasses-json: '>=0.5.2,<0.5.12'
+    mashumaro: '>=3.9.1'
+    adlfs: '>=2023.3.0'
+    protobuf: '!=4.25.0'
+    s3fs: '>=2023.3.0'
+    flyteidl: '>=1.11.0b1'
+  url: https://conda.anaconda.org/conda-forge/noarch/flytekit-1.11.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: acf5fdc7bc5aeed83f7f8500b02d68d5
+    sha256: 2df4e56f582f1e9800f7fc304c043b0165d989fae705ac82875e82f04d0d0d18
+  category: main
+  optional: false
+- name: flytekit
+  version: 1.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    typing-extensions: ''
+    importlib-metadata: ''
+    rich: ''
+    joblib: ''
+    pyarrow: ''
+    pygments: ''
+    jsonpickle: ''
+    grpcio: ''
+    rich-click: ''
+    markdown-it-py: ''
+    isodate: ''
+    grpcio-status: ''
+    marshmallow-enum: ''
+    python: '>=3.8,<3.12'
+    diskcache: '>=5.2.1'
+    python-json-logger: '>=2.0.0'
+    cloudpickle: '>=2.0.0'
+    fsspec: '>=2023.3.0'
+    cookiecutter: '>=1.7.3'
+    gcsfs: '>=2023.3.0'
+    croniter: '>=0.3.20,<4.0.0'
+    docstring_parser: '>=0.9.0'
+    keyring: '>=18.0.1'
+    marshmallow-jsonschema: '>=0.12.0'
+    pytimeparse: '>=1.1.8,<2.0.0'
+    requests: '>=2.18.4,<3.0.0'
+    statsd: '>=3.0.0,<4.0.0'
+    urllib3: '>=1.22,<2.0.0'
+    click: '>=6.6,<9.0'
+    googleapis-common-protos: '>=1.57'
+    docker-py: '>=4.0.0,<7.0.0'
+    pyyaml: '!=6.0.0,!=5.4.0,!=5.4.1'
+    dataclasses-json: '>=0.5.2,<0.5.12'
+    mashumaro: '>=3.9.1'
+    adlfs: '>=2023.3.0'
+    protobuf: '!=4.25.0'
+    s3fs: '>=2023.3.0'
+    flyteidl: '>=1.11.0b1'
   url: https://conda.anaconda.org/conda-forge/noarch/flytekit-1.11.0-pyhd8ed1ab_0.conda
   hash:
     md5: acf5fdc7bc5aeed83f7f8500b02d68d5
@@ -3617,14 +5369,31 @@ package:
 - name: folium
   version: 0.16.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    branca: '>=0.6.0'
-    jinja2: '>=2.9'
     numpy: ''
-    python: '>=3.7'
     requests: ''
     xyzservices: ''
+    python: '>=3.7'
+    jinja2: '>=2.9'
+    branca: '>=0.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.16.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: cb1d2aa705a5b1f0fbdabd1beebce205
+    sha256: 9696ffafd873a40815312e9ea245a863b7796b73dd2759f93174cd65d6bf2144
+  category: main
+  optional: false
+- name: folium
+  version: 0.16.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    numpy: ''
+    requests: ''
+    xyzservices: ''
+    python: '>=3.7'
+    jinja2: '>=2.9'
+    branca: '>=0.6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/folium-0.16.0-pyhd8ed1ab_0.conda
   hash:
     md5: cb1d2aa705a5b1f0fbdabd1beebce205
@@ -3635,6 +5404,17 @@ package:
   version: '2.37'
   manager: conda
   platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  hash:
+    md5: 0c96522c6bdaed4b1566d11387caaf45
+    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  category: main
+  optional: false
+- name: font-ttf-dejavu-sans-mono
+  version: '2.37'
+  manager: conda
+  platform: osx-64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   hash:
@@ -3657,6 +5437,17 @@ package:
   version: '3.000'
   manager: conda
   platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  hash:
+    md5: 34893075a5c9e55cdafac56607368fc6
+    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  category: main
+  optional: false
+- name: font-ttf-inconsolata
+  version: '3.000'
+  manager: conda
+  platform: osx-64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
   hash:
@@ -3679,6 +5470,17 @@ package:
   version: '2.038'
   manager: conda
   platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  hash:
+    md5: 4d59c254e01d9cde7957100457e2d5fb
+    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  category: main
+  optional: false
+- name: font-ttf-source-code-pro
+  version: '2.038'
+  manager: conda
+  platform: osx-64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
   hash:
@@ -3701,6 +5503,17 @@ package:
   version: '0.83'
   manager: conda
   platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+  hash:
+    md5: 6185f640c43843e5ad6fd1c5372c3f80
+    sha256: 056c85b482d58faab5fd4670b6c1f5df0986314cca3bc831d458b22e4ef2c792
+  category: main
+  optional: false
+- name: font-ttf-ubuntu
+  version: '0.83'
+  manager: conda
+  platform: osx-64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
   hash:
@@ -3738,6 +5551,20 @@ package:
 - name: fontconfig
   version: 2.14.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    expat: '>=2.5.0,<3.0a0'
+    freetype: '>=2.12.1,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+  hash:
+    md5: 86cc5867dfbee4178118392bae4a3c89
+    sha256: f63e6d1d6aef8ba6de4fc54d3d7898a153479888d40ffdf2e4cfad6f92679d34
+  category: main
+  optional: false
+- name: fontconfig
+  version: 2.14.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     expat: '>=2.5.0,<3.0a0'
@@ -3764,6 +5591,18 @@ package:
 - name: fonts-conda-ecosystem
   version: '1'
   manager: conda
+  platform: osx-64
+  dependencies:
+    fonts-conda-forge: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  hash:
+    md5: fee5683a3f04bd15cbd8318b096a27ab
+    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  category: main
+  optional: false
+- name: fonts-conda-ecosystem
+  version: '1'
+  manager: conda
   platform: osx-arm64
   dependencies:
     fonts-conda-forge: ''
@@ -3791,12 +5630,27 @@ package:
 - name: fonts-conda-forge
   version: '1'
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    font-ttf-dejavu-sans-mono: ''
     font-ttf-inconsolata: ''
     font-ttf-source-code-pro: ''
     font-ttf-ubuntu: ''
+    font-ttf-dejavu-sans-mono: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  hash:
+    md5: f766549260d6815b0c52253f1fb1bb29
+    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  category: main
+  optional: false
+- name: fonts-conda-forge
+  version: '1'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    font-ttf-inconsolata: ''
+    font-ttf-source-code-pro: ''
+    font-ttf-ubuntu: ''
+    font-ttf-dejavu-sans-mono: ''
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
@@ -3804,7 +5658,7 @@ package:
   category: main
   optional: false
 - name: fonttools
-  version: 4.49.0
+  version: 4.50.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -3814,14 +5668,30 @@ package:
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.*
     unicodedata2: '>=14.0.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.49.0-py39hd1e30aa_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.50.0-py39hd1e30aa_0.conda
   hash:
-    md5: dd1b02484cc8c31d4093111a82b6efb2
-    sha256: 142a8d3288855101804d0c0d2a998dbca1b56c0d9e0e745cbee86878baaac2ea
+    md5: 8b689d531a6f99ef71212081c0126147
+    sha256: 22a510a2cc44444668f995ce0c8a7ac9653a6442c7f45dc903fa598962066593
   category: main
   optional: false
 - name: fonttools
-  version: 4.49.0
+  version: 4.50.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    brotli: ''
+    munkres: ''
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    unicodedata2: '>=14.0.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.50.0-py39ha09f3b3_0.conda
+  hash:
+    md5: a575dd8aa43e8b7e2e1da6bd6acbddc0
+    sha256: 6f319ed091af3d14df5165ceba659869569e6827da9ca084f17237b7e440eee7
+  category: main
+  optional: false
+- name: fonttools
+  version: 4.50.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3830,16 +5700,29 @@ package:
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.*
     unicodedata2: '>=14.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.49.0-py39h17cfd9d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.50.0-py39h17cfd9d_0.conda
   hash:
-    md5: 0ea078a1395ab6ddc465e755fe6273ac
-    sha256: 765f5f689df8ff4bf888b0434e50bf426dcf869c9537dab05678e96a863b2685
+    md5: 9cf95b92068842801c4237e7a799c330
+    sha256: 2f40b1ae9cb965f7683dd69af3db71d9575d4b7363a74e230651a669f25d1abd
   category: main
   optional: false
 - name: fqdn
   version: 1.5.1
   manager: conda
   platform: linux-64
+  dependencies:
+    cached-property: '>=1.3.0'
+    python: '>=2.7,<4'
+  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 642d35437078749ef23a5dca2c9bb1f3
+    sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  category: main
+  optional: false
+- name: fqdn
+  version: 1.5.1
+  manager: conda
+  platform: osx-64
   dependencies:
     cached-property: '>=1.3.0'
     python: '>=2.7,<4'
@@ -3879,6 +5762,19 @@ package:
 - name: freetype
   version: 2.12.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    libpng: '>=1.6.39,<1.7.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  hash:
+    md5: 25152fce119320c980e5470e64834b50
+    sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  category: main
+  optional: false
+- name: freetype
+  version: 2.12.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     libpng: '>=1.6.39,<1.7.0a0'
@@ -3907,6 +5803,20 @@ package:
 - name: freexl
   version: 2.0.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libexpat: '>=2.5.0,<3.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    minizip: '>=4.0.1,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
+  hash:
+    md5: 640c34a8084e2a812bcee5b804597fc9
+    sha256: 9d59f1894c3b526e6806e376e979b81d0df23a836415122b86458aef72cda24a
+  category: main
+  optional: false
+- name: freexl
+  version: 2.0.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libexpat: '>=2.5.0,<3.0a0'
@@ -3924,10 +5834,21 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h516909a_0.tar.bz2
   hash:
-    md5: ac7bc6a654f8f41b352b38f4051135f8
-    sha256: 5d7b6c0ee7743ba41399e9e05a58ccc1cfc903942e49ff6f677f6e423ea7a627
+    md5: bdc16c2b8852914fdbadb8e4d6361a8b
+    sha256: b619c1ec2c2b0951e23c683c6ca33de295183ee82f080e97eda68a7a7a955d85
+  category: main
+  optional: false
+- name: fribidi
+  version: 1.0.10
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
+  hash:
+    md5: f1c6b41e0f56998ecd9a3e210faa1dc0
+    sha256: 4f6db86ecc4984cd4ac88ca52030726c3cfd11a64dfb15c8602025ee3001a2b5
   category: main
   optional: false
 - name: fribidi
@@ -3953,6 +5874,19 @@ package:
   hash:
     md5: 52bd06467f60645e2cf293bd00f957cd
     sha256: 40e9730732769b8ef0797f025f108d998d8d2d4edb0c709da9e6dd65475064a6
+  category: main
+  optional: false
+- name: frozendict
+  version: 2.4.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.0-py39ha09f3b3_0.conda
+  hash:
+    md5: 0fc918c0e051981921878c2d65fc403b
+    sha256: 7ec12ed6358e326dff1ffdd714098b99f49291d347f5ac44839e968a02721105
   category: main
   optional: false
 - name: frozendict
@@ -3985,6 +5919,19 @@ package:
 - name: frozenlist
   version: 1.4.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.4.1-py39ha09f3b3_0.conda
+  hash:
+    md5: b5e09c98363b742af6900c85b987f3ef
+    sha256: c2d3322ee17e65afe8bcf734ca12d76654e7a5c80f1bd2f090d996e2914bfe36
+  category: main
+  optional: false
+- name: frozenlist
+  version: 1.4.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -3996,27 +5943,39 @@ package:
   category: main
   optional: false
 - name: fsspec
-  version: 2024.2.0
+  version: 2024.3.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.2.0-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.3.1-pyhca7485f_0.conda
   hash:
-    md5: fad86b90138cf5d82c6f5a2ed6e683d9
-    sha256: 3f7e123dd82fe99450d1e0ffa389e8218ef8c9ee257c836e21b489548c039ae6
+    md5: b7f0662ef2c9d4404f0af9eef5ed2fde
+    sha256: b8621151939bb5ea4ea4aa84f010e6130a47b1453cd9178283f335816b72a895
   category: main
   optional: false
 - name: fsspec
-  version: 2024.2.0
+  version: 2024.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.3.1-pyhca7485f_0.conda
+  hash:
+    md5: b7f0662ef2c9d4404f0af9eef5ed2fde
+    sha256: b8621151939bb5ea4ea4aa84f010e6130a47b1453cd9178283f335816b72a895
+  category: main
+  optional: false
+- name: fsspec
+  version: 2024.3.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.2.0-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.3.1-pyhca7485f_0.conda
   hash:
-    md5: fad86b90138cf5d82c6f5a2ed6e683d9
-    sha256: 3f7e123dd82fe99450d1e0ffa389e8218ef8c9ee257c836e21b489548c039ae6
+    md5: b7f0662ef2c9d4404f0af9eef5ed2fde
+    sha256: b8621151939bb5ea4ea4aa84f010e6130a47b1453cd9178283f335816b72a895
   category: main
   optional: false
 - name: furo
@@ -4040,15 +5999,33 @@ package:
 - name: furo
   version: 2023.5.20
   manager: conda
+  platform: osx-64
+  dependencies:
+    beautifulsoup4: ''
+    myst-parser: ''
+    sphinx-inline-tabs: ''
+    sphinx-basic-ng: ''
+    python: '>=3.6'
+    sphinx: '>=4'
+    pygments: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/furo-2023.5.20-pyhd8ed1ab_0.conda
+  hash:
+    md5: 786e474a83de249aecf767102d7fd87d
+    sha256: 3513f6e2bc2036e6941b30dd03ea9c98a452e0d311d7dc5d1b45be87e145e3d3
+  category: main
+  optional: false
+- name: furo
+  version: 2023.5.20
+  manager: conda
   platform: osx-arm64
   dependencies:
     beautifulsoup4: ''
     myst-parser: ''
-    pygments: '>=2.7'
+    sphinx-inline-tabs: ''
+    sphinx-basic-ng: ''
     python: '>=3.6'
     sphinx: '>=4'
-    sphinx-basic-ng: ''
-    sphinx-inline-tabs: ''
+    pygments: '>=2.7'
   url: https://conda.anaconda.org/conda-forge/noarch/furo-2023.5.20-pyhd8ed1ab_0.conda
   hash:
     md5: 786e474a83de249aecf767102d7fd87d
@@ -4059,6 +6036,18 @@ package:
   version: 1.0.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 650a7807e689642dddd3590eb817beed
+    sha256: 8c918a63595ae01575b738ddf0bff10dc23a5002d4af4c8b445d1179a76a8efd
+  category: main
+  optional: false
+- name: future
+  version: 1.0.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_0.conda
@@ -4094,6 +6083,18 @@ package:
 - name: gast
   version: 0.5.4
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/gast-0.5.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 8189adbad784030b76bbf81c68d7b0d4
+    sha256: e029d50d55f8fe8cf9323045f84416b7af50e25a0dc1b978f8ba6b9ca8d53ca7
+  category: main
+  optional: false
+- name: gast
+  version: 0.5.4
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.4'
@@ -4104,41 +6105,60 @@ package:
   category: main
   optional: false
 - name: gcsfs
-  version: 2024.2.0
+  version: 2024.3.1
   manager: conda
   platform: linux-64
   dependencies:
     aiohttp: ''
     decorator: '>4.1.2'
-    fsspec: 2024.2.0
+    fsspec: 2024.3.1
     google-auth: '>=1.2'
     google-auth-oauthlib: ''
     google-cloud-storage: '>1.40'
     python: '>=3.7'
     requests: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/gcsfs-2024.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/gcsfs-2024.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: babf81bf8ff3af8bd8ad83ed5b9603a4
-    sha256: eeb396cfaa15eecb1ec34d44801df8b6036c3b4beacf13d08d038f87e8d451e8
+    md5: 2a794cb30f494b38dd57ece3af30ed6a
+    sha256: 3db31215462e399848d49c5258ce03f6c3e72e7c20fb488ad0b1ebbe6a359607
   category: main
   optional: false
 - name: gcsfs
-  version: 2024.2.0
+  version: 2024.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    requests: ''
+    aiohttp: ''
+    google-auth-oauthlib: ''
+    python: '>=3.7'
+    google-auth: '>=1.2'
+    decorator: '>4.1.2'
+    google-cloud-storage: '>1.40'
+    fsspec: 2024.3.1
+  url: https://conda.anaconda.org/conda-forge/noarch/gcsfs-2024.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2a794cb30f494b38dd57ece3af30ed6a
+    sha256: 3db31215462e399848d49c5258ce03f6c3e72e7c20fb488ad0b1ebbe6a359607
+  category: main
+  optional: false
+- name: gcsfs
+  version: 2024.3.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    aiohttp: ''
-    decorator: '>4.1.2'
-    fsspec: 2024.2.0
-    google-auth: '>=1.2'
-    google-auth-oauthlib: ''
-    google-cloud-storage: '>1.40'
-    python: '>=3.7'
     requests: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/gcsfs-2024.2.0-pyhd8ed1ab_0.conda
+    aiohttp: ''
+    google-auth-oauthlib: ''
+    python: '>=3.7'
+    google-auth: '>=1.2'
+    decorator: '>4.1.2'
+    google-cloud-storage: '>1.40'
+    fsspec: 2024.3.1
+  url: https://conda.anaconda.org/conda-forge/noarch/gcsfs-2024.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: babf81bf8ff3af8bd8ad83ed5b9603a4
-    sha256: eeb396cfaa15eecb1ec34d44801df8b6036c3b4beacf13d08d038f87e8d451e8
+    md5: 2a794cb30f494b38dd57ece3af30ed6a
+    sha256: 3db31215462e399848d49c5258ce03f6c3e72e7c20fb488ad0b1ebbe6a359607
   category: main
   optional: false
 - name: gdal
@@ -4159,6 +6179,25 @@ package:
   hash:
     md5: 43d464d6710f81b189dfe84fe7b62af4
     sha256: 64d5b859a4b10a45a0a7eab22e8143f178d9a44f935c8aa32ee75d6111a0b5f9
+  category: main
+  optional: false
+- name: gdal
+  version: 3.8.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    libcxx: '>=16'
+    libgdal: 3.8.4
+    libxml2: '>=2.12.5,<3.0a0'
+    numpy: '>=1.22.4,<2.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.8.4-py39ha0dfb3d_0.conda
+  hash:
+    md5: ccb936d7310c8d946b7eb4c224c2ffde
+    sha256: 9e2d46bad74aa846ce306ca69c11f6b9e11cca10fcfbec253154de7538ec0898
   category: main
   optional: false
 - name: gdal
@@ -4198,6 +6237,21 @@ package:
 - name: gdk-pixbuf
   version: 2.42.10
   manager: conda
+  platform: osx-64
+  dependencies:
+    libglib: '>=2.78.4,<3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gdk-pixbuf-2.42.10-hd9e0ca3_5.conda
+  hash:
+    md5: 308cefd960b6ba51bdbdc5ba9e9b2377
+    sha256: e15a0923d2640020dc7f2ff2b04f09face4ddce6484e09f78752cd0e65ad1cdf
+  category: main
+  optional: false
+- name: gdk-pixbuf
+  version: 2.42.10
+  manager: conda
   platform: osx-arm64
   dependencies:
     libglib: '>=2.78.4,<3.0a0'
@@ -4232,16 +6286,35 @@ package:
 - name: geopandas
   version: 0.14.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    matplotlib-base: ''
+    rtree: ''
+    folium: ''
+    xyzservices: ''
+    python: '>=3.9'
+    mapclassify: '>=2.4.0'
+    fiona: '>=1.8.21'
+    geopandas-base: 0.14.3
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: d8e208e375441bf1404e9693f13f3c25
+    sha256: 15bdc3d85ffa9c6601f57dd5e2780dbcbe52ca5da70164fb5bb1bb4c72b92010
+  category: main
+  optional: false
+- name: geopandas
+  version: 0.14.3
+  manager: conda
   platform: osx-arm64
   dependencies:
-    fiona: '>=1.8.21'
-    folium: ''
-    geopandas-base: 0.14.3
-    mapclassify: '>=2.4.0'
     matplotlib-base: ''
-    python: '>=3.9'
     rtree: ''
+    folium: ''
     xyzservices: ''
+    python: '>=3.9'
+    mapclassify: '>=2.4.0'
+    fiona: '>=1.8.21'
+    geopandas-base: 0.14.3
   url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.3-pyhd8ed1ab_0.conda
   hash:
     md5: d8e208e375441bf1404e9693f13f3c25
@@ -4267,13 +6340,29 @@ package:
 - name: geopandas-base
   version: 0.14.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    packaging: ''
+    python: '>=3.9'
+    pandas: '>=1.4.0'
+    shapely: '>=1.8.0'
+    pyproj: '>=3.3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.3-pyha770c72_0.conda
+  hash:
+    md5: fbac4b2194c962b97324a3f5dd7d2696
+    sha256: 0a8fb5a368d19fd08f7f65dfcff563322cb34e47947cabab8fc7f187d9bc9269
+  category: main
+  optional: false
+- name: geopandas-base
+  version: 0.14.3
+  manager: conda
   platform: osx-arm64
   dependencies:
     packaging: ''
-    pandas: '>=1.4.0'
-    pyproj: '>=3.3.0'
     python: '>=3.9'
+    pandas: '>=1.4.0'
     shapely: '>=1.8.0'
+    pyproj: '>=3.3.0'
   url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.3-pyha770c72_0.conda
   hash:
     md5: fbac4b2194c962b97324a3f5dd7d2696
@@ -4291,6 +6380,19 @@ package:
   hash:
     md5: 8c0f4f71f5a59ceb0c6fa9f51501066d
     sha256: 2593b255cb9c4639d6ea261c47aaed1380216a366546f0468e95c36c2afd1c1a
+  category: main
+  optional: false
+- name: geos
+  version: 3.12.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.1-h93d8f39_0.conda
+  hash:
+    md5: d13f05ed3985f57456b610bab66366db
+    sha256: 6feffb0d1999a22c5f94d2168b1af9c5fbdd25c9a963a6825ee32cf05e5c07f5
   category: main
   optional: false
 - name: geos
@@ -4327,6 +6429,24 @@ package:
 - name: geotiff
   version: 1.7.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    proj: '>=9.3.1,<9.3.2.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.1-h509af15_15.conda
+  hash:
+    md5: 96cb876ae9551821ad4cd6ce860d75f1
+    sha256: e6047c9008746788d265ec6b30551387efd204a5a9a599f0f0359956e8513e76
+  category: main
+  optional: false
+- name: geotiff
+  version: 1.7.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=10.9'
@@ -4357,6 +6477,18 @@ package:
 - name: gettext
   version: 0.21.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    libiconv: '>=1.17,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
+  hash:
+    md5: 1e3aff29ce703d421c43f371ad676cc5
+    sha256: 915d3cd2d777b9b3fc2e87a25901b8e4a6aa1b2b33cf2ba54e9e9ed4f6b67d94
+  category: main
+  optional: false
+- name: gettext
+  version: 0.21.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     libiconv: '>=1.17,<2.0a0'
@@ -4377,6 +6509,18 @@ package:
   hash:
     md5: cddaf2c63ea4a5901cf09524c490ecdc
     sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
+  category: main
+  optional: false
+- name: gflags
+  version: 2.2.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=10.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+  hash:
+    md5: 3f59cc77a929537e42120faf104e0d16
+    sha256: 39540f879057ae529cad131644af111a8c3c48b384ec6212de6a5381e0863948
   category: main
   optional: false
 - name: gflags
@@ -4406,6 +6550,17 @@ package:
 - name: giflib
   version: 5.2.1
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.1-hb7f2c08_3.conda
+  hash:
+    md5: aca150b0186836f893ebac79019e5498
+    sha256: 47515e0874bcf67e438e1d5d093b074c1781f055067195f0d00a7790a56d446d
+  category: main
+  optional: false
+- name: giflib
+  version: 5.2.1
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.1-h1a8c8d9_3.conda
@@ -4430,6 +6585,19 @@ package:
 - name: gitdb
   version: 4.0.11
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    smmap: '>=3.0.1,<6'
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  hash:
+    md5: 623b19f616f2ca0c261441067e18ae40
+    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+  category: main
+  optional: false
+- name: gitdb
+  version: 4.0.11
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -4457,15 +6625,93 @@ package:
 - name: gitpython
   version: 3.1.42
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    gitdb: '>=4.0.1,<5'
     python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
+    gitdb: '>=4.0.1,<5'
   url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.42-pyhd8ed1ab_0.conda
   hash:
     md5: 6bc8e496351bafd761c0922c3ebd989a
     sha256: a11e1cf4404157467d0f51906d1db80bcb8bfe4bb3d3eba703b28e981ea7e308
+  category: main
+  optional: false
+- name: gitpython
+  version: 3.1.42
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+    typing_extensions: '>=3.7.4.3'
+    gitdb: '>=4.0.1,<5'
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.42-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6bc8e496351bafd761c0922c3ebd989a
+    sha256: a11e1cf4404157467d0f51906d1db80bcb8bfe4bb3d3eba703b28e981ea7e308
+  category: main
+  optional: false
+- name: glib
+  version: 2.78.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gettext: '>=0.21.1,<1.0a0'
+    glib-tools: 2.78.4
+    libgcc-ng: '>=12'
+    libglib: 2.78.4
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    python: '*'
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.78.4-hfc55251_0.conda
+  hash:
+    md5: f36a7b2420c3fc3c48a3d609841d8fee
+    sha256: 316c95dcbde46b7418d2b667a7e0c1d05101b673cd8c691d78d8699600a07a5b
+  category: main
+  optional: false
+- name: glib
+  version: 2.78.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gettext: '>=0.21.1,<1.0a0'
+    glib-tools: 2.78.4
+    libcxx: '>=16'
+    libglib: 2.78.4
+    libzlib: '>=1.2.13,<1.3.0a0'
+    python: '*'
+  url: https://conda.anaconda.org/conda-forge/osx-64/glib-2.78.4-h2d185b6_0.conda
+  hash:
+    md5: 0383ef91e41caea857176363c2bf7387
+    sha256: 546775c50a28dcbe22b784d6cc4e8ba3774aac59517858529742657b0563c326
+  category: main
+  optional: false
+- name: glib-tools
+  version: 2.78.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libglib: 2.78.4
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.78.4-hfc55251_0.conda
+  hash:
+    md5: d184ba1bf15a2bbb3be6118c90fd487d
+    sha256: e94494b895f77ba54922ffb1dcfb7f1a987591b823eb5ce608afb2e2391d7d82
+  category: main
+  optional: false
+- name: glib-tools
+  version: 2.78.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+    libglib: 2.78.4
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.78.4-h2d185b6_0.conda
+  hash:
+    md5: f91cde30ad552c39b485bb5ad0ce454c
+    sha256: bf3d98bd8a1e0b105d124468c3ca276194c1a06ddc4a9dc44a77df65c44f8eb8
   category: main
   optional: false
 - name: glog
@@ -4480,6 +6726,19 @@ package:
   hash:
     md5: b31f3565cb84435407594e548a2fb7b2
     sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
+  category: main
+  optional: false
+- name: glog
+  version: 0.6.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gflags: '>=2.2.2,<2.3.0a0'
+    libcxx: '>=12.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+  hash:
+    md5: 69eb97ca709a136c53fdca1f2fd33ddf
+    sha256: fdb38560094fb4a952346dc72a79b3cb09e23e4d0cae9ba4f524e6e88203d3c8
   category: main
   optional: false
 - name: glog
@@ -4506,6 +6765,18 @@ package:
   hash:
     md5: e358c7c5f6824c272b5034b3816438a7
     sha256: cfc4202c23d6895d9c84042d08d5cda47d597772df870d4d2a10fc86dded5576
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h73e2aa4_1.conda
+  hash:
+    md5: 92f8d748d95d97f92fc26cfac9bb5b6e
+    sha256: 1a5b117908deb5a12288aba84dd0cb913f779c31c75f5a57d1a00e659e8fa3d3
   category: main
   optional: false
 - name: gmp
@@ -4540,6 +6811,22 @@ package:
 - name: gmpy2
   version: 2.1.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    gmp: '>=6.2.1,<7.0a0'
+    mpc: '>=1.2.1,<2.0a0'
+    mpfr: '>=4.1.0,<5.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmpy2-2.1.2-py39h2da61ea_1.tar.bz2
+  hash:
+    md5: 57d1deb8ae2f5f74e7da55f2cc4732cc
+    sha256: 05172243422cfd285036f20fc5310e64dd61ccfb1e25501723837dc8ee9b387a
+  category: main
+  optional: false
+- name: gmpy2
+  version: 2.1.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     gmp: '>=6.2.1,<7.0a0'
@@ -4554,67 +6841,100 @@ package:
   category: main
   optional: false
 - name: google-api-core
-  version: 2.17.1
+  version: 2.18.0
   manager: conda
   platform: linux-64
   dependencies:
     google-auth: '>=2.14.1,<3.0.dev0'
     googleapis-common-protos: '>=1.56.2,<2.0.dev0'
+    proto-plus: '>=1.22.3,<2.0.0dev'
     protobuf: '>=3.19.5,<5.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
     python: '>=3.7'
     requests: '>=2.18.0,<3.0.0.dev0'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.17.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.18.0-pyhd8ed1ab_0.conda
   hash:
-    md5: b505c957ab68e07800aaba6287ca008e
-    sha256: a92bf55d70fe4868c7c50163ed876939028ba3a2b513c5742282d8fc12a61074
+    md5: 58d10fd3977fa2142cc64c5d9c7a9d20
+    sha256: 29ea75a93c596466ebc3954ac05e1c3298bf9d95296bc4769fdc95c71e53a19e
   category: main
   optional: false
 - name: google-api-core
-  version: 2.17.1
+  version: 2.18.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    python: '>=3.7'
+    proto-plus: '>=1.22.3,<2.0.0dev'
     google-auth: '>=2.14.1,<3.0.dev0'
     googleapis-common-protos: '>=1.56.2,<2.0.dev0'
     protobuf: '>=3.19.5,<5.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
-    python: '>=3.7'
     requests: '>=2.18.0,<3.0.0.dev0'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.17.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.18.0-pyhd8ed1ab_0.conda
   hash:
-    md5: b505c957ab68e07800aaba6287ca008e
-    sha256: a92bf55d70fe4868c7c50163ed876939028ba3a2b513c5742282d8fc12a61074
+    md5: 58d10fd3977fa2142cc64c5d9c7a9d20
+    sha256: 29ea75a93c596466ebc3954ac05e1c3298bf9d95296bc4769fdc95c71e53a19e
   category: main
   optional: false
-- name: google-api-core-grpc
-  version: 2.17.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    google-api-core: 2.17.1
-    grpcio: '>=1.49.1,<2.0.dev0'
-    grpcio-status: '>=1.49.1,<2.0.dev0'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-grpc-2.17.1-hd8ed1ab_0.conda
-  hash:
-    md5: 9dcac80e562d6471fdbc234604dab09c
-    sha256: f86d21641f1d44c67a81cfa68aca0031c762aaef7220f4ebca161f0455625c2c
-  category: main
-  optional: false
-- name: google-api-core-grpc
-  version: 2.17.1
+- name: google-api-core
+  version: 2.18.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    google-api-core: 2.17.1
+    python: '>=3.7'
+    proto-plus: '>=1.22.3,<2.0.0dev'
+    google-auth: '>=2.14.1,<3.0.dev0'
+    googleapis-common-protos: '>=1.56.2,<2.0.dev0'
+    protobuf: '>=3.19.5,<5.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+    requests: '>=2.18.0,<3.0.0.dev0'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.18.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 58d10fd3977fa2142cc64c5d9c7a9d20
+    sha256: 29ea75a93c596466ebc3954ac05e1c3298bf9d95296bc4769fdc95c71e53a19e
+  category: main
+  optional: false
+- name: google-api-core-grpc
+  version: 2.18.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    google-api-core: 2.18.0
     grpcio: '>=1.49.1,<2.0.dev0'
     grpcio-status: '>=1.49.1,<2.0.dev0'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-grpc-2.17.1-hd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-grpc-2.18.0-hd8ed1ab_0.conda
   hash:
-    md5: 9dcac80e562d6471fdbc234604dab09c
-    sha256: f86d21641f1d44c67a81cfa68aca0031c762aaef7220f4ebca161f0455625c2c
+    md5: 40e7019aeaee275ea669b9820e480f78
+    sha256: c86c76a9242d43c96baee309f588fa4efecbc20d0ef74a16d79fab0b14e519d7
+  category: main
+  optional: false
+- name: google-api-core-grpc
+  version: 2.18.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    grpcio: '>=1.49.1,<2.0.dev0'
+    grpcio-status: '>=1.49.1,<2.0.dev0'
+    google-api-core: 2.18.0
+  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-grpc-2.18.0-hd8ed1ab_0.conda
+  hash:
+    md5: 40e7019aeaee275ea669b9820e480f78
+    sha256: c86c76a9242d43c96baee309f588fa4efecbc20d0ef74a16d79fab0b14e519d7
+  category: main
+  optional: false
+- name: google-api-core-grpc
+  version: 2.18.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    grpcio: '>=1.49.1,<2.0.dev0'
+    grpcio-status: '>=1.49.1,<2.0.dev0'
+    google-api-core: 2.18.0
+  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-grpc-2.18.0-hd8ed1ab_0.conda
+  hash:
+    md5: 40e7019aeaee275ea669b9820e480f78
+    sha256: c86c76a9242d43c96baee309f588fa4efecbc20d0ef74a16d79fab0b14e519d7
   category: main
   optional: false
 - name: google-auth
-  version: 2.28.2
+  version: 2.29.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4627,30 +6947,50 @@ package:
     pyu2f: '>=0.1.5'
     requests: '>=2.20.0,<3.0.0'
     rsa: '>=3.1.4,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.28.2-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.29.0-pyhca7485f_0.conda
   hash:
-    md5: f8879cf0e5b8f7761d01bce40ce7c089
-    sha256: b1ccc8d5110092867c6f58e044248f55836848b06acea280138b1adcae690dff
+    md5: a12a2abc807053bc378b218a2a525c7d
+    sha256: 1eaa741eba0a6d34c80f68438cb8283b2d9d2adf8629d024df14222c0fc0b397
   category: main
   optional: false
 - name: google-auth
-  version: 2.28.2
+  version: 2.29.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    pyasn1-modules: '>=0.2.1'
+    rsa: '>=3.1.4,<5'
+    pyopenssl: '>=20.0.0'
+    pyu2f: '>=0.1.5'
+    requests: '>=2.20.0,<3.0.0'
+    cachetools: '>=2.0.0,<6.0'
+    aiohttp: '>=3.6.2,<4.0.0'
+    cryptography: '>=38.0.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.29.0-pyhca7485f_0.conda
+  hash:
+    md5: a12a2abc807053bc378b218a2a525c7d
+    sha256: 1eaa741eba0a6d34c80f68438cb8283b2d9d2adf8629d024df14222c0fc0b397
+  category: main
+  optional: false
+- name: google-auth
+  version: 2.29.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    aiohttp: '>=3.6.2,<4.0.0'
-    cachetools: '>=2.0.0,<6.0'
-    cryptography: '>=38.0.3'
-    pyasn1-modules: '>=0.2.1'
-    pyopenssl: '>=20.0.0'
     python: '>=3.7'
+    pyasn1-modules: '>=0.2.1'
+    rsa: '>=3.1.4,<5'
+    pyopenssl: '>=20.0.0'
     pyu2f: '>=0.1.5'
     requests: '>=2.20.0,<3.0.0'
-    rsa: '>=3.1.4,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.28.2-pyhca7485f_0.conda
+    cachetools: '>=2.0.0,<6.0'
+    aiohttp: '>=3.6.2,<4.0.0'
+    cryptography: '>=38.0.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.29.0-pyhca7485f_0.conda
   hash:
-    md5: f8879cf0e5b8f7761d01bce40ce7c089
-    sha256: b1ccc8d5110092867c6f58e044248f55836848b06acea280138b1adcae690dff
+    md5: a12a2abc807053bc378b218a2a525c7d
+    sha256: 1eaa741eba0a6d34c80f68438cb8283b2d9d2adf8629d024df14222c0fc0b397
   category: main
   optional: false
 - name: google-auth-oauthlib
@@ -4671,12 +7011,27 @@ package:
 - name: google-auth-oauthlib
   version: 1.2.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    click: '>=6.0.0'
-    google-auth: '>=2.15.0'
     python: '>=3.6'
     requests-oauthlib: '>=0.7.0'
+    click: '>=6.0.0'
+    google-auth: '>=2.15.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2057f12885a73b4d621c075423cec969
+    sha256: 39d031780d9ac2da430ead078a40ff67db3ad57e24ab1e3c68b4e0f2b48a2311
+  category: main
+  optional: false
+- name: google-auth-oauthlib
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+    requests-oauthlib: '>=0.7.0'
+    click: '>=6.0.0'
+    google-auth: '>=2.15.0'
   url: https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.2.0-pyhd8ed1ab_0.conda
   hash:
     md5: 2057f12885a73b4d621c075423cec969
@@ -4712,23 +7067,49 @@ package:
 - name: google-cloud-bigquery
   version: 3.19.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    db-dtypes: '>=0.3.0,<2.0.0dev'
+    python: '>=3.8'
+    protobuf: '>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+    pandas: '>=1.1.0'
+    tqdm: '>=4.7.4,<=5.0.0dev'
+    proto-plus: '>=1.15.0,<2.0.0dev'
     geopandas: '>=0.9.0,<1.0dev'
-    google-cloud-bigquery-core: 3.19.0
-    google-cloud-bigquery-storage: '>=2.6.0,<3.0.0dev'
+    pyarrow: '>=3.0.0'
+    db-dtypes: '>=0.3.0,<2.0.0dev'
     grpcio: '>=1.49.1,<2.0dev'
+    ipywidgets: '>=7.7.0'
     ipykernel: '>=6.0.0'
     ipython: '>=7.23.1,!=8.1.0'
-    ipywidgets: '>=7.7.0'
-    pandas: '>=1.1.0'
-    proto-plus: '>=1.15.0,<2.0.0dev'
-    protobuf: '>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
-    pyarrow: '>=3.0.0'
-    python: '>=3.8'
+    google-cloud-bigquery-storage: '>=2.6.0,<3.0.0dev'
     shapely: '>=1.8.4,<3.0.0dev'
+    google-cloud-bigquery-core: 3.19.0
+  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-bigquery-3.19.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: dd4a8cca66b72bee53373e2926f1d39c
+    sha256: a134a103b50285e521eeaa5bffd6b0b7efb69e6ab2e15f46354105e0d6ede412
+  category: main
+  optional: false
+- name: google-cloud-bigquery
+  version: 3.19.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+    protobuf: '>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+    pandas: '>=1.1.0'
     tqdm: '>=4.7.4,<=5.0.0dev'
+    proto-plus: '>=1.15.0,<2.0.0dev'
+    geopandas: '>=0.9.0,<1.0dev'
+    pyarrow: '>=3.0.0'
+    db-dtypes: '>=0.3.0,<2.0.0dev'
+    grpcio: '>=1.49.1,<2.0dev'
+    ipywidgets: '>=7.7.0'
+    ipykernel: '>=6.0.0'
+    ipython: '>=7.23.1,!=8.1.0'
+    google-cloud-bigquery-storage: '>=2.6.0,<3.0.0dev'
+    shapely: '>=1.8.4,<3.0.0dev'
+    google-cloud-bigquery-core: 3.19.0
   url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-bigquery-3.19.0-pyhd8ed1ab_0.conda
   hash:
     md5: dd4a8cca66b72bee53373e2926f1d39c
@@ -4757,16 +7138,35 @@ package:
 - name: google-cloud-bigquery-core
   version: 3.19.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    google-resumable-media: '>=0.6.0,<3.0dev'
+    google-auth: '>=2.14.1,<3.0.0dev'
+    python-dateutil: '>=2.7.2,<3.0dev'
+    packaging: '>=20.0.0'
+    requests: '>=2.21.0,<3.0.0dev'
+    google-cloud-core: '>=1.6.0,<3.0.0dev'
+    google-api-core-grpc: '>=1.34.1,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-bigquery-core-3.19.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: e9a57c9845bcbaf6df5cb006b399d690
+    sha256: 910415a2a06c29585957638f83837c6f5fb7b901de27eebbebff1cceecbdd682
+  category: main
+  optional: false
+- name: google-cloud-bigquery-core
+  version: 3.19.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    google-api-core-grpc: '>=1.34.1,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*'
-    google-auth: '>=2.14.1,<3.0.0dev'
-    google-cloud-core: '>=1.6.0,<3.0.0dev'
-    google-resumable-media: '>=0.6.0,<3.0dev'
-    packaging: '>=20.0.0'
     python: '>=3.8'
+    google-resumable-media: '>=0.6.0,<3.0dev'
+    google-auth: '>=2.14.1,<3.0.0dev'
     python-dateutil: '>=2.7.2,<3.0dev'
+    packaging: '>=20.0.0'
     requests: '>=2.21.0,<3.0.0dev'
+    google-cloud-core: '>=1.6.0,<3.0.0dev'
+    google-api-core-grpc: '>=1.34.1,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*'
   url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-bigquery-core-3.19.0-pyhd8ed1ab_0.conda
   hash:
     md5: e9a57c9845bcbaf6df5cb006b399d690
@@ -4792,13 +7192,29 @@ package:
 - name: google-cloud-bigquery-storage
   version: 2.24.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    pyarrow: '>=0.15.0'
+    fastavro: '>=0.21.2'
+    pandas: '>=0.21.1'
+    google-cloud-bigquery-storage-core: 2.24.0.*
+  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-bigquery-storage-2.24.0-pyhca7485f_0.conda
+  hash:
+    md5: 86a0630f1f8b18915d909503f17ca1e0
+    sha256: 63935dd8bdc4da2d8164ada820492b7ec9beba3197b5cb9ab34495d8fd56b0cd
+  category: main
+  optional: false
+- name: google-cloud-bigquery-storage
+  version: 2.24.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    fastavro: '>=0.21.2'
-    google-cloud-bigquery-storage-core: 2.24.0.*
-    pandas: '>=0.21.1'
-    pyarrow: '>=0.15.0'
     python: '>=3.8'
+    pyarrow: '>=0.15.0'
+    fastavro: '>=0.21.2'
+    pandas: '>=0.21.1'
+    google-cloud-bigquery-storage-core: 2.24.0.*
   url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-bigquery-storage-2.24.0-pyhca7485f_0.conda
   hash:
     md5: 86a0630f1f8b18915d909503f17ca1e0
@@ -4823,12 +7239,27 @@ package:
 - name: google-cloud-bigquery-storage-core
   version: 2.24.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    protobuf: '>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+    proto-plus: '>=1.22.0,<2.0.0dev'
+    google-api-core-grpc: '>=1.34.0,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-bigquery-storage-core-2.24.0-pyhca7485f_0.conda
+  hash:
+    md5: 1d1a6f7938f1a29044e676d112c0b424
+    sha256: 60994f98e7386bd5836dd04b74112d30286df2bb15e8edf2f2d460dd37821860
+  category: main
+  optional: false
+- name: google-cloud-bigquery-storage-core
+  version: 2.24.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    google-api-core-grpc: '>=1.34.0,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*'
-    proto-plus: '>=1.22.0,<2.0.0dev'
-    protobuf: '>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
     python: '>=3.8'
+    protobuf: '>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+    proto-plus: '>=1.22.0,<2.0.0dev'
+    google-api-core-grpc: '>=1.34.0,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*'
   url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-bigquery-storage-core-2.24.0-pyhca7485f_0.conda
   hash:
     md5: 1d1a6f7938f1a29044e676d112c0b424
@@ -4853,12 +7284,27 @@ package:
 - name: google-cloud-core
   version: 2.4.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    google-auth: '>=1.25.0,<3.0dev'
+    google-api-core: '>=1.31.6,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0'
+    grpcio: '>=1.38.0,<2.0.0dev'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-core-2.4.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1853cdebbfe25fb6ee253855a44945a6
+    sha256: d01b787bad2ec4da9536ce2cedb3e53ed092fe6a4a596c043ab358bb9b2fbcdd
+  category: main
+  optional: false
+- name: google-cloud-core
+  version: 2.4.1
+  manager: conda
   platform: osx-arm64
   dependencies:
-    google-api-core: '>=1.31.6,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0'
-    google-auth: '>=1.25.0,<3.0dev'
-    grpcio: '>=1.38.0,<2.0.0dev'
     python: '>=3.8'
+    google-auth: '>=1.25.0,<3.0dev'
+    google-api-core: '>=1.31.6,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0'
+    grpcio: '>=1.38.0,<2.0.0dev'
   url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-core-2.4.1-pyhd8ed1ab_0.conda
   hash:
     md5: 1853cdebbfe25fb6ee253855a44945a6
@@ -4866,41 +7312,60 @@ package:
   category: main
   optional: false
 - name: google-cloud-storage
-  version: 2.14.0
+  version: 2.16.0
   manager: conda
   platform: linux-64
   dependencies:
-    google-api-core: '>=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0'
-    google-auth: '>=2.23.3,<3.0dev'
+    google-api-core: '>=2.15.0,<3.0.0dev'
+    google-auth: '>=2.26.1,<3.0dev'
     google-cloud-core: '>=2.3.0,<3.0dev'
     google-crc32c: '>=1.0,<2.0dev'
     google-resumable-media: '>=2.6.0'
     protobuf: <5.0.0dev
-    python: '>=3.6'
+    python: '>=3.7'
     requests: '>=2.18.0,<3.0.0dev'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-storage-2.14.0-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-storage-2.16.0-pyhca7485f_0.conda
   hash:
-    md5: 7b2a2b429fd0b5571544019a6814cfe4
-    sha256: 175e88ea6e9cf353d63dfbb0007cb6be9240ab795c38ca4b5d5101b576383698
+    md5: a465dd6977e00f7fd955f03e787a745b
+    sha256: 7c196842cb591516d10af4f90fbf046085f459a326b9cf0e3946f5ec8cae2fbd
   category: main
   optional: false
 - name: google-cloud-storage
-  version: 2.14.0
+  version: 2.16.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    requests: '>=2.18.0,<3.0.0dev'
+    google-cloud-core: '>=2.3.0,<3.0dev'
+    google-crc32c: '>=1.0,<2.0dev'
+    protobuf: <5.0.0dev
+    google-resumable-media: '>=2.6.0'
+    google-api-core: '>=2.15.0,<3.0.0dev'
+    google-auth: '>=2.26.1,<3.0dev'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-storage-2.16.0-pyhca7485f_0.conda
+  hash:
+    md5: a465dd6977e00f7fd955f03e787a745b
+    sha256: 7c196842cb591516d10af4f90fbf046085f459a326b9cf0e3946f5ec8cae2fbd
+  category: main
+  optional: false
+- name: google-cloud-storage
+  version: 2.16.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    google-api-core: '>=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0'
-    google-auth: '>=2.23.3,<3.0dev'
+    python: '>=3.7'
+    requests: '>=2.18.0,<3.0.0dev'
     google-cloud-core: '>=2.3.0,<3.0dev'
     google-crc32c: '>=1.0,<2.0dev'
-    google-resumable-media: '>=2.6.0'
     protobuf: <5.0.0dev
-    python: '>=3.6'
-    requests: '>=2.18.0,<3.0.0dev'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-storage-2.14.0-pyhca7485f_0.conda
+    google-resumable-media: '>=2.6.0'
+    google-api-core: '>=2.15.0,<3.0.0dev'
+    google-auth: '>=2.26.1,<3.0dev'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-storage-2.16.0-pyhca7485f_0.conda
   hash:
-    md5: 7b2a2b429fd0b5571544019a6814cfe4
-    sha256: 175e88ea6e9cf353d63dfbb0007cb6be9240ab795c38ca4b5d5101b576383698
+    md5: a465dd6977e00f7fd955f03e787a745b
+    sha256: 7c196842cb591516d10af4f90fbf046085f459a326b9cf0e3946f5ec8cae2fbd
   category: main
   optional: false
 - name: google-crc32c
@@ -4917,6 +7382,21 @@ package:
   hash:
     md5: 09f92f949dd2754de9146a31492d4edc
     sha256: 21aefa9eb310072f0b2b9315db5fcc483be9a68376ceabf259095456faf7d65e
+  category: main
+  optional: false
+- name: google-crc32c
+  version: 1.1.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cffi: '>=1.0.0'
+    libcrc32c: '>=1.1.2,<1.2.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.1.2-py39heba5dd3_5.conda
+  hash:
+    md5: 7f1909cffc2854341b9f00ef62bb6187
+    sha256: ba88eb2c1785f26e16ef1e9fa84c8356d6d05903557f5f6250ab053e499a0911
   category: main
   optional: false
 - name: google-crc32c
@@ -4950,6 +7430,19 @@ package:
 - name: google-pasta
   version: 0.2.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/google-pasta-0.2.0-pyh8c360ce_0.tar.bz2
+  hash:
+    md5: 26e27d7d3d7fe2336b543dd8e0f12cbf
+    sha256: 6fe6859982e0600bc2347df4e4ad2b374971f1b913fbae468658e40e9095e748
+  category: main
+  optional: false
+- name: google-pasta
+  version: 0.2.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
@@ -4976,10 +7469,23 @@ package:
 - name: google-resumable-media
   version: 2.7.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    google-crc32c: '>=1.0,<2.0.0dev'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-resumable-media-2.7.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 28d1e160d8b2e405b16bb40773135225
+    sha256: b7f08e89a491cfaa904328b96c1700da18d2cc33affefc2d15077e03ad4ec8bf
+  category: main
+  optional: false
+- name: google-resumable-media
+  version: 2.7.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    google-crc32c: '>=1.0,<2.0.0dev'
     python: '>=3.7'
+    google-crc32c: '>=1.0,<2.0.0dev'
   url: https://conda.anaconda.org/conda-forge/noarch/google-resumable-media-2.7.0-pyhd8ed1ab_0.conda
   hash:
     md5: 28d1e160d8b2e405b16bb40773135225
@@ -5002,10 +7508,23 @@ package:
 - name: googleapis-common-protos
   version: 1.63.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    protobuf: '>=3.19.5,<5.0.0dev0,!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.63.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 058e77f4f0285aa4945c5539de931ff0
+    sha256: 41d3eea46623836e2be7234bdbfc0e7a42fc0853229c687cea6d7b652bb4a4fa
+  category: main
+  optional: false
+- name: googleapis-common-protos
+  version: 1.63.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    protobuf: '>=3.19.5,<5.0.0dev0,!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
     python: '>=3.7'
+    protobuf: '>=3.19.5,<5.0.0dev0,!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
   url: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.63.0-pyhd8ed1ab_0.conda
   hash:
     md5: 058e77f4f0285aa4945c5539de931ff0
@@ -5017,12 +7536,24 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-    libstdcxx-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h58526e2_1001.tar.bz2
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
   hash:
-    md5: 8c54672728e8ec6aa6db90cf2806d220
-    sha256: 65da967f3101b737b08222de6a6a14e20e480e7d523a5d1e19ace7b960b5d6b1
+    md5: f87c7b7c2cb45f323ffbce941c78ab7c
+    sha256: 0595b009f20f8f60f13a6398e7cdcbd2acea5f986633adcf85f5a2283c992add
+  category: main
+  optional: false
+- name: graphite2
+  version: 1.3.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h73e2aa4_1003.conda
+  hash:
+    md5: fc7124f86e1d359fc5d878accd9e814c
+    sha256: b71db966e47cd83b16bfcc2099b8fa87c07286f24a0742078fede4c84314f91a
   category: main
   optional: false
 - name: graphite2
@@ -5030,11 +7561,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=11.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-h9f76cd9_1001.tar.bz2
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-hebf3989_1003.conda
   hash:
-    md5: 288b591645cb9cb9c0af7309ac1114f5
-    sha256: 57db1e563cdfe469cd453a2988039118e96ce4b77c9219e2f1022be0e1c2b03f
+    md5: 339991336eeddb70076d8ca826dac625
+    sha256: 2eadafbfc52f5e7df3da3c3b7e5bbe34d970bea1d645ffe60b0b1c3a216657f5
   category: main
   optional: false
 - name: graphviz
@@ -5065,6 +7596,31 @@ package:
 - name: graphviz
   version: 9.0.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    cairo: '>=1.18.0,<2.0a0'
+    fonts-conda-ecosystem: ''
+    gdk-pixbuf: '>=2.42.10,<3.0a0'
+    gtk2: ''
+    gts: '>=0.7.6,<0.8.0a0'
+    libcxx: '>=16.0.6'
+    libexpat: '>=2.5.0,<3.0a0'
+    libgd: '>=2.3.3,<2.4.0a0'
+    libglib: '>=2.78.1,<3.0a0'
+    librsvg: '>=2.56.3,<3.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    pango: '>=1.50.14,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/graphviz-9.0.0-hee74176_1.conda
+  hash:
+    md5: 7cd479251093c332aa9fe93cfb8f698b
+    sha256: 3080dc2f9ea708af0ea94d49348cff05884a149214a5e225e9647eff4cdac849
+  category: main
+  optional: false
+- name: graphviz
+  version: 9.0.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=10.9'
@@ -5088,7 +7644,7 @@ package:
   category: main
   optional: false
 - name: great-expectations
-  version: 0.18.11
+  version: 0.18.12
   manager: conda
   platform: linux-64
   dependencies:
@@ -5121,50 +7677,90 @@ package:
     typing-extensions: '>=3.10.0.0'
     tzlocal: '>=1.2'
     urllib3: '>=1.26'
-  url: https://conda.anaconda.org/conda-forge/noarch/great-expectations-0.18.11-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/great-expectations-0.18.12-pyhd8ed1ab_0.conda
   hash:
-    md5: f5fec30dfe5c45d15f7de3dac276d965
-    sha256: 3c95a8573889782fc227cc6e5273e80cba9fde10af314d86e5868ae9cae74bfe
+    md5: bb82b4df54271dfecebe07f7da6d7a59
+    sha256: 4f0a1928d265f69eadf97e96c48a6ca3fdbd66690da8026c80c2478be6be5456
   category: main
   optional: false
 - name: great-expectations
-  version: 0.18.11
+  version: 0.18.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    packaging: ''
+    python: '>=3.8'
+    requests: '>=2.20'
+    jinja2: '>=2.10'
+    python-dateutil: '>=2.8.1'
+    pandas: '>=1.1.0'
+    click: '>=7.1.2'
+    ipywidgets: '>=7.5.1'
+    colorama: '>=0.4.3'
+    jsonschema: '>=2.5.1'
+    tqdm: '>=4.59.0'
+    scipy: '>=1.6.0'
+    tzlocal: '>=1.2'
+    jsonpatch: '>=1.22'
+    mistune: '>=0.8.4'
+    typing-extensions: '>=3.10.0.0'
+    pytz: '>=2021.3'
+    nbformat: '>=5.0'
+    ruamel.yaml: '>=0.16,<0.17.18'
+    urllib3: '>=1.26'
+    ipython: '>=7.16.3'
+    cryptography: '>=3.2'
+    notebook: '>=6.4.10'
+    pyparsing: '>=2.4'
+    makefun: '>=1.7.0,<2'
+    marshmallow: '>=3.7.1,<4.0.0'
+    numpy: '>=1.20.3'
+    altair: '>=4.2.1,<5.0.0'
+    pydantic: '>=1.9.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/great-expectations-0.18.12-pyhd8ed1ab_0.conda
+  hash:
+    md5: bb82b4df54271dfecebe07f7da6d7a59
+    sha256: 4f0a1928d265f69eadf97e96c48a6ca3fdbd66690da8026c80c2478be6be5456
+  category: main
+  optional: false
+- name: great-expectations
+  version: 0.18.12
   manager: conda
   platform: osx-arm64
   dependencies:
-    altair: '>=4.2.1,<5.0.0'
-    click: '>=7.1.2'
-    colorama: '>=0.4.3'
-    cryptography: '>=3.2'
-    ipython: '>=7.16.3'
-    ipywidgets: '>=7.5.1'
+    packaging: ''
+    python: '>=3.8'
+    requests: '>=2.20'
     jinja2: '>=2.10'
-    jsonpatch: '>=1.22'
+    python-dateutil: '>=2.8.1'
+    pandas: '>=1.1.0'
+    click: '>=7.1.2'
+    ipywidgets: '>=7.5.1'
+    colorama: '>=0.4.3'
     jsonschema: '>=2.5.1'
+    tqdm: '>=4.59.0'
+    scipy: '>=1.6.0'
+    tzlocal: '>=1.2'
+    jsonpatch: '>=1.22'
+    mistune: '>=0.8.4'
+    typing-extensions: '>=3.10.0.0'
+    pytz: '>=2021.3'
+    nbformat: '>=5.0'
+    ruamel.yaml: '>=0.16,<0.17.18'
+    urllib3: '>=1.26'
+    ipython: '>=7.16.3'
+    cryptography: '>=3.2'
+    notebook: '>=6.4.10'
+    pyparsing: '>=2.4'
     makefun: '>=1.7.0,<2'
     marshmallow: '>=3.7.1,<4.0.0'
-    mistune: '>=0.8.4'
-    nbformat: '>=5.0'
-    notebook: '>=6.4.10'
     numpy: '>=1.20.3'
-    packaging: ''
-    pandas: '>=1.1.0'
+    altair: '>=4.2.1,<5.0.0'
     pydantic: '>=1.9.2'
-    pyparsing: '>=2.4'
-    python: '>=3.8'
-    python-dateutil: '>=2.8.1'
-    pytz: '>=2021.3'
-    requests: '>=2.20'
-    ruamel.yaml: '>=0.16,<0.17.18'
-    scipy: '>=1.6.0'
-    tqdm: '>=4.59.0'
-    typing-extensions: '>=3.10.0.0'
-    tzlocal: '>=1.2'
-    urllib3: '>=1.26'
-  url: https://conda.anaconda.org/conda-forge/noarch/great-expectations-0.18.11-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/great-expectations-0.18.12-pyhd8ed1ab_0.conda
   hash:
-    md5: f5fec30dfe5c45d15f7de3dac276d965
-    sha256: 3c95a8573889782fc227cc6e5273e80cba9fde10af314d86e5868ae9cae74bfe
+    md5: bb82b4df54271dfecebe07f7da6d7a59
+    sha256: 4f0a1928d265f69eadf97e96c48a6ca3fdbd66690da8026c80c2478be6be5456
   category: main
   optional: false
 - name: greenlet
@@ -5180,6 +7776,20 @@ package:
   hash:
     md5: a240d46f8f326c4af01de1a1d8e615d0
     sha256: 3cc114aaf9051dc40dc63be9969284a6691fdbf9d55668a7e245de9bc3bbcf38
+  category: main
+  optional: false
+- name: greenlet
+  version: 3.0.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/greenlet-3.0.3-py39hd253f6c_0.conda
+  hash:
+    md5: 49761a832d2843cb4fee86788f44d0f5
+    sha256: 13f0152db5f0d4002862e5c8287e33d648a5301474cf3e9ed6e12009d3050651
   category: main
   optional: false
 - name: greenlet
@@ -5216,17 +7826,35 @@ package:
 - name: grpcio
   version: 1.59.3
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    libcxx: '>=16'
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
     libgrpc: 1.59.3
     libzlib: '>=1.2.13,<1.3.0a0'
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.59.3-py39h047a24b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/grpcio-1.59.3-py39h512e3ab_0.conda
   hash:
-    md5: 1afaf768107e5ab3284afb7d64d4a99c
-    sha256: 9f508baa6330ecf5a4a8129049e25ae40b2e534979a52995a6df08d8b65b7651
+    md5: c41a6dcb4b7620902b304a5b296db491
+    sha256: 905aaf937f6884180490ddc9a43b98114c976f343ea0cb0c3d052ab92cff5f00
+  category: main
+  optional: false
+- name: grpcio
+  version: 1.59.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    libgrpc: 1.59.3
+    libzlib: '>=1.2.13,<1.3.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.59.3-py39h52f163a_0.conda
+  hash:
+    md5: 65c1499ad010b38f0acab66e753f43b8
+    sha256: 9939546b8eaf9a5666b31f872e6d70950139b108a557f3a1a3f14f0548af1fb3
   category: main
   optional: false
 - name: grpcio-status
@@ -5247,16 +7875,114 @@ package:
 - name: grpcio-status
   version: 1.59.3
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    googleapis-common-protos: '>=1.5.5'
-    grpcio: '>=1.59.3'
-    protobuf: '>=4.21.6'
     python: '>=3.7'
+    googleapis-common-protos: '>=1.5.5'
+    protobuf: '>=4.21.6'
+    grpcio: '>=1.59.3'
   url: https://conda.anaconda.org/conda-forge/noarch/grpcio-status-1.59.3-pyhd8ed1ab_0.conda
   hash:
     md5: 667999da148378ada5b9f13e7f3850c3
     sha256: 45c00a3feaf80f29cbc4b2f6a7ef73b08ce4e4a847b32a82eed443c7dd95d0c9
+  category: main
+  optional: false
+- name: grpcio-status
+  version: 1.59.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+    googleapis-common-protos: '>=1.5.5'
+    protobuf: '>=4.21.6'
+    grpcio: '>=1.59.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/grpcio-status-1.59.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 667999da148378ada5b9f13e7f3850c3
+    sha256: 45c00a3feaf80f29cbc4b2f6a7ef73b08ce4e4a847b32a82eed443c7dd95d0c9
+  category: main
+  optional: false
+- name: gst-plugins-base
+  version: 1.22.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    alsa-lib: '>=1.2.10,<1.3.0.0a0'
+    gettext: '>=0.21.1,<1.0a0'
+    gstreamer: 1.22.9
+    libexpat: '>=2.5.0,<3.0a0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.78.3,<3.0a0'
+    libogg: '>=1.3.4,<1.4.0a0'
+    libopus: '>=1.3.1,<2.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libstdcxx-ng: '>=12'
+    libvorbis: '>=1.3.7,<1.4.0a0'
+    libxcb: '>=1.15,<1.16.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    xorg-libx11: '>=1.8.7,<2.0a0'
+    xorg-libxau: '>=1.0.11,<2.0a0'
+    xorg-libxext: '>=1.3.4,<2.0a0'
+    xorg-libxrender: '>=0.9.11,<0.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.9-h8e1006c_0.conda
+  hash:
+    md5: 614b81f8ed66c56b640faee7076ad14a
+    sha256: a4312c96a670fdbf9ff0c3efd935e42fa4b655ff33dcc52c309b76a2afaf03f0
+  category: main
+  optional: false
+- name: gst-plugins-base
+  version: 1.22.9
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gettext: '>=0.21.1,<1.0a0'
+    gstreamer: 1.22.9
+    libcxx: '>=15'
+    libglib: '>=2.78.3,<3.0a0'
+    libogg: '>=1.3.4,<1.4.0a0'
+    libopus: '>=1.3.1,<2.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libvorbis: '>=1.3.7,<1.4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gst-plugins-base-1.22.9-h3fb38fc_0.conda
+  hash:
+    md5: a0a4e1596c79cb67ba243e5e4dfd559f
+    sha256: c633c837b6e24da03129144ac1ab5940f43035a639b39bb2a1b086ea2f025e8f
+  category: main
+  optional: false
+- name: gstreamer
+  version: 1.22.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    gettext: '>=0.21.1,<1.0a0'
+    glib: '>=2.78.3,<3.0a0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.78.3,<3.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.9-h98fc4e7_0.conda
+  hash:
+    md5: bcc7157b06fce7f5e055402a8135dfd8
+    sha256: aa2395bf1790f72d2706bac77430f765ec1318ca22e60e791c13ae452c045263
+  category: main
+  optional: false
+- name: gstreamer
+  version: 1.22.9
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gettext: '>=0.21.1,<1.0a0'
+    glib: '>=2.78.3,<3.0a0'
+    libcxx: '>=15'
+    libglib: '>=2.78.3,<3.0a0'
+    libiconv: '>=1.17,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gstreamer-1.22.9-hf63bbb8_0.conda
+  hash:
+    md5: 1581bb03c4655191284a3eab9ee8690d
+    sha256: be9d64972f997e1f865673cbb059a8c653f1fb38ff5e6c6a049699823bad0d9f
   category: main
   optional: false
 - name: gtk2
@@ -5281,6 +8007,23 @@ package:
   hash:
     md5: 410f86e58e880dcc7b0e910a8e89c05c
     sha256: b946ba60d177d72157cad8af51723f1d081a4794741d35debe53f8b2c807f3af
+  category: main
+  optional: false
+- name: gtk2
+  version: 2.24.33
+  manager: conda
+  platform: osx-64
+  dependencies:
+    atk-1.0: '>=2.38.0'
+    cairo: '>=1.18.0,<2.0a0'
+    gdk-pixbuf: '>=2.42.10,<3.0a0'
+    gettext: '>=0.21.1,<1.0a0'
+    libglib: '>=2.78.4,<3.0a0'
+    pango: '>=1.50.14,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gtk2-2.24.33-h8ca4665_4.conda
+  hash:
+    md5: ff451625250bf843393ca3d660accab3
+    sha256: 5283dfb9a96d78a67e0cbf6e4592411bb19eaf27f2c7c14b47e63162e71317d2
   category: main
   optional: false
 - name: gtk2
@@ -5317,6 +8060,19 @@ package:
 - name: gts
   version: 0.7.6
   manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    libglib: '>=2.76.3,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gts-0.7.6-h53e17e3_4.conda
+  hash:
+    md5: 848cc963fcfbd063c7a023024aa3bec0
+    sha256: d5b82a36f7e9d7636b854e56d1b4fe01c4d895128a7b73e2ec6945b691ff3314
+  category: main
+  optional: false
+- name: gts
+  version: 0.7.6
+  manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=15.0.7'
@@ -5340,6 +8096,21 @@ package:
   hash:
     md5: a5355f72e68b8e114db59844ab5e6609
     sha256: a96b3b110bd9e8d0c3199209adf797923592f02d1869d716e320b0edc61a1785
+  category: main
+  optional: false
+- name: gunicorn
+  version: 21.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    packaging: ''
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    setuptools: '>=3.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gunicorn-21.2.0-py39h6e9494a_1.conda
+  hash:
+    md5: fa8ff108ccec5fa7bc5fd3622b30f0cd
+    sha256: c852849bfd342702145799141079bee72148b54a560b344b301821799285e6c6
   category: main
   optional: false
 - name: gunicorn
@@ -5373,10 +8144,23 @@ package:
 - name: h11
   version: 0.14.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    typing_extensions: ''
+    python: '>=3'
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b21ed0883505ba1910994f1df031a428
+    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
+  category: main
+  optional: false
+- name: h11
+  version: 0.14.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3'
     typing_extensions: ''
+    python: '>=3'
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b21ed0883505ba1910994f1df031a428
@@ -5390,11 +8174,27 @@ package:
   dependencies:
     hpack: '>=4.0,<5'
     hyperframe: '>=6.0,<7'
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/h2-4.1.0-py39hf3d152e_0.tar.bz2
   hash:
-    md5: b748fbf7060927a6e82df7cb5ee8f097
-    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+    md5: 4d6e35bbcba4f0c06f02a285f5602333
+    sha256: f2aaa56f152e889f2f9d7db78f4b0534dce91c8de3e2a5b2627fbfcb01b14054
+  category: main
+  optional: false
+- name: h2
+  version: 4.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    hpack: '>=4.0,<5'
+    hyperframe: '>=6.0,<7'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/h2-4.1.0-py39h6e9494a_0.tar.bz2
+  hash:
+    md5: d926c73961d5ccfe6e8b2b18a9316a9a
+    sha256: 0d0b28ed10072f3e58c66992a1af76f7e7ea9c0922b04821955b05039dbca414
   category: main
   optional: false
 - name: h2
@@ -5402,9 +8202,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.6.1'
     hpack: '>=4.0,<5'
     hyperframe: '>=6.0,<7'
-    python: '>=3.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b748fbf7060927a6e82df7cb5ee8f097
@@ -5426,6 +8226,22 @@ package:
   hash:
     md5: f4e131bcc793c2746beca216d13db900
     sha256: eb19a7f87d770612ab0267427d2f0ac07a0d5584d9e4d539019e7e934a2a3278
+  category: main
+  optional: false
+- name: h5py
+  version: 3.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cached-property: ''
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    numpy: '>=1.22.4,<2.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.10.0-nompi_py39h9420513_101.conda
+  hash:
+    md5: 60e349d82eecd97910178c43c5c8c83d
+    sha256: 598656f6f12f4fe3826ed5ce107c78dfb8a7cec61b9e11e6ea24836d7ba09f09
   category: main
   optional: false
 - name: h5py
@@ -5465,6 +8281,24 @@ package:
 - name: harfbuzz
   version: 8.3.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    cairo: '>=1.18.0,<2.0a0'
+    freetype: '>=2.12.1,<3.0a0'
+    graphite2: ''
+    icu: '>=73.2,<74.0a0'
+    libcxx: '>=16.0.6'
+    libglib: '>=2.78.1,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-8.3.0-hf45c392_0.conda
+  hash:
+    md5: 41d890485f909e4ecdc608741718c75e
+    sha256: c6ea14e4f4869bc78b27276c09832af845dfa415585362ed6064e37a1b5fe9c5
+  category: main
+  optional: false
+- name: harfbuzz
+  version: 8.3.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=10.9'
@@ -5493,6 +8327,20 @@ package:
   hash:
     md5: bd77f8da987968ec3927990495dc22e4
     sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
+  category: main
+  optional: false
+- name: hdf4
+  version: 4.2.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+  hash:
+    md5: 7ce543bf38dbfae0de9af112ee178af2
+    sha256: 8c767cc71226e9eb62649c903c68ba73c5f5e7e3696ec0319d1f90586cebec7d
   category: main
   optional: false
 - name: hdf4
@@ -5531,6 +8379,25 @@ package:
 - name: hdf5
   version: 1.14.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libaec: '>=1.1.2,<2.0a0'
+    libcurl: '>=8.4.0,<9.0a0'
+    libcxx: '>=16.0.6'
+    libgfortran: 5.*
+    libgfortran5: '>=13.2.0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h691f4bf_100.conda
+  hash:
+    md5: 8e2ac4ae815a8c9743fe37d70f48f075
+    sha256: 158dd2ab901659b47e8f7ee0ec1d9e45a1fedc4871391a44a1c8b9e8ba4c9c6b
+  category: main
+  optional: false
+- name: hdf5
+  version: 1.14.3
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=10.9'
@@ -5562,6 +8429,18 @@ package:
 - name: hpack
   version: 4.0.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 914d6646c4dbb1fd3ff539830a12fd71
+    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  category: main
+  optional: false
+- name: hpack
+  version: 4.0.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
@@ -5572,7 +8451,7 @@ package:
   category: main
   optional: false
 - name: httpcore
-  version: 1.0.4
+  version: 1.0.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -5582,27 +8461,44 @@ package:
     h2: '>=3,<5'
     python: '>=3.8'
     sniffio: 1.*
-  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 20f047662cf4fa8b97836111df87dbb4
-    sha256: dec07ca00223d52433e7c20c71d5e645a7828b3e50206d855ad7a540869341f2
+    md5: a6b9a0158301e697e4d0a36a3d60e133
+    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
   category: main
   optional: false
 - name: httpcore
-  version: 1.0.4
+  version: 1.0.5
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    anyio: '>=3.0,<5.0'
     certifi: ''
-    h11: '>=0.13,<0.15'
-    h2: '>=3,<5'
     python: '>=3.8'
     sniffio: 1.*
-  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.4-pyhd8ed1ab_0.conda
+    h2: '>=3,<5'
+    anyio: '>=3.0,<5.0'
+    h11: '>=0.13,<0.15'
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 20f047662cf4fa8b97836111df87dbb4
-    sha256: dec07ca00223d52433e7c20c71d5e645a7828b3e50206d855ad7a540869341f2
+    md5: a6b9a0158301e697e4d0a36a3d60e133
+    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
+  category: main
+  optional: false
+- name: httpcore
+  version: 1.0.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    certifi: ''
+    python: '>=3.8'
+    sniffio: 1.*
+    h2: '>=3,<5'
+    anyio: '>=3.0,<5.0'
+    h11: '>=0.13,<0.15'
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: a6b9a0158301e697e4d0a36a3d60e133
+    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
   category: main
   optional: false
 - name: httpx
@@ -5625,14 +8521,31 @@ package:
 - name: httpx
   version: 0.27.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    certifi: ''
+    idna: ''
+    anyio: ''
+    sniffio: ''
+    python: '>=3.8'
+    httpcore: 1.*
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9f359af5a886fd6ca6b2b6ea02e58332
+    sha256: fdaf341fb2630b7afe8238315448fc93947f77ebfa4da68bb349e1bcf820af58
+  category: main
+  optional: false
+- name: httpx
+  version: 0.27.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    anyio: ''
     certifi: ''
-    httpcore: 1.*
     idna: ''
-    python: '>=3.8'
+    anyio: ''
     sniffio: ''
+    python: '>=3.8'
+    httpcore: 1.*
   url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
   hash:
     md5: 9f359af5a886fd6ca6b2b6ea02e58332
@@ -5640,7 +8553,7 @@ package:
   category: main
   optional: false
 - name: huggingface_hub
-  version: 0.21.4
+  version: 0.22.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -5652,35 +8565,66 @@ package:
     requests: ''
     tqdm: '>=4.42.1'
     typing-extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.21.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.22.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d47cf217a7bcc3a03dd1c6169c3f0f98
-    sha256: e748e5f1ed8cbcbdcc4dd0e0da14063687bb1c3b65c4266f81b73cb56801805e
+    md5: b9f58e10a6247f5ca5d70a6040f62943
+    sha256: 2b6e1276089d2563b047497ecc1ce9d4a502594852c46886f881a4129d1993ce
   category: main
   optional: false
 - name: huggingface_hub
-  version: 0.21.4
+  version: 0.22.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    requests: ''
+    filelock: ''
+    python: '>=3.8'
+    pyyaml: '>=5.1'
+    packaging: '>=20.9'
+    typing-extensions: '>=3.7.4.3'
+    fsspec: '>=2023.5.0'
+    tqdm: '>=4.42.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.22.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: b9f58e10a6247f5ca5d70a6040f62943
+    sha256: 2b6e1276089d2563b047497ecc1ce9d4a502594852c46886f881a4129d1993ce
+  category: main
+  optional: false
+- name: huggingface_hub
+  version: 0.22.1
   manager: conda
   platform: osx-arm64
   dependencies:
+    requests: ''
     filelock: ''
-    fsspec: '>=2023.5.0'
-    packaging: '>=20.9'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    requests: ''
-    tqdm: '>=4.42.1'
+    packaging: '>=20.9'
     typing-extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.21.4-pyhd8ed1ab_0.conda
+    fsspec: '>=2023.5.0'
+    tqdm: '>=4.42.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.22.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d47cf217a7bcc3a03dd1c6169c3f0f98
-    sha256: e748e5f1ed8cbcbdcc4dd0e0da14063687bb1c3b65c4266f81b73cb56801805e
+    md5: b9f58e10a6247f5ca5d70a6040f62943
+    sha256: 2b6e1276089d2563b047497ecc1ce9d4a502594852c46886f881a4129d1993ce
   category: main
   optional: false
 - name: hyperframe
   version: 6.0.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 9f765cbfab6870c8435b9eefecd7a1f4
+    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  category: main
+  optional: false
+- name: hyperframe
+  version: 6.0.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
@@ -5717,6 +8661,17 @@ package:
 - name: icu
   version: '73.2'
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+  hash:
+    md5: 5cc301d759ec03f28328428e28f65591
+    sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
+  category: main
+  optional: false
+- name: icu
+  version: '73.2'
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
@@ -5741,10 +8696,23 @@ package:
 - name: identify
   version: 2.5.35
   manager: conda
+  platform: osx-64
+  dependencies:
+    ukkonen: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.35-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9472bfd206a2b7bb8143835e37667054
+    sha256: 971683b13d1b820157bef9993c63dd8b0611d2d60fc4b522da163aee2e70e518
+  category: main
+  optional: false
+- name: identify
+  version: 2.5.35
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
     ukkonen: ''
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.35-pyhd8ed1ab_0.conda
   hash:
     md5: 9472bfd206a2b7bb8143835e37667054
@@ -5766,6 +8734,18 @@ package:
 - name: idna
   version: '3.6'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1a76f09108576397c41c0b0c5bd84134
+    sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
+  category: main
+  optional: false
+- name: idna
+  version: '3.6'
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
@@ -5790,6 +8770,18 @@ package:
 - name: imagesize
   version: 1.4.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 7de5386c8fea29e76b303f37dde4c352
+    sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
+  category: main
+  optional: false
+- name: imagesize
+  version: 1.4.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.4'
@@ -5815,6 +8807,19 @@ package:
 - name: importlib-metadata
   version: 6.10.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    zipp: '>=0.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.10.0-pyha770c72_0.conda
+  hash:
+    md5: ae2ad334f34040e147cc5824b450463b
+    sha256: 4b823af311e7f5093fca41ec0142d0e1ec9b3d1ee91924dc63133611bdfcaee5
+  category: main
+  optional: false
+- name: importlib-metadata
+  version: 6.10.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
@@ -5826,35 +8831,60 @@ package:
   category: main
   optional: false
 - name: importlib-resources
-  version: 6.3.0
+  version: 6.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib_resources: '>=6.3.0,<6.3.1.0a0'
+    importlib_resources: '>=6.4.0,<6.4.1.0a0'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 828e394294c4a0e31872a9f420cf92f7
-    sha256: ed401d44578cec3bf8bd924bee7867c6d86c0707e55dd543b99640fa0fc85e47
+    md5: dcbadab7a68738a028e195ab68ab2d2e
+    sha256: 38db827f445ae437a15d50a94816ae67a48285d0700f736af3eb90800a71f079
   category: main
   optional: false
 - name: importlib-resources
-  version: 6.3.0
+  version: 6.4.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    importlib_resources: '>=6.4.0,<6.4.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: dcbadab7a68738a028e195ab68ab2d2e
+    sha256: 38db827f445ae437a15d50a94816ae67a48285d0700f736af3eb90800a71f079
+  category: main
+  optional: false
+- name: importlib-resources
+  version: 6.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib_resources: '>=6.3.0,<6.3.1.0a0'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.3.0-pyhd8ed1ab_0.conda
+    importlib_resources: '>=6.4.0,<6.4.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 828e394294c4a0e31872a9f420cf92f7
-    sha256: ed401d44578cec3bf8bd924bee7867c6d86c0707e55dd543b99640fa0fc85e47
+    md5: dcbadab7a68738a028e195ab68ab2d2e
+    sha256: 38db827f445ae437a15d50a94816ae67a48285d0700f736af3eb90800a71f079
   category: main
   optional: false
 - name: importlib_metadata
   version: 6.10.0
   manager: conda
   platform: linux-64
+  dependencies:
+    importlib-metadata: '>=6.10.0,<6.10.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.10.0-hd8ed1ab_0.conda
+  hash:
+    md5: c063ddbb9908499fd4f20b31dc67065a
+    sha256: a3688dc4fb2ed84e4f11738375eee542800ca0bcb343cf5993f4e3e092dcc6bf
+  category: main
+  optional: false
+- name: importlib_metadata
+  version: 6.10.0
+  manager: conda
+  platform: osx-64
   dependencies:
     importlib-metadata: '>=6.10.0,<6.10.1.0a0'
   url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.10.0-hd8ed1ab_0.conda
@@ -5876,29 +8906,42 @@ package:
   category: main
   optional: false
 - name: importlib_resources
-  version: 6.3.0
+  version: 6.4.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 18850e65ca439066484607b26ed09ecd
-    sha256: 8ad2fdd72f6a0ebefaa1496d2f43f100596f1733468fd9b549891f6195a5b8cb
+    md5: c5d3907ad8bd7bf557521a1833cf7e6d
+    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
   category: main
   optional: false
 - name: importlib_resources
-  version: 6.3.0
+  version: 6.4.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    zipp: '>=3.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: c5d3907ad8bd7bf557521a1833cf7e6d
+    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+  category: main
+  optional: false
+- name: importlib_resources
+  version: 6.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 18850e65ca439066484607b26ed09ecd
-    sha256: 8ad2fdd72f6a0ebefaa1496d2f43f100596f1733468fd9b549891f6195a5b8cb
+    md5: c5d3907ad8bd7bf557521a1833cf7e6d
+    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
   category: main
   optional: false
 - name: ipykernel
@@ -5929,23 +8972,49 @@ package:
 - name: ipykernel
   version: 6.29.3
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    __osx: ''
-    appnope: ''
-    comm: '>=0.1.1'
-    debugpy: '>=1.6.5'
-    ipython: '>=7.23.1'
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    matplotlib-inline: '>=0.1'
-    nest-asyncio: ''
     packaging: ''
     psutil: ''
+    nest-asyncio: ''
+    __osx: ''
+    appnope: ''
     python: '>=3.8'
-    pyzmq: '>=24'
     tornado: '>=6.1'
+    jupyter_client: '>=6.1.12'
+    jupyter_core: '>=4.12,!=5.0.*'
+    ipython: '>=7.23.1'
+    matplotlib-inline: '>=0.1'
+    debugpy: '>=1.6.5'
+    comm: '>=0.1.1'
     traitlets: '>=5.4.0'
+    pyzmq: '>=24'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.3-pyh3cd1d5f_0.conda
+  hash:
+    md5: 28e74fca8d8abf09c1ed0d190a17e307
+    sha256: ef2f9c1d83afd693db3793c368c5c6afcd37a416958ece490a2e1fbcd85012eb
+  category: main
+  optional: false
+- name: ipykernel
+  version: 6.29.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    packaging: ''
+    psutil: ''
+    nest-asyncio: ''
+    __osx: ''
+    appnope: ''
+    python: '>=3.8'
+    tornado: '>=6.1'
+    jupyter_client: '>=6.1.12'
+    jupyter_core: '>=4.12,!=5.0.*'
+    ipython: '>=7.23.1'
+    matplotlib-inline: '>=0.1'
+    debugpy: '>=1.6.5'
+    comm: '>=0.1.1'
+    traitlets: '>=5.4.0'
+    pyzmq: '>=24'
   url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.3-pyh3cd1d5f_0.conda
   hash:
     md5: 28e74fca8d8abf09c1ed0d190a17e307
@@ -5979,21 +9048,45 @@ package:
 - name: ipython
   version: 8.18.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    typing_extensions: ''
     __unix: ''
     decorator: ''
     exceptiongroup: ''
-    jedi: '>=0.16'
     matplotlib-inline: ''
-    pexpect: '>4.3'
-    pickleshare: ''
-    prompt-toolkit: '>=3.0.41,<3.1.0'
-    pygments: '>=2.4.0'
-    python: '>=3.9'
     stack_data: ''
+    pickleshare: ''
+    python: '>=3.9'
+    pygments: '>=2.4.0'
     traitlets: '>=5'
+    jedi: '>=0.16'
+    pexpect: '>4.3'
+    prompt-toolkit: '>=3.0.41,<3.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.18.1-pyh707e725_3.conda
+  hash:
+    md5: 15c6f45a45f7ac27f6d60b0b084f6761
+    sha256: d98d615ac8ad71de698afbc50e8269570d4b89706821c4ff3058a4ceec69bd9b
+  category: main
+  optional: false
+- name: ipython
+  version: 8.18.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     typing_extensions: ''
+    __unix: ''
+    decorator: ''
+    exceptiongroup: ''
+    matplotlib-inline: ''
+    stack_data: ''
+    pickleshare: ''
+    python: '>=3.9'
+    pygments: '>=2.4.0'
+    traitlets: '>=5'
+    jedi: '>=0.16'
+    pexpect: '>4.3'
+    prompt-toolkit: '>=3.0.41,<3.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.18.1-pyh707e725_3.conda
   hash:
     md5: 15c6f45a45f7ac27f6d60b0b084f6761
@@ -6020,13 +9113,30 @@ package:
 - name: ipywidgets
   version: 8.1.2
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    comm: '>=0.1.3'
-    ipython: '>=6.1.0'
-    jupyterlab_widgets: '>=3.0.10,<3.1.0'
     python: '>=3.7'
     traitlets: '>=4.3.1'
+    ipython: '>=6.1.0'
+    comm: '>=0.1.3'
+    jupyterlab_widgets: '>=3.0.10,<3.1.0'
+    widgetsnbextension: '>=4.0.10,<4.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 67f86478c78637f68c1f3858973021f2
+    sha256: 0be846f1374faa2d9b6f5e100187d56afa9268221f7c7815265f30aa008da8ca
+  category: main
+  optional: false
+- name: ipywidgets
+  version: 8.1.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+    traitlets: '>=4.3.1'
+    ipython: '>=6.1.0'
+    comm: '>=0.1.3'
+    jupyterlab_widgets: '>=3.0.10,<3.1.0'
     widgetsnbextension: '>=4.0.10,<4.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.2-pyhd8ed1ab_0.conda
   hash:
@@ -6050,10 +9160,23 @@ package:
 - name: isodate
   version: 0.6.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    six: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.6.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 4a62c93c1b5c0b920508ae3fd285eaf5
+    sha256: af8f801e093da52a50ca0ea0510dfaf6898fea37e66d08d335e370235dede9fc
+  category: main
+  optional: false
+- name: isodate
+  version: 0.6.1
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
     six: ''
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.6.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 4a62c93c1b5c0b920508ae3fd285eaf5
@@ -6076,10 +9199,23 @@ package:
 - name: isoduration
   version: 20.11.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    arrow: '>=0.15.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 4cb68948e0b8429534380243d063a27a
+    sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  category: main
+  optional: false
+- name: isoduration
+  version: 20.11.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    arrow: '>=0.15.0'
     python: '>=3.7'
+    arrow: '>=0.15.0'
   url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 4cb68948e0b8429534380243d063a27a
@@ -6101,6 +9237,18 @@ package:
 - name: itsdangerous
   version: 2.1.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.1.2-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 3c3de74912f11d2b590184f03c7cd09b
+    sha256: 31e3492686b4e92b53db9b48bc0eb03873b1caaf28629fee7d2d47627a2c56d3
+  category: main
+  optional: false
+- name: itsdangerous
+  version: 2.1.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -6126,6 +9274,19 @@ package:
 - name: jaraco.classes
   version: 3.3.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    more-itertools: ''
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: c541ae264c9f1f21d83fc30dffb908ee
+    sha256: 232b40de8176fa7fb66a893653f8ae03c29616e04a83dae5a47df94b74e256ca
+  category: main
+  optional: false
+- name: jaraco.classes
+  version: 3.3.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     more-itertools: ''
@@ -6134,6 +9295,81 @@ package:
   hash:
     md5: c541ae264c9f1f21d83fc30dffb908ee
     sha256: 232b40de8176fa7fb66a893653f8ae03c29616e04a83dae5a47df94b74e256ca
+  category: main
+  optional: false
+- name: jaraco.context
+  version: 4.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-4.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 53511e966e3ced065fbb1d3d5470d16d
+    sha256: 7ce041636e6a62bf5f54b2d45f506dc77e27cd854fd754df975382f636282619
+  category: main
+  optional: false
+- name: jaraco.context
+  version: 4.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-4.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 53511e966e3ced065fbb1d3d5470d16d
+    sha256: 7ce041636e6a62bf5f54b2d45f506dc77e27cd854fd754df975382f636282619
+  category: main
+  optional: false
+- name: jaraco.context
+  version: 4.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-4.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 53511e966e3ced065fbb1d3d5470d16d
+    sha256: 7ce041636e6a62bf5f54b2d45f506dc77e27cd854fd754df975382f636282619
+  category: main
+  optional: false
+- name: jaraco.functools
+  version: 4.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    more-itertools: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 547670a612fd335eaa5ffbf0fa75cb64
+    sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
+  category: main
+  optional: false
+- name: jaraco.functools
+  version: 4.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    more-itertools: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 547670a612fd335eaa5ffbf0fa75cb64
+    sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
+  category: main
+  optional: false
+- name: jaraco.functools
+  version: 4.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    more-itertools: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 547670a612fd335eaa5ffbf0fa75cb64
+    sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
   category: main
   optional: false
 - name: jedi
@@ -6152,10 +9388,23 @@ package:
 - name: jedi
   version: 0.19.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    parso: '>=0.8.3,<0.9.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 81a3be0b2023e1ea8555781f0ad904a2
+    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+  category: main
+  optional: false
+- name: jedi
+  version: 0.19.1
+  manager: conda
   platform: osx-arm64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
     python: '>=3.6'
+    parso: '>=0.8.3,<0.9.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
   hash:
     md5: 81a3be0b2023e1ea8555781f0ad904a2
@@ -6190,10 +9439,23 @@ package:
 - name: jinja2
   version: 3.1.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    markupsafe: '>=2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: e7d8df6509ba635247ff9aea31134262
+    sha256: fd517b7dd3a61eca34f8a6f9f92f306397149cae1204fce72ac3d227107dafdc
+  category: main
+  optional: false
+- name: jinja2
+  version: 3.1.3
+  manager: conda
   platform: osx-arm64
   dependencies:
-    markupsafe: '>=2.0'
     python: '>=3.7'
+    markupsafe: '>=2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: e7d8df6509ba635247ff9aea31134262
@@ -6215,6 +9477,18 @@ package:
 - name: jmespath
   version: 1.0.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
+    sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
+  category: main
+  optional: false
+- name: jmespath
+  version: 1.0.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -6240,10 +9514,23 @@ package:
 - name: joblib
   version: 1.3.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    setuptools: ''
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4da50d410f553db77e62ab62ffaa1abc
+    sha256: 31e05d47970d956206188480b038829d24ac11fe8216409d8584d93d40233878
+  category: main
+  optional: false
+- name: joblib
+  version: 1.3.2
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     setuptools: ''
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
   hash:
     md5: 4da50d410f553db77e62ab62ffaa1abc
@@ -6260,6 +9547,17 @@ package:
   hash:
     md5: 9961b1f100c3b6852bd97c9233d06979
     sha256: 5646496ca07dfa1486d27ed07282967007811dfc63d6394652e87f94166ecae3
+  category: main
+  optional: false
+- name: json-c
+  version: '0.17'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.17-h8e11ae5_0.conda
+  hash:
+    md5: 266d2e4ebbf37091c8322937392bb540
+    sha256: 2a493095fe1292108ff1799a1b47ababe82d844bfa3abcf2252676c1017a1e04
   category: main
   optional: false
 - name: json-c
@@ -6288,6 +9586,18 @@ package:
 - name: json5
   version: 0.9.24
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.24-pyhd8ed1ab_0.conda
+  hash:
+    md5: fc9780a517b51ea3798fc011c17ffd51
+    sha256: 148a427d4867ecd367b2bb9c2ef11ae7795abeabc8454f802f28ff692b3ce1aa
+  category: main
+  optional: false
+- name: json5
+  version: 0.9.24
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7,<4.0'
@@ -6313,10 +9623,23 @@ package:
 - name: jsonpatch
   version: '1.33'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    jsonpointer: '>=1.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
+  hash:
+    md5: bfdb7c5c6ad1077c82a69a8642c87aff
+    sha256: fbb17e33ace3225c6416d1604637c1058906b8223da968cc015128985336b2b4
+  category: main
+  optional: false
+- name: jsonpatch
+  version: '1.33'
+  manager: conda
   platform: osx-arm64
   dependencies:
-    jsonpointer: '>=1.9'
     python: '>=3.8'
+    jsonpointer: '>=1.9'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
   hash:
     md5: bfdb7c5c6ad1077c82a69a8642c87aff
@@ -6327,6 +9650,19 @@ package:
   version: 3.0.2
   manager: conda
   platform: linux-64
+  dependencies:
+    importlib_metadata: ''
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-3.0.2-pyhd8ed1ab_1.conda
+  hash:
+    md5: f351864256e291b24b5a3bedda184bff
+    sha256: c947f2a64e4f06c722973894afb8e26df3aa2212e2e742def3506ccbad42141b
+  category: main
+  optional: false
+- name: jsonpickle
+  version: 3.0.2
+  manager: conda
+  platform: osx-64
   dependencies:
     importlib_metadata: ''
     python: '>=3.7'
@@ -6365,6 +9701,19 @@ package:
 - name: jsonpointer
   version: '2.4'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py39h6e9494a_3.conda
+  hash:
+    md5: 7712a5f0d4f3f7d9ec69fb24dcf9bf0a
+    sha256: a775708266d1243d31dc682f0fd9b0d8811653b82c8d89cb312d44685508e1f5
+  category: main
+  optional: false
+- name: jsonpointer
+  version: '2.4'
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -6396,13 +9745,31 @@ package:
 - name: jsonschema
   version: 4.21.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    python: '>=3.8'
     attrs: '>=22.2.0'
     importlib_resources: '>=1.4.0'
-    jsonschema-specifications: '>=2023.03.6'
     pkgutil-resolve-name: '>=1.3.10'
+    jsonschema-specifications: '>=2023.03.6'
+    referencing: '>=0.28.4'
+    rpds-py: '>=0.7.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 8a3a3d01629da20befa340919e3dd2c4
+    sha256: c5c1b4e08e91fdd697289015be1a176409b4e63942899a43b276f1f250be8129
+  category: main
+  optional: false
+- name: jsonschema
+  version: 4.21.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     python: '>=3.8'
+    attrs: '>=22.2.0'
+    importlib_resources: '>=1.4.0'
+    pkgutil-resolve-name: '>=1.3.10'
+    jsonschema-specifications: '>=2023.03.6'
     referencing: '>=0.28.4'
     rpds-py: '>=0.7.1'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
@@ -6428,10 +9795,24 @@ package:
 - name: jsonschema-specifications
   version: 2023.12.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    importlib_resources: '>=1.4.0'
+    referencing: '>=0.31.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: a0e4efb5f35786a05af4809a2fb1f855
+    sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
+  category: main
+  optional: false
+- name: jsonschema-specifications
+  version: 2023.12.1
+  manager: conda
   platform: osx-arm64
   dependencies:
-    importlib_resources: '>=1.4.0'
     python: '>=3.8'
+    importlib_resources: '>=1.4.0'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
   hash:
@@ -6463,18 +9844,39 @@ package:
 - name: jsonschema-with-format-nongpl
   version: 4.21.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    fqdn: ''
+    python: ''
     idna: ''
+    rfc3339-validator: ''
+    uri-template: ''
+    fqdn: ''
     isoduration: ''
     jsonpointer: '>1.13'
-    jsonschema: '>=4.21.1,<4.21.2.0a0'
-    python: ''
-    rfc3339-validator: ''
-    rfc3986-validator: '>0.1.0'
-    uri-template: ''
     webcolors: '>=1.11'
+    rfc3986-validator: '>0.1.0'
+    jsonschema: '>=4.21.1,<4.21.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 26bce4b5405738c09304d4f4796b2c2a
+    sha256: 6e458c325c097956ac4605ef386f0d67bad5223041cedd66819892988b72f83a
+  category: main
+  optional: false
+- name: jsonschema-with-format-nongpl
+  version: 4.21.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: ''
+    idna: ''
+    rfc3339-validator: ''
+    uri-template: ''
+    fqdn: ''
+    isoduration: ''
+    jsonpointer: '>1.13'
+    webcolors: '>=1.11'
+    rfc3986-validator: '>0.1.0'
+    jsonschema: '>=4.21.1,<4.21.2.0a0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
   hash:
     md5: 26bce4b5405738c09304d4f4796b2c2a
@@ -6491,12 +9893,32 @@ package:
     jupyter_console: ''
     nbconvert: ''
     notebook: ''
-    python: '>=3.6'
-    qtconsole-base: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-1.0.0-pyhd8ed1ab_10.conda
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    qtconsole: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/jupyter-1.0.0-py39hf3d152e_9.conda
   hash:
-    md5: 056b8cc3d9b03f54fc49e6d70d7dc359
-    sha256: 308b521b149e7a1739f717538b929bc2d87b9001b94f13ee8baa939632a86150
+    md5: b99828f9a77b6106a72b541427a90957
+    sha256: c309d7ab20b44dd123fd40fb5cf717f386404912521e3b586c96ce018109d054
+  category: main
+  optional: false
+- name: jupyter
+  version: 1.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ipykernel: ''
+    ipywidgets: ''
+    jupyter_console: ''
+    nbconvert: ''
+    notebook: ''
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    qtconsole: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/jupyter-1.0.0-py39h6e9494a_9.conda
+  hash:
+    md5: 59bebdd70986cd5e06cafc32c609612f
+    sha256: 26e5fc44fa638c4e67dfe9c6960b6b673233d2309258bc6d7ba0edbf75649e54
   category: main
   optional: false
 - name: jupyter
@@ -6509,12 +9931,12 @@ package:
     jupyter_console: ''
     nbconvert: ''
     notebook: ''
-    python: '>=3.6'
-    qtconsole-base: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-1.0.0-pyhd8ed1ab_10.conda
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter-1.0.0-py39h2804cbe_9.conda
   hash:
-    md5: 056b8cc3d9b03f54fc49e6d70d7dc359
-    sha256: 308b521b149e7a1739f717538b929bc2d87b9001b94f13ee8baa939632a86150
+    md5: 9052c4ca944cccc46d58958ec3affe02
+    sha256: 370057a9b78f48cc4df52f82e62eb285b74e41784c1d267057a74ef8ae1c99f3
   category: main
   optional: false
 - name: jupyter-cache
@@ -6540,17 +9962,37 @@ package:
 - name: jupyter-cache
   version: 0.6.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    attrs: ''
+    pyyaml: ''
     click: ''
     importlib-metadata: ''
-    nbclient: '>=0.2,<0.8'
-    nbformat: ''
-    python: '>=3.8'
-    pyyaml: ''
-    sqlalchemy: '>=1.3.12,<3'
     tabulate: ''
+    nbformat: ''
+    attrs: ''
+    python: '>=3.8'
+    sqlalchemy: '>=1.3.12,<3'
+    nbclient: '>=0.2,<0.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-cache-0.6.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2e360820ae68e3d28e1a5a9d2714ca5c
+    sha256: b22ba507904f33fcc7b218cc2a3ed8d39027524d0f223f3696b8344b7c5a1e1f
+  category: main
+  optional: false
+- name: jupyter-cache
+  version: 0.6.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pyyaml: ''
+    click: ''
+    importlib-metadata: ''
+    tabulate: ''
+    nbformat: ''
+    attrs: ''
+    python: '>=3.8'
+    sqlalchemy: '>=1.3.12,<3'
+    nbclient: '>=0.2,<0.8'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-cache-0.6.1-pyhd8ed1ab_0.conda
   hash:
     md5: 2e360820ae68e3d28e1a5a9d2714ca5c
@@ -6574,11 +10016,25 @@ package:
 - name: jupyter-lsp
   version: 2.2.4
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    python: '>=3.8'
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 91f93e1ebf6535be518715432d89fd92
+    sha256: 8000b1904a2a10cf039b46305781128e1a93da4c2fd857445b4924ecf3535bdb
+  category: main
+  optional: false
+- name: jupyter-lsp
+  version: 2.2.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     python: '>=3.8'
+    importlib-metadata: '>=4.8.3'
+    jupyter_server: '>=1.1.2'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.4-pyhd8ed1ab_0.conda
   hash:
     md5: 91f93e1ebf6535be518715432d89fd92
@@ -6606,15 +10062,33 @@ package:
 - name: jupyter_client
   version: 8.6.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    importlib_metadata: '>=4.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
     python: '>=3.8'
     python-dateutil: '>=2.8.2'
+    jupyter_core: '>=4.12,!=5.0.*'
+    importlib_metadata: '>=4.8.3'
+    traitlets: '>=5.3'
     pyzmq: '>=23.0'
     tornado: '>=6.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: c03972cfce69ad913d520c652e5ed908
+    sha256: c7d10d7941fd2e61480e49d3b2b21a530af4ae4b0d449a1746a72a38bacb63e2
+  category: main
+  optional: false
+- name: jupyter_client
+  version: 8.6.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    jupyter_core: '>=4.12,!=5.0.*'
+    importlib_metadata: '>=4.8.3'
     traitlets: '>=5.3'
+    pyzmq: '>=23.0'
+    tornado: '>=6.2'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.1-pyhd8ed1ab_0.conda
   hash:
     md5: c03972cfce69ad913d520c652e5ed908
@@ -6644,17 +10118,37 @@ package:
 - name: jupyter_console
   version: 6.6.3
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    ipykernel: '>=6.14'
     ipython: ''
-    jupyter_client: '>=7.0.0'
-    jupyter_core: '>=4.12,!=5.0.*'
-    prompt_toolkit: '>=3.0.30'
     pygments: ''
     python: '>=3.7'
     pyzmq: '>=17'
+    jupyter_core: '>=4.12,!=5.0.*'
+    jupyter_client: '>=7.0.0'
+    ipykernel: '>=6.14'
     traitlets: '>=5.4'
+    prompt_toolkit: '>=3.0.30'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_console-6.6.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7cf6f52a66f8e3cd9d8b6c231262dcab
+    sha256: 4e51764d5fe2f6e43d83bcfbcf8b4da6569721bf82eaf4d647be8717cd6be75a
+  category: main
+  optional: false
+- name: jupyter_console
+  version: 6.6.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    ipython: ''
+    pygments: ''
+    python: '>=3.7'
+    pyzmq: '>=17'
+    jupyter_core: '>=4.12,!=5.0.*'
+    jupyter_client: '>=7.0.0'
+    ipykernel: '>=6.14'
+    traitlets: '>=5.4'
+    prompt_toolkit: '>=3.0.30'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_console-6.6.3-pyhd8ed1ab_0.conda
   hash:
     md5: 7cf6f52a66f8e3cd9d8b6c231262dcab
@@ -6677,6 +10171,21 @@ package:
   category: main
   optional: false
 - name: jupyter_core
+  version: 5.7.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    platformdirs: '>=2.5'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.7.1-py39h6e9494a_0.conda
+  hash:
+    md5: 9611b1806866adc1693cfb5a323f16e4
+    sha256: f30dc74ac083f9c97d5287b335ea193e0ddc27f02195f677436df84d6ccdf59e
+  category: main
+  optional: false
+- name: jupyter_core
   version: 5.7.2
   manager: conda
   platform: osx-arm64
@@ -6692,7 +10201,7 @@ package:
   category: main
   optional: false
 - name: jupyter_events
-  version: 0.9.1
+  version: 0.10.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -6704,29 +10213,48 @@ package:
     rfc3339-validator: ''
     rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 331ea2fc883fc5f2fc002a4e66e38bc5
-    sha256: 9054dea8926daf867ee0f366b3b45579e1bd16cbc7667d1f7541531d037fdbfd
+    md5: ed45423c41b3da15ea1df39b1f80c2ca
+    sha256: cd3f41dc093162a41d4bae171e40a1b9b115c4d488e9bb837a8fa9d084931fb9
   category: main
   optional: false
 - name: jupyter_events
-  version: 0.9.1
+  version: 0.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    referencing: ''
+    rfc3339-validator: ''
+    python: '>=3.8'
+    pyyaml: '>=5.3'
+    rfc3986-validator: '>=0.1.1'
+    traitlets: '>=5.3'
+    python-json-logger: '>=2.0.4'
+    jsonschema-with-format-nongpl: '>=4.18.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: ed45423c41b3da15ea1df39b1f80c2ca
+    sha256: cd3f41dc093162a41d4bae171e40a1b9b115c4d488e9bb837a8fa9d084931fb9
+  category: main
+  optional: false
+- name: jupyter_events
+  version: 0.10.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    jsonschema-with-format-nongpl: '>=4.18.0'
-    python: '>=3.8'
-    python-json-logger: '>=2.0.4'
-    pyyaml: '>=5.3'
     referencing: ''
     rfc3339-validator: ''
+    python: '>=3.8'
+    pyyaml: '>=5.3'
     rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.1-pyhd8ed1ab_0.conda
+    python-json-logger: '>=2.0.4'
+    jsonschema-with-format-nongpl: '>=4.18.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 331ea2fc883fc5f2fc002a4e66e38bc5
-    sha256: 9054dea8926daf867ee0f366b3b45579e1bd16cbc7667d1f7541531d037fdbfd
+    md5: ed45423c41b3da15ea1df39b1f80c2ca
+    sha256: cd3f41dc093162a41d4bae171e40a1b9b115c4d488e9bb837a8fa9d084931fb9
   category: main
   optional: false
 - name: jupyter_server
@@ -6762,27 +10290,57 @@ package:
 - name: jupyter_server
   version: 2.13.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    packaging: ''
+    jinja2: ''
+    prometheus_client: ''
+    websocket-client: ''
+    argon2-cffi: ''
+    overrides: ''
+    jupyter_server_terminals: ''
+    python: '>=3.8'
+    terminado: '>=0.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
+    tornado: '>=6.2.0'
+    nbconvert-core: '>=6.4.4'
+    pyzmq: '>=24'
+    jupyter_client: '>=7.4.4'
+    nbformat: '>=5.3.0'
+    traitlets: '>=5.6.0'
+    anyio: '>=3.1.0'
+    send2trash: '>=1.8.2'
+    jupyter_events: '>=0.9.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.13.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: e242df505f194c4932fbb840a99207e2
+    sha256: 7e3259506b1b8500ebac4b4b097629ca8c32ee70d1c1df122052fea65c7cbae0
+  category: main
+  optional: false
+- name: jupyter_server
+  version: 2.13.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    anyio: '>=3.1.0'
-    argon2-cffi: ''
-    jinja2: ''
-    jupyter_client: '>=7.4.4'
-    jupyter_core: '>=4.12,!=5.0.*'
-    jupyter_events: '>=0.9.0'
-    jupyter_server_terminals: ''
-    nbconvert-core: '>=6.4.4'
-    nbformat: '>=5.3.0'
-    overrides: ''
     packaging: ''
+    jinja2: ''
     prometheus_client: ''
-    python: '>=3.8'
-    pyzmq: '>=24'
-    send2trash: '>=1.8.2'
-    terminado: '>=0.8.3'
-    tornado: '>=6.2.0'
-    traitlets: '>=5.6.0'
     websocket-client: ''
+    argon2-cffi: ''
+    overrides: ''
+    jupyter_server_terminals: ''
+    python: '>=3.8'
+    terminado: '>=0.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
+    tornado: '>=6.2.0'
+    nbconvert-core: '>=6.4.4'
+    pyzmq: '>=24'
+    jupyter_client: '>=7.4.4'
+    nbformat: '>=5.3.0'
+    traitlets: '>=5.6.0'
+    anyio: '>=3.1.0'
+    send2trash: '>=1.8.2'
+    jupyter_events: '>=0.9.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.13.0-pyhd8ed1ab_0.conda
   hash:
     md5: e242df505f194c4932fbb840a99207e2
@@ -6793,6 +10351,19 @@ package:
   version: 0.5.3
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+    terminado: '>=0.8.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 219b3833aa8ed91d47d1be6ca03f30be
+    sha256: 038efbc7e4b2e72d49ed193cfb2bbbe9fbab2459786ce9350301f466a32567db
+  category: main
+  optional: false
+- name: jupyter_server_terminals
+  version: 0.5.3
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
     terminado: '>=0.8.3'
@@ -6845,24 +10416,51 @@ package:
 - name: jupyterlab
   version: 4.1.5
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    async-lru: '>=1.0.0'
-    httpx: '>=0.25.0'
-    importlib_metadata: '>=4.8.3'
-    importlib_resources: '>=1.4'
+    packaging: ''
+    tomli: ''
+    traitlets: ''
     ipykernel: ''
-    jinja2: '>=3.0.3'
-    jupyter-lsp: '>=2.0.0'
     jupyter_core: ''
+    python: '>=3.8'
+    tornado: '>=6.2.0'
+    jinja2: '>=3.0.3'
+    importlib_metadata: '>=4.8.3'
     jupyter_server: '>=2.4.0,<3'
+    importlib_resources: '>=1.4'
+    jupyter-lsp: '>=2.0.0'
+    async-lru: '>=1.0.0'
     jupyterlab_server: '>=2.19.0,<3'
     notebook-shim: '>=0.2'
+    httpx: '>=0.25.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.1.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 04b1ca9d7ac414b3f5c3fb16066c6861
+    sha256: b098b79ef34d5c6a9ef7fc482bd2373072820006757ed7db33328af88fb91496
+  category: main
+  optional: false
+- name: jupyterlab
+  version: 4.1.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     packaging: ''
-    python: '>=3.8'
     tomli: ''
-    tornado: '>=6.2.0'
     traitlets: ''
+    ipykernel: ''
+    jupyter_core: ''
+    python: '>=3.8'
+    tornado: '>=6.2.0'
+    jinja2: '>=3.0.3'
+    importlib_metadata: '>=4.8.3'
+    jupyter_server: '>=2.4.0,<3'
+    importlib_resources: '>=1.4'
+    jupyter-lsp: '>=2.0.0'
+    async-lru: '>=1.0.0'
+    jupyterlab_server: '>=2.19.0,<3'
+    notebook-shim: '>=0.2'
+    httpx: '>=0.25.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.1.5-pyhd8ed1ab_0.conda
   hash:
     md5: 04b1ca9d7ac414b3f5c3fb16066c6861
@@ -6885,10 +10483,23 @@ package:
 - name: jupyterlab_pygments
   version: 0.3.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    pygments: '>=2.4.1,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: afcd1b53bcac8844540358e33f33d28f
+    sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
+  category: main
+  optional: false
+- name: jupyterlab_pygments
+  version: 0.3.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    pygments: '>=2.4.1,<3'
     python: '>=3.7'
+    pygments: '>=2.4.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
   hash:
     md5: afcd1b53bcac8844540358e33f33d28f
@@ -6918,17 +10529,37 @@ package:
 - name: jupyterlab_server
   version: 2.25.4
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    babel: '>=2.10'
-    importlib-metadata: '>=4.8.3'
+    python: '>=3.8'
+    packaging: '>=21.3'
     jinja2: '>=3.0.3'
+    importlib-metadata: '>=4.8.3'
+    jupyter_server: '>=1.21,<3'
+    requests: '>=2.31'
+    babel: '>=2.10'
     json5: '>=0.9.0'
     jsonschema: '>=4.18'
-    jupyter_server: '>=1.21,<3'
-    packaging: '>=21.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: ffd61670ae09d2d3c637f6afd29db443
+    sha256: d0336d0c0223a66d648b24cfd1512fd7aebc85550d47f55ad5edbd53f482e7e5
+  category: main
+  optional: false
+- name: jupyterlab_server
+  version: 2.25.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     python: '>=3.8'
+    packaging: '>=21.3'
+    jinja2: '>=3.0.3'
+    importlib-metadata: '>=4.8.3'
+    jupyter_server: '>=1.21,<3'
     requests: '>=2.31'
+    babel: '>=2.10'
+    json5: '>=0.9.0'
+    jsonschema: '>=4.18'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.4-pyhd8ed1ab_0.conda
   hash:
     md5: ffd61670ae09d2d3c637f6afd29db443
@@ -6939,6 +10570,18 @@ package:
   version: 3.0.10
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.10-pyhd8ed1ab_0.conda
+  hash:
+    md5: 16b73b2c4ff7dda8bbecf88aadfe2027
+    sha256: 7c14d0b377ddd2e21f23d2f55fbd827aca726860e504a131b67ef936aef2b8c4
+  category: main
+  optional: false
+- name: jupyterlab_widgets
+  version: 3.0.10
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.10-pyhd8ed1ab_0.conda
@@ -6980,15 +10623,33 @@ package:
 - name: jupytext
   version: 1.16.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    pyyaml: ''
+    packaging: ''
+    toml: ''
+    nbformat: ''
+    mdit-py-plugins: ''
+    python: '>=3.8'
+    markdown-it-py: '>=1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.16.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 14a45070afec994235a23ae09b098cce
+    sha256: 450d03ec711a5cbd643f99f4fb2f08aa167db7a0cb54dcbb53700c81b290c316
+  category: main
+  optional: false
+- name: jupytext
+  version: 1.16.1
+  manager: conda
   platform: osx-arm64
   dependencies:
-    markdown-it-py: '>=1.0'
-    mdit-py-plugins: ''
-    nbformat: ''
-    packaging: ''
-    python: '>=3.8'
     pyyaml: ''
+    packaging: ''
     toml: ''
+    nbformat: ''
+    mdit-py-plugins: ''
+    python: '>=3.8'
+    markdown-it-py: '>=1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.16.1-pyhd8ed1ab_0.conda
   hash:
     md5: 14a45070afec994235a23ae09b098cce
@@ -7007,6 +10668,19 @@ package:
   hash:
     md5: f7e7077802927590efc8bf7328208f12
     sha256: ee0934ff426d3cab015055808bed33eb9d20f635ec14bc421c596f4b70927102
+  category: main
+  optional: false
+- name: kealib
+  version: 1.5.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.3-h5f07ac3_0.conda
+  hash:
+    md5: 7a0924f6214e4c17b6062b21d1240253
+    sha256: 54a847faf2d2aea83c149d98634646edb8e7f346faefc6af1aa52106200b43aa
   category: main
   optional: false
 - name: kealib
@@ -7037,6 +10711,18 @@ package:
 - name: keras
   version: 2.15.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/keras-2.15.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 91e789823c9a5577a0a6979d7e594159
+    sha256: 7a1144e42f7815a216c46038e3c71b004feb3082fb4e9b9cf9abc5da725d8448
+  category: main
+  optional: false
+- name: keras
+  version: 2.15.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
@@ -7047,35 +10733,56 @@ package:
   category: main
   optional: false
 - name: keyring
-  version: 24.3.1
+  version: 25.0.0
   manager: conda
   platform: linux-64
   dependencies:
     importlib_metadata: '>=4.11.4'
     jaraco.classes: ''
+    jaraco.context: ''
+    jaraco.functools: ''
     jeepney: '>=0.4.2'
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.*
     secretstorage: '>=3.2'
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyring-24.3.1-py39hf3d152e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/keyring-25.0.0-py39hf3d152e_0.conda
   hash:
-    md5: 2482396e5d629d60526bce6268cfde6a
-    sha256: 8d231971f2ab5a9ab17d0b792021e287b982cb28c5258a93076a7fb937fa40c5
+    md5: 9dffaab106d52fe3a52b303253f9b251
+    sha256: a5f89e3bddc2031a9d550e2e4ae3766a55a1a53d4808bf304c7ffee5ab725d28
   category: main
   optional: false
 - name: keyring
-  version: 24.3.1
+  version: 25.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    importlib_metadata: '>=4.11.4'
+    jaraco.classes: ''
+    jaraco.context: ''
+    jaraco.functools: ''
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/keyring-25.0.0-py39h6e9494a_0.conda
+  hash:
+    md5: 7116583f9a9df43462b5860330fdce38
+    sha256: 1904fbeb9d6ea150514a59f58775e04420b5d760e6b222753a3616eee492e3bb
+  category: main
+  optional: false
+- name: keyring
+  version: 25.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     importlib_metadata: '>=4.11.4'
     jaraco.classes: ''
+    jaraco.context: ''
+    jaraco.functools: ''
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/keyring-24.3.1-py39h2804cbe_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/keyring-25.0.0-py39h2804cbe_0.conda
   hash:
-    md5: 692efb054402209710ffea6a93960f33
-    sha256: 8182aa6970a92eed22d05e2a007d07c64cae655bf51538fa36cf00623e47bf8c
+    md5: 1314ad438df943a4e57da2cc51cc0cc8
+    sha256: c4949d83989c746c5b1a28edb6a02df7892b78cda277ac8126c97b8744237e4f
   category: main
   optional: false
 - name: keyutils
@@ -7103,6 +10810,20 @@ package:
   hash:
     md5: c9f74d717e5a2847a9f8b779c54130f2
     sha256: 620d2aa2c3f016aa569b4a679688cb34f27c05e08555e4860099cf001bd740e4
+  category: main
+  optional: false
+- name: kiwisolver
+  version: 1.4.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py39h8ee36c8_1.conda
+  hash:
+    md5: 6072db04642b21329b0502a177ec18bf
+    sha256: 1ef89b03dd04951e0d78dd36e678b276f18b94326a85b271251e41465aded09b
   category: main
   optional: false
 - name: kiwisolver
@@ -7138,6 +10859,20 @@ package:
 - name: krb5
   version: 1.21.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    libedit: '>=3.1.20191231,<4.0a0'
+    openssl: '>=3.1.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+  hash:
+    md5: 80505a68783f01dc8d7308c075261b2f
+    sha256: 081ae2008a21edf57c048f331a17c65d1ccb52d6ca2f87ee031a73eff4dc0fc6
+  category: main
+  optional: false
+- name: krb5
+  version: 1.21.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=15.0.7'
@@ -7161,6 +10896,20 @@ package:
   hash:
     md5: d9c3df17c3020b839d47f252ba6885fd
     sha256: 624ee9537664756032437b6378497b9cbd90d9a6bbca6e805615615314a6d480
+  category: main
+  optional: false
+- name: kubernetes
+  version: 1.23.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    kubernetes-client: 1.23.6
+    kubernetes-node: 1.23.6
+    kubernetes-server: 1.23.6
+  url: https://conda.anaconda.org/conda-forge/osx-64/kubernetes-1.23.6-h694c41f_0.tar.bz2
+  hash:
+    md5: 15d632fc1aa27bf07ffa49293001314e
+    sha256: 58f02f5e80d03ebe21131abec6234d6163ef9058cb3c8e6e9e570990602b0e54
   category: main
   optional: false
 - name: kubernetes
@@ -7191,6 +10940,17 @@ package:
   category: main
   optional: false
 - name: kubernetes-client
+  version: 1.23.6
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/kubernetes-client-1.23.6-h12d39d3_0.tar.bz2
+  hash:
+    md5: d1d1813735923043bd8f955accfcd58f
+    sha256: 498305675babb8a86982d596418cda2278953816a414cbd37fe2da5984ff7b50
+  category: main
+  optional: false
+- name: kubernetes-client
   version: 1.25.3
   manager: conda
   platform: osx-arm64
@@ -7212,6 +10972,17 @@ package:
   hash:
     md5: f706346637b6175a91d7fc3b5c04db16
     sha256: 9be6b6d2fc4fc90741e2efb12a7e3b60f3bb44e6c458ef6e6fe8824635020c87
+  category: main
+  optional: false
+- name: kubernetes-node
+  version: 1.23.6
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/kubernetes-node-1.23.6-h12d39d3_0.tar.bz2
+  hash:
+    md5: 0e810138f6453ce694da9247b68032db
+    sha256: 122c046da126d554238e289479e38c4d1300597ab8ea96007c3bf1468d5c5b62
   category: main
   optional: false
 - name: kubernetes-node
@@ -7240,6 +11011,18 @@ package:
   category: main
   optional: false
 - name: kubernetes-server
+  version: 1.23.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    kubernetes-node: 1.23.6
+  url: https://conda.anaconda.org/conda-forge/osx-64/kubernetes-server-1.23.6-h12d39d3_0.tar.bz2
+  hash:
+    md5: b6f60a6a061f9bf2d5e36c79cd8514b0
+    sha256: b75e8fa3e198c7b527a28253907d326bc04a820c32684ceaab21241e1bfe3260
+  category: main
+  optional: false
+- name: kubernetes-server
   version: 1.25.3
   manager: conda
   platform: osx-arm64
@@ -7249,6 +11032,18 @@ package:
   hash:
     md5: fe30b91760c813b6083a0285787b1ca4
     sha256: dcef741d5f7d922b8b7490057e8532214197489dead2de22dee136055d8705ee
+  category: main
+  optional: false
+- name: lame
+  version: '3.100'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+  hash:
+    md5: a8832b479f93521a9e7b5b743803be51
+    sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
   category: main
   optional: false
 - name: lcms2
@@ -7263,6 +11058,19 @@ package:
   hash:
     md5: 51bb7010fc86f70eee639b4bb7a894f5
     sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+  category: main
+  optional: false
+- name: lcms2
+  version: '2.16'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+  hash:
+    md5: 1442db8f03517834843666c422238c9b
+    sha256: 222ebc0a55544b9922f61e75015d02861e65b48f12113af41d48ba0814e14e4e
   category: main
   optional: false
 - name: lcms2
@@ -7305,6 +11113,18 @@ package:
 - name: lerc
   version: 4.0.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=13.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  hash:
+    md5: f9d6a4c82889d5ecedec1d90eb673c55
+    sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  category: main
+  optional: false
+- name: lerc
+  version: 4.0.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=13.0.1'
@@ -7330,6 +11150,18 @@ package:
 - name: libabseil
   version: '20230802.1'
   manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
+  hash:
+    md5: 6554f5fb47c025273268bcdb7bf3cd48
+    sha256: 05431a6adb376a865e10d4ae673399d7890083c06f61cf18edb7c6629e75f39e
+  category: main
+  optional: false
+- name: libabseil
+  version: '20230802.1'
+  manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=15.0.7'
@@ -7340,28 +11172,40 @@ package:
   category: main
   optional: false
 - name: libaec
-  version: 1.1.2
+  version: 1.1.3
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
   hash:
-    md5: 127b0be54c1c90760d7fe02ea7a56426
-    sha256: fdde15e74dc099ab1083823ec0f615958e53d9a8fae10405af977de251668bea
+    md5: 5e97e271911b8b2001a8b71860c32faa
+    sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
   category: main
   optional: false
 - name: libaec
-  version: 1.1.2
+  version: 1.1.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+  hash:
+    md5: 66d3c1f6dd4636216b4fca7a748d50eb
+    sha256: dae5921339c5d89f4bf58a95fd4e9c76270dbf7f6a94f3c5081b574905fcccf8
+  category: main
+  optional: false
+- name: libaec
+  version: 1.1.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
   hash:
-    md5: b7962cdc2cedcc9f8d12928824c11fbd
-    sha256: c9d6f01d511bd3686ce590addf829f34031b95e3feb34418496cbb45924c5d17
+    md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+    sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
   category: main
   optional: false
 - name: libarchive
@@ -7382,6 +11226,26 @@ package:
   hash:
     md5: 3bf887827d1968275978361a6e405e4f
     sha256: 340ed0bb02fe26a2b2e29cedf6559e2999b820f434e745c108e788d629ae4b17
+  category: main
+  optional: false
+- name: libarchive
+  version: 3.7.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libxml2: '>=2.12.2,<3.0.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    lzo: '>=2.10,<3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.2-hd35d340_1.conda
+  hash:
+    md5: 8c7b79b20a67287a87b39df8a8c8dcc4
+    sha256: f458515a49c56e117e05fe607493b7683a7bf06d2a625b59e378dbbf7f308895
   category: main
   optional: false
 - name: libarchive
@@ -7441,6 +11305,39 @@ package:
 - name: libarrow
   version: 13.0.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-crt-cpp: '>=0.26.0,<0.26.1.0a0'
+    aws-sdk-cpp: '>=1.11.210,<1.11.211.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    glog: '>=0.6.0,<0.7.0a0'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libbrotlidec: '>=1.1.0,<1.2.0a0'
+    libbrotlienc: '>=1.1.0,<1.2.0a0'
+    libcxx: '>=14'
+    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
+    libgrpc: '>=1.59.3,<1.60.0a0'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libre2-11: '>=2023.6.2,<2024.0a0'
+    libthrift: '>=0.19.0,<0.19.1.0a0'
+    libutf8proc: '>=2.8.0,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+    orc: '>=1.9.2,<1.9.3.0a0'
+    re2: ''
+    snappy: '>=1.1.10,<2.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-13.0.0-hdae7707_23_cpu.conda
+  hash:
+    md5: 799848b44f6d7cc4a9cd5511101a7b59
+    sha256: 1f79ceed195d10cbc8a47141c0b4402161ac37ee4c4899c79f2e13ec7782719c
+  category: main
+  optional: false
+- name: libarrow
+  version: 13.0.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     aws-crt-cpp: '>=0.26.0,<0.26.1.0a0'
@@ -7485,6 +11382,18 @@ package:
 - name: libblas
   version: 3.9.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libopenblas: '>=0.3.26,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-21_osx64_openblas.conda
+  hash:
+    md5: 23286066c595986aa0df6452a8416c08
+    sha256: 5381eab20f4793996cf22e58461ea8a3a4dff1442bb45663b5920f2d26288688
+  category: main
+  optional: false
+- name: libblas
+  version: 3.9.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libopenblas: '>=0.3.26,<1.0a0'
@@ -7499,10 +11408,21 @@ package:
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.84.0-ha770c72_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.84.0-ha770c72_2.conda
   hash:
-    md5: 63a2690ffde5448bd8bbf19b5d1d366c
-    sha256: f5ac6b12768e5c735d2c8e4e1e05093b105d649a68f02f6a5349f5cb61719b9c
+    md5: 85d30a3fcc0f1cfc252776208af546a1
+    sha256: 5a7843db33422d043256af27f288836f51530b058653bdb074704eb72282f601
+  category: main
+  optional: false
+- name: libboost-headers
+  version: 1.84.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-headers-1.84.0-h694c41f_2.conda
+  hash:
+    md5: 37678c6938655e8862e121b48101365a
+    sha256: e51f3b877ab4a7a68bf1e1f95e9b007d716e85547078bfd5f6f7f114545dc26e
   category: main
   optional: false
 - name: libboost-headers
@@ -7510,10 +11430,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-headers-1.84.0-hce30654_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-headers-1.84.0-hce30654_2.conda
   hash:
-    md5: 6e665d044322dfffd437d7c6090e64f2
-    sha256: 006d0e4e266b806eb2280c6e3250e79a011428c21a706ee7d3e4251f66d1f278
+    md5: bf16112d5337a9a80d7126ac3a2cee7c
+    sha256: 2850952cc521318b6a5b18d8f55c86149b779a9103cca9875ff128ce9b6d6400
   category: main
   optional: false
 - name: libbrotlicommon
@@ -7526,6 +11446,17 @@ package:
   hash:
     md5: aec6c91c7371c26392a06708a73c70e5
     sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: 9e6c31441c9aa24e41ace40d6151aab6
+    sha256: f57c57c442ef371982619f82af8735f93a4f50293022cfd1ffaf2ff89c2e0b2a
   category: main
   optional: false
 - name: libbrotlicommon
@@ -7550,6 +11481,18 @@ package:
   hash:
     md5: f07002e225d7a60a694d42a7bf5ff53f
     sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libbrotlicommon: 1.1.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: 9ee0bab91b2ca579e10353738be36063
+    sha256: b11939c4c93c29448660ab5f63273216969d1f2f315dd9be60f3c43c4e61a50c
   category: main
   optional: false
 - name: libbrotlidec
@@ -7580,6 +11523,18 @@ package:
 - name: libbrotlienc
   version: 1.1.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libbrotlicommon: 1.1.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: 8a421fe09c6187f0eb5e2338a8a8be6d
+    sha256: bc964c23e1a60ca1afe7bac38a9c1f2af3db4a8072c9f2eac4e4de537a844ac7
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.1.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libbrotlicommon: 1.1.0
@@ -7587,6 +11542,19 @@ package:
   hash:
     md5: d7e077f326a98b2cc60087eaff7c730b
     sha256: 690dfc98e891ee1871c54166d30f6e22edfc2d7d6b29e7988dde5f1ce271c81a
+  category: main
+  optional: false
+- name: libcap
+  version: '2.69'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    attr: '>=2.5.1,<2.6.0a0'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
+  hash:
+    md5: 25cb5999faa414e5ccb2c1388f62d3d5
+    sha256: 942f9564b4228609f017b6617425d29a74c43b8a030e12239fa4458e5cb6323c
   category: main
   optional: false
 - name: libcblas
@@ -7604,6 +11572,18 @@ package:
 - name: libcblas
   version: 3.9.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libblas: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-21_osx64_openblas.conda
+  hash:
+    md5: 7a1b54774bad723e8ba01ca48eb301b5
+    sha256: e2b1455612d4cfb3ac3170f0c538516ebd0b113780ac6603338245354e1b2f02
+  category: main
+  optional: false
+- name: libcblas
+  version: 3.9.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libblas: 3.9.0
@@ -7611,6 +11591,62 @@ package:
   hash:
     md5: 48e9d42c65ce664d8fccef2ac6af853c
     sha256: 4510e3e4824693c3f80fc54e72d81dd89acaa6e6d68cd948af0870a640ea7eeb
+  category: main
+  optional: false
+- name: libclang
+  version: 15.0.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libclang13: 15.0.7
+    libgcc-ng: '>=12'
+    libllvm15: '>=15.0.7,<15.1.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_h127d8a8_5.conda
+  hash:
+    md5: 09b94dd3a7e304df5b83176239347920
+    sha256: 606b79c8a4a926334191d79f4a1447aac1d82c43344e3a603cbba31ace859b8f
+  category: main
+  optional: false
+- name: libclang
+  version: 15.0.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libclang13: 15.0.7
+    libcxx: '>=16.0.6'
+    libllvm15: '>=15.0.7,<15.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-15.0.7-default_h7151d67_5.conda
+  hash:
+    md5: 2e7eb31c1431630f111be17f7f0cb948
+    sha256: ea3c840b7e931228007f1dc21c1cfe8e3e833990da9e92fff9c23c98d035b89a
+  category: main
+  optional: false
+- name: libclang13
+  version: 15.0.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libllvm15: '>=15.0.7,<15.1.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h5d6823c_5.conda
+  hash:
+    md5: 2d694a9ffdcc30e89dea34a8dcdab6ae
+    sha256: 91ecfcf545a5d4588e9fad5db2b5b04eeef18cae1c03b790829ef8b978f06ccd
+  category: main
+  optional: false
+- name: libclang13
+  version: 15.0.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16.0.6'
+    libllvm15: '>=15.0.7,<15.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang13-15.0.7-default_h0edc4dd_5.conda
+  hash:
+    md5: 3bfcf640ab0956a9db86335e917100e3
+    sha256: fec1ff1ae4a49f96eefeae9dd14ea8d9e591fc29995861ad49e92104ae6bb8e6
   category: main
   optional: false
 - name: libcrc32c
@@ -7629,6 +11665,18 @@ package:
 - name: libcrc32c
   version: 1.1.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=11.1.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  hash:
+    md5: 23d6d5a69918a438355d7cbc4c3d54c9
+    sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
+  category: main
+  optional: false
+- name: libcrc32c
+  version: 1.1.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=11.1.0'
@@ -7638,8 +11686,23 @@ package:
     sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
   category: main
   optional: false
+- name: libcups
+  version: 2.3.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    krb5: '>=1.21.1,<1.22.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+  hash:
+    md5: d4529f4dff3057982a7617c7ac58fde3
+    sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
+  category: main
+  optional: false
 - name: libcurl
-  version: 8.6.0
+  version: 8.7.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -7650,14 +11713,31 @@ package:
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.6.0-hca28451_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.7.1-hca28451_0.conda
   hash:
-    md5: 704739398d858872cb91610f49f0ef29
-    sha256: 357ce806adf1818dc8dccdcd64627758e1858eb0d8a9c91aae4a0eeee2a44608
+    md5: 755c7f876815003337d2c61ff5d047e5
+    sha256: 82a75e9a5d9ee5b2f487d850ec5d4edc18a56eb9527608a95a916c40baae3843
   category: main
   optional: false
 - name: libcurl
-  version: 8.6.0
+  version: 8.7.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    krb5: '>=1.21.2,<1.22.0a0'
+    libnghttp2: '>=1.58.0,<2.0a0'
+    libssh2: '>=1.11.0,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.7.1-h726d00d_0.conda
+  hash:
+    md5: fa58e5eaa12006bc3289a71357bef167
+    sha256: 06cb1bd3bbaf905213777d6ade190ac4c7fb7a20dfe0cf901c977dbbc6cec265
+  category: main
+  optional: false
+- name: libcurl
+  version: 8.7.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -7667,10 +11747,21 @@ package:
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.6.0-h2d989ff_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.7.1-h2d989ff_0.conda
   hash:
-    md5: 3c0b1d8a9c8952e97c240fe0133dd27e
-    sha256: 85d2cbba4b0435a6fbf22963a50d2fd8cf2124eb76118e62d616ef355003c5a5
+    md5: 34b9171710f0d9bf093d55bdc36ff355
+    sha256: 973ac9368efca712a8fd19fe68524d7d9a3087fd88ad6b7fcdf60c3d2e19a498
+  category: main
+  optional: false
+- name: libcxx
+  version: 16.0.6
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+  hash:
+    md5: 7d6972792161077908b62971802f289a
+    sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
   category: main
   optional: false
 - name: libcxx
@@ -7694,6 +11785,17 @@ package:
   hash:
     md5: 1635570038840ee3f9c71d22aa5b8b6d
     sha256: 985ad27aa0ba7aad82afa88a8ede6a1aacb0aaca950d710f15d85360451e72fd
+  category: main
+  optional: false
+- name: libdeflate
+  version: '1.19'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
+  hash:
+    md5: 6a45f543c2beb40023df5ee7e3cedfbd
+    sha256: d0f789120fedd0881b129aba9993ec5dcf0ecca67a71ea20c74394e41adcb503
   category: main
   optional: false
 - name: libdeflate
@@ -7723,6 +11825,18 @@ package:
 - name: libedit
   version: 3.1.20191231
   manager: conda
+  platform: osx-64
+  dependencies:
+    ncurses: '>=6.1,<7.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-hed1e85f_2.tar.bz2
+  hash:
+    md5: 779da5393199c3af97bd8f12c804b749
+    sha256: 5af7fd4a68bce10114b18eea4fb4ca638b4ecd4b6dfea11d97b89ee4e728210b
+  category: main
+  optional: false
+- name: libedit
+  version: 3.1.20191231
+  manager: conda
   platform: osx-arm64
   dependencies:
     ncurses: '>=6.2,<7.0.0a0'
@@ -7742,6 +11856,17 @@ package:
   hash:
     md5: 172bf1cd1ff8629f2b1179945ed45055
     sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  hash:
+    md5: 899db79329439820b7e8f8de41bca902
+    sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
   category: main
   optional: false
 - name: libev
@@ -7771,6 +11896,18 @@ package:
 - name: libevent
   version: 2.1.12
   manager: conda
+  platform: osx-64
+  dependencies:
+    openssl: '>=3.1.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  hash:
+    md5: e38e467e577bd193a7d5de7c2c540b04
+    sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  category: main
+  optional: false
+- name: libevent
+  version: 2.1.12
+  manager: conda
   platform: osx-arm64
   dependencies:
     openssl: '>=3.1.1,<4.0a0'
@@ -7790,6 +11927,17 @@ package:
   hash:
     md5: e7ba12deb7020dd080c6c70e7b6f6a3d
     sha256: 331bb7c7c05025343ebd79f86ae612b9e1e74d2687b8f3179faec234f986ce19
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.6.2
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
+  hash:
+    md5: 3d1d51c8f716d97c864d12f7af329526
+    sha256: a188a77b275d61159a32ab547f7d17892226e7dac4518d2c6ac3ac8fc8dfde92
   category: main
   optional: false
 - name: libexpat
@@ -7818,12 +11966,38 @@ package:
 - name: libffi
   version: 3.4.2
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  hash:
+    md5: ccb34fb14960ad8b125962d3d79b31a9
+    sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  category: main
+  optional: false
+- name: libffi
+  version: 3.4.2
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
   hash:
     md5: 086914b672be056eb70fd4285b6783b6
     sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  category: main
+  optional: false
+- name: libflac
+  version: 1.4.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gettext: '>=0.21.1,<1.0a0'
+    libgcc-ng: '>=12'
+    libogg: '>=1.3.4,<1.4.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
+  hash:
+    md5: ee48bf17cc83a00f59ca1494d5646869
+    sha256: 65908b75fa7003167b8a8f0001e11e58ed5b1ef5e98b96ab2ba66d7c1b822c7d
   category: main
   optional: false
 - name: libgcc-ng
@@ -7850,6 +12024,18 @@ package:
   hash:
     md5: 32d16ad533c59bb0a3c5ffaf16110829
     sha256: d1bd47faa29fec7288c7b212198432b07f890d3d6f646078da93b059c2e9daff
+  category: main
+  optional: false
+- name: libgcrypt
+  version: 1.10.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libgpg-error: '>=1.47,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgcrypt-1.10.3-h49d49c5_0.conda
+  hash:
+    md5: 9a87bef20f74258ff46f8deefd2842d6
+    sha256: 34e23c3e0baf53adbcbe5f160b901d94e3f3edc23894274c8248658e9a80f455
   category: main
   optional: false
 - name: libgcrypt
@@ -7887,6 +12073,31 @@ package:
   hash:
     md5: cfebc557e54905dadc355c0e9f003004
     sha256: b74f95a6e1f3b31a74741b39cba83ed99fc82d17243c0fd3b5ab16ddd48ab89d
+  category: main
+  optional: false
+- name: libgd
+  version: 2.3.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    expat: ''
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    icu: '>=73.2,<74.0a0'
+    libexpat: '>=2.5.0,<3.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp: ''
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgd-2.3.3-h0dceb68_9.conda
+  hash:
+    md5: 1feb43971521d430bf826f8398598c5b
+    sha256: 4ed8546ff3356fc42f0e155446a060b14ee4aa96802e2da586532861deb3b917
   category: main
   optional: false
 - name: libgd
@@ -7971,6 +12182,57 @@ package:
 - name: libgdal
   version: 3.8.4
   manager: conda
+  platform: osx-64
+  dependencies:
+    blosc: '>=1.21.5,<2.0a0'
+    cfitsio: '>=4.3.1,<4.3.2.0a0'
+    freexl: '>=2.0.0,<3.0a0'
+    geos: '>=3.12.1,<3.12.2.0a0'
+    geotiff: '>=1.7.1,<1.8.0a0'
+    giflib: '>=5.2.1,<5.3.0a0'
+    hdf4: '>=4.2.15,<4.2.16.0a0'
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    json-c: '>=0.17,<0.18.0a0'
+    kealib: '>=1.5.3,<1.6.0a0'
+    lerc: '>=4.0.0,<5.0a0'
+    libaec: '>=1.1.2,<2.0a0'
+    libarchive: '>=3.7.2,<3.8.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=16'
+    libdeflate: '>=1.19,<1.20.0a0'
+    libexpat: '>=2.5.0,<3.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libkml: '>=1.3.0,<1.4.0a0'
+    libnetcdf: '>=4.9.2,<4.9.3.0a0'
+    libpng: '>=1.6.42,<1.7.0a0'
+    libpq: '>=16.2,<17.0a0'
+    libspatialite: '>=5.1.0,<5.2.0a0'
+    libsqlite: '>=3.45.1,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libxml2: '>=2.12.5,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    openjpeg: '>=2.5.0,<3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    pcre2: '>=10.42,<10.43.0a0'
+    poppler: '>=24.2.0,<24.3.0a0'
+    postgresql: ''
+    proj: '>=9.3.1,<9.3.2.0a0'
+    tiledb: '>=2.20.0,<2.21.0a0'
+    xerces-c: '>=3.2.5,<3.3.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.8.4-h46636ed_0.conda
+  hash:
+    md5: 5cf7d0f51e6e9dd8d175d8660b843024
+    sha256: 12a0151e5e0d05590bcf5c6abf2fe36977df8b1198564198c167ed05492d5b1b
+  category: main
+  optional: false
+- name: libgdal
+  version: 3.8.4
+  manager: conda
   platform: osx-arm64
   dependencies:
     blosc: '>=1.21.5,<2.0a0'
@@ -8022,6 +12284,18 @@ package:
 - name: libgfortran
   version: 5.0.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libgfortran5: 13.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  hash:
+    md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+    sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  category: main
+  optional: false
+- name: libgfortran
+  version: 5.0.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libgfortran5: 13.2.0
@@ -8058,6 +12332,18 @@ package:
 - name: libgfortran5
   version: 13.2.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    llvm-openmp: '>=8.0.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  hash:
+    md5: e4fb4d23ec2870ff3c40d10afe305aec
+    sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  category: main
+  optional: false
+- name: libgfortran5
+  version: 13.2.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     llvm-openmp: '>=8.0.0'
@@ -8080,6 +12366,20 @@ package:
   hash:
     md5: 806406c7008aab9b295d0cea4d5f90e0
     sha256: 1393f41401f5858e12ec77476e844b86c4d11cc0d82150adaca74f0401cd1b87
+  category: main
+  optional: false
+- name: libgirepository
+  version: 1.78.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cairo: '>=1.16.0,<2.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libglib: '>=2.78.0,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgirepository-1.78.1-h388745a_1.conda
+  hash:
+    md5: 4ea5c5ce9f5c51e73fb28976d9462ef3
+    sha256: 63e2b20f155fa9a3e78b39579267501e72c246fc18fa8447853d156f628a3782
   category: main
   optional: false
 - name: libgirepository
@@ -8112,6 +12412,23 @@ package:
   hash:
     md5: d86baf8740d1a906b9716f2a0bac2f2d
     sha256: 3a03a5254d2fd29c1e0ffda7250e22991dfbf2c854301fd56c408d97a647cfbd
+  category: main
+  optional: false
+- name: libglib
+  version: 2.78.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gettext: '>=0.21.1,<1.0a0'
+    libcxx: '>=16'
+    libffi: '>=3.4,<4.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    pcre2: '>=10.42,<10.43.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.78.4-hab64008_0.conda
+  hash:
+    md5: ff7e302784375cfc3157b8120a18124d
+    sha256: 122060ba63fd27e53672dbac7dc0b4f55a6432993446f4ed3c30a69a9457c615
   category: main
   optional: false
 - name: libglib
@@ -8153,6 +12470,25 @@ package:
 - name: libgoogle-cloud
   version: 2.12.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcrc32c: '>=1.1.2,<1.2.0a0'
+    libcurl: '>=8.4.0,<9.0a0'
+    libcxx: '>=16.0.6'
+    libgrpc: '>=1.59.2,<1.60.0a0'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    openssl: '>=3.1.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-hc0857f6_4.conda
+  hash:
+    md5: 976555c39f83093265491c9c081a801c
+    sha256: 1bf47f43796369ec85a27221ab9a84ecc848f93a88049d046cd8521c25b129f6
+  category: main
+  optional: false
+- name: libgoogle-cloud
+  version: 2.12.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=10.9'
@@ -8181,6 +12517,19 @@ package:
   hash:
     md5: 4d18d86916705d352d5f4adfb7f0edd3
     sha256: c448c6d86d27e10b9e844172000540e9cbfe9c28f968db87f949ba05add9bd50
+  category: main
+  optional: false
+- name: libgpg-error
+  version: '1.48'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gettext: '>=0.21.1,<1.0a0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgpg-error-1.48-h29b4ebe_0.conda
+  hash:
+    md5: ca280b4ab3b4cf0d4335b7869a835d93
+    sha256: ac468527fa3e52e075facf717e0f7bc2d250708341ffbb969a864e1fccccda75
   category: main
   optional: false
 - name: libgpg-error
@@ -8219,20 +12568,41 @@ package:
 - name: libgrpc
   version: 1.59.3
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    c-ares: '>=1.26.0,<2.0a0'
+    __osx: '>=10.9'
+    c-ares: '>=1.21.0,<2.0a0'
     libabseil: '>=20230802.1,<20230803.0a0'
-    libcxx: '>=16'
+    libcxx: '>=16.0.6'
     libprotobuf: '>=4.24.4,<4.24.5.0a0'
     libre2-11: '>=2023.6.2,<2024.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.1,<4.0a0'
+    openssl: '>=3.1.4,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.59.3-h9560976_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.59.3-ha7f534c_0.conda
   hash:
-    md5: 31e7f059601587954b1370fe172d3114
-    sha256: 9c0291bf797df0cee46d870bd410968e5955b0573c6b603c0ee7a5fcac06ad91
+    md5: a557d871e80f2dd22efd78e00f9a1597
+    sha256: 1b7330bb2aa16ca0dd319e97a829d5494fb2459a841b54f7631932b144e38624
+  category: main
+  optional: false
+- name: libgrpc
+  version: 1.59.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=10.9'
+    c-ares: '>=1.21.0,<2.0a0'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcxx: '>=16.0.6'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libre2-11: '>=2023.6.2,<2024.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.4,<4.0a0'
+    re2: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.59.3-hbcf6334_0.conda
+  hash:
+    md5: e9c7cbc84af929dd47501629a5e19713
+    sha256: 54cacd1fc7503d48c135301a775568f15089b537b3c56804767c627a89a20c30
   category: main
   optional: false
 - name: libhwloc
@@ -8249,6 +12619,19 @@ package:
     sha256: 6950fee24766d03406e0f6f965262a5d98829c71eed8d1004f313892423b559b
   category: main
   optional: false
+- name: libhwloc
+  version: 2.9.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    libxml2: '>=2.11.5,<3.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.9.3-default_h961836e_1009.conda
+  hash:
+    md5: 0dfacfef521f5ea278c8136d590421d8
+    sha256: ec5047c81fdefdbf63559554bc74d9644ea1e715f5d05298844c01893732fcfb
+  category: main
+  optional: false
 - name: libiconv
   version: '1.17'
   manager: conda
@@ -8259,6 +12642,17 @@ package:
   hash:
     md5: d66573916ffcf376178462f1b61c941e
     sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.17'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+  hash:
+    md5: 6c3628d047e151efba7cf08c5e54d1ca
+    sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
   category: main
   optional: false
 - name: libiconv
@@ -8282,6 +12676,17 @@ package:
   hash:
     md5: ea25936bb4080d843790b586850f82b8
     sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  category: main
+  optional: false
+- name: libjpeg-turbo
+  version: 3.0.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  hash:
+    md5: 72507f8e3961bc968af17435060b6dd6
+    sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
   category: main
   optional: false
 - name: libjpeg-turbo
@@ -8315,6 +12720,22 @@ package:
 - name: libkml
   version: 1.3.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libboost-headers: ''
+    libcxx: '>=15.0.7'
+    libexpat: '>=2.5.0,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    uriparser: '>=0.9.7,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hab3ca0e_1018.conda
+  hash:
+    md5: 535b1bb4896b113c14dfa64141370a12
+    sha256: f546750a59b85a4b721f69e34e797ceddb93c438ee384db285e3344490d6a9b5
+  category: main
+  optional: false
+- name: libkml
+  version: 1.3.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libboost-headers: ''
@@ -8343,6 +12764,18 @@ package:
 - name: liblapack
   version: 3.9.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libblas: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-21_osx64_openblas.conda
+  hash:
+    md5: cf0e4d82cfca6cd9d6c9ed3df45907c9
+    sha256: 5d0ef4743e8684ad436e31bd3c378d48642815a20c260d358668ba29cd80987a
+  category: main
+  optional: false
+- name: liblapack
+  version: 3.9.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libblas: 3.9.0
@@ -8352,41 +12785,35 @@ package:
     sha256: a917e99f26d205df1ec22d7a9fff0d2f2f3c7ba06ea2be886dc220a8340d5917
   category: main
   optional: false
-- name: libmagma
-  version: 2.7.2
+- name: libllvm15
+  version: 15.0.7
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17'
-    _openmp_mutex: '>=4.5'
-    cudatoolkit: '>=11.8,<12'
-    libblas: '>=3.9.0,<4.0a0'
     libgcc-ng: '>=12'
-    liblapack: '>=3.9.0,<4.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmagma-2.7.2-h09b5827_2.conda
+    libxml2: '>=2.12.1,<3.0.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hb3ce162_4.conda
   hash:
-    md5: f6de79234f35c2fcc2e49dc66436601d
-    sha256: 4dd54775f2cfa9c09f4b4cc58a6db00bad50b30e65adf62ffe4213a30d962766
+    md5: 8a35df3cbc0c8b12cc8af9473ae75eef
+    sha256: e71584c0f910140630580fdd0a013029a52fd31e435192aea2aa8d29005262d1
   category: main
   optional: false
-- name: libmagma_sparse
-  version: 2.7.2
+- name: libllvm15
+  version: 15.0.7
   manager: conda
-  platform: linux-64
+  platform: osx-64
   dependencies:
-    __glibc: '>=2.17'
-    _openmp_mutex: '>=4.5'
-    cudatoolkit: '>=11.8,<12'
-    libblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    liblapack: '>=3.9.0,<4.0a0'
-    libmagma: '>=2.7.2,<2.7.3.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmagma_sparse-2.7.2-h09b5827_3.conda
+    libcxx: '>=16'
+    libxml2: '>=2.12.1,<3.0.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-hbedff68_4.conda
   hash:
-    md5: 53157a5777c664896654d8dbc9fd6bf9
-    sha256: ee4a2367446763e6a4ef6d2fa5aea06adfd4ff44853f7390a02b0da77c6f129c
+    md5: bdc80cf2aa69d6eb8dd101dfd804db07
+    sha256: a0598cc166e92c6c63e58a7eaa184fa0b8b467693b965dbe19f1c9ff37e134c3
   category: main
   optional: false
 - name: libnetcdf
@@ -8412,6 +12839,31 @@ package:
   hash:
     md5: b2414908e43c442ddc68e6148774a304
     sha256: 0b4d984c7be21531e9254ce742e04101f7f7e77c0bbb7074855c0806c28323b0
+  category: main
+  optional: false
+- name: libnetcdf
+  version: 4.9.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    blosc: '>=1.21.5,<2.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    hdf4: '>=4.2.15,<4.2.16.0a0'
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    libaec: '>=1.1.2,<2.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=16.0.6'
+    libxml2: '>=2.12.2,<3.0.0a0'
+    libzip: '>=1.10.1,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+    zlib: ''
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h7760872_113.conda
+  hash:
+    md5: bce76ace6497221c2a2a02840aaceac5
+    sha256: 3d6a950d82a8dfb9fa51c263e543cfa9c113703add20646ec85401e7b557da49
   category: main
   optional: false
 - name: libnetcdf
@@ -8459,6 +12911,23 @@ package:
 - name: libnghttp2
   version: 1.58.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    c-ares: '>=1.23.0,<2.0a0'
+    libcxx: '>=16.0.6'
+    libev: '>=4.33,<5.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
+  hash:
+    md5: faecc55c2a8155d9ff1c0ff9a0fef64f
+    sha256: 412fd768e787e586602f8e9ea52bf089f3460fc630f6987f0cbd89b70e9a4380
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.58.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=10.9'
@@ -8497,6 +12966,29 @@ package:
     sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
   category: main
   optional: false
+- name: libogg
+  version: 1.3.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=9.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.4-h7f98852_1.tar.bz2
+  hash:
+    md5: 6e8cc2173440d77708196c5b93771680
+    sha256: b88afeb30620b11bed54dac4295aa57252321446ba4e6babd7dce4b9ffde9b25
+  category: main
+  optional: false
+- name: libogg
+  version: 1.3.4
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.4-h35c211d_1.tar.bz2
+  hash:
+    md5: a7ab4b53ef18c598ffaa597230bc3ba1
+    sha256: e3cec0c66d352d822b7a90db8edbc62f237fca079b6044e5b27f6ca529f7d9d9
+  category: main
+  optional: false
 - name: libopenblas
   version: 0.3.26
   manager: conda
@@ -8514,6 +13006,20 @@ package:
 - name: libopenblas
   version: 0.3.26
   manager: conda
+  platform: osx-64
+  dependencies:
+    libgfortran: 5.*
+    libgfortran5: '>=12.3.0'
+    llvm-openmp: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.26-openmp_hfef2a42_0.conda
+  hash:
+    md5: 9df60162aea811087267b515f359536c
+    sha256: 4a5994cc608708eca19b90b642a144bb073e4a1cd27b824281dfcae67917204e
+  category: main
+  optional: false
+- name: libopenblas
+  version: 0.3.26
+  manager: conda
   platform: osx-arm64
   dependencies:
     libgfortran: 5.*
@@ -8523,6 +13029,29 @@ package:
   hash:
     md5: 000970261d954431ccca3cce68d873d8
     sha256: 2a59b92c412fd0f59a8079dfa21c561ae17e72e72e47d4d7aee474bf6fd642e1
+  category: main
+  optional: false
+- name: libopus
+  version: 1.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=9.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
+  hash:
+    md5: 15345e56d527b330e1cacbdf58676e8f
+    sha256: 0e1c2740ebd1c93226dc5387461bbcf8142c518f2092f3ea7551f77755decc8f
+  category: main
+  optional: false
+- name: libopus
+  version: 1.3.1
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopus-1.3.1-hc929b4f_1.tar.bz2
+  hash:
+    md5: 380b9ea5f6a7a277e6c1ac27d034369b
+    sha256: c126fc225bece591a8f010e95ca7d010ea2d02df9251830bec24a19bf823fc31
   category: main
   optional: false
 - name: libpng
@@ -8536,6 +13065,18 @@ package:
   hash:
     md5: 009981dd9cfcaa4dbfa25ffaed86bcae
     sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
+  category: main
+  optional: false
+- name: libpng
+  version: 1.6.43
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
+  hash:
+    md5: 65dcddb15965c9de2c0365cb14910532
+    sha256: 13e646d24b5179e6b0a5ece4451a587d759f55d9a360b7015f8f96eff4524b8f
   category: main
   optional: false
 - name: libpng
@@ -8558,10 +13099,23 @@ package:
     krb5: '>=1.21.2,<1.22.0a0'
     libgcc-ng: '>=12'
     openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_1.conda
   hash:
-    md5: fe0e297faf462ee579c95071a5211665
-    sha256: 352748b0499a22e2a8e103f071b8d9357e1fb710c0aec0f79895d3ba03dccb03
+    md5: 9e49ec2a61d02623b379dc332eb6889d
+    sha256: e03a8439b79e013840c44c957d37dbce10316888b2b5dc7dcfcfc0cfe3a3b128
+  category: main
+  optional: false
+- name: libpq
+  version: '16.2'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    krb5: '>=1.21.2,<1.22.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_1.conda
+  hash:
+    md5: a10ef466bbc68a8e74112a8e26028d66
+    sha256: bfb252cb14b88a75ba4af930c16dccae265dce0afdf5abde7de1718181aa2cea
   category: main
   optional: false
 - name: libpq
@@ -8571,10 +13125,10 @@ package:
   dependencies:
     krb5: '>=1.21.2,<1.22.0a0'
     openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.2-h0f8b458_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.2-h0f8b458_1.conda
   hash:
-    md5: fea5d30234a7158f4eaa915b5a6e0c9c
-    sha256: 0ad2265131a6d79fcfe8c5b7a04884f7377f981d18af775ebb71bc61b0c938b6
+    md5: e236a8e95b82a454e333f22418b9c879
+    sha256: 7a6a195d37f6fe2f2d608033755f6e9522c9a2b7b07e52529159105f635c6cae
   category: main
   optional: false
 - name: libprotobuf
@@ -8595,15 +13149,31 @@ package:
 - name: libprotobuf
   version: 4.24.4
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     libabseil: '>=20230802.1,<20230803.0a0'
     libcxx: '>=15'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.24.4-h810fc01_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.24.4-hc4f2305_0.conda
   hash:
-    md5: 36d9b941d8686f7926415275f8f75829
-    sha256: 9b2cd4027b081a9f90069b429e52bf177ea4968032c684ea5d5c6d78e9e11c08
+    md5: b0f4b64fca855d81e9cde1ceecbcb333
+    sha256: 6516b3a430ae3678190a1ece9a8cb38a3ddd9c3acedc3955b76c1e668eeb2eb1
+  category: main
+  optional: false
+- name: libprotobuf
+  version: 4.24.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=10.9'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcxx: '>=16.0.6'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.24.4-hc9861d8_0.conda
+  hash:
+    md5: ac5438d981e105e053b341eb30c44273
+    sha256: 2e81e023f463ef239e2fb7f56a4e8eed61a1d8e9ca3f2f07bec1668cc369b2ce
   category: main
   optional: false
 - name: libre2-11
@@ -8618,6 +13188,20 @@ package:
   hash:
     md5: e61d774293f3ccfb82561a627e846de4
     sha256: 63ebe0a3244b5f1c61337b5b387a2bacd1ca88cd894229a8cd538ef9a4b51d1a
+  category: main
+  optional: false
+- name: libre2-11
+  version: 2023.09.01
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.09.01-h4694dbf_1.conda
+  hash:
+    md5: c33c8c1b04c200c2c2aac01571d3a2cf
+    sha256: cacd50ad7a7dd052dc38e79f6910aee82c032d4a8b5e85aeee9ee64f6bbac2da
   category: main
   optional: false
 - name: libre2-11
@@ -8654,6 +13238,23 @@ package:
 - name: librsvg
   version: 2.56.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    gdk-pixbuf: '>=2.42.10,<3.0a0'
+    gettext: '>=0.21.1,<1.0a0'
+    libglib: '>=2.78.1,<3.0a0'
+    libxml2: '>=2.12.1,<3.0.0a0'
+    pango: '>=1.50.14,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.56.3-h1877882_1.conda
+  hash:
+    md5: 43b31ab0e9cf3538fb3ab138ee663a0b
+    sha256: 29c94b30363cdcae427a2a303de3c634db05f1e28101b6e865e135e72fa8b7ec
+  category: main
+  optional: false
+- name: librsvg
+  version: 2.56.3
+  manager: conda
   platform: osx-arm64
   dependencies:
     cairo: '>=1.18.0,<2.0a0'
@@ -8680,6 +13281,20 @@ package:
   hash:
     md5: 20c3c14bc491f30daecaa6f73e2223ae
     sha256: 03e248787162a1804683c614c0681c2488fa6d9f353cb32e2f8c1158157165ea
+  category: main
+  optional: false
+- name: librttopo
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    geos: '>=3.12.1,<3.12.2.0a0'
+    libcxx: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-hf05f67e_15.conda
+  hash:
+    md5: e65bedc9d9779a161cf26b6d12305246
+    sha256: 10c46efefda5cc77143832a186f517e401098907cf9c3ec7406a5c242bb34e33
   category: main
   optional: false
 - name: librttopo
@@ -8713,6 +13328,20 @@ package:
 - name: libsecret
   version: 0.18.8
   manager: conda
+  platform: osx-64
+  dependencies:
+    gettext: '>=0.19.8.1,<1.0a0'
+    libgcrypt: '>=1.10.1,<2.0a0'
+    libglib: '>=2.70.2,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsecret-0.18.8-hc7eb428_2.tar.bz2
+  hash:
+    md5: 2fac4a5ee39b33170786ed29efe49e73
+    sha256: 67aaf2e7686272631afa4c4982b61553195ed52640f9855f44c4ae28d020ed61
+  category: main
+  optional: false
+- name: libsecret
+  version: 0.18.8
+  manager: conda
   platform: osx-arm64
   dependencies:
     gettext: '>=0.19.8.1,<1.0a0'
@@ -8724,16 +13353,46 @@ package:
     sha256: 1a86748681f1435763d981ec965e87c4bb281c5e463cd80c82a2841d3553be89
   category: main
   optional: false
+- name: libsndfile
+  version: 1.2.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    lame: '>=3.100,<3.101.0a0'
+    libflac: '>=1.4.3,<1.5.0a0'
+    libgcc-ng: '>=12'
+    libogg: '>=1.3.4,<1.4.0a0'
+    libopus: '>=1.3.1,<2.0a0'
+    libstdcxx-ng: '>=12'
+    libvorbis: '>=1.3.7,<1.4.0a0'
+    mpg123: '>=1.32.1,<1.33.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
+  hash:
+    md5: ef1910918dd895516a769ed36b5b3a4e
+    sha256: f709cbede3d4f3aee4e2f8d60bd9e256057f410bd60b8964cb8cf82ec1457573
+  category: main
+  optional: false
 - name: libsodium
   version: 1.0.18
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h516909a_1.tar.bz2
   hash:
-    md5: c3788462a6fbddafdb413a9f9053e58d
-    sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
+    md5: e1ca1a4b82f7b51b29318f80cebae84a
+    sha256: 86e0ef59cbec7e68e372b3380f5809669968d3f674a9b8f2f76f7059c83b4ad1
+  category: main
+  optional: false
+- name: libsodium
+  version: 1.0.18
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
+  hash:
+    md5: 24632c09ed931af617fe6d5292919cab
+    sha256: 2da45f14e3d383b4b9e3a8bacc95cd2832aac2dbf9fbc70d255d384a310c5660
   category: main
   optional: false
 - name: libsodium
@@ -8758,6 +13417,18 @@ package:
   hash:
     md5: d87fbe9c0ff589e802ff13872980bfd9
     sha256: 588fbd0c11bc44e354365d5f836183216a4ed17d680b565ff416a93b839f1a8b
+  category: main
+  optional: false
+- name: libspatialindex
+  version: 1.9.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=11.1.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libspatialindex-1.9.3-he49afe7_4.tar.bz2
+  hash:
+    md5: b1c13764417c32fa87fac733caa82a64
+    sha256: 443db45215e08fbf134a019486c20540d9903c1d9b14ac28ba299f8a730069da
   category: main
   optional: false
 - name: libspatialindex
@@ -8792,6 +13463,29 @@ package:
   hash:
     md5: 127d36f9ee392fa81b45e81867ce30ab
     sha256: 2d07badb81296f42dd0c59b02dbf7d64ca2c78c086226327c1e11e11f71effbd
+  category: main
+  optional: false
+- name: libspatialite
+  version: 5.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    freexl: '>=2.0.0,<3.0a0'
+    geos: '>=3.12.1,<3.12.2.0a0'
+    libcxx: '>=16.0.6'
+    libiconv: '>=1.17,<2.0a0'
+    librttopo: '>=1.1.0,<1.2.0a0'
+    libsqlite: '>=3.44.2,<4.0a0'
+    libxml2: '>=2.12.2,<3.0.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    proj: '>=9.3.1,<9.3.2.0a0'
+    sqlite: ''
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-hebe6af1_4.conda
+  hash:
+    md5: 9e8f3012e1b4460819395357cc7c4371
+    sha256: 48ff63495ed9ed86db1fb62ea51e1053747e76481200fb33aa164f7bdb1bec93
   category: main
   optional: false
 - name: libspatialite
@@ -8833,6 +13527,18 @@ package:
 - name: libsqlite
   version: 3.45.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.2-h92b6c6a_0.conda
+  hash:
+    md5: 086f56e13a96a6cfb1bf640505ae6b70
+    sha256: 320ec73a4e3dd377757a2595770b8137ec4583df4d7782472d76377cdbdc4543
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.45.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     libzlib: '>=1.2.13,<1.3.0a0'
@@ -8859,6 +13565,19 @@ package:
 - name: libssh2
   version: 1.11.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  hash:
+    md5: ca3a72efba692c59a90d4b9fc0dfe774
+    sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+  category: main
+  optional: false
+- name: libssh2
+  version: 1.11.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libzlib: '>=1.2.13,<1.3.0a0'
@@ -8880,6 +13599,24 @@ package:
     sha256: a56c5b11f1e73a86e120e6141a42d9e935a99a2098491ac9e15347a1476ce777
   category: main
   optional: false
+- name: libsystemd0
+  version: '255'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libcap: '>=2.69,<2.70.0a0'
+    libgcc-ng: '>=12'
+    libgcrypt: '>=1.10.3,<2.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_1.conda
+  hash:
+    md5: 3366af27f0b593544a6cd453c7932ac5
+    sha256: af27b0d225435d03f378a119f8eab6b280c53557a3c84cdb3bb8fd3167615aed
+  category: main
+  optional: false
 - name: libthrift
   version: 0.19.0
   manager: conda
@@ -8894,6 +13631,21 @@ package:
   hash:
     md5: 8cdb7d41faa0260875ba92414c487e2d
     sha256: 719add2cf20d144ef9962c57cd0f77178259bdb3aae1cded2e2b2b7c646092f5
+  category: main
+  optional: false
+- name: libthrift
+  version: 0.19.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    libevent: '>=2.1.12,<2.1.13.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.3,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
+  hash:
+    md5: b152655bfad7c2374ff03be0596052b6
+    sha256: 4346c25ef6e2ff3d0fc93074238508531188ecd0dbea6414f6cb93a7775072c4
   category: main
   optional: false
 - name: libthrift
@@ -8934,6 +13686,25 @@ package:
 - name: libtiff
   version: 4.6.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    lerc: '>=4.0.0,<5.0a0'
+    libcxx: '>=15.0.7'
+    libdeflate: '>=1.19,<1.20.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+  hash:
+    md5: 2ca10a325063e000ad6d2a5900061e0d
+    sha256: 1ef5bd7295f4316b111f70ad21356fb9f0de50b85a341cac9e3a61ac6487fdf1
+  category: main
+  optional: false
+- name: libtiff
+  version: 4.6.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     lerc: '>=4.0.0,<5.0a0'
@@ -8957,23 +13728,17 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-    cudatoolkit: '>=11.8,<12'
-    cudnn: '>=8.8.0.121,<9.0a0'
     libcblas: '>=3.9.0,<4.0a0'
     libgcc-ng: '>=12'
-    libmagma: '>=2.7.2,<2.7.3.0a0'
-    libmagma_sparse: '>=2.7.2,<2.7.3.0a0'
     libprotobuf: '>=4.24.4,<4.24.5.0a0'
     libstdcxx-ng: '>=12'
     libuv: '>=1.46.0,<2.0a0'
-    magma: '>=2.7.2,<2.7.3.0a0'
     mkl: '>=2023.2.0,<2024.0a0'
-    nccl: '>=2.19.4.1,<3.0a0'
     sleef: '>=3.5.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.1.2-cuda118_h3d7bd98_300.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.1.2-cpu_mkl_hadc400e_100.conda
   hash:
-    md5: 19f2c0ac4037db9622363dbdcdd21df0
-    sha256: 80c47ee854a10b028841f581c8651b85ed2453d086b8a8a784326606bbb7a945
+    md5: 54f228509c64d8de523ee6ab19e5f3e9
+    sha256: e904bb9260816595e34c5fed07ce8d1ae5572bce36c283425fbec0bddcd3ce88
   category: main
   optional: false
 - name: libutf8proc
@@ -8986,6 +13751,17 @@ package:
   hash:
     md5: ede4266dc02e875fe1ea77b25dd43747
     sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
+  category: main
+  optional: false
+- name: libutf8proc
+  version: 2.8.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+  hash:
+    md5: db98dc3e58cbc11583180609c429c17d
+    sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
   category: main
   optional: false
 - name: libutf8proc
@@ -9026,12 +13802,50 @@ package:
 - name: libuv
   version: 1.48.0
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.48.0-h67532ce_0.conda
+  hash:
+    md5: c8e7344c74f0d86584f7ecdc9f25c198
+    sha256: fb87f7bfd464a3a841d23f418c86a206818da0c4346984392071d9342c9ea367
+  category: main
+  optional: false
+- name: libuv
+  version: 1.48.0
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.48.0-h93a5062_0.conda
   hash:
     md5: abfd49e80f13453b62a56be226120ea8
     sha256: 60bed2a7a85096387ab0381cbc32ea2da7f8dd99bd90e440983019c0cdd96ad1
+  category: main
+  optional: false
+- name: libvorbis
+  version: 1.3.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=7.5.0'
+    libogg: '>=1.3.2,<1.4.0a0'
+    libstdcxx-ng: '>=7.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-he1b5a44_0.tar.bz2
+  hash:
+    md5: de5b60f584a98d397cc589fcabfa3889
+    sha256: 7ad72b75a143ea0bbd72f088b6150db9de66f0c2f25e5745e96aca0a16918d7f
+  category: main
+  optional: false
+- name: libvorbis
+  version: 1.3.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=11.0.0'
+    libogg: '>=1.3.4,<1.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libvorbis-1.3.7-h046ec9c_0.tar.bz2
+  hash:
+    md5: fbbda1fede0aadaa252f6919148c4ce1
+    sha256: fbcce1005efcd616e452dea07fe34893d8dd13c65628e74920eeb68ac549faf7
   category: main
   optional: false
 - name: libwebp
@@ -9049,6 +13863,22 @@ package:
   hash:
     md5: 0ebb65e8d86843865796c7c95a941f34
     sha256: cc5e55531d8067ea379b145861aea8c749a545912bc016372f5e3c69cc925efd
+  category: main
+  optional: false
+- name: libwebp
+  version: 1.3.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    giflib: '>=5.2.1,<5.3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-1.3.2-h44782d1_1.conda
+  hash:
+    md5: 46d48ff2cd600a82db18d7b83471aa86
+    sha256: 4d7e1efb76e398f578c5a3d0905c5eca1e4a93298aed6e2f7a10854f6671dfe8
   category: main
   optional: false
 - name: libwebp
@@ -9082,6 +13912,17 @@ package:
 - name: libwebp-base
   version: 1.3.2
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
+  hash:
+    md5: 4e7e9d244e87d66c18d36894fd6a8ae5
+    sha256: fa7580f26fec4c28321ec2ece1257f3293e0c646c635e9904679f4a8369be401
+  category: main
+  optional: false
+- name: libwebp-base
+  version: 1.3.2
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
@@ -9103,6 +13944,20 @@ package:
   hash:
     md5: 33277193f5b92bad9fdd230eb700929c
     sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
+  category: main
+  optional: false
+- name: libxcb
+  version: '1.15'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pthread-stubs: ''
+    xorg-libxau: ''
+    xorg-libxdmcp: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+  hash:
+    md5: 5513f57e0238c87c12dffedbcc9c1a4a
+    sha256: f41904f466acc8b3197f37f2dd3a08da75720c7f7464d9267635debc4ac1902b
   category: main
   optional: false
 - name: libxcb
@@ -9131,6 +13986,23 @@ package:
     sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   category: main
   optional: false
+- name: libxkbcommon
+  version: 1.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
+    libxml2: '>=2.12.6,<3.0a0'
+    xkeyboard-config: ''
+    xorg-libxau: '>=1.0.11,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h662e7e4_0.conda
+  hash:
+    md5: b32c0da42b1f24a98577bb3d7fc0b995
+    sha256: 3d97d7f964237f42452295d461afdbc51e93f72e2c80be516f56de80e3bb6621
+  category: main
+  optional: false
 - name: libxml2
   version: 2.12.6
   manager: conda
@@ -9141,10 +14013,25 @@ package:
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.6-h232c23b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.6-h232c23b_1.conda
   hash:
-    md5: d86653ff5ccb88bf7f13833fdd8789e0
-    sha256: 4646ae14fb226080d2bfeb89510147abebd603bab1c80bb6b3c02a01c10c6ee5
+    md5: 6853448e9ca1cfd5f15382afd2a6d123
+    sha256: c0bd693bb1a7e5aba388a0c79be16ff92e2411e03aaa920f94b4b33bf099e254
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.12.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    icu: '>=73.2,<74.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    xz: '>=5.2.6,<6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.6-hc0ae0f7_1.conda
+  hash:
+    md5: bd85e0ca9e1ffaadc3b56079fd956035
+    sha256: 07a5dc7316d4c1ff3d924df6a76e6a13380d702fa5b3b1889e56d0672e5b8201
   category: main
   optional: false
 - name: libxml2
@@ -9156,10 +14043,10 @@ package:
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.6-h0d0cfa8_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.6-h0d0cfa8_1.conda
   hash:
-    md5: 4713f0d8bb1e50cc4757c118b6fe20d5
-    sha256: 38a5e25e1fd3b59fd31301f39a0f02ca28925d7d102348921b9366e580cd810c
+    md5: c08526c957192192e1e7b4f622761144
+    sha256: f18775ca8494ead5451d4acfc53fa7ebf7a8b5ed04c43bcc50fab847c9780cb3
   category: main
   optional: false
 - name: libzip
@@ -9175,6 +14062,20 @@ package:
   hash:
     md5: ac79812548e7e8cf61f7b0abdef01d3b
     sha256: 84e93f189072dcfcbe77744f19c7e4171523fbecfaba7352e5a23bbe014574c7
+  category: main
+  optional: false
+- name: libzip
+  version: 1.10.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
+  hash:
+    md5: 6112b3173f3aa2f12a8f40d07a77cc35
+    sha256: 0689e4a6e67e80027e43eefb8a365273405a01f5ab2ece97319155b8be5d64f6
   category: main
   optional: false
 - name: libzip
@@ -9206,6 +14107,17 @@ package:
 - name: libzlib
   version: 1.2.13
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+  hash:
+    md5: 4a3ad23f6e16f99c04e166767193d700
+    sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.2.13
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
@@ -9215,33 +14127,56 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 18.1.1
+  version: 18.1.2
   manager: conda
   platform: linux-64
   dependencies:
     libzlib: '>=1.2.13,<1.3.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-18.1.1-h4dfa4b3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-18.1.2-h4dfa4b3_0.conda
   hash:
-    md5: 89023cfc92c7e9dd2e822ebdb4f753b0
-    sha256: a85cadbb1b00d181a6462700c3d1da7092c53b3f1f90c76ec560fef34aff226b
+    md5: 0118c8a03e3dbbb6b348ef71e94ac7af
+    sha256: a27691201ccf157e7b53390f29f66469957302a05abb22a6b6d6701673bba3bb
   category: main
   optional: false
 - name: llvm-openmp
-  version: 18.1.1
+  version: 18.1.2
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.2-hb6ac08f_0.conda
+  hash:
+    md5: e7f7e91cfabd8c7172c9ae405214dd68
+    sha256: dc40b678f5be2caf4e89ee3dc9037399d0bcd46543bc258dc46e1b92d241c6a6
+  category: main
+  optional: false
+- name: llvm-openmp
+  version: 18.1.2
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.1-hcd81f8e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.2-hcd81f8e_0.conda
   hash:
-    md5: 4f878f28804ed85e5191132c12c1fca5
-    sha256: 38cf66997aae1bb20575ca829c322cb255c23652609576f76590f4ab7e35572a
+    md5: 34646dc152f3949a2f8a67136d406dce
+    sha256: 2ed8ae5a4c6122d542564a9bb9d4961ed7d2fb9581f0ea8bd81e3a83e614b110
   category: main
   optional: false
 - name: locket
   version: 1.0.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 91e27ef3d05cc772ce627e51cff111c4
+    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  category: main
+  optional: false
+- name: locket
+  version: 1.0.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
   url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
@@ -9280,6 +14215,20 @@ package:
 - name: lz4
   version: 4.3.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py39h91cfb08_0.conda
+  hash:
+    md5: 3a809e3cf5adb89819ebd964d26fbb33
+    sha256: 60a0d2a5878636b556923b8a54dc6e992f69ce8b2a3a062c3d8f91ea627ba545
+  category: main
+  optional: false
+- name: lz4
+  version: 4.3.3
+  manager: conda
   platform: osx-arm64
   dependencies:
     lz4-c: '>=1.9.3,<1.10.0a0'
@@ -9302,6 +14251,18 @@ package:
   hash:
     md5: 318b08df404f9c9be5712aaa5a6f0bb0
     sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  category: main
+  optional: false
+- name: lz4-c
+  version: 1.9.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  hash:
+    md5: aa04f7143228308662696ac24023f991
+    sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
   category: main
   optional: false
 - name: lz4-c
@@ -9331,6 +14292,17 @@ package:
 - name: lzo
   version: '2.10'
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-haf1e3a3_1000.tar.bz2
+  hash:
+    md5: 0b6bca372a95d6c602c7a922e928ce79
+    sha256: c8a9401eff2efbbcc6da03d0066ee85d72402f7658c240e7968c64052a0d0493
+  category: main
+  optional: false
+- name: lzo
+  version: '2.10'
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h642e427_1000.tar.bz2
@@ -9339,25 +14311,22 @@ package:
     sha256: ae029e5c16893071d29a11ddbfdbdb01b2ebf10d1785f54370934439d8b71817
   category: main
   optional: false
-- name: magma
-  version: 2.7.2
+- name: makefun
+  version: 1.15.2
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17'
-    cudatoolkit: '>=11.8,<12'
-    libmagma: '>=2.7.2,<2.7.3.0a0'
-    libmagma_sparse: 2.7.2
-  url: https://conda.anaconda.org/conda-forge/linux-64/magma-2.7.2-h4aca40b_3.conda
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/makefun-1.15.2-pyhd8ed1ab_0.conda
   hash:
-    md5: fe218300f1dfb9fbedbd210b3b9e020e
-    sha256: 9e3240a60a16269c986bcd3d1bee9e35cf81a843ff33b68ee6a2a1e7cbb7fd1c
+    md5: f0ebb89ab17982033d8f0fea244b0822
+    sha256: bcd48b9d591a5cc97803701c25aeec06122baf3af4e799e764eddcede112533b
   category: main
   optional: false
 - name: makefun
   version: 1.15.2
   manager: conda
-  platform: linux-64
+  platform: osx-64
   dependencies:
     python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/makefun-1.15.2-pyhd8ed1ab_0.conda
@@ -9395,11 +14364,25 @@ package:
 - name: mako
   version: 1.3.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    importlib-metadata: ''
+    python: '>=3.6'
+    markupsafe: '>=0.9.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: a6b5f0124bc6d061350edd6d7f96dd05
+    sha256: 5f21876a83bcc040196d7f3950d576eb492bf0f6293eacd55e48e2c58a069bce
+  category: main
+  optional: false
+- name: mako
+  version: 1.3.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     importlib-metadata: ''
-    markupsafe: '>=0.9.2'
     python: '>=3.6'
+    markupsafe: '>=0.9.2'
   url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.2-pyhd8ed1ab_0.conda
   hash:
     md5: a6b5f0124bc6d061350edd6d7f96dd05
@@ -9426,14 +14409,31 @@ package:
 - name: mapclassify
   version: 2.6.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    networkx: '>=2.7'
-    numpy: '>=1.23'
-    pandas: '>=1.4,!=1.5.0'
     python: '>=3.9'
+    numpy: '>=1.23'
     scikit-learn: '>=1.0'
     scipy: '>=1.8'
+    networkx: '>=2.7'
+    pandas: '>=1.4,!=1.5.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6aceae1ad4f16cf7b73ee04189947f98
+    sha256: 204ab8b242229d422b33cfec07ea61cefa8bd22375a16658afbabaafce031d64
+  category: main
+  optional: false
+- name: mapclassify
+  version: 2.6.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    numpy: '>=1.23'
+    scikit-learn: '>=1.0'
+    scipy: '>=1.8'
+    networkx: '>=2.7'
+    pandas: '>=1.4,!=1.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
   hash:
     md5: 6aceae1ad4f16cf7b73ee04189947f98
@@ -9456,10 +14456,23 @@ package:
 - name: markdown
   version: '3.6'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    importlib-metadata: '>=4.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: 06e9bebf748a0dea03ecbe1f0e27e909
+    sha256: fce1fde00359696983989699c00f9891194c4ebafea647a8d21b7e2e3329b56e
+  category: main
+  optional: false
+- name: markdown
+  version: '3.6'
+  manager: conda
   platform: osx-arm64
   dependencies:
-    importlib-metadata: '>=4.4'
     python: '>=3.6'
+    importlib-metadata: '>=4.4'
   url: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
   hash:
     md5: 06e9bebf748a0dea03ecbe1f0e27e909
@@ -9483,11 +14496,25 @@ package:
 - name: markdown-it-py
   version: 2.2.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    mdurl: '>=0.1,<1'
     python: '>=3.7'
     typing_extensions: '>=3.7.4'
+    mdurl: '>=0.1,<1'
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-2.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: b2928a6c6d52d7e3562b4a59c3214e3a
+    sha256: 65ed439862c1851463f03a9bc5109992ce3e3e025e9a2d76d13ca19f576eee9f
+  category: main
+  optional: false
+- name: markdown-it-py
+  version: 2.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+    typing_extensions: '>=3.7.4'
+    mdurl: '>=0.1,<1'
   url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-2.2.0-pyhd8ed1ab_0.conda
   hash:
     md5: b2928a6c6d52d7e3562b4a59c3214e3a
@@ -9506,6 +14533,19 @@ package:
   hash:
     md5: 9a9a22eb1f83c44953319ee3b027769f
     sha256: 855d305ceda4751cdd495923104dd34da5a6be45e4fd50a4e80361d9f95bcb38
+  category: main
+  optional: false
+- name: markupsafe
+  version: 2.1.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.5-py39ha09f3b3_0.conda
+  hash:
+    md5: db347b50af50d030b73be1d1e457cac2
+    sha256: 2fbc1105e680dd34e44f59c67ad30b5e5fbbed65ce4dfb09dac0df811bc24f73
   category: main
   optional: false
 - name: markupsafe
@@ -9537,10 +14577,23 @@ package:
 - name: marshmallow
   version: 3.21.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    packaging: '>=17.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/marshmallow-3.21.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: ae303aa7dc100bc3bc01b5a3b7ca3567
+    sha256: d1c825bebd47db2327819562d23560b1e9cb50c73e964848a6f2e58f61d962d1
+  category: main
+  optional: false
+- name: marshmallow
+  version: 3.21.1
+  manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: '>=17.0'
     python: '>=3.8'
+    packaging: '>=17.0'
   url: https://conda.anaconda.org/conda-forge/noarch/marshmallow-3.21.1-pyhd8ed1ab_0.conda
   hash:
     md5: ae303aa7dc100bc3bc01b5a3b7ca3567
@@ -9553,11 +14606,26 @@ package:
   platform: linux-64
   dependencies:
     marshmallow: '>=2.0.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/marshmallow-enum-1.5.1-pyh9f0ad1d_3.tar.bz2
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/marshmallow-enum-1.5.1-py39hde42818_2.tar.bz2
   hash:
-    md5: 67c5202bf14543cd1bb97f129d3f26dd
-    sha256: 7729d878c2129d691e86b81fce346320a0152a6bbfc862a8c12ec646763f4857
+    md5: cf3771b0c8d7662dff2212b4db9dd27b
+    sha256: 3fbc341d3a4dc6a5fa8063b19330a6e598f2832c86f74924453a8511869d2624
+  category: main
+  optional: false
+- name: marshmallow-enum
+  version: 1.5.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    marshmallow: '>=2.0.0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/marshmallow-enum-1.5.1-py39hde42818_2.tar.bz2
+  hash:
+    md5: 9fc9b6435d828044de3701b1ce6ef0df
+    sha256: 95aff28070c789f3f9302a991a358c84dcbd547729464491e0f0b4ec8926eb9c
   category: main
   optional: false
 - name: marshmallow-enum
@@ -9565,8 +14633,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    marshmallow: '>=2.0.0'
     python: ''
+    marshmallow: '>=2.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/marshmallow-enum-1.5.1-pyh9f0ad1d_3.tar.bz2
   hash:
     md5: 67c5202bf14543cd1bb97f129d3f26dd
@@ -9589,10 +14657,23 @@ package:
 - name: marshmallow-jsonschema
   version: 0.13.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    marshmallow: '>=3.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/marshmallow-jsonschema-0.13.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: bd47c87386365fcaf782c9c407b50507
+    sha256: 74c6bd772e9ed1b33bdb216737186eae36fca27dbf0e1cb6bd9847494f08c9d6
+  category: main
+  optional: false
+- name: marshmallow-jsonschema
+  version: 0.13.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    marshmallow: '>=3.11'
     python: '>=3.6'
+    marshmallow: '>=3.11'
   url: https://conda.anaconda.org/conda-forge/noarch/marshmallow-jsonschema-0.13.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: bd47c87386365fcaf782c9c407b50507
@@ -9603,6 +14684,19 @@ package:
   version: '3.12'
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    typing-extensions: '>=4.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/mashumaro-3.12-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1a8457271699e24f59dbaadc92e7330f
+    sha256: c0b2c8b745a5492aabe9cbece7be6dcbd1458166333c7f96c11741640ed348da
+  category: main
+  optional: false
+- name: mashumaro
+  version: '3.12'
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
     typing-extensions: '>=4.1.0'
@@ -9656,6 +14750,33 @@ package:
 - name: matplotlib-base
   version: 3.8.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.12'
+    certifi: '>=2020.06.20'
+    contourpy: '>=1.0.1'
+    cycler: '>=0.10'
+    fonttools: '>=4.22.0'
+    freetype: '>=2.12.1,<3.0a0'
+    importlib-resources: '>=3.2.0'
+    kiwisolver: '>=1.3.1'
+    libcxx: '>=16'
+    numpy: '>=1.22.4,<2.0a0'
+    packaging: '>=20.0'
+    pillow: '>=8'
+    pyparsing: '>=2.3.1'
+    python: '>=3.9,<3.10.0a0'
+    python-dateutil: '>=2.7'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.3-py39h7070ae8_0.conda
+  hash:
+    md5: 241e91172dfaa6ad66e3c838a6185641
+    sha256: 4173787e0ff755e25ebe1c4bb9e0a64fd397cd0fa18f28e54a592cc1af2b6049
+  category: main
+  optional: false
+- name: matplotlib-base
+  version: 3.8.3
+  manager: conda
   platform: osx-arm64
   dependencies:
     certifi: '>=2020.06.20'
@@ -9695,10 +14816,23 @@ package:
 - name: matplotlib-inline
   version: 0.1.6
   manager: conda
+  platform: osx-64
+  dependencies:
+    traitlets: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b21613793fcc81d944c76c9f2864a7de
+    sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+  category: main
+  optional: false
+- name: matplotlib-inline
+  version: 0.1.6
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
     traitlets: ''
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b21613793fcc81d944c76c9f2864a7de
@@ -9721,10 +14855,23 @@ package:
 - name: mdit-py-plugins
   version: 0.4.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    markdown-it-py: '>=1.0.0,<4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6c5358a10873a15398b6f15f60cb5e1f
+    sha256: 1ddac8d2be448cd1fbe49d2ca09df7e10d99679d53146a917f8bb4899f76d0ca
+  category: main
+  optional: false
+- name: mdit-py-plugins
+  version: 0.4.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    markdown-it-py: '>=1.0.0,<4.0.0'
     python: '>=3.8'
+    markdown-it-py: '>=1.0.0,<4.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6c5358a10873a15398b6f15f60cb5e1f
@@ -9735,6 +14882,18 @@ package:
   version: 0.1.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 776a8dd9e824f77abac30e6ef43a8f7a
+    sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+  category: main
+  optional: false
+- name: mdurl
+  version: 0.1.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
@@ -9777,6 +14936,24 @@ package:
 - name: minizip
   version: 4.0.5
   manager: conda
+  platform: osx-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libcxx: '>=16'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.5-h37d7099_0.conda
+  hash:
+    md5: 2203b2e83c20305b3d669556c345c8e9
+    sha256: 426f4db1d56cdefa478a5ece35ed7624860548ace87d6ad927c4c9c6a7a20fec
+  category: main
+  optional: false
+- name: minizip
+  version: 4.0.5
+  manager: conda
   platform: osx-arm64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
@@ -9796,6 +14973,18 @@ package:
   version: 3.0.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5cbee699846772cc939bef23a0d524ed
+    sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
+  category: main
+  optional: false
+- name: mistune
+  version: 3.0.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
@@ -9830,6 +15019,19 @@ package:
     sha256: 046073737bf73153b0c39e343b197cdf0b7867d336962369407465a17ea5979a
   category: main
   optional: false
+- name: mkl
+  version: 2022.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    llvm-openmp: '>=14.0.6'
+    tbb: 2021.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/mkl-2022.2.1-h44ed08c_16952.conda
+  hash:
+    md5: a51e7035c0075d4341942a5894ef20b9
+    sha256: 70896885df3cf031ac547c42f27384f769f190bc2bfb9e2520a7ef2c34db4806
+  category: main
+  optional: false
 - name: ml_dtypes
   version: 0.2.0
   manager: conda
@@ -9844,6 +15046,21 @@ package:
   hash:
     md5: 97e48908f75e32b0382b1aba3a3dbffe
     sha256: 075bc750ecd95c7fc64be32181a6818d2bb7e9a965123c7eb8f1e0f3e29ab00a
+  category: main
+  optional: false
+- name: ml_dtypes
+  version: 0.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    numpy: '>=1.22.4,<2.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/ml_dtypes-0.2.0-py39hcc9a0c8_2.conda
+  hash:
+    md5: d7047358980c481b056abbce772338c7
+    sha256: c57a511548bc13ccc0007afd4a2b699000563c74d13d38c14dd264e66f61f390
   category: main
   optional: false
 - name: ml_dtypes
@@ -9905,6 +15122,47 @@ package:
 - name: mlflow
   version: 2.7.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    alembic: <2,!=1.10
+    click: '>=7.0,<9'
+    cloudpickle: <3
+    databricks-cli: '>=0.8.7,<1'
+    docker-py: '>=4.0.0,<7'
+    entrypoints: <1
+    flask: <3
+    gitpython: '>=2.1.0,<4'
+    gunicorn: <22
+    importlib-metadata: <7,>=3.7.0,!=4.7.0
+    jinja2: <4,>=2.11
+    markdown: <4,>=3.3
+    matplotlib-base: <4
+    numpy: <2
+    openssl: ''
+    packaging: <24
+    pandas: <3
+    prometheus_flask_exporter: <1
+    protobuf: '>=3.12.0,<5'
+    pyarrow: <14,>=4.0.0
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    pytz: <2024
+    pyyaml: '>=5.1,<7'
+    querystring_parser: <2
+    requests: '>=2.17.3,<3'
+    scikit-learn: <2
+    scipy: <2
+    sqlalchemy: '>=1.4.0,<3'
+    sqlparse: '>=0.4.0,<1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/mlflow-2.7.0-py39h8ac9d56_0.conda
+  hash:
+    md5: 21c33f5f9e9a1d053544620b5d00bc79
+    sha256: c98ec57de0451c1045e8e462d859aeda8c948a6eb87ac55d23e65063bd914159
+  category: main
+  optional: false
+- name: mlflow
+  version: 2.7.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     alembic: <2,!=1.10
@@ -9960,6 +15218,20 @@ package:
 - name: modin
   version: 0.28.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    modin-dask: 0.28.0
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/modin-0.28.0-py39h6e9494a_0.conda
+  hash:
+    md5: e240c76fd1104c2681dce94af6e9facc
+    sha256: ad88d88d53aaa5e2a366709f46989475aea168eb2d10daba738f5c4e2f4695a1
+  category: main
+  optional: false
+- name: modin
+  version: 0.28.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     modin-dask: 0.28.0
@@ -9987,6 +15259,24 @@ package:
   hash:
     md5: 88880e1fc6ba6b759e7d0429fed741f8
     sha256: c9fbb625f88191618fd9cd8b9c4ba7b490a12c87b283bc1115d34b698190f4c7
+  category: main
+  optional: false
+- name: modin-core
+  version: 0.28.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    fsspec: '>=2022.11.0'
+    numpy: '>=1.22.4'
+    packaging: '>=21.0'
+    pandas: '>=2.2,<2.3'
+    psutil: '>=5.8.0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/modin-core-0.28.0-py39h6e9494a_0.conda
+  hash:
+    md5: a6f9748ee9de1f41e12565d534813e39
+    sha256: 6cece38062322e656cfd91ba0661fe300407234e390337e404b245a4c30b6080
   category: main
   optional: false
 - name: modin-core
@@ -10026,6 +15316,22 @@ package:
 - name: modin-dask
   version: 0.28.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    dask: '>=2.22.0'
+    distributed: '>=2.22.0'
+    modin-core: 0.28.0
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/modin-dask-0.28.0-py39h6e9494a_0.conda
+  hash:
+    md5: 60224e14c75aa0619a0efb08aeee8d4b
+    sha256: e03a929af284ac9bcf357d2d9da203972c4e0281270f4a966d476fe39ec8eca0
+  category: main
+  optional: false
+- name: modin-dask
+  version: 0.28.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     dask: '>=2.22.0'
@@ -10043,6 +15349,18 @@ package:
   version: 10.2.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: d5c98e9706fdc5328d49a9bf2ce5fb42
+    sha256: 9e49e9484ff279453f0b55323a3f0c7cb97440c74f69eecda1f4ad29fae5cd3c
+  category: main
+  optional: false
+- name: more-itertools
+  version: 10.2.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -10080,6 +15398,19 @@ package:
 - name: mpc
   version: 1.3.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    gmp: '>=6.2.1,<7.0a0'
+    mpfr: '>=4.1.0,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h81bd1dd_0.conda
+  hash:
+    md5: c752c0eb6c250919559172c011e5f65b
+    sha256: 2ae945a15c8a984d581dcfb974ad3b5d877a6527de2c95a3363e6b4490b2f312
+  category: main
+  optional: false
+- name: mpc
+  version: 1.3.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     gmp: '>=6.2.1,<7.0a0'
@@ -10106,6 +15437,18 @@ package:
 - name: mpfr
   version: 4.2.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    gmp: '>=6.2.1,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.2.1-h0c69b56_0.conda
+  hash:
+    md5: d545aecded064848432bc994075dfccf
+    sha256: e7c93a5399661b0528981c6fd53e8614eee3f9ba97f92e8167c092c4a5d9368c
+  category: main
+  optional: false
+- name: mpfr
+  version: 4.2.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     gmp: '>=6.2.1,<7.0a0'
@@ -10115,10 +15458,35 @@ package:
     sha256: 811ca63177cf638ac01442fc8d1148d3a0cef18dc1f870fceed1feb24be6fd8f
   category: main
   optional: false
+- name: mpg123
+  version: 1.32.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.4-h59595ed_0.conda
+  hash:
+    md5: 3f1017b4141e943d9bc8739237f749e8
+    sha256: 512f4ad7eda3b2c9a1cc9f7931932aefa6e79567e35b76de03895e769cb3b43c
+  category: main
+  optional: false
 - name: mpmath
   version: 1.3.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: dbf6e2d89137da32fa6670f3bffc024e
+    sha256: a4f025c712ec1502a55c471b56a640eaeebfce38dd497d5a1a33729014cac47a
+  category: main
+  optional: false
+- name: mpmath
+  version: 1.3.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_0.conda
@@ -10140,7 +15508,7 @@ package:
   category: main
   optional: false
 - name: msal
-  version: 1.27.0
+  version: 1.28.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -10148,25 +15516,40 @@ package:
     pyjwt: <3,>=1.0.0
     python: '>=3.6'
     requests: <3,>=2.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/msal-1.27.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/msal-1.28.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 95a138b82ec36756dd8c4bd25e564597
-    sha256: e3f5876e8ea2078aba5b34d6dde53910afc8f88bf6d9eec11c0bee9eb9ba6ea8
+    md5: 6f11e244d25bd0f23fd2f8f7e3c21c9e
+    sha256: ce36a188f4148810b12d298d0fc369ce46ad16efef2acc6fc03fb9aa4a68cdcc
   category: main
   optional: false
 - name: msal
-  version: 1.27.0
+  version: 1.28.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    pyjwt: <3,>=1.0.0
+    requests: <3,>=2.0.0
+    cryptography: <45,>=0.6
+  url: https://conda.anaconda.org/conda-forge/noarch/msal-1.28.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6f11e244d25bd0f23fd2f8f7e3c21c9e
+    sha256: ce36a188f4148810b12d298d0fc369ce46ad16efef2acc6fc03fb9aa4a68cdcc
+  category: main
+  optional: false
+- name: msal
+  version: 1.28.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    cryptography: <45,>=0.6
-    pyjwt: <3,>=1.0.0
     python: '>=3.6'
+    pyjwt: <3,>=1.0.0
     requests: <3,>=2.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/msal-1.27.0-pyhd8ed1ab_0.conda
+    cryptography: <45,>=0.6
+  url: https://conda.anaconda.org/conda-forge/noarch/msal-1.28.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 95a138b82ec36756dd8c4bd25e564597
-    sha256: e3f5876e8ea2078aba5b34d6dde53910afc8f88bf6d9eec11c0bee9eb9ba6ea8
+    md5: 6f11e244d25bd0f23fd2f8f7e3c21c9e
+    sha256: ce36a188f4148810b12d298d0fc369ce46ad16efef2acc6fc03fb9aa4a68cdcc
   category: main
   optional: false
 - name: msal_extensions
@@ -10185,6 +15568,24 @@ package:
   hash:
     md5: 74312f2baf4e602530545e5c2b532fbe
     sha256: 650f8abd6ffb20e2d07dcebe98cee4f4aa1e14194ac6f19e5f6af75642122b33
+  category: main
+  optional: false
+- name: msal_extensions
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libsecret: ''
+    msal: '>=0.4.1,<2.0'
+    packaging: ''
+    portalocker: '>=1.6,<3.0'
+    pygobject: '>=3,<4'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/msal_extensions-1.1.0-py39h6e9494a_1.conda
+  hash:
+    md5: 9a1c3be0f877ecbb47df44144a79e4a0
+    sha256: 34df8ac13f32f482a4933baf7315445b53f904ac1a958be1289063f410b375c4
   category: main
   optional: false
 - name: msal_extensions
@@ -10223,6 +15624,21 @@ package:
 - name: msgpack-python
   version: 1.0.7
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.0.7-py39h6be1789_0.conda
+  hash:
+    md5: 41e836f12229ef10ceb7b54383702aeb
+    sha256: f00d36cf25d0059be8473255b1bfa0ddae5b52fc5cb78c2b94bcf38b2bb5d971
+  category: main
+  optional: false
+- name: msgpack-python
+  version: 1.0.7
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=10.9'
@@ -10247,6 +15663,19 @@ package:
   hash:
     md5: e2005168d5a334f88a1d95d02e139239
     sha256: 9d07c952bd052b95155942d07d30d95eb0d8dfecfc9b0b40b8ba50323dc719da
+  category: main
+  optional: false
+- name: multidict
+  version: 6.0.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.0.5-py39ha30fb19_0.conda
+  hash:
+    md5: 326ed77e6a7a635f37555e85f9029697
+    sha256: d01cbd410def2d8c928d7796e5a33f83731a701f5a675d0cdf6efe7added79ab
   category: main
   optional: false
 - name: multidict
@@ -10277,6 +15706,18 @@ package:
 - name: multimethod
   version: 1.9.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/multimethod-1.9.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 48223af3f697ccd9b114adb6a66e0f11
+    sha256: 7fcfda7b4a1d74205fcfdefd93804226a6eaffc74a319414c7d8d88f9249db3b
+  category: main
+  optional: false
+- name: multimethod
+  version: 1.9.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
@@ -10287,38 +15728,64 @@ package:
   category: main
   optional: false
 - name: multiprocess
-  version: 0.70.16
+  version: 0.70.15
   manager: conda
   platform: linux-64
   dependencies:
-    dill: '>=0.3.8'
+    dill: '>=0.3.6'
     libgcc-ng: '>=12'
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.16-py39hd1e30aa_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.15-py39hd1e30aa_1.conda
   hash:
-    md5: 9cef252eafc7a1a0ddba737290a1c4e2
-    sha256: 805bc36c1aa37d80757b96cae7f12944343f1099c68813606416e35486c703d3
+    md5: ba981804a87d06ba9899e938c3178ed2
+    sha256: 7f9c6d04b5ec3df502599ebd3e86a95194bb7358d70c23374f8b71a89040194a
   category: main
   optional: false
 - name: multiprocess
-  version: 0.70.16
+  version: 0.70.15
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    dill: '>=0.3.8'
+    dill: '>=0.3.6'
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.16-py39h17cfd9d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/multiprocess-0.70.15-py39hdc70f33_1.conda
   hash:
-    md5: 785e3f2fca33cf22a899ad2f25b1f6df
-    sha256: 9d9d0ebe8f7ab624ff3951ef2ca9a12a46ce2fae9a17f78596322fa043f4290b
+    md5: fb095a5ac1085f0e0bb5051818520144
+    sha256: c1b42c332f6ed3aa83b5b0d3949c9288fa9895c551c6bc1ff1c54f740813c721
+  category: main
+  optional: false
+- name: multiprocess
+  version: 0.70.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    dill: '>=0.3.6'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.15-py39h0f82c59_1.conda
+  hash:
+    md5: 3b94f36e225c5b5fe8d37ce3577cf72c
+    sha256: 0675aaf60406afb644f42b714f58979feaa99892e98aca83b81b8376df7b5997
   category: main
   optional: false
 - name: munkres
   version: 1.1.4
   manager: conda
   platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 2ba8498c1018c1e9c61eb99b973dfe19
+    sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  category: main
+  optional: false
+- name: munkres
+  version: 1.1.4
+  manager: conda
+  platform: osx-64
   dependencies:
     python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
@@ -10354,6 +15821,18 @@ package:
 - name: mypy_extensions
   version: 1.0.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+  hash:
+    md5: 4eccaeba205f0aed9ac3a9ea58568ca3
+    sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+  category: main
+  optional: false
+- name: mypy_extensions
+  version: 1.0.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -10363,306 +15842,499 @@ package:
     sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
   category: main
   optional: false
-- name: myst-nb
-  version: 0.17.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib-metadata: ''
-    ipykernel: ''
-    ipython: ''
-    jupyter-cache: '>=0.5.0,<0.7.0'
-    myst-parser: '>=0.18.0,<0.19.0'
-    nbclient: ''
-    nbformat: '>=5.0,<6'
-    python: '>=3.7'
-    pyyaml: ''
-    sphinx: '>=4,<6'
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/myst-nb-0.17.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 40190b7d06f86b63d28fa78aaa39c023
-    sha256: 37bcf6de8618a0668ef6b364b14e0eceea87b202a3882c59dcd85bc1172a5402
-  category: main
-  optional: false
-- name: myst-nb
-  version: 0.17.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    importlib-metadata: ''
-    ipykernel: ''
-    ipython: ''
-    jupyter-cache: '>=0.5.0,<0.7.0'
-    myst-parser: '>=0.18.0,<0.19.0'
-    nbclient: ''
-    nbformat: '>=5.0,<6'
-    python: '>=3.7'
-    pyyaml: ''
-    sphinx: '>=4,<6'
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/myst-nb-0.17.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 40190b7d06f86b63d28fa78aaa39c023
-    sha256: 37bcf6de8618a0668ef6b364b14e0eceea87b202a3882c59dcd85bc1172a5402
-  category: main
-  optional: false
-- name: myst-parser
-  version: 0.18.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    docutils: '>=0.15,<0.20'
-    jinja2: ''
-    markdown-it-py: '>=1.0.0,<3.0.0'
-    mdit-py-plugins: '>=0.3.1,<1'
-    python: '>=3.7'
-    pyyaml: ''
-    sphinx: '>=4,<6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/myst-parser-0.18.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: bcfdf5c7d8bf5c6f6be7b4c66fff2eca
-    sha256: 260812a430adee3598103d75704c1c855a9816a3895971ca0190d0f5e1e8165a
-  category: main
-  optional: false
-- name: myst-parser
-  version: 0.18.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    docutils: '>=0.15,<0.20'
-    jinja2: ''
-    markdown-it-py: '>=1.0.0,<3.0.0'
-    mdit-py-plugins: '>=0.3.1,<1'
-    python: '>=3.7'
-    pyyaml: ''
-    sphinx: '>=4,<6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/myst-parser-0.18.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: bcfdf5c7d8bf5c6f6be7b4c66fff2eca
-    sha256: 260812a430adee3598103d75704c1c855a9816a3895971ca0190d0f5e1e8165a
-  category: main
-  optional: false
-- name: nbclient
-  version: 0.7.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    nbformat: '>=5.1'
-    python: '>=3.7'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: f7aa15f77d29b11caa1df1eb15383c59
-    sha256: f26afcbbdd4bd1245db514c6ebc6ef18cc12067145dcab229b6f88653575d44c
-  category: main
-  optional: false
-- name: nbclient
-  version: 0.7.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    nbformat: '>=5.1'
-    python: '>=3.7'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: f7aa15f77d29b11caa1df1eb15383c59
-    sha256: f26afcbbdd4bd1245db514c6ebc6ef18cc12067145dcab229b6f88653575d44c
-  category: main
-  optional: false
-- name: nbconvert
-  version: 7.16.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    nbconvert-core: 7.16.2
-    nbconvert-pandoc: 7.16.2
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e14e35cc4a5c90694bb41c5317b576a8
-    sha256: 551bbd14019a1df2f44b7e392f590674f63547bcfc7729b93bc4de46125f8565
-  category: main
-  optional: false
-- name: nbconvert
-  version: 7.16.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    nbconvert-core: 7.16.2
-    nbconvert-pandoc: 7.16.2
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e14e35cc4a5c90694bb41c5317b576a8
-    sha256: 551bbd14019a1df2f44b7e392f590674f63547bcfc7729b93bc4de46125f8565
-  category: main
-  optional: false
-- name: nbconvert-core
-  version: 7.16.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    beautifulsoup4: ''
-    bleach: ''
-    defusedxml: ''
-    entrypoints: '>=0.2.2'
-    jinja2: '>=3.0'
-    jupyter_core: '>=4.7'
-    jupyterlab_pygments: ''
-    markupsafe: '>=2.0'
-    mistune: '>=2.0.3,<4'
-    nbclient: '>=0.5.0'
-    nbformat: '>=5.1'
-    packaging: ''
-    pandocfilters: '>=1.4.1'
-    pygments: '>=2.4.1'
-    python: '>=3.8'
-    tinycss2: ''
-    traitlets: '>=5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5ab3248dd05c543dc631276455ef6a54
-    sha256: e1fe894114763addc98ef147a78fcd9a518bf97d268394c356b80c572c78c82f
-  category: main
-  optional: false
-- name: nbconvert-core
-  version: 7.16.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    beautifulsoup4: ''
-    bleach: ''
-    defusedxml: ''
-    entrypoints: '>=0.2.2'
-    jinja2: '>=3.0'
-    jupyter_core: '>=4.7'
-    jupyterlab_pygments: ''
-    markupsafe: '>=2.0'
-    mistune: '>=2.0.3,<4'
-    nbclient: '>=0.5.0'
-    nbformat: '>=5.1'
-    packaging: ''
-    pandocfilters: '>=1.4.1'
-    pygments: '>=2.4.1'
-    python: '>=3.8'
-    tinycss2: ''
-    traitlets: '>=5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5ab3248dd05c543dc631276455ef6a54
-    sha256: e1fe894114763addc98ef147a78fcd9a518bf97d268394c356b80c572c78c82f
-  category: main
-  optional: false
-- name: nbconvert-pandoc
-  version: 7.16.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    nbconvert-core: 7.16.2
-    pandoc: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7a0bfebd69213722427cb61b077b4187
-    sha256: 9887eb63dd5131b9bc5a250e29d018b12ad4f3bbfb7ceb59c5923fb405cc36ce
-  category: main
-  optional: false
-- name: nbconvert-pandoc
-  version: 7.16.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    nbconvert-core: 7.16.2
-    pandoc: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7a0bfebd69213722427cb61b077b4187
-    sha256: 9887eb63dd5131b9bc5a250e29d018b12ad4f3bbfb7ceb59c5923fb405cc36ce
-  category: main
-  optional: false
-- name: nbformat
-  version: 5.10.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    jsonschema: '>=2.6'
-    jupyter_core: ''
-    python: '>=3.8'
-    python-fastjsonschema: ''
-    traitlets: '>=5.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: ca3d437c0ef2e87f63d085822c74c49a
-    sha256: 774ba7f0f175851723d9e1524ca5246b431eca1b1e22387b58a80ad0dcd7acd8
-  category: main
-  optional: false
-- name: nbformat
-  version: 5.10.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    jsonschema: '>=2.6'
-    jupyter_core: ''
-    python: '>=3.8'
-    python-fastjsonschema: ''
-    traitlets: '>=5.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: ca3d437c0ef2e87f63d085822c74c49a
-    sha256: 774ba7f0f175851723d9e1524ca5246b431eca1b1e22387b58a80ad0dcd7acd8
-  category: main
-  optional: false
-- name: nccl
-  version: 2.20.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cuda-version: '>=11.8,<12.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nccl-2.20.5.1-h6103f9b_0.conda
-  hash:
-    md5: bedb0b33c5e3e6fbd4dce4f6f07fea72
-    sha256: 0ccf2718580f5cfc173ddc6b073512de24395a316176071288ec97a97e876c22
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.4'
+- name: mysql-common
+  version: 8.0.33
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+    libstdcxx-ng: '>=12'
+    openssl: '>=3.1.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_6.conda
   hash:
-    md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
-    sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
+    md5: 80bf3b277c120dd294b51d404b931a75
+    sha256: c8b2c5c9d0d013a4f6ef96cb4b339bfdc53a74232d8c61ed08178e5b1ec4eb63
   category: main
   optional: false
-- name: ncurses
-  version: '6.4'
+- name: mysql-common
+  version: 8.0.33
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
     __osx: '>=10.9'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
+    libcxx: '>=16.0.6'
+    openssl: '>=3.1.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/mysql-common-8.0.33-h1d20c9b_6.conda
   hash:
-    md5: 52b6f254a7b9663e854f44b6570ed982
-    sha256: f6890634f815e8408d08f36503353f8dfd7b055e4c3b9ea2ee52180255cf4b0a
+    md5: ad07fbd8dc7992e5e004f7bdfdee246d
+    sha256: b6b18aeed435d4075b4aac3559a070a6caa5a174a339e8de87785fca2f8f57a6
+  category: main
+  optional: false
+- name: mysql-libs
+  version: 8.0.33
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    mysql-common: 8.0.33
+    openssl: '>=3.1.4,<4.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_6.conda
+  hash:
+    md5: e87530d1b12dd7f4e0f856dc07358d60
+    sha256: 78c905637dac79b197395065c169d452b8ca2a39773b58e45e23114f1cb6dcdb
+  category: main
+  optional: false
+- name: mysql-libs
+  version: 8.0.33
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    mysql-common: 8.0.33
+    openssl: '>=3.1.4,<4.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/mysql-libs-8.0.33-hed35180_6.conda
+  hash:
+    md5: c27fddc4d3c2d471d1d706b243570f37
+    sha256: 87d754167fddf342b894e377fdcaac096c93c941773267ad9c89bb7b64924a33
+  category: main
+  optional: false
+- name: myst-nb
+  version: 0.17.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    importlib-metadata: ''
+    ipykernel: ''
+    ipython: ''
+    jupyter-cache: '>=0.5.0,<0.7.0'
+    myst-parser: '>=0.18.0,<0.19.0'
+    nbclient: ''
+    nbformat: '>=5.0,<6'
+    python: '>=3.7'
+    pyyaml: ''
+    sphinx: '>=4,<6'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/myst-nb-0.17.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 40190b7d06f86b63d28fa78aaa39c023
+    sha256: 37bcf6de8618a0668ef6b364b14e0eceea87b202a3882c59dcd85bc1172a5402
+  category: main
+  optional: false
+- name: myst-nb
+  version: 0.17.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pyyaml: ''
+    typing_extensions: ''
+    ipython: ''
+    importlib-metadata: ''
+    ipykernel: ''
+    nbclient: ''
+    python: '>=3.7'
+    nbformat: '>=5.0,<6'
+    sphinx: '>=4,<6'
+    myst-parser: '>=0.18.0,<0.19.0'
+    jupyter-cache: '>=0.5.0,<0.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/myst-nb-0.17.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 40190b7d06f86b63d28fa78aaa39c023
+    sha256: 37bcf6de8618a0668ef6b364b14e0eceea87b202a3882c59dcd85bc1172a5402
+  category: main
+  optional: false
+- name: myst-nb
+  version: 0.17.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pyyaml: ''
+    typing_extensions: ''
+    ipython: ''
+    importlib-metadata: ''
+    ipykernel: ''
+    nbclient: ''
+    python: '>=3.7'
+    nbformat: '>=5.0,<6'
+    sphinx: '>=4,<6'
+    myst-parser: '>=0.18.0,<0.19.0'
+    jupyter-cache: '>=0.5.0,<0.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/myst-nb-0.17.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 40190b7d06f86b63d28fa78aaa39c023
+    sha256: 37bcf6de8618a0668ef6b364b14e0eceea87b202a3882c59dcd85bc1172a5402
+  category: main
+  optional: false
+- name: myst-parser
+  version: 0.18.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    docutils: '>=0.15,<0.20'
+    jinja2: ''
+    markdown-it-py: '>=1.0.0,<3.0.0'
+    mdit-py-plugins: '>=0.3.1,<1'
+    python: '>=3.7'
+    pyyaml: ''
+    sphinx: '>=4,<6'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/myst-parser-0.18.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: bcfdf5c7d8bf5c6f6be7b4c66fff2eca
+    sha256: 260812a430adee3598103d75704c1c855a9816a3895971ca0190d0f5e1e8165a
+  category: main
+  optional: false
+- name: myst-parser
+  version: 0.18.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pyyaml: ''
+    typing-extensions: ''
+    jinja2: ''
+    python: '>=3.7'
+    markdown-it-py: '>=1.0.0,<3.0.0'
+    sphinx: '>=4,<6'
+    docutils: '>=0.15,<0.20'
+    mdit-py-plugins: '>=0.3.1,<1'
+  url: https://conda.anaconda.org/conda-forge/noarch/myst-parser-0.18.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: bcfdf5c7d8bf5c6f6be7b4c66fff2eca
+    sha256: 260812a430adee3598103d75704c1c855a9816a3895971ca0190d0f5e1e8165a
+  category: main
+  optional: false
+- name: myst-parser
+  version: 0.18.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pyyaml: ''
+    typing-extensions: ''
+    jinja2: ''
+    python: '>=3.7'
+    markdown-it-py: '>=1.0.0,<3.0.0'
+    sphinx: '>=4,<6'
+    docutils: '>=0.15,<0.20'
+    mdit-py-plugins: '>=0.3.1,<1'
+  url: https://conda.anaconda.org/conda-forge/noarch/myst-parser-0.18.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: bcfdf5c7d8bf5c6f6be7b4c66fff2eca
+    sha256: 260812a430adee3598103d75704c1c855a9816a3895971ca0190d0f5e1e8165a
+  category: main
+  optional: false
+- name: nbclient
+  version: 0.7.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    jupyter_client: '>=6.1.12'
+    jupyter_core: '>=4.12,!=5.0.*'
+    nbformat: '>=5.1'
+    python: '>=3.7'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: f7aa15f77d29b11caa1df1eb15383c59
+    sha256: f26afcbbdd4bd1245db514c6ebc6ef18cc12067145dcab229b6f88653575d44c
+  category: main
+  optional: false
+- name: nbclient
+  version: 0.7.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    jupyter_client: '>=6.1.12'
+    jupyter_core: '>=4.12,!=5.0.*'
+    nbformat: '>=5.1'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: f7aa15f77d29b11caa1df1eb15383c59
+    sha256: f26afcbbdd4bd1245db514c6ebc6ef18cc12067145dcab229b6f88653575d44c
+  category: main
+  optional: false
+- name: nbclient
+  version: 0.7.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+    jupyter_client: '>=6.1.12'
+    jupyter_core: '>=4.12,!=5.0.*'
+    nbformat: '>=5.1'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: f7aa15f77d29b11caa1df1eb15383c59
+    sha256: f26afcbbdd4bd1245db514c6ebc6ef18cc12067145dcab229b6f88653575d44c
+  category: main
+  optional: false
+- name: nbconvert
+  version: 7.16.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    nbconvert-core: 7.16.3
+    nbconvert-pandoc: 7.16.3
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.3-hd8ed1ab_0.conda
+  hash:
+    md5: b0c9bbbe54a11a6db3bec51eb0ef0281
+    sha256: c9bb08085ba1508607cd1ba839a31f1164e3ed15f4e499a490b71721d1df7ec5
+  category: main
+  optional: false
+- name: nbconvert
+  version: 7.16.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    nbconvert-core: 7.16.3
+    nbconvert-pandoc: 7.16.3
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.3-hd8ed1ab_0.conda
+  hash:
+    md5: b0c9bbbe54a11a6db3bec51eb0ef0281
+    sha256: c9bb08085ba1508607cd1ba839a31f1164e3ed15f4e499a490b71721d1df7ec5
+  category: main
+  optional: false
+- name: nbconvert
+  version: 7.16.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    nbconvert-core: 7.16.3
+    nbconvert-pandoc: 7.16.3
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.3-hd8ed1ab_0.conda
+  hash:
+    md5: b0c9bbbe54a11a6db3bec51eb0ef0281
+    sha256: c9bb08085ba1508607cd1ba839a31f1164e3ed15f4e499a490b71721d1df7ec5
+  category: main
+  optional: false
+- name: nbconvert-core
+  version: 7.16.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    beautifulsoup4: ''
+    bleach: ''
+    defusedxml: ''
+    entrypoints: '>=0.2.2'
+    jinja2: '>=3.0'
+    jupyter_core: '>=4.7'
+    jupyterlab_pygments: ''
+    markupsafe: '>=2.0'
+    mistune: '>=2.0.3,<4'
+    nbclient: '>=0.5.0'
+    nbformat: '>=5.1'
+    packaging: ''
+    pandocfilters: '>=1.4.1'
+    pygments: '>=2.4.1'
+    python: '>=3.8'
+    tinycss2: ''
+    traitlets: '>=5.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0cab42b4917e71df9dc2224b9940ef19
+    sha256: 522d28206fbafa634763da1ae9119a9edd141d8c516ed13878f77b67921e1bb5
+  category: main
+  optional: false
+- name: nbconvert-core
+  version: 7.16.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    packaging: ''
+    beautifulsoup4: ''
+    defusedxml: ''
+    bleach: ''
+    tinycss2: ''
+    jupyterlab_pygments: ''
+    python: '>=3.8'
+    jinja2: '>=3.0'
+    entrypoints: '>=0.2.2'
+    markupsafe: '>=2.0'
+    jupyter_core: '>=4.7'
+    traitlets: '>=5.0'
+    pandocfilters: '>=1.4.1'
+    nbformat: '>=5.1'
+    pygments: '>=2.4.1'
+    nbclient: '>=0.5.0'
+    mistune: '>=2.0.3,<4'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0cab42b4917e71df9dc2224b9940ef19
+    sha256: 522d28206fbafa634763da1ae9119a9edd141d8c516ed13878f77b67921e1bb5
+  category: main
+  optional: false
+- name: nbconvert-core
+  version: 7.16.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    packaging: ''
+    beautifulsoup4: ''
+    defusedxml: ''
+    bleach: ''
+    tinycss2: ''
+    jupyterlab_pygments: ''
+    python: '>=3.8'
+    jinja2: '>=3.0'
+    entrypoints: '>=0.2.2'
+    markupsafe: '>=2.0'
+    jupyter_core: '>=4.7'
+    traitlets: '>=5.0'
+    pandocfilters: '>=1.4.1'
+    nbformat: '>=5.1'
+    pygments: '>=2.4.1'
+    nbclient: '>=0.5.0'
+    mistune: '>=2.0.3,<4'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0cab42b4917e71df9dc2224b9940ef19
+    sha256: 522d28206fbafa634763da1ae9119a9edd141d8c516ed13878f77b67921e1bb5
+  category: main
+  optional: false
+- name: nbconvert-pandoc
+  version: 7.16.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    nbconvert-core: 7.16.3
+    pandoc: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.3-hd8ed1ab_0.conda
+  hash:
+    md5: 1344bbd74e8bcd1acdd8ec0824e9840c
+    sha256: d22ef91db4ca9592860168499b4d6e5443eca0176190431321ee78ef9cc977df
+  category: main
+  optional: false
+- name: nbconvert-pandoc
+  version: 7.16.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pandoc: ''
+    nbconvert-core: 7.16.3
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.3-hd8ed1ab_0.conda
+  hash:
+    md5: 1344bbd74e8bcd1acdd8ec0824e9840c
+    sha256: d22ef91db4ca9592860168499b4d6e5443eca0176190431321ee78ef9cc977df
+  category: main
+  optional: false
+- name: nbconvert-pandoc
+  version: 7.16.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pandoc: ''
+    nbconvert-core: 7.16.3
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.3-hd8ed1ab_0.conda
+  hash:
+    md5: 1344bbd74e8bcd1acdd8ec0824e9840c
+    sha256: d22ef91db4ca9592860168499b4d6e5443eca0176190431321ee78ef9cc977df
+  category: main
+  optional: false
+- name: nbformat
+  version: 5.10.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    jsonschema: '>=2.6'
+    jupyter_core: ''
+    python: '>=3.8'
+    python-fastjsonschema: ''
+    traitlets: '>=5.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: ca3d437c0ef2e87f63d085822c74c49a
+    sha256: 774ba7f0f175851723d9e1524ca5246b431eca1b1e22387b58a80ad0dcd7acd8
+  category: main
+  optional: false
+- name: nbformat
+  version: 5.10.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    jupyter_core: ''
+    python-fastjsonschema: ''
+    python: '>=3.8'
+    traitlets: '>=5.1'
+    jsonschema: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: ca3d437c0ef2e87f63d085822c74c49a
+    sha256: 774ba7f0f175851723d9e1524ca5246b431eca1b1e22387b58a80ad0dcd7acd8
+  category: main
+  optional: false
+- name: nbformat
+  version: 5.10.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    jupyter_core: ''
+    python-fastjsonschema: ''
+    python: '>=3.8'
+    traitlets: '>=5.1'
+    jsonschema: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: ca3d437c0ef2e87f63d085822c74c49a
+    sha256: 774ba7f0f175851723d9e1524ca5246b431eca1b1e22387b58a80ad0dcd7acd8
+  category: main
+  optional: false
+- name: ncurses
+  version: 6.4.20240210
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
+  hash:
+    md5: 97da8860a0da5413c7c98a3b3838a645
+    sha256: aa0f005b6727aac6507317ed490f0904430584fa8ca722657e7f0fb94741de81
+  category: main
+  optional: false
+- name: ncurses
+  version: 6.4.20240210
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4.20240210-h73e2aa4_0.conda
+  hash:
+    md5: 50f28c512e9ad78589e3eab34833f762
+    sha256: 50b72acf08acbc4e5332807653e2ca6b26d4326e8af16fad1fd3f2ce9ea55503
+  category: main
+  optional: false
+- name: ncurses
+  version: 6.4.20240210
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4.20240210-h078ce10_0.conda
+  hash:
+    md5: 616ae8691e6608527d0071e6766dcb81
+    sha256: 06f0905791575e2cd3aa961493c56e490b3d82ad9eb49f1c332bd338b0216911
   category: main
   optional: false
 - name: nest-asyncio
   version: 1.6.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6598c056f64dc8800d40add25e4e2c34
+    sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
+  category: main
+  optional: false
+- name: nest-asyncio
+  version: 1.6.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
@@ -10687,6 +16359,18 @@ package:
   version: 3.2.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.2.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 425fce3b531bed6ec3c74fab3e5f0a1c
+    sha256: 7629aa4f9f8cdff45ea7a4701fe58dccce5bf2faa01c26eb44cbb27b7e15ca9d
+  category: main
+  optional: false
+- name: networkx
+  version: 3.2.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.2.1-pyhd8ed1ab_0.conda
@@ -10723,10 +16407,23 @@ package:
 - name: nodeenv
   version: 1.8.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    setuptools: ''
+    python: 2.7|>=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.8.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2a75b296096adabbabadd5e9782e5fcc
+    sha256: 1320306234552717149f36f825ddc7e27ea295f24829e9db4cc6ceaff0b032bd
+  category: main
+  optional: false
+- name: nodeenv
+  version: 1.8.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: 2.7|>=3.7
     setuptools: ''
+    python: 2.7|>=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.8.0-pyhd8ed1ab_0.conda
   hash:
     md5: 2a75b296096adabbabadd5e9782e5fcc
@@ -10764,14 +16461,31 @@ package:
 - name: notebook
   version: 7.1.2
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab: '>=4.1.1,<4.2'
-    jupyterlab_server: '>=2.22.1,<3'
-    notebook-shim: '>=0.2,<0.3'
     python: '>=3.8'
     tornado: '>=6.2.0'
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab_server: '>=2.22.1,<3'
+    notebook-shim: '>=0.2,<0.3'
+    jupyterlab: '>=4.1.1,<4.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.1.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: fa781da51f05c9211b75b5e7bcff8136
+    sha256: ed5987efcf3a394c4ab12288b4fe7d858784aabc591cebf3dabcd1cdbc7b7347
+  category: main
+  optional: false
+- name: notebook
+  version: 7.1.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+    tornado: '>=6.2.0'
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab_server: '>=2.22.1,<3'
+    notebook-shim: '>=0.2,<0.3'
+    jupyterlab: '>=4.1.1,<4.2'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.1.2-pyhd8ed1ab_0.conda
   hash:
     md5: fa781da51f05c9211b75b5e7bcff8136
@@ -10794,10 +16508,23 @@ package:
 - name: notebook-shim
   version: 0.2.4
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    jupyter_server: '>=1.8,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3d85618e2c97ab896b5b5e298d32b5b3
+    sha256: 9b5fdef9ebe89222baa9da2796ebe7bc02ec6c5a1f61327b651d6b92cf9a0230
+  category: main
+  optional: false
+- name: notebook-shim
+  version: 0.2.4
+  manager: conda
   platform: osx-arm64
   dependencies:
-    jupyter_server: '>=1.8,<3'
     python: '>=3.7'
+    jupyter_server: '>=1.8,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
   hash:
     md5: 3d85618e2c97ab896b5b5e298d32b5b3
@@ -10815,6 +16542,18 @@ package:
   hash:
     md5: da0ec11a6454ae19bff5b02ed881a2b1
     sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
+  category: main
+  optional: false
+- name: nspr
+  version: '4.35'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
+  hash:
+    md5: a9e56c98d13d8b7ce72bf4357317c29b
+    sha256: da6e19bd0ff31e219760e647cfe1cc499a8cdfaff305f06c56d495ca062b86de
   category: main
   optional: false
 - name: nspr
@@ -10844,6 +16583,21 @@ package:
   hash:
     md5: 54b56c2fdf973656b748e0378900ec13
     sha256: a9bc94d03df48014011cf6caaf447f2ef86a5edf7c70d70002ec4b59f5a4e198
+  category: main
+  optional: false
+- name: nss
+  version: '3.98'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+    libsqlite: '>=3.45.1,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    nspr: '>=4.35,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.98-ha05da47_0.conda
+  hash:
+    md5: 79d062716d8e1f77cf806c6fe0f4405c
+    sha256: 3d99dd976aeb8678e4ac5fcbd574e1de50cdc57b742e22855f294c8047d5c68e
   category: main
   optional: false
 - name: nss
@@ -10882,6 +16636,23 @@ package:
 - name: numpy
   version: 1.23.5
   manager: conda
+  platform: osx-64
+  dependencies:
+    libblas: '>=3.9.0,<4.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
+    libcxx: '>=14.0.6'
+    liblapack: '>=3.9.0,<4.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.23.5-py39hdfa1d0c_0.conda
+  hash:
+    md5: 162e42439dbb526b1acb08f35546eaa4
+    sha256: 069c2c0a37457a6625269a932c19d83f64857149415b9fe37012ddc17e20b09a
+  category: main
+  optional: false
+- name: numpy
+  version: 1.23.5
+  manager: conda
   platform: osx-arm64
   dependencies:
     libblas: '>=3.9.0,<4.0a0'
@@ -10914,12 +16685,27 @@ package:
 - name: oauthlib
   version: 3.2.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    cryptography: ''
+    blinker: ''
+    python: '>=3.6'
+    pyjwt: '>=1.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.2.2-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 8f882b197fd9c4941a787926baea4868
+    sha256: 0cfd5146a91d3974f4abfc2a45de890371d510a77238fe553e036ec8c031dc5b
+  category: main
+  optional: false
+- name: oauthlib
+  version: 3.2.2
+  manager: conda
   platform: osx-arm64
   dependencies:
-    blinker: ''
     cryptography: ''
-    pyjwt: '>=1.0.0'
+    blinker: ''
     python: '>=3.6'
+    pyjwt: '>=1.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.2.2-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 8f882b197fd9c4941a787926baea4868
@@ -10943,6 +16729,25 @@ package:
   hash:
     md5: b7daae3b7f6ac91b5d5a9c046b7adbdf
     sha256: 83370d694316b40036270969cf8c3cd3bd3340ddcdc72a79cc4208f43a402536
+  category: main
+  optional: false
+- name: onnx
+  version: 1.15.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    numpy: '>=1.22.4,<2.0a0'
+    protobuf: ''
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    typing-extensions: '>=3.6.2.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/onnx-1.15.0-py39h3e801cf_0.conda
+  hash:
+    md5: b6003760e84a6fd1ad3bd66439f839d5
+    sha256: 046ef793b29d2d142c1c4b745939c8fdf0fe97939cc11a317859344340d8f3c8
   category: main
   optional: false
 - name: onnx
@@ -10983,12 +16788,28 @@ package:
 - name: onnxconverter-common
   version: 1.13.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    numpy: ''
+    packaging: ''
+    protobuf: ''
+    onnx: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/onnxconverter-common-1.13.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: a1749e40ac6377dc5b3cde8fe683f5c9
+    sha256: 8320927bbbae5f9dd4ba2abb2c046f9629111ac49ef539f537876a57af54d2ed
+  category: main
+  optional: false
+- name: onnxconverter-common
+  version: 1.13.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     numpy: ''
-    onnx: ''
     packaging: ''
     protobuf: ''
+    onnx: ''
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/onnxconverter-common-1.13.0-pyhd8ed1ab_0.tar.bz2
   hash:
@@ -10997,7 +16818,7 @@ package:
   category: main
   optional: false
 - name: openai
-  version: 1.14.0
+  version: 1.14.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -11009,29 +16830,48 @@ package:
     sniffio: ''
     tqdm: '>4'
     typing-extensions: '>=4.7,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/openai-1.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/openai-1.14.3-pyhd8ed1ab_0.conda
   hash:
-    md5: dbcb7019fbb2d03eee4b4435425097b4
-    sha256: fe302835e25244e987633e2cf8c6e7f38f9d649abdf685e8c5cf6f7a73f0d2a2
+    md5: 0c216c2228d136632cc7e19097f7aaac
+    sha256: 5d919b945556b42ad2d86e0a585ed95353baf1571ab5c95e97f86fe1fa80e138
   category: main
   optional: false
 - name: openai
-  version: 1.14.0
+  version: 1.14.3
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    anyio: '>=3.5.0,<5'
+    sniffio: ''
+    python: '>=3.7.1'
     distro: '>=1.7.0,<2'
     httpx: '>=0.23.0,<1'
     pydantic: '>=1.9.0,<3'
-    python: '>=3.7.1'
-    sniffio: ''
     tqdm: '>4'
+    anyio: '>=3.5.0,<5'
     typing-extensions: '>=4.7,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/openai-1.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/openai-1.14.3-pyhd8ed1ab_0.conda
   hash:
-    md5: dbcb7019fbb2d03eee4b4435425097b4
-    sha256: fe302835e25244e987633e2cf8c6e7f38f9d649abdf685e8c5cf6f7a73f0d2a2
+    md5: 0c216c2228d136632cc7e19097f7aaac
+    sha256: 5d919b945556b42ad2d86e0a585ed95353baf1571ab5c95e97f86fe1fa80e138
+  category: main
+  optional: false
+- name: openai
+  version: 1.14.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    sniffio: ''
+    python: '>=3.7.1'
+    distro: '>=1.7.0,<2'
+    httpx: '>=0.23.0,<1'
+    pydantic: '>=1.9.0,<3'
+    tqdm: '>4'
+    anyio: '>=3.5.0,<5'
+    typing-extensions: '>=4.7,<5'
+  url: https://conda.anaconda.org/conda-forge/noarch/openai-1.14.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0c216c2228d136632cc7e19097f7aaac
+    sha256: 5d919b945556b42ad2d86e0a585ed95353baf1571ab5c95e97f86fe1fa80e138
   category: main
   optional: false
 - name: openjpeg
@@ -11048,6 +16888,21 @@ package:
   hash:
     md5: 7f2e286780f072ed750df46dc2631138
     sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+  category: main
+  optional: false
+- name: openjpeg
+  version: 2.5.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+  hash:
+    md5: 05a14cc9d725dd74995927968d6547e3
+    sha256: dc9c405119b9b54f8ca5984da27ba498bd848ab4f0f580da6f293009ca5adc13
   category: main
   optional: false
 - name: openjpeg
@@ -11072,10 +16927,22 @@ package:
   dependencies:
     ca-certificates: ''
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
   hash:
-    md5: 51a753e64a3027bd7e23a189b1f6e91e
-    sha256: c02c12bdb898daacf7eb3d09859f93ea8f285fd1a6132ff6ff0493ab52c7fe57
+    md5: 9d731343cff6ee2e5a25c4a091bf8e2a
+    sha256: 2c689444ed19a603be457284cf2115ee728a3fafb7527326e96054dee7cdc1a7
+  category: main
+  optional: false
+- name: openssl
+  version: 3.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_1.conda
+  hash:
+    md5: 570a6f04802df580be529f3a72d2bbf7
+    sha256: 7ae0ac6a1673584a8a380c2ff3d46eca48ed53bc7174c0d4eaa0dd2f247a0984
   category: main
   optional: false
 - name: openssl
@@ -11084,16 +16951,29 @@ package:
   platform: osx-arm64
   dependencies:
     ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda
   hash:
-    md5: 421cc6e8715447b73c2c57dcf78cb9d2
-    sha256: 13663fcd4abc8681b31ccbad39800fee2127cb6159b51a989ed48a816af36cf5
+    md5: eb580fb888d93d5d550c557323ac5cee
+    sha256: 519dc941d7ab0ebf31a2878d85c2f444450e7c5f6f41c4d07252c6bb3417b78b
   category: main
   optional: false
 - name: opt_einsum
   version: 3.3.0
   manager: conda
   platform: linux-64
+  dependencies:
+    numpy: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.3.0-pyhc1e730c_2.conda
+  hash:
+    md5: 7a94ac68b892daa9f17ae8a52b31ed81
+    sha256: 1995657f10e23dbe534219f754c66b7fb2a805d68a3385abdacb7807a915b0c3
+  category: main
+  optional: false
+- name: opt_einsum
+  version: 3.3.0
+  manager: conda
+  platform: osx-64
   dependencies:
     numpy: ''
     python: '>=3.6'
@@ -11137,6 +17017,24 @@ package:
 - name: orc
   version: 1.9.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    snappy: '>=1.1.10,<2.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.2-h9ab30d4_0.conda
+  hash:
+    md5: 8fb76f7b135aec885cfe47c52b2eb4b5
+    sha256: a948db80c0b756db07abce1972d6b8d1a08a7ced5a687b02435348c81443de08
+  category: main
+  optional: false
+- name: orc
+  version: 1.9.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=10.9'
@@ -11168,10 +17066,23 @@ package:
 - name: overrides
   version: 7.7.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    typing_utils: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+    sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
+  category: main
+  optional: false
+- name: overrides
+  version: 7.7.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
     typing_utils: ''
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
   hash:
     md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
@@ -11182,6 +17093,18 @@ package:
   version: '23.2'
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 79002079284aa895f883c6b7f3f88fd6
+    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+  category: main
+  optional: false
+- name: packaging
+  version: '23.2'
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
@@ -11224,6 +17147,24 @@ package:
 - name: pandas
   version: 2.2.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+    numpy: '>=1.22.4,<2.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python-dateutil: '>=2.8.1'
+    python-tzdata: '>=2022a'
+    python_abi: 3.9.*
+    pytz: '>=2020.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.1-py39haf03413_0.conda
+  hash:
+    md5: d29dc35b665029951dae988810f84508
+    sha256: f6651dbf55da899a4e2590c910bee764b6f3ead78eb5e35e104ccaeb884f9fc7
+  category: main
+  optional: false
+- name: pandas
+  version: 2.2.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=16'
@@ -11254,6 +17195,18 @@ package:
 - name: pandera
   version: 0.18.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    pandera-base: '>=0.18.3,<0.18.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pandera-0.18.3-hd8ed1ab_0.conda
+  hash:
+    md5: a8e2857c67ded4b6d0ab6fabbb9ec065
+    sha256: 80daf30527d62c5694a89ae551be4aff40d7a82c9d25b73ea6b6e24309a5a50d
+  category: main
+  optional: false
+- name: pandera
+  version: 0.18.3
+  manager: conda
   platform: osx-arm64
   dependencies:
     pandera-base: '>=0.18.3,<0.18.4.0a0'
@@ -11286,17 +17239,37 @@ package:
 - name: pandera-base
   version: 0.18.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    pydantic: ''
+    wrapt: ''
+    python: '>=3.8'
+    packaging: '>=20.0'
+    numpy: '>=1.19.0'
+    pandas: '>=1.2.0'
+    typing_inspect: '>=0.6.0'
+    typeguard: '>=3.0.2'
+    multimethod: <=1.10.0
+  url: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.18.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: e96ee36cbebac49688a927b3b74c38ed
+    sha256: 00b0994260df53f85077e478ba6dbdbc227f62c4e077ec6a7906722e91df223f
+  category: main
+  optional: false
+- name: pandera-base
+  version: 0.18.3
+  manager: conda
   platform: osx-arm64
   dependencies:
-    multimethod: <=1.10.0
-    numpy: '>=1.19.0'
-    packaging: '>=20.0'
-    pandas: '>=1.2.0'
     pydantic: ''
-    python: '>=3.8'
-    typeguard: '>=3.0.2'
-    typing_inspect: '>=0.6.0'
     wrapt: ''
+    python: '>=3.8'
+    packaging: '>=20.0'
+    numpy: '>=1.19.0'
+    pandas: '>=1.2.0'
+    typing_inspect: '>=0.6.0'
+    typeguard: '>=3.0.2'
+    multimethod: <=1.10.0
   url: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.18.3-pyhd8ed1ab_0.conda
   hash:
     md5: e96ee36cbebac49688a927b3b74c38ed
@@ -11317,6 +17290,17 @@ package:
 - name: pandoc
   version: 3.1.12.3
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/pandoc-3.1.12.3-h694c41f_0.conda
+  hash:
+    md5: dbd54d0b1e33c2c2713ca41fb32c51f6
+    sha256: a1b36cfe362fd70ebb2ce7afa0ba6e5ccadfbb6a805bc0132f1642f151af080e
+  category: main
+  optional: false
+- name: pandoc
+  version: 3.1.12.3
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/pandoc-3.1.12.3-hce30654_0.conda
@@ -11329,6 +17313,18 @@ package:
   version: 1.5.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '!=3.0,!=3.1,!=3.2,!=3.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 457c2c8c08e54905d6954e79cb5b5db9
+    sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  category: main
+  optional: false
+- name: pandocfilters
+  version: 1.5.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '!=3.0,!=3.1,!=3.2,!=3.3'
   url: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
@@ -11367,6 +17363,25 @@ package:
   hash:
     md5: 5c0cc002bf4eaa56448b0729efd6e96c
     sha256: 53d3442fb39eb9f0ac36646769469f2f825afaeda984719002460efd7c3d354f
+  category: main
+  optional: false
+- name: pango
+  version: 1.52.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    fribidi: '>=1.0.10,<2.0a0'
+    harfbuzz: '>=8.3.0,<9.0a0'
+    libglib: '>=2.78.4,<3.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pango-1.52.1-h7f2093b_0.conda
+  hash:
+    md5: 5525033b1743273720d851e430b3eaed
+    sha256: 93ccddbcd2845bdbb5bc65ef3c7039170f1ccb4a1c21fa062986b82665ec513b
   category: main
   optional: false
 - name: pango
@@ -11413,19 +17428,41 @@ package:
 - name: papermill
   version: 2.5.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    requests: ''
+    pyyaml: ''
+    click: ''
+    black: ''
+    entrypoints: ''
+    tenacity: ''
+    ansiwrap: ''
+    python: '>=3.7'
+    nbformat: '>=5.1.2'
+    tqdm: '>=4.32.2'
+    nbclient: '>=0.2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/papermill-2.5.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: e6e69b90afd3d0597da8f1f74cc4bd58
+    sha256: c9896ec2358bf9da079ce34b986d8843ecf75f840d2d719f430b665cfa674a59
+  category: main
+  optional: false
+- name: papermill
+  version: 2.5.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    ansiwrap: ''
-    black: ''
-    click: ''
-    entrypoints: ''
-    nbclient: '>=0.2.0'
-    nbformat: '>=5.1.2'
-    python: '>=3.7'
-    pyyaml: ''
     requests: ''
+    pyyaml: ''
+    click: ''
+    black: ''
+    entrypoints: ''
     tenacity: ''
+    ansiwrap: ''
+    python: '>=3.7'
+    nbformat: '>=5.1.2'
     tqdm: '>=4.32.2'
+    nbclient: '>=0.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/papermill-2.5.0-pyhd8ed1ab_0.conda
   hash:
     md5: e6e69b90afd3d0597da8f1f74cc4bd58
@@ -11450,12 +17487,27 @@ package:
 - name: paramiko
   version: 3.4.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    cryptography: '>=3.3'
+    bcrypt: '>=3.2'
+    pynacl: '>=1.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a5e792523b028b06d7ce6e65a6cd4a33
+    sha256: 2e66359261954a79b66858c30e69ea6dd4380bf8bd733940527386b25e31dd13
+  category: main
+  optional: false
+- name: paramiko
+  version: 3.4.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    bcrypt: '>=3.2'
-    cryptography: '>=3.3'
-    pynacl: '>=1.5'
     python: '>=3.6'
+    cryptography: '>=3.3'
+    bcrypt: '>=3.2'
+    pynacl: '>=1.5'
   url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: a5e792523b028b06d7ce6e65a6cd4a33
@@ -11477,6 +17529,18 @@ package:
 - name: parso
   version: 0.8.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 17a565a0c3899244e938cdf417e7b094
+    sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+  category: main
+  optional: false
+- name: parso
+  version: 0.8.3
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
@@ -11503,11 +17567,25 @@ package:
 - name: partd
   version: 1.4.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    toolz: ''
     locket: ''
     python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: acf4b7c0bcd5fa3b0e05801c4d2accd6
+    sha256: b248238da2bb9dfe98e680af911dc7013af86095e3ec8baf08905555632d34c7
+  category: main
+  optional: false
+- name: partd
+  version: 1.4.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     toolz: ''
+    locket: ''
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
   hash:
     md5: acf4b7c0bcd5fa3b0e05801c4d2accd6
@@ -11518,6 +17596,18 @@ package:
   version: 0.12.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 17064acba08d3686f1135b5ec1b32b12
+    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
+  category: main
+  optional: false
+- name: pathspec
+  version: 0.12.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
@@ -11554,6 +17644,18 @@ package:
 - name: pcre
   version: '8.45'
   manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=11.1.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pcre-8.45-he49afe7_0.tar.bz2
+  hash:
+    md5: 0526850419e04ac003bc0b65a78dc4cc
+    sha256: 8002279cf4084fbf219f137c2bdef2825d076a5a57a14d1d922d7c5fa7872a5c
+  category: main
+  optional: false
+- name: pcre
+  version: '8.45'
+  manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=11.1.0'
@@ -11575,6 +17677,19 @@ package:
   hash:
     md5: 679c8961826aa4b50653bce17ee52abe
     sha256: 3ca54ff0abcda964af7d4724d389ae20d931159ae1881cfe57ad4b0ab9e6a380
+  category: main
+  optional: false
+- name: pcre2
+  version: '10.42'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.42-h0ad2156_0.conda
+  hash:
+    md5: 41de8bab2d5e5cd6daaba1896e81d366
+    sha256: 689559d94b64914e503d2ced53b78afc19562ed1ccfb284040797a6d41bb564c
   category: main
   optional: false
 - name: pcre2
@@ -11606,10 +17721,23 @@ package:
 - name: pexpect
   version: 4.9.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    ptyprocess: '>=0.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 629f3203c99b32e0988910c93e77f3b6
+    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  category: main
+  optional: false
+- name: pexpect
+  version: 4.9.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    ptyprocess: '>=0.5'
     python: '>=3.7'
+    ptyprocess: '>=0.5'
   url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
   hash:
     md5: 629f3203c99b32e0988910c93e77f3b6
@@ -11621,11 +17749,25 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pickleshare-0.7.5-py39hde42818_1002.tar.bz2
   hash:
-    md5: 415f0ebb6198cc2801c73438a9fb5761
-    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+    md5: 2dc9995512c80256532250a6fd616b14
+    sha256: f3864a023507cda727997bcdf17baf404c98342a4dea6eb834b5e1fc9bdc388b
+  category: main
+  optional: false
+- name: pickleshare
+  version: 0.7.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pickleshare-0.7.5-py39hde42818_1002.tar.bz2
+  hash:
+    md5: ea16ea8f9953518f231b76ca97acea9a
+    sha256: eb2f1ef2bed9ed433e5992c4b875ed3894acddf79b40ee29af768e902348cca7
   category: main
   optional: false
 - name: pickleshare
@@ -11661,6 +17803,28 @@ package:
   hash:
     md5: 2972754dc054bb079d1d121918b5126f
     sha256: 6936d54f9830ac66bee7b26187eb2297d80febe110e978cd9ae6a54e62ec6aaf
+  category: main
+  optional: false
+- name: pillow
+  version: 10.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    freetype: '>=2.12.1,<3.0a0'
+    lcms2: '>=2.16,<3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libxcb: '>=1.15,<1.16.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openjpeg: '>=2.5.0,<3.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    tk: '>=8.6.13,<8.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.2.0-py39hdd30358_0.conda
+  hash:
+    md5: 38aef4e0b3355d32485cd4a199296a5b
+    sha256: 70d5e8c36b1ac538d212816474594cf87aaa0c2e8f98308e952357df1b6b1c4f
   category: main
   optional: false
 - name: pillow
@@ -11702,11 +17866,25 @@ package:
 - name: pip
   version: '24.0'
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    python: '>=3.7'
     setuptools: ''
     wheel: ''
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: f586ac1e56c8638b64f9c8122a7b8a67
+    sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
+  category: main
+  optional: false
+- name: pip
+  version: '24.0'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    setuptools: ''
+    wheel: ''
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
   hash:
     md5: f586ac1e56c8638b64f9c8122a7b8a67
@@ -11724,6 +17902,18 @@ package:
   hash:
     md5: 71004cbf7924e19c02746ccde9fd7123
     sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
+  category: main
+  optional: false
+- name: pixman
+  version: 0.43.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
+  hash:
+    md5: cb134c1e03fd32f4e6bea3f6de2614fd
+    sha256: 3ab44e12e566c67a6e9fd831f557ab195456aa996b8dd9af19787ca80caa5cd1
   category: main
   optional: false
 - name: pixman
@@ -11753,6 +17943,18 @@ package:
 - name: pkgutil-resolve-name
   version: 1.3.10
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+  hash:
+    md5: 405678b942f2481cecdb3e010f4925d9
+    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
+  category: main
+  optional: false
+- name: pkgutil-resolve-name
+  version: 1.3.10
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
@@ -11778,6 +17980,19 @@ package:
 - name: platformdirs
   version: 3.11.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    typing-extensions: '>=4.6.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 8f567c0a74aa44cf732f15773b4083b0
+    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+  category: main
+  optional: false
+- name: platformdirs
+  version: 3.11.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -11805,6 +18020,20 @@ package:
 - name: plotly
   version: 5.19.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    packaging: ''
+    python: '>=3.6'
+    tenacity: '>=6.2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/plotly-5.19.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 669cd7065794633b9e64e6a9612ec700
+    sha256: fa9ae81e1f304f1480378ea25d559748e061c5b8d55b3ade433c3bc483dbae9e
+  category: main
+  optional: false
+- name: plotly
+  version: 5.19.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     packaging: ''
@@ -11816,8 +18045,32 @@ package:
     sha256: fa9ae81e1f304f1480378ea25d559748e061c5b8d55b3ade433c3bc483dbae9e
   category: main
   optional: false
+- name: ply
+  version: '3.11'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-py_1.tar.bz2
+  hash:
+    md5: 7205635cd71531943440fbfe3b6b5727
+    sha256: 2cd6fae8f9cbc806b7f828f006ae4a83c23fac917cacfd73c37ce322d4324e53
+  category: main
+  optional: false
+- name: ply
+  version: '3.11'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-py_1.tar.bz2
+  hash:
+    md5: 7205635cd71531943440fbfe3b6b5727
+    sha256: 2cd6fae8f9cbc806b7f828f006ae4a83c23fac917cacfd73c37ce322d4324e53
+  category: main
+  optional: false
 - name: polars
-  version: 0.20.15
+  version: 0.20.17
   manager: conda
   platform: linux-64
   dependencies:
@@ -11826,14 +18079,29 @@ package:
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.*
     typing_extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/polars-0.20.15-py39h87fa3cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/polars-0.20.17-py39h87fa3cb_0.conda
   hash:
-    md5: fd5fb1c8bf319ea2edc3feede63f88e1
-    sha256: 97dbca690a6805c4483115dfb57b998da3506b42c6cb9669eb9fa73f7e39788e
+    md5: 6a2ac5515e8f4b5aff4e41e60c514532
+    sha256: afc4aac478c7b60c1214a58e4175cd2299330e70512de3c28af18b713d101e68
   category: main
   optional: false
 - name: polars
-  version: 0.20.15
+  version: 0.20.17
+  manager: conda
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.16.0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    typing_extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/polars-0.20.17-py39hcc1e243_0.conda
+  hash:
+    md5: 2cadbd83308ee0e78b62e4707b880309
+    sha256: 3a2f9581d7ba400c003cf6b73cd3f14c2b37f8f09c2a30d413129127145a204f
+  category: main
+  optional: false
+- name: polars
+  version: 0.20.17
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -11841,10 +18109,10 @@ package:
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.*
     typing_extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/polars-0.20.15-py39h08ca3d8_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/polars-0.20.17-py39h08ca3d8_0.conda
   hash:
-    md5: bc4b06d948d57003cd5f482e77856ca0
-    sha256: 34e841ad27b077f7cf93e6da1be05e2519da1eec12b7791f729503122f206cb4
+    md5: c544345111324210efaed43f9f5bb266
+    sha256: cdbe8f41dda3e5a8cac19a2a11295f7ee24cb30ffc7bf05e18a53c2b5162ceee
   category: main
   optional: false
 - name: poppler
@@ -11874,6 +18142,35 @@ package:
   hash:
     md5: 7e715c1572de09d6106c5a31fa70ffca
     sha256: 55bb2deb67c76bd9f5592bf9765cc879cf11e555c4f8879292cbd5544e88887e
+  category: main
+  optional: false
+- name: poppler
+  version: 24.02.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    gettext: '>=0.21.1,<1.0a0'
+    lcms2: '>=2.16,<3.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=16'
+    libglib: '>=2.78.3,<3.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.42,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    nspr: '>=4.35,<5.0a0'
+    nss: '>=3.97,<4.0a0'
+    openjpeg: '>=2.5.0,<3.0a0'
+    poppler-data: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.02.0-h0c752f9_0.conda
+  hash:
+    md5: 064e1d83d148b0ff5fa9ddd21141d0b1
+    sha256: 54400c2961eca96f14ecbb9ccdac457ef7f86ee6741e38aa71db47eee22b76b6
   category: main
   optional: false
 - name: poppler
@@ -11919,6 +18216,17 @@ package:
 - name: poppler-data
   version: 0.4.12
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+  hash:
+    md5: d8d7293c5b37f39b2ac32940621c6592
+    sha256: 2f227e17b3c0346112815faa605502b66c1c4511a856127f2899abf15a98a2cf
+  category: main
+  optional: false
+- name: poppler-data
+  version: 0.4.12
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
@@ -11943,6 +18251,19 @@ package:
 - name: portalocker
   version: 2.8.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/portalocker-2.8.2-py39h6e9494a_1.conda
+  hash:
+    md5: f13186cc46a4593ffce2f29e4f0fbebf
+    sha256: 6f3611666a1beeda9c0d1e5a652e2879dcf7c7e6416dbbae03c62f5ecf79b7ac
+  category: main
+  optional: false
+- name: portalocker
+  version: 2.8.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -11961,16 +18282,35 @@ package:
     krb5: '>=1.21.2,<1.22.0a0'
     libgcc-ng: '>=12'
     libpq: '16.2'
-    libxml2: '>=2.12.5,<3.0a0'
+    libxml2: '>=2.12.6,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tzcode: ''
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.2-h7387d8b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.2-h82ecc9d_1.conda
   hash:
-    md5: 4e86738066b4966f0357f661b3691cae
-    sha256: 5b4fcfbd51957bb51fb1d2d28c3e9d8f4a50be0ac1be9c40083b1e9a39df7f3d
+    md5: 7a5806219d0f77ce8393375d040df065
+    sha256: 7fc52e69478973f173f055ade6c4087564362be9172c294b493a79671fef9a7e
+  category: main
+  optional: false
+- name: postgresql
+  version: '16.2'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    krb5: '>=1.21.2,<1.22.0a0'
+    libpq: '16.2'
+    libxml2: '>=2.12.6,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    readline: '>=8.2,<9.0a0'
+    tzcode: ''
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.2-h06f2bd8_1.conda
+  hash:
+    md5: fe36c4a9254176dde4ca696016c50aa8
+    sha256: 2a96af8385c51e97950ed00d802186069bf4933b3be111956508ab6be158d463
   category: main
   optional: false
 - name: postgresql
@@ -11980,20 +18320,20 @@ package:
   dependencies:
     krb5: '>=1.21.2,<1.22.0a0'
     libpq: '16.2'
-    libxml2: '>=2.12.5,<3.0a0'
+    libxml2: '>=2.12.6,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tzcode: ''
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/postgresql-16.2-h1d0603d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/postgresql-16.2-hf829917_1.conda
   hash:
-    md5: 29f3fd38f23da95692ab11af12fdb6da
-    sha256: 01b5bb78c909778fefca380bb808044850adba2972cd92f8fe6ead122a34fc45
+    md5: a80492a97dc9c6f05b4181b8ab4dfb14
+    sha256: cfc337097f145a3e527c45b2ab40663421480acc225c3eb997459a80e5e1f9ae
   category: main
   optional: false
 - name: pre-commit
-  version: 3.6.2
+  version: 3.7.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -12003,33 +18343,63 @@ package:
     python: '>=3.9'
     pyyaml: '>=5.1'
     virtualenv: '>=20.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.6.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.0-pyha770c72_0.conda
   hash:
-    md5: 61534ee57ffdf26d7b1b514d33daccc4
-    sha256: 8eb9f5965c37d2bbee9302e16cc7c5517ee06491986356112be13431a043681e
+    md5: 846ba0877cda9c4f11e13720cacd1968
+    sha256: b7a1d56fb1374df77019521bbcbe109ff17337181c4d392918e5ec1a10a9df87
   category: main
   optional: false
 - name: pre-commit
-  version: 3.6.2
+  version: 3.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    pyyaml: '>=5.1'
+    identify: '>=1.0.0'
+    nodeenv: '>=0.11.1'
+    cfgv: '>=2.0.0'
+    virtualenv: '>=20.10.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.0-pyha770c72_0.conda
+  hash:
+    md5: 846ba0877cda9c4f11e13720cacd1968
+    sha256: b7a1d56fb1374df77019521bbcbe109ff17337181c4d392918e5ec1a10a9df87
+  category: main
+  optional: false
+- name: pre-commit
+  version: 3.7.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    cfgv: '>=2.0.0'
-    identify: '>=1.0.0'
-    nodeenv: '>=0.11.1'
     python: '>=3.9'
     pyyaml: '>=5.1'
+    identify: '>=1.0.0'
+    nodeenv: '>=0.11.1'
+    cfgv: '>=2.0.0'
     virtualenv: '>=20.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.6.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.0-pyha770c72_0.conda
   hash:
-    md5: 61534ee57ffdf26d7b1b514d33daccc4
-    sha256: 8eb9f5965c37d2bbee9302e16cc7c5517ee06491986356112be13431a043681e
+    md5: 846ba0877cda9c4f11e13720cacd1968
+    sha256: b7a1d56fb1374df77019521bbcbe109ff17337181c4d392918e5ec1a10a9df87
   category: main
   optional: false
 - name: progressbar2
   version: 4.4.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+    python-utils: '>=3.8.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/progressbar2-4.4.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: aca82be28a1c676a3e0365e83892f412
+    sha256: 3661ceb2d69fa43cfba498486aee45e7f69e3a83c27430ca8aa21b27e5686d09
+  category: main
+  optional: false
+- name: progressbar2
+  version: 4.4.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
     python-utils: '>=3.8.1'
@@ -12072,6 +18442,23 @@ package:
 - name: proj
   version: 9.3.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcurl: '>=8.4.0,<9.0a0'
+    libcxx: '>=16.0.6'
+    libsqlite: '>=3.44.2,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    sqlite: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/proj-9.3.1-h81faed2_0.conda
+  hash:
+    md5: 3940ef505861767d26659645f9ec0460
+    sha256: 51bc021e25c88a12151d6ab4d3e956e72ea21d2684315f6ea99ee699aaefc1ea
+  category: main
+  optional: false
+- name: proj
+  version: 9.3.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=10.9'
@@ -12101,6 +18488,18 @@ package:
 - name: prometheus_client
   version: 0.20.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9a19b94034dd3abb2b348c8b93388035
+    sha256: 757cd91d01c2e0b64fadf6bc9a11f558cf7638d897dfbaf7415ddf324d5405c9
+  category: main
+  optional: false
+- name: prometheus_client
+  version: 0.20.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
@@ -12127,6 +18526,20 @@ package:
 - name: prometheus_flask_exporter
   version: 0.23.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    flask: ''
+    prometheus_client: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_flask_exporter-0.23.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: bff3dd780880d653865a542dc13741ed
+    sha256: 6601b7520b3c18d07d2ef8086377c1af8ef85fcbd9122d786a69494585b31235
+  category: main
+  optional: false
+- name: prometheus_flask_exporter
+  version: 0.23.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     flask: ''
@@ -12154,10 +18567,23 @@ package:
 - name: prompt-toolkit
   version: 3.0.42
   manager: conda
+  platform: osx-64
+  dependencies:
+    wcwidth: ''
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
+  hash:
+    md5: 0bf64bf10eee21f46ac83c161917fa86
+    sha256: 58525b2a9305fb154b2b0d43a48b9a6495441b80e4fbea44f2a34a597d2cef16
+  category: main
+  optional: false
+- name: prompt-toolkit
+  version: 3.0.42
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     wcwidth: ''
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
   hash:
     md5: 0bf64bf10eee21f46ac83c161917fa86
@@ -12168,6 +18594,18 @@ package:
   version: 3.0.42
   manager: conda
   platform: linux-64
+  dependencies:
+    prompt-toolkit: '>=3.0.42,<3.0.43.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.42-hd8ed1ab_0.conda
+  hash:
+    md5: 85a2189ecd2fcdd86e92b2d4ea8fe461
+    sha256: fd2185d501bf34cb4c121f2f5ade9157ac75e1644a9da81355c4c8f9c1b82d4d
+  category: main
+  optional: false
+- name: prompt_toolkit
+  version: 3.0.42
+  manager: conda
+  platform: osx-64
   dependencies:
     prompt-toolkit: '>=3.0.42,<3.0.43.0a0'
   url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.42-hd8ed1ab_0.conda
@@ -12204,10 +18642,23 @@ package:
 - name: proto-plus
   version: 1.23.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    protobuf: '>=3.19.0,<5.0.0dev'
+  url: https://conda.anaconda.org/conda-forge/noarch/proto-plus-1.23.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 26c043ffe1c027eaed894d70ea04a18d
+    sha256: 2c9ca8233672032fb372792b1e4c2a556205e631dc375c2c606eab478f32349d
+  category: main
+  optional: false
+- name: proto-plus
+  version: 1.23.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    protobuf: '>=3.19.0,<5.0.0dev'
     python: '>=3.6'
+    protobuf: '>=3.19.0,<5.0.0dev'
   url: https://conda.anaconda.org/conda-forge/noarch/proto-plus-1.23.0-pyhd8ed1ab_0.conda
   hash:
     md5: 26c043ffe1c027eaed894d70ea04a18d
@@ -12230,6 +18681,24 @@ package:
   hash:
     md5: c25d58de8c0408f157ce2937bf6d2043
     sha256: 191a019f70fa8819842a93e6e1d4a371c3e3926740a47c51a6b840d95a61f601
+  category: main
+  optional: false
+- name: protobuf
+  version: 4.24.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcxx: '>=16.0.6'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/protobuf-4.24.4-py39h31269fc_0.conda
+  hash:
+    md5: 4f6b85a78cb55f8bf9b19f2943c981b7
+    sha256: 9adf770eaff4b547e5adf27cf5cc890675cb83b27043fb7569c53932be571e93
   category: main
   optional: false
 - name: protobuf
@@ -12267,11 +18736,25 @@ package:
 - name: protoc-gen-openapiv2
   version: 0.0.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    googleapis-common-protos: ''
+    python: '>=3.6'
+    protobuf: '>=4.21.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/protoc-gen-openapiv2-0.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7a0af408c81dccfc5a420fb1f27c9064
+    sha256: a6b561d1d09f4d88e256efc10cc6065866acf53efd32d03509a5b8c0aed40f3e
+  category: main
+  optional: false
+- name: protoc-gen-openapiv2
+  version: 0.0.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     googleapis-common-protos: ''
-    protobuf: '>=4.21.0'
     python: '>=3.6'
+    protobuf: '>=4.21.0'
   url: https://conda.anaconda.org/conda-forge/noarch/protoc-gen-openapiv2-0.0.1-pyhd8ed1ab_0.conda
   hash:
     md5: 7a0af408c81dccfc5a420fb1f27c9064
@@ -12290,6 +18773,19 @@ package:
   hash:
     md5: ec86403fde8793ac1c36f8afa3d15902
     sha256: d0fa2b24b7245483208014e3567ef3aeeb3242b77ba1002c46923a60a3a05c3b
+  category: main
+  optional: false
+- name: psutil
+  version: 5.9.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.8-py39ha09f3b3_0.conda
+  hash:
+    md5: e8737c3c0c404559b0e2c8a9eb91e977
+    sha256: 944c585e1496e22c6457a202127a49f93c81f9b02df46f75200c0fd315a00abb
   category: main
   optional: false
 - name: psutil
@@ -12323,6 +18819,21 @@ package:
 - name: psycopg2
   version: 2.9.9
   manager: conda
+  platform: osx-64
+  dependencies:
+    libpq: '>=16.1,<17.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/psycopg2-2.9.9-py39h41b6f7b_0.conda
+  hash:
+    md5: a24bc3feec4620aeb36d60e5d2773adc
+    sha256: 1eda217b6664773634a1b760b9f13e56280c1159f9a016eb23eb93d421be5c66
+  category: main
+  optional: false
+- name: psycopg2
+  version: 2.9.9
+  manager: conda
   platform: osx-arm64
   dependencies:
     libpq: '>=16.1,<17.0a0'
@@ -12351,10 +18862,23 @@ package:
 - name: psycopg2-binary
   version: 2.9.9
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    psycopg2: '>=2.9.9,<2.9.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/psycopg2-binary-2.9.9-pyhd8ed1ab_0.conda
+  hash:
+    md5: c15b2ec0570f8988819eea58286dbc19
+    sha256: bb6184a3de8a6fddaed9104539ada9ac7c5e2bd900284ccf96ef5e4e285e75db
+  category: main
+  optional: false
+- name: psycopg2-binary
+  version: 2.9.9
+  manager: conda
   platform: osx-arm64
   dependencies:
-    psycopg2: '>=2.9.9,<2.9.10.0a0'
     python: '>=3.6'
+    psycopg2: '>=2.9.9,<2.9.10.0a0'
   url: https://conda.anaconda.org/conda-forge/noarch/psycopg2-binary-2.9.9-pyhd8ed1ab_0.conda
   hash:
     md5: c15b2ec0570f8988819eea58286dbc19
@@ -12371,6 +18895,17 @@ package:
   hash:
     md5: 22dad4df6e8630e8dff2428f6f6a7036
     sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+  category: main
+  optional: false
+- name: pthread-stubs
+  version: '0.4'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+  hash:
+    md5: addd19059de62181cd11ae8f4ef26084
+    sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
   category: main
   optional: false
 - name: pthread-stubs
@@ -12399,6 +18934,18 @@ package:
 - name: ptyprocess
   version: 0.7.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 359eeb6536da0e687af562ed265ec263
+    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  category: main
+  optional: false
+- name: ptyprocess
+  version: 0.7.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
@@ -12408,10 +18955,38 @@ package:
     sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
   category: main
   optional: false
+- name: pulseaudio-client
+  version: '16.1'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    dbus: '>=1.13.6,<2.0a0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.76.4,<3.0a0'
+    libsndfile: '>=1.2.2,<1.3.0a0'
+    libsystemd0: '>=254'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-16.1-hb77b528_5.conda
+  hash:
+    md5: ac902ff3c1c6d750dd0dfc93a974ab74
+    sha256: 9981c70893d95c8cac02e7edd1a9af87f2c8745b772d529f08b7f9dafbe98606
+  category: main
+  optional: false
 - name: pure_eval
   version: 0.2.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 6784285c7e55cb7212efabc79e4c2883
+    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+  category: main
+  optional: false
+- name: pure_eval
+  version: 0.2.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
@@ -12436,6 +19011,18 @@ package:
   version: 0.10.9.7
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/py4j-0.10.9.7-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 0f01a52cf858aef86632a8ab08011c0c
+    sha256: 5a1d134f58dbc2c77b7985069a5485fe4aa09d49f1b545087913af62559ff738
+  category: main
+  optional: false
+- name: py4j
+  version: 0.10.9.7
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/py4j-0.10.9.7-pyhd8ed1ab_0.tar.bz2
@@ -12476,6 +19063,22 @@ package:
 - name: pyarrow
   version: 13.0.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libarrow: 13.0.0
+    libcxx: '>=14'
+    numpy: '>=1.22.4,<2.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-13.0.0-py39h8632116_23_cpu.conda
+  hash:
+    md5: b49feea876499e9169549f9e522029b8
+    sha256: 1f9918533e6190210048b935709727c0f1a673b5db5c7c685e813873218ed39d
+  category: main
+  optional: false
+- name: pyarrow
+  version: 13.0.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libarrow: 13.0.0
@@ -12505,10 +19108,23 @@ package:
 - name: pyarrow-hotfix
   version: '0.6'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+    pyarrow: '>=0.14'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: ccc06e6ef2064ae129fab3286299abda
+    sha256: 9b767969d059c106aac6596438a7e7ebd3aa1e2ff6553d4b7e05126dfebf4bd6
+  category: main
+  optional: false
+- name: pyarrow-hotfix
+  version: '0.6'
+  manager: conda
   platform: osx-arm64
   dependencies:
-    pyarrow: '>=0.14'
     python: '>=3.5'
+    pyarrow: '>=0.14'
   url: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
   hash:
     md5: ccc06e6ef2064ae129fab3286299abda
@@ -12519,6 +19135,18 @@ package:
   version: 0.5.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.5.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: fb1a800972b072aa4d16450983c81418
+    sha256: 8b116da9acbb471e107203c11acaffcb259aca2367aa7e83e796e43ed5d381b3
+  category: main
+  optional: false
+- name: pyasn1
+  version: 0.5.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.5.1-pyhd8ed1ab_0.conda
@@ -12555,10 +19183,23 @@ package:
 - name: pyasn1-modules
   version: 0.3.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    pyasn1: '>=0.4.6,<0.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 26db749166cdca55e5ef1ffdc7767d0e
+    sha256: 7867ba43b6ef1e66054ca6b70f59bbef4cdb0cc761f0be3b66d79d15bd43143b
+  category: main
+  optional: false
+- name: pyasn1-modules
+  version: 0.3.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    pyasn1: '>=0.4.6,<0.6.0'
     python: '>=3.6'
+    pyasn1: '>=0.4.6,<0.6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 26db749166cdca55e5ef1ffdc7767d0e
@@ -12583,6 +19224,20 @@ package:
 - name: pycairo
   version: 1.26.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pycairo-1.26.0-py39h98db87f_0.conda
+  hash:
+    md5: f2b18d13eccce2b713a06675a3b31ad8
+    sha256: 89afd72b42e7db08a71b35eae108c7b38974474ee99d430a3fd1911bee532380
+  category: main
+  optional: false
+- name: pycairo
+  version: 1.26.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     cairo: '>=1.18.0,<2.0a0'
@@ -12595,27 +19250,39 @@ package:
   category: main
   optional: false
 - name: pycparser
-  version: '2.21'
+  version: '2.22'
   manager: conda
   platform: linux-64
   dependencies:
-    python: 2.7.*|>=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
   hash:
-    md5: 076becd9e05608f8dc72757d5f3a91ff
-    sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+    md5: 844d9eb3b43095b031874477f7d70088
+    sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
   category: main
   optional: false
 - name: pycparser
-  version: '2.21'
+  version: '2.22'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+  hash:
+    md5: 844d9eb3b43095b031874477f7d70088
+    sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
+  category: main
+  optional: false
+- name: pycparser
+  version: '2.22'
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: 2.7.*|>=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
   hash:
-    md5: 076becd9e05608f8dc72757d5f3a91ff
-    sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+    md5: 844d9eb3b43095b031874477f7d70088
+    sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
   category: main
   optional: false
 - name: pydantic
@@ -12636,6 +19303,20 @@ package:
 - name: pydantic
   version: 1.10.14
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    typing-extensions: '>=4.2.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-1.10.14-py39ha09f3b3_0.conda
+  hash:
+    md5: ee0eda42563d26e60a20d2907723afb1
+    sha256: 0bcaa75d9dee087991f20f89f7b1b5a3553d8680748d02204eb93aa7754956ee
+  category: main
+  optional: false
+- name: pydantic
+  version: 1.10.14
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -12651,6 +19332,18 @@ package:
   version: 2.17.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 140a7f159396547e9799aa98f9f0742e
+    sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
+  category: main
+  optional: false
+- name: pygments
+  version: 2.17.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
@@ -12693,6 +19386,25 @@ package:
 - name: pygobject
   version: 3.48.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libgirepository: ''
+    libglib: '>=2.78.4,<3.0a0'
+    libiconv: ''
+    pycairo: ''
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pygobject-3.48.1-py39hd2ce206_0.conda
+  hash:
+    md5: 2f6cf64674b290798fa724129ba27df7
+    sha256: 361ad4d6e532674ddfac6f5d28447906ac7a54738422e4d806ee068944ee7aba
+  category: main
+  optional: false
+- name: pygobject
+  version: 3.48.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     cairo: '>=1.18.0,<2.0a0'
@@ -12713,6 +19425,18 @@ package:
   version: 2.8.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.8.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 74f76d4868dbba5870f2cf1d9b12d8f3
+    sha256: d7cb7fbafd767e938db10820c76a9c16d91faf5a081842159cc185787879eb07
+  category: main
+  optional: false
+- name: pyjwt
+  version: 2.8.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.8.0-pyhd8ed1ab_1.conda
@@ -12753,6 +19477,22 @@ package:
 - name: pynacl
   version: 1.5.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    cffi: '>=1.4.1'
+    libsodium: '>=1.0.18,<1.0.19.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/pynacl-1.5.0-py39hdc70f33_3.conda
+  hash:
+    md5: 2d6bf7df608e80d7ad571be07746afcb
+    sha256: 6625a03a7cee82ed46fcfbeb91f1b00c01dfb2e4d9fc90be9a2d353ba4aa8b0d
+  category: main
+  optional: false
+- name: pynacl
+  version: 1.5.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     cffi: '>=1.4.1'
@@ -12769,6 +19509,21 @@ package:
 - name: pyobjc-core
   version: '10.2'
   manager: conda
+  platform: osx-64
+  dependencies:
+    libffi: '>=3.4,<4.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.2-py39h8602b6b_0.conda
+  hash:
+    md5: 37b6b21536780b9665b9c84908318d7a
+    sha256: 6517faf0ad9a22763655b682dc41d53b08c388bcb67c77d1654158baf609ae3f
+  category: main
+  optional: false
+- name: pyobjc-core
+  version: '10.2'
+  manager: conda
   platform: osx-arm64
   dependencies:
     libffi: '>=3.4,<4.0a0'
@@ -12779,6 +19534,21 @@ package:
   hash:
     md5: 2316c0a8bfbb9314cd22cf1c5b83ac3b
     sha256: cc3d5e2ba7cd678600aa8f10434dea88ff798bc40e9733595fbad387c265410c
+  category: main
+  optional: false
+- name: pyobjc-framework-cocoa
+  version: '10.2'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libffi: '>=3.4,<4.0a0'
+    pyobjc-core: 10.2.*
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.2-py39h8602b6b_0.conda
+  hash:
+    md5: 271f368ad661bf3bba2d5740ac8ee24c
+    sha256: e69322b541ceca63691ee40d5745642b90b3f280a64b878e9c67259b551d3223
   category: main
   optional: false
 - name: pyobjc-framework-cocoa
@@ -12812,10 +19582,23 @@ package:
 - name: pyopenssl
   version: 24.0.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    cryptography: '>=41.0.5,<43'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: b50aec2c744a5c493c09cce9e2e7533e
+    sha256: bacd1d38585f447e2809e7621283661da7c97cfa20f545edb0ac5838356ed87b
+  category: main
+  optional: false
+- name: pyopenssl
+  version: 24.0.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    cryptography: '>=41.0.5,<43'
     python: '>=3.7'
+    cryptography: '>=41.0.5,<43'
   url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: b50aec2c744a5c493c09cce9e2e7533e
@@ -12826,6 +19609,18 @@ package:
   version: 3.1.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: b9a4dacf97241704529131a0dfc0494f
+    sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
+  category: main
+  optional: false
+- name: pyparsing
+  version: 3.1.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
@@ -12865,6 +19660,21 @@ package:
 - name: pyproj
   version: 3.6.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    certifi: ''
+    proj: '>=9.3.1,<9.3.2.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py39h50371c4_5.conda
+  hash:
+    md5: 3d3ea2d86757dc1aabb013775b0a6869
+    sha256: b01f80c96b3466922714c01fe0788677fb3e3a359d5291a54e5954b271d1f20d
+  category: main
+  optional: false
+- name: pyproj
+  version: 3.6.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     certifi: ''
@@ -12877,17 +19687,100 @@ package:
     sha256: d056de9eb7e7b568a003d5a24caa7a9c73e2cf34cbac0aecd253056157770ea3
   category: main
   optional: false
+- name: pyqt
+  version: 5.15.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    pyqt5-sip: 12.12.2
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    qt-main: '>=5.15.8,<5.16.0a0'
+    sip: '>=6.7.11,<6.8.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.9-py39h52134e7_5.conda
+  hash:
+    md5: e1f148e57d071b09187719df86f513c1
+    sha256: a0d0662c73b343931dbd66d9c25ec74f40115512568a87bf4d01af8d1a8ddf1c
+  category: main
+  optional: false
+- name: pyqt
+  version: 5.15.9
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    pyqt5-sip: 12.12.2
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    qt-main: '>=5.15.8,<5.16.0a0'
+    sip: '>=6.7.11,<6.8.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyqt-5.15.9-py39h3dce684_5.conda
+  hash:
+    md5: ecc396e7a7badba032c3f9dd30c40e9c
+    sha256: 58e3f096357bc899fa446bc9ff28cf04feaa3cb7b394b2fcf7e4facce442ff72
+  category: main
+  optional: false
+- name: pyqt5-sip
+  version: 12.12.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    packaging: ''
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    sip: ''
+    toml: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.12.2-py39h3d6467e_5.conda
+  hash:
+    md5: 93aff412f3e49fdb43361c0215cbd72d
+    sha256: 86efec5e57111794e039bb14dfce23d9df6ed8df139ab1404086140eba6d4d7c
+  category: main
+  optional: false
+- name: pyqt5-sip
+  version: 12.12.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    packaging: ''
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    sip: ''
+    toml: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyqt5-sip-12.12.2-py39hb11a7c1_5.conda
+  hash:
+    md5: 10288bdb5ec36c5207d79deee15c6be5
+    sha256: ab6ffa5e1755f72cddd9ff45bf681ec710b914705258d6462f606ecf873ff435
+  category: main
+  optional: false
 - name: pysocks
   version: 1.7.1
   manager: conda
   platform: linux-64
   dependencies:
-    __unix: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pysocks-1.7.1-py39hf3d152e_5.tar.bz2
   hash:
-    md5: 2a7de29fb590ca14b5243c4c812c8025
-    sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+    md5: d34b97a2386932b97c7cb80916a673e7
+    sha256: 42d46baeab725d3c70d22a4258549e9f0f1a72b740166cd9c3b394c4369cb306
+  category: main
+  optional: false
+- name: pysocks
+  version: 1.7.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pysocks-1.7.1-py39h6e9494a_5.tar.bz2
+  hash:
+    md5: e6845a71941ffc957c9e4ac0c4c88edd
+    sha256: 452a784735cc5c45b8494697885bb3530e3af83ac1e9931961a5667c10ea67ba
   category: main
   optional: false
 - name: pysocks
@@ -12895,12 +19788,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __unix: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pysocks-1.7.1-py39h2804cbe_5.tar.bz2
   hash:
-    md5: 2a7de29fb590ca14b5243c4c812c8025
-    sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+    md5: 831038e9e2af74015b03d82209ac5f87
+    sha256: 33258403558102b27ccc918338eb90906028f8f3f2b2af549b3232335dc355e1
   category: main
   optional: false
 - name: pyspark
@@ -12922,13 +19815,29 @@ package:
 - name: pyspark
   version: 3.5.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    python: '>=3.8'
     numpy: '>=1.15'
     pandas: '>=1.0.5'
-    py4j: 0.10.9.7
     pyarrow: '>=4.0.0'
+    py4j: 0.10.9.7
+  url: https://conda.anaconda.org/conda-forge/noarch/pyspark-3.5.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: fc1824942077c7ed5f0e24ff869c6f37
+    sha256: 6ba987ac0a2c5c6de98b4ce943e72cfbfca1134678c3984959cdb11070997005
+  category: main
+  optional: false
+- name: pyspark
+  version: 3.5.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     python: '>=3.8'
+    numpy: '>=1.15'
+    pandas: '>=1.0.5'
+    pyarrow: '>=4.0.0'
+    py4j: 0.10.9.7
   url: https://conda.anaconda.org/conda-forge/noarch/pyspark-3.5.1-pyhd8ed1ab_0.conda
   hash:
     md5: fc1824942077c7ed5f0e24ff869c6f37
@@ -12936,7 +19845,7 @@ package:
   category: main
   optional: false
 - name: python
-  version: 3.9.18
+  version: 3.9.19
   manager: conda
   platform: linux-64
   dependencies:
@@ -12945,47 +19854,81 @@ package:
     libffi: '>=3.4,<4.0a0'
     libgcc-ng: '>=12'
     libnsl: '>=2.0.1,<2.1.0a0'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libsqlite: '>=3.45.2,<4.0a0'
     libuuid: '>=2.38.1,<3.0a0'
     libxcrypt: '>=4.4.36'
     libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    ncurses: '>=6.4.20240210,<7.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.18-h0755675_1_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.19-h0755675_0_cpython.conda
   hash:
-    md5: 255a7002aeec7a067ff19b545aca6328
-    sha256: c0e800d255a771926007043d2859cbbbdb1387477ec813f085640c8887b391a2
+    md5: d9ee3647fbd9e8595b8df759b2bbefb8
+    sha256: b9253ca9ca5427e6da4b1d43353a110e0f2edfab9c951afb4bf01cbae2825b31
   category: main
   optional: false
 - name: python
-  version: 3.9.18
+  version: 3.9.19
+  manager: conda
+  platform: osx-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libsqlite: '>=3.45.2,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    ncurses: '>=6.4.20240210,<7.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    readline: '>=8.2,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+    xz: '>=5.2.6,<6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.9.19-h7a9c478_0_cpython.conda
+  hash:
+    md5: 7d53d366acd9dbfb498c69326ccb520a
+    sha256: 58b76be84683bc03112b3ed7e377e99af24844ebf7d7568f6466a2dae7a887fe
+  category: main
+  optional: false
+- name: python
+  version: 3.9.19
   manager: conda
   platform: osx-arm64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
     libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libsqlite: '>=3.45.2,<4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    ncurses: '>=6.4.20240210,<7.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.9.18-hd7ebdb9_1_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.9.19-hd7ebdb9_0_cpython.conda
   hash:
-    md5: c48f67fd7147f37c941037de0a328560
-    sha256: 7336d2cfefff2466f1f60144f10f5bf98f9d176a8c72ca85336baa5dc32299ef
+    md5: 45c4d173b12154f746be3b49b1190634
+    sha256: 3b93f7a405f334043758dfa8aaca050429a954a37721a6462ebd20e94ef7c5a0
   category: main
   optional: false
 - name: python-dateutil
   version: 2.9.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    six: '>=1.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
+  category: main
+  optional: false
+- name: python-dateutil
+  version: 2.9.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
     six: '>=1.5'
@@ -13023,6 +19966,18 @@ package:
 - name: python-fastjsonschema
   version: 2.19.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4d3ceee3af4b0f9a1f48f57176bf8625
+    sha256: 38b2db169d65cc5595e3ce63294c4fdb6a242ecf71f70b3ad8cad3bd4230d82f
+  category: main
+  optional: false
+- name: python-fastjsonschema
+  version: 2.19.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.3'
@@ -13033,33 +19988,57 @@ package:
   category: main
   optional: false
 - name: python-flatbuffers
-  version: 24.3.7
+  version: 24.3.25
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-flatbuffers-24.3.7-pyh59ac667_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-flatbuffers-24.3.25-pyh59ac667_0.conda
   hash:
-    md5: 24c1a37849fcd4c74923a38b029b208f
-    sha256: cacba4db8e9e8500f11fb5e43bd7ef5f0d43ba58f668f74544924e7dba63b7e8
+    md5: dfc884dcd61ff6543fde37a41b7d7f31
+    sha256: 6a9d285fef959480eccbc69e276ede64e292c8eee35ddc727d5a0fb9a4bcc3a2
   category: main
   optional: false
 - name: python-flatbuffers
-  version: 24.3.7
+  version: 24.3.25
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-flatbuffers-24.3.25-pyh59ac667_0.conda
+  hash:
+    md5: dfc884dcd61ff6543fde37a41b7d7f31
+    sha256: 6a9d285fef959480eccbc69e276ede64e292c8eee35ddc727d5a0fb9a4bcc3a2
+  category: main
+  optional: false
+- name: python-flatbuffers
+  version: 24.3.25
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-flatbuffers-24.3.7-pyh59ac667_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-flatbuffers-24.3.25-pyh59ac667_0.conda
   hash:
-    md5: 24c1a37849fcd4c74923a38b029b208f
-    sha256: cacba4db8e9e8500f11fb5e43bd7ef5f0d43ba58f668f74544924e7dba63b7e8
+    md5: dfc884dcd61ff6543fde37a41b7d7f31
+    sha256: 6a9d285fef959480eccbc69e276ede64e292c8eee35ddc727d5a0fb9a4bcc3a2
   category: main
   optional: false
 - name: python-json-logger
   version: 2.0.7
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  hash:
+    md5: a61bf9ec79426938ff785eb69dbb1960
+    sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  category: main
+  optional: false
+- name: python-json-logger
+  version: 2.0.7
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
@@ -13105,19 +20084,41 @@ package:
 - name: python-kubernetes
   version: 29.0.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    certifi: '>=14.05.14'
-    google-auth: '>=1.0.1'
-    oauthlib: '>=3.2.2'
-    python: '>=3.6'
-    python-dateutil: '>=2.5.3'
-    pyyaml: '>=5.4.1'
     requests: ''
     requests-oauthlib: ''
+    python: '>=3.6'
     six: '>=1.9.0'
-    urllib3: '>=1.24.2,<2.0'
+    pyyaml: '>=5.4.1'
+    python-dateutil: '>=2.5.3'
+    certifi: '>=14.05.14'
+    google-auth: '>=1.0.1'
     websocket-client: '>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.*'
+    oauthlib: '>=3.2.2'
+    urllib3: '>=1.24.2,<2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-kubernetes-29.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a94f4c6a1cff1e9837a8b62ae35c673f
+    sha256: 30e268b5e3299ae77f5bc34a2e290e47d5663f72be2ae3451ae7c24936670a74
+  category: main
+  optional: false
+- name: python-kubernetes
+  version: 29.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    requests: ''
+    requests-oauthlib: ''
+    python: '>=3.6'
+    six: '>=1.9.0'
+    pyyaml: '>=5.4.1'
+    python-dateutil: '>=2.5.3'
+    certifi: '>=14.05.14'
+    google-auth: '>=1.0.1'
+    websocket-client: '>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.*'
+    oauthlib: '>=3.2.2'
+    urllib3: '>=1.24.2,<2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/python-kubernetes-29.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: a94f4c6a1cff1e9837a8b62ae35c673f
@@ -13128,6 +20129,19 @@ package:
   version: 8.0.4
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    text-unidecode: '>=1.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-slugify-8.0.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4b11845622b3c3178c0e989235b53975
+    sha256: a1270bfd4f1d648766c8f95403f208e50d34af94761bc553a960102c6bff9fa0
+  category: main
+  optional: false
+- name: python-slugify
+  version: 8.0.4
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
     text-unidecode: '>=1.3'
@@ -13154,6 +20168,18 @@ package:
   version: '2024.1'
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 98206ea9954216ee7540f0c773f2104d
+    sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
+  category: main
+  optional: false
+- name: python-tzdata
+  version: '2024.1'
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
@@ -13178,6 +20204,19 @@ package:
   version: 3.8.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+    typing_extensions: '>3.10.0.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-utils-3.8.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 89703b4f38bd1c0353881f085bc8fdaa
+    sha256: 56aac9317cde48fc8ff59806587afd4d1c262dcd7598f94c0748a2ec51523d09
+  category: main
+  optional: false
+- name: python-utils
+  version: 3.8.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
     typing_extensions: '>3.10.0.2'
@@ -13218,6 +20257,20 @@ package:
 - name: python-xxhash
   version: 3.4.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    xxhash: '>=0.8.2,<0.8.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-xxhash-3.4.1-py39hdc70f33_0.conda
+  hash:
+    md5: 69a7ee634ee74be28ca77036e6550c99
+    sha256: 55039275108af1024c2f4e002bd0a52250f44fafacd7a1e967de864859c34bda
+  category: main
+  optional: false
+- name: python-xxhash
+  version: 3.4.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -13238,6 +20291,17 @@ package:
   hash:
     md5: bfe4b3259a8ac6cdf0037752904da6a7
     sha256: 7e0157e35929711e1a986c18a8bfb7a38a2209cfada16b541ebb0481f74376d6
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.9'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.9-4_cp39.conda
+  hash:
+    md5: 2d9f6c00555127a9058cfa955adf1090
+    sha256: a2b38ce566d9f48a49369f46c50912300a6ac09bf1c58a0d6c2caab074ee551e
   category: main
   optional: false
 - name: python_abi
@@ -13266,6 +20330,18 @@ package:
 - name: pytimeparse
   version: 1.1.8
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/pytimeparse-1.1.8-py_0.tar.bz2
+  hash:
+    md5: edde7e7260599f9860002187486b3e01
+    sha256: 313cbde8ded706790d4fb8ea114ba1d706ff5be0780f63c01de81f569e593a03
+  category: main
+  optional: false
+- name: pytimeparse
+  version: 1.1.8
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
@@ -13280,25 +20356,18 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    __cuda: ''
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-    cudatoolkit: '>=11.8,<12'
-    cudnn: '>=8.8.0.121,<9.0a0'
     filelock: ''
     fsspec: ''
     jinja2: ''
     libcblas: '>=3.9.0,<4.0a0'
     libgcc-ng: '>=12'
-    libmagma: '>=2.7.2,<2.7.3.0a0'
-    libmagma_sparse: '>=2.7.2,<2.7.3.0a0'
     libprotobuf: '>=4.24.4,<4.24.5.0a0'
     libstdcxx-ng: '>=12'
     libtorch: 2.1.2.*
     libuv: '>=1.46.0,<2.0a0'
-    magma: '>=2.7.2,<2.7.3.0a0'
     mkl: '>=2023.2.0,<2024.0a0'
-    nccl: '>=2.19.4.1,<3.0a0'
     networkx: ''
     numpy: '>=1.22.4,<2.0a0'
     python: '>=3.9,<3.10.0a0'
@@ -13306,10 +20375,38 @@ package:
     sleef: '>=3.5.1,<4.0a0'
     sympy: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.1.2-cuda118_py39hcb596ef_300.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.1.2-cpu_mkl_py39h9c325db_100.conda
   hash:
-    md5: d7355cce6a80513f7e9980e5e2e836be
-    sha256: 4f84efcd67159d4117b9519da2542da4f71c21e2abe2dae3368a54e365df6d98
+    md5: bb34e51d3542a1b4b6afc04f28585055
+    sha256: c363db53861a5ffe1613e57a8c3624f447fa203dde66f52b29ddb9859fb2e8bc
+  category: main
+  optional: false
+- name: pytorch
+  version: 2.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    filelock: ''
+    fsspec: ''
+    jinja2: ''
+    libcblas: '>=3.9.0,<4.0a0'
+    libcxx: '>=15.0.7'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libuv: '>=1.46.0,<2.0a0'
+    llvm-openmp: '>=16.0.6'
+    mkl: '>=2022.2.1,<2023.0a0'
+    networkx: ''
+    numpy: '>=1.22.4,<2.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    sleef: '>=3.5.1,<4.0a0'
+    sympy: ''
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/pytorch-2.1.0-cpu_mkl_py39h0a49516_100.conda
+  hash:
+    md5: a3d21e02ee1f4551b728dcaf9d97f99a
+    sha256: cbc26a8691107d3833f5876a37eb0b9f73fd68d66e62011f6f4aa800ebcd0aa4
   category: main
   optional: false
 - name: pytorch
@@ -13356,6 +20453,18 @@ package:
 - name: pytz
   version: '2023.4'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 89445e229eb2d6605be88e0908afc912
+    sha256: c988e6b9032ac2f917540a1d5a2268f45c01892c392fd7eee9d5c60270337835
+  category: main
+  optional: false
+- name: pytz
+  version: '2023.4'
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -13381,10 +20490,23 @@ package:
 - name: pyu2f
   version: 0.1.5
   manager: conda
+  platform: osx-64
+  dependencies:
+    six: ''
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyu2f-0.1.5-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: caabbeaa83928d0c3e3949261daa18eb
+    sha256: 667a5a30b65a60b15f38fa4cb09efd6d2762b5a0a9563acd9555eaa5e0b953a2
+  category: main
+  optional: false
+- name: pyu2f
+  version: 0.1.5
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=2.7'
     six: ''
+    python: '>=2.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pyu2f-0.1.5-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: caabbeaa83928d0c3e3949261daa18eb
@@ -13395,6 +20517,19 @@ package:
   version: 0.1.0
   manager: conda
   platform: linux-64
+  dependencies:
+    __unix: ''
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh1179c8e_3.tar.bz2
+  hash:
+    md5: 2807a0becd1d986fe1ef9b7f8135f215
+    sha256: 6502696aaef571913b22a808b15c185bd8ea4aabb952685deb29e6a6765761cb
+  category: main
+  optional: false
+- name: pywin32-on-windows
+  version: 0.1.0
+  manager: conda
+  platform: osx-64
   dependencies:
     __unix: ''
     python: '>=2.7'
@@ -13435,6 +20570,20 @@ package:
 - name: pyyaml
   version: 6.0.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    yaml: '>=0.2.5,<0.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py39hdc70f33_1.conda
+  hash:
+    md5: 542378f49240a94056b50ab1385b3bfb
+    sha256: 4a8d084617571ecb8d816fe4c46b672d8b9b4bd354cbfdbb6c843143abe3896f
+  category: main
+  optional: false
+- name: pyyaml
+  version: 6.0.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -13466,6 +20615,23 @@ package:
 - name: pyzmq
   version: 25.1.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    libsodium: '>=1.0.18,<1.0.19.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    zeromq: '>=4.3.5,<4.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.2-py39hcb7a90d_0.conda
+  hash:
+    md5: 39754a321b3dece3df9a0eb213d43dc8
+    sha256: 9e491ef2066050c2c34a49aeddf2be773cee59bcdde037f6ef6b114690f21f69
+  category: main
+  optional: false
+- name: pyzmq
+  version: 25.1.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=10.9'
@@ -13480,6 +20646,116 @@ package:
     sha256: 23e9a498414af4613c51d93dd74c6c20f63a03545c7b11b7b0bdeaf70f194d1c
   category: main
   optional: false
+- name: qt-main
+  version: 5.15.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    alsa-lib: '>=1.2.10,<1.3.0.0a0'
+    dbus: '>=1.13.6,<2.0a0'
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    gst-plugins-base: '>=1.22.9,<1.23.0a0'
+    gstreamer: '>=1.22.9,<1.23.0a0'
+    harfbuzz: '>=8.3.0,<9.0a0'
+    icu: '>=73.2,<74.0a0'
+    krb5: '>=1.21.2,<1.22.0a0'
+    libclang: '>=15.0.7,<16.0a0'
+    libclang13: '>=15.0.7'
+    libcups: '>=2.3.3,<2.4.0a0'
+    libevent: '>=2.1.12,<2.1.13.0a0'
+    libexpat: '>=2.5.0,<3.0a0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.78.3,<3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.42,<1.7.0a0'
+    libpq: '>=16.2,<17.0a0'
+    libsqlite: '>=3.45.1,<4.0a0'
+    libstdcxx-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
+    libxkbcommon: '>=1.6.0,<2.0a0'
+    libxml2: '>=2.12.5,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    mysql-libs: '>=8.0.33,<8.1.0a0'
+    nspr: '>=4.35,<5.0a0'
+    nss: '>=3.97,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    pulseaudio-client: '>=16.1,<16.2.0a0'
+    xcb-util: '>=0.4.0,<0.5.0a0'
+    xcb-util-image: '>=0.4.0,<0.5.0a0'
+    xcb-util-keysyms: '>=0.4.0,<0.5.0a0'
+    xcb-util-renderutil: '>=0.3.9,<0.4.0a0'
+    xcb-util-wm: '>=0.4.1,<0.5.0a0'
+    xorg-libice: '>=1.1.1,<2.0a0'
+    xorg-libsm: '>=1.2.4,<2.0a0'
+    xorg-libx11: '>=1.8.7,<2.0a0'
+    xorg-libxext: '>=1.3.4,<2.0a0'
+    xorg-xf86vidmodeproto: ''
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h5810be5_19.conda
+  hash:
+    md5: 54866f708d43002a514d0b9b0f84bc11
+    sha256: 41228ec12346d640ef1f549885d8438e98b1be0fdeb68cd1dd3938f255cbd719
+  category: main
+  optional: false
+- name: qt-main
+  version: 5.15.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gst-plugins-base: '>=1.22.9,<1.23.0a0'
+    gstreamer: '>=1.22.9,<1.23.0a0'
+    icu: '>=73.2,<74.0a0'
+    krb5: '>=1.21.2,<1.22.0a0'
+    libclang: '>=15.0.7,<16.0a0'
+    libclang13: '>=15.0.7'
+    libcxx: '>=14'
+    libglib: '>=2.78.3,<3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.42,<1.7.0a0'
+    libpq: '>=16.2,<17.0a0'
+    libsqlite: '>=3.45.1,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    mysql-libs: '>=8.0.33,<8.1.0a0'
+    nspr: '>=4.35,<5.0a0'
+    nss: '>=3.97,<4.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/qt-main-5.15.8-h4385fff_19.conda
+  hash:
+    md5: e9e7fc8f8b31e436472e6c2697dfa9fa
+    sha256: f1ab73268198fe66c0b438b58b34bc56b987d0c411c4d60882c9474186a7d7f0
+  category: main
+  optional: false
+- name: qtconsole
+  version: 5.5.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    pyqt: ''
+    python: '>=3.7'
+    qtconsole-base: '>=5.5.1,<5.5.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/qtconsole-5.5.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: eb44d4dc1e8c84287c4fb28518ffedd0
+    sha256: c102ef2919dc780086ee59cb1dd9823603bf6e6d394eace6ae53c84c97661e9d
+  category: main
+  optional: false
+- name: qtconsole
+  version: 5.5.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pyqt: ''
+    python: '>=3.7'
+    qtconsole-base: '>=5.5.1,<5.5.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/qtconsole-5.5.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: eb44d4dc1e8c84287c4fb28518ffedd0
+    sha256: c102ef2919dc780086ee59cb1dd9823603bf6e6d394eace6ae53c84c97661e9d
+  category: main
+  optional: false
 - name: qtconsole-base
   version: 5.5.1
   manager: conda
@@ -13502,16 +20778,16 @@ package:
 - name: qtconsole-base
   version: 5.5.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    ipykernel: '>=4.1'
-    jupyter_client: '>=4.1'
-    jupyter_core: ''
     packaging: ''
     pygments: ''
-    python: '>=3.8'
-    qtpy: '>=2.4.0'
     traitlets: ''
+    jupyter_core: ''
+    python: '>=3.8'
+    ipykernel: '>=4.1'
+    jupyter_client: '>=4.1'
+    qtpy: '>=2.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/qtconsole-base-5.5.1-pyha770c72_0.conda
   hash:
     md5: 5528a3eda283b421055c89bface19a1c
@@ -13534,7 +20810,7 @@ package:
 - name: qtpy
   version: 2.4.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
     packaging: ''
     python: '>=3.7'
@@ -13548,6 +20824,20 @@ package:
   version: 1.2.4
   manager: conda
   platform: linux-64
+  dependencies:
+    python: ''
+    requests: ''
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/querystring_parser-1.2.4-py_0.tar.bz2
+  hash:
+    md5: 0ebdca9b753c2e082e5b5ad06aa76b41
+    sha256: 06977a9af6d8605fb6068d8af6bb9c1cb565f8f5e15aa6cf0fb94109d4148b54
+  category: main
+  optional: false
+- name: querystring_parser
+  version: 1.2.4
+  manager: conda
+  platform: osx-64
   dependencies:
     python: ''
     requests: ''
@@ -13602,6 +20892,18 @@ package:
 - name: re2
   version: 2023.09.01
   manager: conda
+  platform: osx-64
+  dependencies:
+    libre2-11: 2023.09.01
+  url: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.09.01-hb168e87_1.conda
+  hash:
+    md5: 81ce9e6ddc1c123aecc59234aa12d3b1
+    sha256: e8c9d1fc5c254573bd46e46e4cc4dea6d6101d353ea54081f682438f815e224a
+  category: main
+  optional: false
+- name: re2
+  version: 2023.09.01
+  manager: conda
   platform: osx-arm64
   dependencies:
     libre2-11: 2023.09.01
@@ -13622,6 +20924,18 @@ package:
   hash:
     md5: 47d31b792659ce70f470b5c82fdfb7a4
     sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  category: main
+  optional: false
+- name: readline
+  version: '8.2'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ncurses: '>=6.3,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  hash:
+    md5: f17f77f2acf4d344734bda76829ce14e
+    sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
   category: main
   optional: false
 - name: readline
@@ -13654,11 +20968,26 @@ package:
 - name: recommonmark
   version: 0.7.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3'
+    docutils: '>=0.11'
+    commonmark: '>=0.8.1'
+    sphinx: '>=1.3.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/recommonmark-0.7.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b3becf9905b8c7ba839072f65e693253
+    sha256: 2bd6134e7540a1d458be34aef4a94a839540cba29ac75cc558be6a394549b8a6
+  category: main
+  optional: false
+- name: recommonmark
+  version: 0.7.1
+  manager: conda
   platform: osx-arm64
   dependencies:
-    commonmark: '>=0.8.1'
-    docutils: '>=0.11'
     python: '>=3'
+    docutils: '>=0.11'
+    commonmark: '>=0.8.1'
     sphinx: '>=1.3.1'
   url: https://conda.anaconda.org/conda-forge/noarch/recommonmark-0.7.1-pyhd8ed1ab_0.tar.bz2
   hash:
@@ -13683,10 +21012,24 @@ package:
 - name: referencing
   version: 0.34.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    attrs: '>=22.2.0'
+    rpds-py: '>=0.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.34.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: e4492c22e314be5c75db3469e3bbf3d9
+    sha256: 2e631e9e1d49280770573f7acc7441b70181b2dc21948bb1be15eaae80550672
+  category: main
+  optional: false
+- name: referencing
+  version: 0.34.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    attrs: '>=22.2.0'
     python: '>=3.8'
+    attrs: '>=22.2.0'
     rpds-py: '>=0.7.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.34.0-pyhd8ed1ab_0.conda
   hash:
@@ -13713,12 +21056,28 @@ package:
 - name: requests
   version: 2.31.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    python: '>=3.7'
+    idna: '>=2.5,<4'
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
-    idna: '>=2.5,<4'
+    urllib3: '>=1.21.1,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a30144e4156cdbb236f99ebb49828f8b
+    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+  category: main
+  optional: false
+- name: requests
+  version: 2.31.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     python: '>=3.7'
+    idna: '>=2.5,<4'
+    certifi: '>=2017.4.17'
+    charset-normalizer: '>=2,<4'
     urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
   hash:
@@ -13727,31 +21086,45 @@ package:
   category: main
   optional: false
 - name: requests-oauthlib
-  version: 1.4.0
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
     oauthlib: '>=3.0.0'
     python: '>=3.4'
     requests: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a55b220de8970208f583e38639cfbecc
-    sha256: 909ec1510bbb6fad9276534352025f428050a4deeea86e68d61c8c580938ac82
+    md5: 87ce3f09ae7e1d3d0f748a1a634ea3b7
+    sha256: 3d2b0ad106ad5745445c2eb7e7f90b0ce75dc9f4d8c518eb6fd75aad3c80c2cc
   category: main
   optional: false
 - name: requests-oauthlib
-  version: 1.4.0
+  version: 2.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.4'
+    requests: '>=2.0.0'
+    oauthlib: '>=3.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-2.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 87ce3f09ae7e1d3d0f748a1a634ea3b7
+    sha256: 3d2b0ad106ad5745445c2eb7e7f90b0ce75dc9f4d8c518eb6fd75aad3c80c2cc
+  category: main
+  optional: false
+- name: requests-oauthlib
+  version: 2.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    oauthlib: '>=3.0.0'
     python: '>=3.4'
     requests: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.4.0-pyhd8ed1ab_0.conda
+    oauthlib: '>=3.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a55b220de8970208f583e38639cfbecc
-    sha256: 909ec1510bbb6fad9276534352025f428050a4deeea86e68d61c8c580938ac82
+    md5: 87ce3f09ae7e1d3d0f748a1a634ea3b7
+    sha256: 3d2b0ad106ad5745445c2eb7e7f90b0ce75dc9f4d8c518eb6fd75aad3c80c2cc
   category: main
   optional: false
 - name: rfc3339-validator
@@ -13770,10 +21143,23 @@ package:
 - name: rfc3339-validator
   version: 0.1.4
   manager: conda
+  platform: osx-64
+  dependencies:
+    six: ''
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: fed45fc5ea0813240707998abe49f520
+    sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  category: main
+  optional: false
+- name: rfc3339-validator
+  version: 0.1.4
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.5'
     six: ''
+    python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: fed45fc5ea0813240707998abe49f520
@@ -13784,6 +21170,18 @@ package:
   version: 0.1.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 912a71cc01012ee38e6b90ddd561e36f
+    sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  category: main
+  optional: false
+- name: rfc3986-validator
+  version: 0.1.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
@@ -13822,12 +21220,27 @@ package:
 - name: rich
   version: 13.7.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    markdown-it-py: '>=2.2.0'
-    pygments: '>=2.13.0,<3.0.0'
     python: '>=3.7.0'
     typing_extensions: '>=4.0.0,<5.0.0'
+    pygments: '>=2.13.0,<3.0.0'
+    markdown-it-py: '>=2.2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: ba445bf767ae6f0d959ff2b40c20912b
+    sha256: 2b26d58aa59e46f933c3126367348651b0dab6e0bf88014e857415bb184a4667
+  category: main
+  optional: false
+- name: rich
+  version: 13.7.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7.0'
+    typing_extensions: '>=4.0.0,<5.0.0'
+    pygments: '>=2.13.0,<3.0.0'
+    markdown-it-py: '>=2.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
   hash:
     md5: ba445bf767ae6f0d959ff2b40c20912b
@@ -13851,10 +21264,24 @@ package:
 - name: rich-click
   version: 1.7.4
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    click: '>=7,<9'
+    rich: '>=10'
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-click-1.7.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: a3e6556c7cfce33ba7dae23fb17d3303
+    sha256: 91e0b041cf663d4a8e27f1cf572d265d90fdf3a58fa6513bc41292572ca5462f
+  category: main
+  optional: false
+- name: rich-click
+  version: 1.7.4
+  manager: conda
   platform: osx-arm64
   dependencies:
-    click: '>=7,<9'
     python: '>=3.7'
+    click: '>=7,<9'
     rich: '>=10'
   url: https://conda.anaconda.org/conda-forge/noarch/rich-click-1.7.4-pyhd8ed1ab_0.conda
   hash:
@@ -13874,6 +21301,19 @@ package:
   hash:
     md5: ca1e1ff2be5c41142e412c83b88960e4
     sha256: 1bc9bdf6f4a14f38f8decf967fc40bfcd1ab069f012ef0f109163d1ef7b7c633
+  category: main
+  optional: false
+- name: rpds-py
+  version: 0.18.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.18.0-py39hcf47035_0.conda
+  hash:
+    md5: 0e8641e9f0d42d844cf17f5520225e6e
+    sha256: 02f4bc23980602a53243f46ec08e4bf8f3fb9e53c09322624af38ff4aebc0056
   category: main
   optional: false
 - name: rpds-py
@@ -13905,10 +21345,23 @@ package:
 - name: rsa
   version: '4.9'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    pyasn1: '>=0.1.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 03bf410858b2cefc267316408a77c436
+    sha256: 23214cdc15a41d14136754857fd9cd46ca3c55a7e751da3b3a48c673f0ee2a57
+  category: main
+  optional: false
+- name: rsa
+  version: '4.9'
+  manager: conda
   platform: osx-arm64
   dependencies:
-    pyasn1: '>=0.1.3'
     python: '>=3.6'
+    pyasn1: '>=0.1.3'
   url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 03bf410858b2cefc267316408a77c436
@@ -13927,6 +21380,20 @@ package:
   hash:
     md5: faa24f3fca2a71dc81878ac242f653eb
     sha256: 91816e8ed8a9aaa7c351578131a85403ad600ebe1799628fe56e9eddf22daf3e
+  category: main
+  optional: false
+- name: rtree
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libspatialindex: '>=1.9.3,<1.9.4.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/rtree-1.2.0-py39h7d0d40a_0.conda
+  hash:
+    md5: d3fe322db2ce58e65f1e964a11a8b979
+    sha256: 628968440a4cbefffde514b2d8482e069086a55250fc5e078d34076e57641188
   category: main
   optional: false
 - name: rtree
@@ -13962,6 +21429,21 @@ package:
 - name: ruamel.yaml
   version: 0.17.17
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    ruamel.yaml.clib: '>=0.1.2'
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.17.17-py39ha09f3b3_2.conda
+  hash:
+    md5: b594c875bb95d5fdd63ce4357364ac6c
+    sha256: 651ff88b109d82c69c02fac80688da47d3f052e05148693d30d174ae83714f12
+  category: main
+  optional: false
+- name: ruamel.yaml
+  version: 0.17.17
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -13991,6 +21473,19 @@ package:
 - name: ruamel.yaml.clib
   version: 0.2.8
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py39ha09f3b3_0.conda
+  hash:
+    md5: 835c656934865805c0b02dbff74fe5b7
+    sha256: cd879e616da91e627297a6816955d59ea544c1111a0ce128e7fa2e86ab61680f
+  category: main
+  optional: false
+- name: ruamel.yaml.clib
+  version: 0.2.8
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -14015,33 +21510,48 @@ package:
   category: main
   optional: false
 - name: s3fs
-  version: 2024.2.0
+  version: 2024.3.1
   manager: conda
   platform: linux-64
   dependencies:
     aiobotocore: '>=2.5.4,<3.0.0'
     aiohttp: ''
-    fsspec: 2024.2.0
+    fsspec: 2024.3.1
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a0d35978a4caf8b78957dac03e2bc039
-    sha256: b67e93d4584b26e7cb6f98e7415daf72d531ca854fdc0d0fe2d5e281fad8ec28
+    md5: 09003467a61e115c4652f8b1ffa7ccbb
+    sha256: a893cf822ca952cacb89ffa3daf312a4c367056a94db942ad792dcd672940f42
   category: main
   optional: false
 - name: s3fs
-  version: 2024.2.0
+  version: 2024.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aiohttp: ''
+    python: '>=3.8'
+    aiobotocore: '>=2.5.4,<3.0.0'
+    fsspec: 2024.3.1
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 09003467a61e115c4652f8b1ffa7ccbb
+    sha256: a893cf822ca952cacb89ffa3daf312a4c367056a94db942ad792dcd672940f42
+  category: main
+  optional: false
+- name: s3fs
+  version: 2024.3.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    aiobotocore: '>=2.5.4,<3.0.0'
     aiohttp: ''
-    fsspec: 2024.2.0
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.2.0-pyhd8ed1ab_0.conda
+    aiobotocore: '>=2.5.4,<3.0.0'
+    fsspec: 2024.3.1
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a0d35978a4caf8b78957dac03e2bc039
-    sha256: b67e93d4584b26e7cb6f98e7415daf72d531ca854fdc0d0fe2d5e281fad8ec28
+    md5: 09003467a61e115c4652f8b1ffa7ccbb
+    sha256: a893cf822ca952cacb89ffa3daf312a4c367056a94db942ad792dcd672940f42
   category: main
   optional: false
 - name: scikit-learn
@@ -14062,6 +21572,25 @@ package:
   hash:
     md5: 34570aedcdc0281c66ce0ed300844111
     sha256: 72fe5a1a19a4ed66a8e0aeceee256e58c7a7b3dd9a97139c6e7b2ba73e0c9f63
+  category: main
+  optional: false
+- name: scikit-learn
+  version: 1.4.1.post1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    joblib: '>=1.2.0'
+    libcxx: '>=16'
+    llvm-openmp: '>=17.0.6'
+    numpy: '>=1.22.4,<2.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    scipy: ''
+    threadpoolctl: '>=2.0.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.4.1.post1-py39hf36d3f6_0.conda
+  hash:
+    md5: 6840465b23096b25f4f2340441599b54
+    sha256: 622c1d231e1d41a89021f6e2ebbcd3fdc2dc5198331ee4b05b21ff2bb504b45f
   category: main
   optional: false
 - name: scikit-learn
@@ -14102,6 +21631,26 @@ package:
   hash:
     md5: 6ab241b2023730f6b41712dc1b503afa
     sha256: 8b2312d5be30bfb226e83af8e070c65df6816d0a9b179f51b9f915990bfd86ee
+  category: main
+  optional: false
+- name: scipy
+  version: 1.12.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libblas: '>=3.9.0,<4.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
+    libcxx: '>=15'
+    libgfortran: 5.*
+    libgfortran5: '>=13.2.0'
+    liblapack: '>=3.9.0,<4.0a0'
+    numpy: '>=1.22.4,<2.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.12.0-py39h0ed1e0f_2.conda
+  hash:
+    md5: dcc2e3dd279432335b58f986d91dd9fd
+    sha256: 3a721490dff7c37d6e516ab3991761afa5586e3722f97a793dba538ee9cfa310
   category: main
   optional: false
 - name: scipy
@@ -14156,6 +21705,20 @@ package:
 - name: send2trash
   version: 1.8.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: ''
+    pyobjc-framework-cocoa: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+  hash:
+    md5: 2657c3de5371c571aef6678afb4aaadd
+    sha256: dca4022bae47618ed738ab7d45ead5202d174b741cfb98e4484acdc6e76da32a
+  category: main
+  optional: false
+- name: send2trash
+  version: 1.8.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: ''
@@ -14171,6 +21734,18 @@ package:
   version: 69.2.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: da214ecd521a720a9d521c68047682dc
+    sha256: 78a75c75a5dacda6de5f4056c9c990141bdaf4f64245673a590594d00bc63713
+  category: main
+  optional: false
+- name: setuptools
+  version: 69.2.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
@@ -14210,6 +21785,21 @@ package:
 - name: shapely
   version: 2.0.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    geos: '>=3.12.1,<3.12.2.0a0'
+    numpy: '>=1.22.4,<2.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.3-py39h19e25c1_0.conda
+  hash:
+    md5: 139065ace3542c37f2f6c2def6a7248f
+    sha256: ef82124eacdccc7109306fab623a130689e0e2efa65b5930aafe9de67ecdbfe3
+  category: main
+  optional: false
+- name: shapely
+  version: 2.0.3
+  manager: conda
   platform: osx-arm64
   dependencies:
     geos: '>=3.12.1,<3.12.2.0a0'
@@ -14222,10 +21812,58 @@ package:
     sha256: 2bd385c02e2ef0a9a15bf3a1e79ab40119a441d03ffa72339ac2f5c73c583eed
   category: main
   optional: false
+- name: sip
+  version: 6.7.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    packaging: ''
+    ply: ''
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    tomli: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.12-py39h3d6467e_0.conda
+  hash:
+    md5: e667a3ab0df62c54e60e1843d2e6defb
+    sha256: fd50c71dc05daf9d28663d448d17f150b3eb79ae629198c73e2186b5b1e990dc
+  category: main
+  optional: false
+- name: sip
+  version: 6.7.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    packaging: ''
+    ply: ''
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    tomli: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/sip-6.7.12-py39h110ca85_0.conda
+  hash:
+    md5: 4c3651b3e1e14064a05a3d722d1ba7cb
+    sha256: 0c105b599c2e9ba83692a32e14df44fe8eee0d8042550bfa6218f48d641dfbf1
+  category: main
+  optional: false
 - name: six
   version: 1.16.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  hash:
+    md5: e5f25f8dbc060e9a8d912e432202afc2
+    sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  category: main
+  optional: false
+- name: six
+  version: 1.16.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
@@ -14268,16 +21906,35 @@ package:
 - name: skl2onnx
   version: 1.16.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    numpy: '>=1.15'
-    onnx: '>=1.2.1'
-    onnxconverter-common: '>=1.7.0'
     packaging: ''
     protobuf: ''
     python: '>=3.6'
-    scikit-learn: '>=0.19'
+    numpy: '>=1.15'
     scipy: '>=1.0'
+    scikit-learn: '>=0.19'
+    onnxconverter-common: '>=1.7.0'
+    onnx: '>=1.2.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/skl2onnx-1.16.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 52a160919ba780e1971e6db6a9f91e81
+    sha256: d0b120a4eed4cc29f32d115f0f49dae9ff1665f004d6aba00654e91c1f8540d7
+  category: main
+  optional: false
+- name: skl2onnx
+  version: 1.16.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    packaging: ''
+    protobuf: ''
+    python: '>=3.6'
+    numpy: '>=1.15'
+    scipy: '>=1.0'
+    scikit-learn: '>=0.19'
+    onnxconverter-common: '>=1.7.0'
+    onnx: '>=1.2.1'
   url: https://conda.anaconda.org/conda-forge/noarch/skl2onnx-1.16.0-pyhd8ed1ab_0.conda
   hash:
     md5: 52a160919ba780e1971e6db6a9f91e81
@@ -14291,10 +21948,22 @@ package:
   dependencies:
     _openmp_mutex: '>=4.5'
     libgcc-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.5.1-h9b69904_2.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.5.1-h28343ad_2.tar.bz2
   hash:
-    md5: 6e016cf4c525d04a7bd038cee53ad3fd
-    sha256: 77d644a16f682e6d01df63fe9d25315011393498b63cf08c0e548780e46b2170
+    md5: a41b5f5f2ee067f55d9774815d3d42db
+    sha256: 17457848ad97e9e8c2ff5f56316b68284e16ed854c46460c0ba7374e880dba1f
+  category: main
+  optional: false
+- name: sleef
+  version: 3.5.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    llvm-openmp: '>=12.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/sleef-3.5.1-h5412eb4_2.tar.bz2
+  hash:
+    md5: 07992f27f5407bd5fc7b69cc7b9931cc
+    sha256: 5e5a83b418c8c3d0885cd94428fa5cf251ffb7d245a124fcc172d7311a4d071e
   category: main
   optional: false
 - name: sleef
@@ -14303,16 +21972,28 @@ package:
   platform: osx-arm64
   dependencies:
     llvm-openmp: '>=12.0.1'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.5.1-h156473d_2.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.5.1-he9cb808_2.tar.bz2
   hash:
-    md5: bd159e7f04dbf79b06ed2bd37e112458
-    sha256: a3d20bed697aaababfcb53ca2011486cf5e44e20855142c170fa0826df5f952c
+    md5: bb73bb3beec3fef3870d8cd328a39bd8
+    sha256: b01163e1e97f3eada667d45196f9695e9fa1fa82cd89c35d52fc025e0af2777c
   category: main
   optional: false
 - name: smmap
   version: 5.0.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 62f26a3d1387acee31322208f0cfa3e0
+    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+  category: main
+  optional: false
+- name: smmap
+  version: 5.0.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
@@ -14349,6 +22030,18 @@ package:
 - name: snappy
   version: 1.1.10
   manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+  hash:
+    md5: 4320a8781f14cd959689b86e349f3b73
+    sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
+  category: main
+  optional: false
+- name: snappy
+  version: 1.1.10
+  manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=14.0.6'
@@ -14373,6 +22066,18 @@ package:
 - name: sniffio
   version: 1.3.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 490730480d76cf9c8f8f2849719c6e2b
+    sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+  category: main
+  optional: false
+- name: sniffio
+  version: 1.3.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -14386,6 +22091,18 @@ package:
   version: 2.2.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=2'
+  url: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 4d22a9315e78c6827f806065957d566e
+    sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
+  category: main
+  optional: false
+- name: snowballstemmer
+  version: 2.2.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=2'
   url: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2
@@ -14442,6 +22159,38 @@ package:
 - name: snowflake-connector-python
   version: 3.7.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    asn1crypto: '>0.24.0,<2.0.0'
+    certifi: '>=2017.4.17'
+    cffi: '>=1.9,<2.0.0'
+    charset-normalizer: '>=2,<4'
+    cryptography: '>=3.1.0,<43.0.0'
+    filelock: '>=3.5,<4'
+    idna: '>=2.5,<4'
+    libcxx: '>=16'
+    numpy: '>=1.22.4,<2.0a0'
+    packaging: ''
+    platformdirs: '>=2.6.0,<4.0.0'
+    pyjwt: <3.0.0
+    pyopenssl: '>=16.2.0,<25.0.0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    pytz: ''
+    requests: <3.0.0
+    sortedcontainers: '>=2.4.0'
+    tomlkit: ''
+    typing_extensions: '>=4.3,<5'
+    urllib3: '>=1.21.1,<2'
+  url: https://conda.anaconda.org/conda-forge/osx-64/snowflake-connector-python-3.7.1-py39haf03413_2.conda
+  hash:
+    md5: 0aaa98c22a1a8c0b4744bcf6616bdfb4
+    sha256: 3540360351e3b37671b7c30118c0d599390d73b8187d691fccba0ef6fd57825d
+  category: main
+  optional: false
+- name: snowflake-connector-python
+  version: 3.7.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     asn1crypto: '>0.24.0,<2.0.0'
@@ -14486,6 +22235,18 @@ package:
 - name: sortedcontainers
   version: 2.4.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 6d6552722448103793743dabfbda532d
+    sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+  category: main
+  optional: false
+- name: sortedcontainers
+  version: 2.4.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=2.7'
@@ -14510,6 +22271,18 @@ package:
 - name: soupsieve
   version: '2.5'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+    sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  category: main
+  optional: false
+- name: soupsieve
+  version: '2.5'
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
@@ -14551,26 +22324,55 @@ package:
 - name: sphinx
   version: 4.5.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    alabaster: '>=0.7,<0.8'
-    babel: '>=1.3'
-    colorama: '>=0.3.5'
-    docutils: '>=0.14,<0.18'
-    imagesize: ''
-    importlib-metadata: '>=4.4'
-    jinja2: '>=2.3'
     packaging: ''
-    pygments: '>=2.0'
-    python: '>=3.6'
-    requests: '>=2.5.0'
-    snowballstemmer: '>=1.1'
+    sphinxcontrib-jsmath: ''
     sphinxcontrib-applehelp: ''
     sphinxcontrib-devhelp: ''
-    sphinxcontrib-htmlhelp: '>=2.0.0'
-    sphinxcontrib-jsmath: ''
     sphinxcontrib-qthelp: ''
+    imagesize: ''
+    python: '>=3.6'
+    importlib-metadata: '>=4.4'
+    pygments: '>=2.0'
+    alabaster: '>=0.7,<0.8'
+    requests: '>=2.5.0'
+    jinja2: '>=2.3'
+    snowballstemmer: '>=1.1'
+    babel: '>=1.3'
+    sphinxcontrib-htmlhelp: '>=2.0.0'
     sphinxcontrib-serializinghtml: '>=1.1.5'
+    colorama: '>=0.3.5'
+    docutils: '>=0.14,<0.18'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-4.5.0-pyh6c4a22f_0.tar.bz2
+  hash:
+    md5: 46b38d88c4270ff9ba78a89c83c66345
+    sha256: 2fe70d936cc969e20f07a7df64438587261f187d4f08e1c0f412cdd1d632730c
+  category: main
+  optional: false
+- name: sphinx
+  version: 4.5.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    packaging: ''
+    sphinxcontrib-jsmath: ''
+    sphinxcontrib-applehelp: ''
+    sphinxcontrib-devhelp: ''
+    sphinxcontrib-qthelp: ''
+    imagesize: ''
+    python: '>=3.6'
+    importlib-metadata: '>=4.4'
+    pygments: '>=2.0'
+    alabaster: '>=0.7,<0.8'
+    requests: '>=2.5.0'
+    jinja2: '>=2.3'
+    snowballstemmer: '>=1.1'
+    babel: '>=1.3'
+    sphinxcontrib-htmlhelp: '>=2.0.0'
+    sphinxcontrib-serializinghtml: '>=1.1.5'
+    colorama: '>=0.3.5'
+    docutils: '>=0.14,<0.18'
   url: https://conda.anaconda.org/conda-forge/noarch/sphinx-4.5.0-pyh6c4a22f_0.tar.bz2
   hash:
     md5: 46b38d88c4270ff9ba78a89c83c66345
@@ -14599,16 +22401,35 @@ package:
 - name: sphinx-autoapi
   version: 2.1.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    astroid: '>=2.7'
-    jinja2: ''
-    python: '>=3.6'
     pyyaml: ''
-    sphinx: '>=3.0'
+    jinja2: ''
+    unidecode: ''
     sphinxcontrib-dotnetdomain: ''
     sphinxcontrib-golangdomain: ''
+    python: '>=3.6'
+    sphinx: '>=3.0'
+    astroid: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-autoapi-2.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6cb2b182390f837ce98737e92b9461f7
+    sha256: 07f4a813627c3b4f4e1175366b58574d886f14ea94df855c3c69cb0676d004e4
+  category: main
+  optional: false
+- name: sphinx-autoapi
+  version: 2.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pyyaml: ''
+    jinja2: ''
     unidecode: ''
+    sphinxcontrib-dotnetdomain: ''
+    sphinxcontrib-golangdomain: ''
+    python: '>=3.6'
+    sphinx: '>=3.0'
+    astroid: '>=2.7'
   url: https://conda.anaconda.org/conda-forge/noarch/sphinx-autoapi-2.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6cb2b182390f837ce98737e92b9461f7
@@ -14631,6 +22452,19 @@ package:
 - name: sphinx-basic-ng
   version: 1.0.0b2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    sphinx: '>=4.0,<8.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-basic-ng-1.0.0b2-pyhd8ed1ab_1.conda
+  hash:
+    md5: a631f5c7b7f5045448f966ad71aa2881
+    sha256: 3c7a6a8bb6c9921741ef940cd61ff1694beac3c95ca7e9ad4b0ea32e2f6ac2fa
+  category: main
+  optional: false
+- name: sphinx-basic-ng
+  version: 1.0.0b2
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -14658,10 +22492,24 @@ package:
 - name: sphinx-click
   version: 5.1.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    click: '>=6.0'
+    sphinx: '>=2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-click-5.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3d7a8ef24d20f30ed2ce7468b8ae5c89
+    sha256: 1ad63a6f1dc72cc10ee67217cdfc64f6f8c0a827a1afa0c89d0e6306762945bd
+  category: main
+  optional: false
+- name: sphinx-click
+  version: 5.1.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    click: '>=6.0'
     python: '>=3.6'
+    click: '>=6.0'
     sphinx: '>=2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/sphinx-click-5.1.0-pyhd8ed1ab_0.conda
   hash:
@@ -14685,6 +22533,19 @@ package:
 - name: sphinx-copybutton
   version: 0.5.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3'
+    sphinx: '>=1.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: ac832cc43adc79118cf6e23f1f9b8995
+    sha256: 7ea21f009792e7c69612ddba367afe0412b3fdff2e92f439e8cd222de4b40bfe
+  category: main
+  optional: false
+- name: sphinx-copybutton
+  version: 0.5.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3'
@@ -14712,6 +22573,20 @@ package:
 - name: sphinx-inline-tabs
   version: 2023.4.21
   manager: conda
+  platform: osx-64
+  dependencies:
+    beautifulsoup4: ''
+    python: '>=3.6'
+    sphinx: '>3'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-inline-tabs-2023.4.21-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4addb035e43d09440597352079305513
+    sha256: 142f45bb224380f13f800ae3769f0d2aa3efcd9c49e5389b48863d03c08a801a
+  category: main
+  optional: false
+- name: sphinx-inline-tabs
+  version: 2023.4.21
+  manager: conda
   platform: osx-arm64
   dependencies:
     beautifulsoup4: ''
@@ -14739,6 +22614,19 @@ package:
 - name: sphinx-issues
   version: 1.2.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+    sphinx: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-issues-1.2.0-py_0.tar.bz2
+  hash:
+    md5: 2d5c0dddca9bb724dcf5a3fb295a2266
+    sha256: 9d98392bff12194c45c6f13c6c93d0b15b2fe489de5746654e732009fce41a86
+  category: main
+  optional: false
+- name: sphinx-issues
+  version: 1.2.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
@@ -14766,6 +22654,20 @@ package:
 - name: sphinx-panels
   version: 0.6.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    docutils: ''
+    python: '>=3.6'
+    sphinx: '>=2,<5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-panels-0.6.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 6eec6480601f5d15babf9c3b3987f34a
+    sha256: c6043ff3f25905453f5c11d1620a4bc118a87a3eda02a3041f4ef98d8e6e6389
+  category: main
+  optional: false
+- name: sphinx-panels
+  version: 0.6.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     docutils: ''
@@ -14794,11 +22696,25 @@ package:
 - name: sphinx-prompt
   version: 1.4.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    pygments: ''
+    sphinx: ''
+    python: '>=3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-prompt-1.4.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 88ee91e8679603f2a5bd036d52919cc2
+    sha256: 3690b4b70322adc77f18c2b31545ddbbe69f1627de76ea9deace8c9809550bab
+  category: main
+  optional: false
+- name: sphinx-prompt
+  version: 1.4.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     pygments: ''
-    python: '>=3.0'
     sphinx: ''
+    python: '>=3.0'
   url: https://conda.anaconda.org/conda-forge/noarch/sphinx-prompt-1.4.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 88ee91e8679603f2a5bd036d52919cc2
@@ -14823,12 +22739,27 @@ package:
 - name: sphinx-tabs
   version: 3.4.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    docutils: '>=0.16.0'
     pygments: ''
     python: '>=3.6'
     sphinx: '>=2,<5'
+    docutils: '>=0.16.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-tabs-3.4.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b04565a0bfac26170025770fe3256dcd
+    sha256: 79228ab583277a527456786f2060211bfed2647259b960566af1718d44dae2aa
+  category: main
+  optional: false
+- name: sphinx-tabs
+  version: 3.4.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pygments: ''
+    python: '>=3.6'
+    sphinx: '>=2,<5'
+    docutils: '>=0.16.0'
   url: https://conda.anaconda.org/conda-forge/noarch/sphinx-tabs-3.4.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b04565a0bfac26170025770fe3256dcd
@@ -14852,6 +22783,20 @@ package:
 - name: sphinx-tags
   version: 0.2.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    pre-commit: ''
+    python: '>=3.6'
+    sphinx: '>4'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-tags-0.2.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 690eb6bc03d9154ac1e679d7c861b845
+    sha256: 16848eedb611ed28abffc1d8594d07df08659a8135c100c1131a8223b99b556d
+  category: main
+  optional: false
+- name: sphinx-tags
+  version: 0.2.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     pre-commit: ''
@@ -14879,6 +22824,19 @@ package:
 - name: sphinx_fontawesome
   version: 0.0.6
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+    sphinx: '>=1.5.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx_fontawesome-0.0.6-pyh8c360ce_0.tar.bz2
+  hash:
+    md5: fc037d1b4a799959b8770375e6458bfd
+    sha256: 2125421eada1cbafdc5e0058e07a417f7f6c938b447eb63e80fbe8403e7235e5
+  category: main
+  optional: false
+- name: sphinx_fontawesome
+  version: 0.0.6
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
@@ -14904,6 +22862,18 @@ package:
 - name: sphinxcontrib-applehelp
   version: 1.0.4
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5a31a7d564f551d0e6dff52fd8cb5b16
+    sha256: 802810d8321d55e5666806d565e72949eabf77ad510fe2758ce1da2441675ef1
+  category: main
+  optional: false
+- name: sphinxcontrib-applehelp
+  version: 1.0.4
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -14928,6 +22898,18 @@ package:
 - name: sphinxcontrib-devhelp
   version: 1.0.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.2-py_0.tar.bz2
+  hash:
+    md5: 68e01cac9d38d0e717cd5c87bc3d2cc9
+    sha256: 66cca7eccb7f92eee53f9f5a552e3e1d643daa3a1ebd03c185e2819e5c491576
+  category: main
+  optional: false
+- name: sphinxcontrib-devhelp
+  version: 1.0.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -14953,6 +22935,19 @@ package:
 - name: sphinxcontrib-dotnetdomain
   version: '0.4'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+    sphinx: '>=0.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-dotnetdomain-0.4-py_0.tar.bz2
+  hash:
+    md5: fb61a7369f505b4bb98e1530c3e09f9f
+    sha256: bcec8d02205dc27bc399e42513d204f8557b8b06a9546ed784c283086850211c
+  category: main
+  optional: false
+- name: sphinxcontrib-dotnetdomain
+  version: '0.4'
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
@@ -14979,6 +22974,19 @@ package:
 - name: sphinxcontrib-golangdomain
   version: 0.2.0.dev0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+    sphinx: '>=1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-golangdomain-0.2.0.dev0-py_0.tar.bz2
+  hash:
+    md5: d1a73c192888d08cedec232602c22f32
+    sha256: 1610ab148559364b6927e481f5c97f31c8130ffcca2dc16d1c4b33c281e408d6
+  category: main
+  optional: false
+- name: sphinxcontrib-golangdomain
+  version: 0.2.0.dev0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
@@ -15004,6 +23012,18 @@ package:
 - name: sphinxcontrib-htmlhelp
   version: 2.0.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6c8c4d6eb2325e59290ac6dbbeacd5f0
+    sha256: aeff20be994e6f9520a91fc177a33cb3e4d0911cdf8d27e575d001f00afa33fd
+  category: main
+  optional: false
+- name: sphinxcontrib-htmlhelp
+  version: 2.0.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -15028,6 +23048,18 @@ package:
 - name: sphinxcontrib-jsmath
   version: 1.0.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: da1d979339e2714c30a8e806a33ec087
+    sha256: d4337d83b8edba688547766fc80f1ac86d6ec86ceeeda93f376acc04079c5ce2
+  category: main
+  optional: false
+- name: sphinxcontrib-jsmath
+  version: 1.0.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -15054,11 +23086,25 @@ package:
 - name: sphinxcontrib-mermaid
   version: 0.9.2
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    sphinx: ''
     docutils: ''
     python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-mermaid-0.9.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 54a6a75e5b3989f1d925d8e5674bbbcb
+    sha256: bb02467bb3569406d978112f299e8d8b0832cc495b8bbd5d591858ddbe3a291d
+  category: main
+  optional: false
+- name: sphinxcontrib-mermaid
+  version: 0.9.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     sphinx: ''
+    docutils: ''
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-mermaid-0.9.2-pyhd8ed1ab_0.conda
   hash:
     md5: 54a6a75e5b3989f1d925d8e5674bbbcb
@@ -15080,6 +23126,18 @@ package:
 - name: sphinxcontrib-qthelp
   version: 1.0.3
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2
+  hash:
+    md5: d01180388e6d1838c3e1ad029590aa7a
+    sha256: 35d8f01fc798d38b72ae003c040d2dee650d315f904268a1f793d4d59460d1e2
+  category: main
+  optional: false
+- name: sphinxcontrib-qthelp
+  version: 1.0.3
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -15104,6 +23162,18 @@ package:
 - name: sphinxcontrib-serializinghtml
   version: 1.1.5
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2
+  hash:
+    md5: 9ff55a0901cf952f05c654394de76bf7
+    sha256: 890bbf815cff114ddbb618b9876d492fce07d02956c1d7b3d46cb7f835f563f6
+  category: main
+  optional: false
+- name: sphinxcontrib-serializinghtml
+  version: 1.1.5
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -15130,10 +23200,24 @@ package:
 - name: sphinxcontrib-youtube
   version: 1.2.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    requests: ''
+    python: '>=3.6'
+    sphinx: '>=0.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-youtube-1.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 08b58a79c8cc29922dd65fff31577008
+    sha256: 90e8c853aa0f99ad82ae28f8289f7d56153970bd81dcc9f810ab9ec051d9365a
+  category: main
+  optional: false
+- name: sphinxcontrib-youtube
+  version: 1.2.0
+  manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
     requests: ''
+    python: '>=3.6'
     sphinx: '>=0.6'
   url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-youtube-1.2.0-pyhd8ed1ab_0.conda
   hash:
@@ -15142,7 +23226,7 @@ package:
   category: main
   optional: false
 - name: sqlalchemy
-  version: 2.0.28
+  version: 2.0.29
   manager: conda
   platform: linux-64
   dependencies:
@@ -15151,14 +23235,29 @@ package:
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.*
     typing-extensions: '>=4.6.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.28-py39hd1e30aa_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.29-py39hd1e30aa_0.conda
   hash:
-    md5: 0b3b73db2d2931fa07a98e0ba1a6764b
-    sha256: 5f2074a4750c14134f0c35a6c7f0a731534f78ecc3dd578dc4f362ea8dc62075
+    md5: 73068cb68de45fae9c27989c4d0e722f
+    sha256: ea79a5f0ef320f0cfd336a55cb92bcdef2abf98b83fcdbaa0afa6c5d14075875
   category: main
   optional: false
 - name: sqlalchemy
-  version: 2.0.28
+  version: 2.0.29
+  manager: conda
+  platform: osx-64
+  dependencies:
+    greenlet: '!=0.4.17'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    typing-extensions: '>=4.6.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/sqlalchemy-2.0.29-py39ha09f3b3_0.conda
+  hash:
+    md5: bf50a33f593a504eb82637a3bb90d0bb
+    sha256: aed0613826da4cee04037d1308ff6366558eca271dafd10ef25506b3514bad22
+  category: main
+  optional: false
+- name: sqlalchemy
+  version: 2.0.29
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -15166,10 +23265,10 @@ package:
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.*
     typing-extensions: '>=4.6.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlalchemy-2.0.28-py39h17cfd9d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlalchemy-2.0.29-py39h17cfd9d_0.conda
   hash:
-    md5: 1b66bccb5e13f902e86255d5ce8c8e8e
-    sha256: 8953b2bba824a6feaad98840aaa57a3c889f4621883bd67c41595ece7b5a599e
+    md5: dea3032485b3fb978ecbb0feac193539
+    sha256: bb86774008fbedec67b4ad726c5f66cfe84173053b71b10486d826ce9fb828d7
   category: main
   optional: false
 - name: sqlite
@@ -15186,6 +23285,21 @@ package:
   hash:
     md5: 1423efca06ed343c1da0fc429bae0779
     sha256: 22d2692c82b73480c9adc80472bfb241262586edaf1dac1a7504434e47185d3c
+  category: main
+  optional: false
+- name: sqlite
+  version: 3.45.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libsqlite: 3.45.2
+    libzlib: '>=1.2.13,<1.3.0a0'
+    ncurses: '>=6.4,<7.0a0'
+    readline: '>=8.2,<9.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.45.2-h7461747_0.conda
+  hash:
+    md5: fc4dae09f6b38084f3bfc87c77032584
+    sha256: c9c1b7d6025d5efa74f4ddbda1ae72a721f041ad3d4a6ec3dda600befe9dffaa
   category: main
   optional: false
 - name: sqlite
@@ -15218,6 +23332,18 @@ package:
 - name: sqlparse
   version: 0.4.4
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sqlparse-0.4.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2e2f31b3b1c866c29636377e14f8c4c6
+    sha256: 7972c9b15dafa1885f3d4cd22dc4edea4cd969d12739fb71f8632f2c3350706a
+  category: main
+  optional: false
+- name: sqlparse
+  version: 0.4.4
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -15245,6 +23371,21 @@ package:
 - name: stack_data
   version: 0.6.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    asttokens: ''
+    executing: ''
+    pure_eval: ''
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: e7df0fdd404616638df5ece6e69ba7af
+    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  category: main
+  optional: false
+- name: stack_data
+  version: 0.6.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     asttokens: ''
@@ -15272,6 +23413,18 @@ package:
 - name: statsd
   version: 3.3.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/statsd-3.3.0-py_0.tar.bz2
+  hash:
+    md5: 8f5c03d5657905e6c70c3e6e522bfb4e
+    sha256: 3553501b2981764bdd650d83a8d03886e9ffcbe7930327e5d2043322953da8ca
+  category: main
+  optional: false
+- name: statsd
+  version: 3.3.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
@@ -15296,6 +23449,18 @@ package:
 - name: stringcase
   version: 1.2.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/stringcase-1.2.0-py_0.tar.bz2
+  hash:
+    md5: 26a9caf3173939377bac7152379daac0
+    sha256: ebd515c57537799ee7829055fe9aa93d1c4695334b991fe1de9d7947f53f18f2
+  category: main
+  optional: false
+- name: stringcase
+  version: 1.2.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
@@ -15323,12 +23488,27 @@ package:
 - name: sympy
   version: '1.12'
   manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+    python: '*'
+    mpmath: '>=0.19'
+    gmpy2: '>=2.0.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12-pypyh9d50eac_103.conda
+  hash:
+    md5: 2f7d6347d7acf6edf1ac7f2189f44c8f
+    sha256: 0025dd4e6411423903bf478d1b9fbff0cbbbe546f51c9375dfd6729ef2e1a1ac
+  category: main
+  optional: false
+- name: sympy
+  version: '1.12'
+  manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
-    gmpy2: '>=2.0.8'
+    python: '*'
     mpmath: '>=0.19'
-    python: '>=3.8'
+    gmpy2: '>=2.0.8'
   url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12-pypyh9d50eac_103.conda
   hash:
     md5: 2f7d6347d7acf6edf1ac7f2189f44c8f
@@ -15339,6 +23519,18 @@ package:
   version: 0.9.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
+  hash:
+    md5: 4759805cce2d914c38472f70bf4d8bcb
+    sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
+  category: main
+  optional: false
+- name: tabulate
+  version: 0.9.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
@@ -15373,10 +23565,35 @@ package:
     sha256: ded4de0d5a3eb7b47ed829f0ed0e3c61ccd428308bde52d8d22ced228038223b
   category: main
   optional: false
+- name: tbb
+  version: 2021.11.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15'
+    libhwloc: '>=2.9.3,<2.9.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.11.0-h7728843_1.conda
+  hash:
+    md5: 29e29beba9deb0ef66bee015c5bf3c14
+    sha256: 6d531daba5ccf150b58d434fa72b1da0da04e8f14ab71bdad289a90d355f47e8
+  category: main
+  optional: false
 - name: tblib
   version: 3.0.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 04eedddeb68ad39871c8127dd1c21f4f
+    sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
+  category: main
+  optional: false
+- name: tblib
+  version: 3.0.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
@@ -15401,6 +23618,18 @@ package:
   version: 8.2.3
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-8.2.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1482e77f87c6a702a7e05ef22c9b197b
+    sha256: 860c11e7369d6a86fcc9c6cbca49d5c457f6c0a27faeacca4d46267f9dd10d78
+  category: main
+  optional: false
+- name: tenacity
+  version: 8.2.3
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/tenacity-8.2.3-pyhd8ed1ab_0.conda
@@ -15448,21 +23677,45 @@ package:
 - name: tensorboard
   version: 2.15.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    six: '>=1.9'
+    numpy: '>=1.12.0'
+    setuptools: '>=41.0.0'
+    markdown: '>=2.6.8'
+    absl-py: '>=0.4'
+    requests: '>=2.21.0,<3'
+    werkzeug: '>=1.0.1'
+    google-auth: '>=1.6.3,<3'
+    protobuf: '>=3.19.6'
+    grpcio: '>=1.48.2'
+    tensorboard-data-server: '>=0.7.0,<0.8.0'
+    google-auth-oauthlib: '>=0.5,<2'
+  url: https://conda.anaconda.org/conda-forge/noarch/tensorboard-2.15.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: be92712a3adb1f9371551a72c5881cd9
+    sha256: 37c9ecd571c227f3c062d8d38c9e0b6c6454cb4533f498be5cf991a9cd370b99
+  category: main
+  optional: false
+- name: tensorboard
+  version: 2.15.2
+  manager: conda
   platform: osx-arm64
   dependencies:
-    absl-py: '>=0.4'
-    google-auth: '>=1.6.3,<3'
-    google-auth-oauthlib: '>=0.5,<2'
-    grpcio: '>=1.48.2'
-    markdown: '>=2.6.8'
-    numpy: '>=1.12.0'
-    protobuf: '>=3.19.6'
     python: '>=3.8'
-    requests: '>=2.21.0,<3'
-    setuptools: '>=41.0.0'
     six: '>=1.9'
-    tensorboard-data-server: '>=0.7.0,<0.8.0'
+    numpy: '>=1.12.0'
+    setuptools: '>=41.0.0'
+    markdown: '>=2.6.8'
+    absl-py: '>=0.4'
+    requests: '>=2.21.0,<3'
     werkzeug: '>=1.0.1'
+    google-auth: '>=1.6.3,<3'
+    protobuf: '>=3.19.6'
+    grpcio: '>=1.48.2'
+    tensorboard-data-server: '>=0.7.0,<0.8.0'
+    google-auth-oauthlib: '>=0.5,<2'
   url: https://conda.anaconda.org/conda-forge/noarch/tensorboard-2.15.2-pyhd8ed1ab_0.conda
   hash:
     md5: be92712a3adb1f9371551a72c5881cd9
@@ -15482,6 +23735,20 @@ package:
   hash:
     md5: 385936ccbb943d2be60177871c1c0bb5
     sha256: 0389876d33062d7859a8078e6658569ea5df7a06206852c8dd02314e0db170b5
+  category: main
+  optional: false
+- name: tensorboard-data-server
+  version: 0.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    openssl: '>=3.1.3,<4.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/tensorboard-data-server-0.7.0-py39he8b0a07_1.conda
+  hash:
+    md5: d4d0a09da91604f5a8b3f66bc5d7193e
+    sha256: 5d06949defa921353a97701ff669b4e55c77e31855dfe910be7debe9c03fd937
   category: main
   optional: false
 - name: tensorboard-data-server
@@ -15511,6 +23778,21 @@ package:
   hash:
     md5: 610e35885724577aa45c32ac5e3a6888
     sha256: d2f7f80ea6ce4c2d0ec992c6fea57cf2bdd111d6065cb01ac5d53542d5248c1a
+  category: main
+  optional: false
+- name: tensorflow
+  version: 2.15.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    tensorflow-base: 2.15.0
+    tensorflow-estimator: 2.15.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/tensorflow-2.15.0-cpu_py39hb71d5be_2.conda
+  hash:
+    md5: 08060f56b168740ecddb503f5d201be3
+    sha256: dae7d7e16aa3abfaef27360751bbfa451f8216249b6fd6c322becbc945b073ac
   category: main
   optional: false
 - name: tensorflow
@@ -15572,6 +23854,52 @@ package:
   hash:
     md5: 973044417623cce843b3f8068a7f2b93
     sha256: 897a6f9602aee8daf0e645dc697ad5aacca61ef5a2f02c53b6a66fd5a30db476
+  category: main
+  optional: false
+- name: tensorflow-base
+  version: 2.15.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    absl-py: '>=1.0.0'
+    astunparse: '>=1.6.0'
+    flatbuffers: '>=23.5.26,<23.5.27.0a0'
+    gast: '>=0.2.1,!=0.5.0,!=0.5.1,!=0.5.2'
+    giflib: '>=5.2.1,<5.3.0a0'
+    google-pasta: '>=0.1.1'
+    grpcio: 1.59.*
+    h5py: '>=2.9.0'
+    icu: '>=73.2,<74.0a0'
+    keras: '>=2.15,<2.16'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=15'
+    libgrpc: '>=1.59.3,<1.60.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libsqlite: '>=3.44.2,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    ml_dtypes: 0.2.0.*
+    numpy: '>=1.22.4,<2.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+    opt_einsum: '>=2.3.2'
+    packaging: ''
+    protobuf: '>=3.20.3,<5,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+    python: '>=3.9,<3.10.0a0'
+    python-flatbuffers: '>=23.5.26'
+    python_abi: 3.9.*
+    six: '>=1.12'
+    snappy: '>=1.1.10,<2.0a0'
+    tensorboard: '>=2.15,<2.16'
+    termcolor: '>=1.1.0'
+    typing_extensions: '>=3.6.6'
+    wrapt: '>=1.11.0,<1.15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tensorflow-base-2.15.0-cpu_py39h1d1916d_2.conda
+  hash:
+    md5: 53be17bb1d7a3ec1bddf9ffbb87190c2
+    sha256: 5b76b8dd404bfaac01f2a2819f0101e5110d8a94f300eb92fe4c177d57e69273
   category: main
   optional: false
 - name: tensorflow-base
@@ -15639,6 +23967,22 @@ package:
 - name: tensorflow-estimator
   version: 2.15.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15'
+    openssl: '>=3.2.0,<4.0a0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    tensorflow-base: 2.15.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/tensorflow-estimator-2.15.0-cpu_py39h805f699_2.conda
+  hash:
+    md5: 9c4d4faafcd4f7562b8a704a3a620e2a
+    sha256: ef2376d6eb860f7b81d37a5ada4c8d13ac92d57e46bffec10f95c3587f79bd6f
+  category: main
+  optional: false
+- name: tensorflow-estimator
+  version: 2.15.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=15'
@@ -15656,6 +24000,18 @@ package:
   version: 2.4.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/termcolor-2.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a5033708ad9283907c3b1bc1f90d0d0d
+    sha256: 59588d41f2c02d599fd6528583013d85bd47d17b1acec11edbb29deadd81fbca
+  category: main
+  optional: false
+- name: termcolor
+  version: 2.4.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/termcolor-2.4.0-pyhd8ed1ab_0.conda
@@ -15694,6 +24050,21 @@ package:
 - name: terminado
   version: 0.18.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: ''
+    ptyprocess: ''
+    python: '>=3.8'
+    tornado: '>=6.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+  hash:
+    md5: 00b54981b923f5aefcd5e8547de056d5
+    sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
+  category: main
+  optional: false
+- name: terminado
+  version: 0.18.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     __osx: ''
@@ -15721,6 +24092,18 @@ package:
 - name: text-unidecode
   version: '1.3'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_1.conda
+  hash:
+    md5: ba8aba332d8868897ce44ad74015a7fe
+    sha256: db64669a918dec8c744f80a85b9c82216b79298256c7c8bd19bdba54a02f8914
+  category: main
+  optional: false
+- name: text-unidecode
+  version: '1.3'
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.4'
@@ -15745,6 +24128,18 @@ package:
 - name: textwrap3
   version: 0.9.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/textwrap3-0.9.2-py_0.tar.bz2
+  hash:
+    md5: 1f84e74e9dbe2e5ae38c58496bffaca8
+    sha256: d7b40d3a3f1c2e74bbea5ee845b34a30abc1ae8e4f2a92f4a58800e1e669c076
+  category: main
+  optional: false
+- name: textwrap3
+  version: 0.9.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
@@ -15775,15 +24170,33 @@ package:
 - name: tf2onnx
   version: 1.16.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    numpy: '>=1.14.1'
-    onnx: '>=1.4.1'
-    python: '>=3.8'
-    python-flatbuffers: '>=1.12'
     requests: ''
     six: ''
+    python: '>=3.8'
+    numpy: '>=1.14.1'
     tensorflow: '>=2.6'
+    python-flatbuffers: '>=1.12'
+    onnx: '>=1.4.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/tf2onnx-1.16.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3882e49e3d01c69231a7e48d09ca0ec6
+    sha256: 17b0ed248ed0a5ac822ed6a4fa55b122c7c4ab01e069d4dacec5606f6d655233
+  category: main
+  optional: false
+- name: tf2onnx
+  version: 1.16.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    requests: ''
+    six: ''
+    python: '>=3.8'
+    numpy: '>=1.14.1'
+    tensorflow: '>=2.6'
+    python-flatbuffers: '>=1.12'
+    onnx: '>=1.4.1'
   url: https://conda.anaconda.org/conda-forge/noarch/tf2onnx-1.16.1-pyhd8ed1ab_0.conda
   hash:
     md5: 3882e49e3d01c69231a7e48d09ca0ec6
@@ -15791,27 +24204,39 @@ package:
   category: main
   optional: false
 - name: threadpoolctl
-  version: 3.3.0
+  version: 3.4.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.3.0-pyhc1e730c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.4.0-pyhc1e730c_0.conda
   hash:
-    md5: 698d2d2b621640bddb9191f132967c9f
-    sha256: 5ba8bd3f2d49b3b860eb4481ca9505c57d4427212eb12cadd2b351309d5c28e6
+    md5: b296278eef667c673bf51de6535bad88
+    sha256: 4f4ad4f2a4ee8875cf2cb9c80abf4c7383e5e53cfec41104da7058569d9063b7
   category: main
   optional: false
 - name: threadpoolctl
-  version: 3.3.0
+  version: 3.4.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.4.0-pyhc1e730c_0.conda
+  hash:
+    md5: b296278eef667c673bf51de6535bad88
+    sha256: 4f4ad4f2a4ee8875cf2cb9c80abf4c7383e5e53cfec41104da7058569d9063b7
+  category: main
+  optional: false
+- name: threadpoolctl
+  version: 3.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.3.0-pyhc1e730c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.4.0-pyhc1e730c_0.conda
   hash:
-    md5: 698d2d2b621640bddb9191f132967c9f
-    sha256: 5ba8bd3f2d49b3b860eb4481ca9505c57d4427212eb12cadd2b351309d5c28e6
+    md5: b296278eef667c673bf51de6535bad88
+    sha256: 4f4ad4f2a4ee8875cf2cb9c80abf4c7383e5e53cfec41104da7058569d9063b7
   category: main
   optional: false
 - name: tiledb
@@ -15837,6 +24262,31 @@ package:
   hash:
     md5: 20101f907b5fab4089b034f827e01b91
     sha256: abc460ddf0205dfbeb987678ca882fedcf152d91fbfe7acba2a46c10a306d9cd
+  category: main
+  optional: false
+- name: tiledb
+  version: 2.20.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    azure-core-cpp: '>=1.10.3,<1.10.4.0a0'
+    azure-storage-blobs-cpp: '>=12.10.0,<12.10.1.0a0'
+    azure-storage-common-cpp: '>=12.5.0,<12.5.1.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=16'
+    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
+    libxml2: '>=2.12.5,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.20.0-h8fd0293_0.conda
+  hash:
+    md5: 6585a0f5ff3f277826a392e1a5ab0ee6
+    sha256: 6d1d383dcd6722f99ce26d4e042eb1ea69da4d62256f29b9318d3849d56a359c
   category: main
   optional: false
 - name: tiledb
@@ -15879,6 +24329,19 @@ package:
 - name: tinycss2
   version: 1.2.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+    webencodings: '>=0.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 7234c9eefff659501cd2fe0d2ede4d48
+    sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
+  category: main
+  optional: false
+- name: tinycss2
+  version: 1.2.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -15900,6 +24363,18 @@ package:
   hash:
     md5: d453b98d9c83e71da0741bb0ff4d76bc
     sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  hash:
+    md5: bf830ba5afc507c6232d4ef0fb1a882d
+    sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
   category: main
   optional: false
 - name: tk
@@ -15929,6 +24404,18 @@ package:
 - name: toml
   version: 0.10.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: f832c45a477c78bebd107098db465095
+    sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
+  category: main
+  optional: false
+- name: toml
+  version: 0.10.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=2.7'
@@ -15953,6 +24440,18 @@ package:
 - name: tomli
   version: 2.0.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5844808ffab9ebdb694585b50ba02a96
+    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  category: main
+  optional: false
+- name: tomli
+  version: 2.0.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -15977,6 +24476,18 @@ package:
 - name: tomlkit
   version: 0.12.4
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.4-pyha770c72_0.conda
+  hash:
+    md5: 37c47ea93ef00dd80d880fc4ba21256a
+    sha256: 8d45c266bf919788abacd9828f4a2101d7216f6d4fc7c8d3417034fe0d795a18
+  category: main
+  optional: false
+- name: tomlkit
+  version: 0.12.4
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
@@ -15990,6 +24501,18 @@ package:
   version: 0.12.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2fcb582444635e2c402e8569bb94e039
+    sha256: 22b0a9790317526e08609d5dfdd828210ae89e6d444a9e954855fc29012e90c6
+  category: main
+  optional: false
+- name: toolz
+  version: 0.12.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
@@ -16027,6 +24550,19 @@ package:
 - name: tornado
   version: '6.4'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4-py39ha09f3b3_0.conda
+  hash:
+    md5: 4541517b5a605bf45d4a5fb074bb4cf5
+    sha256: 4466eabed63d4a979b8f1aefc3241b91a70ee186e69ce23e5fbe23c122033c16
+  category: main
+  optional: false
+- name: tornado
+  version: '6.4'
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -16053,6 +24589,19 @@ package:
 - name: tqdm
   version: 4.66.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    colorama: ''
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2b8dfb969f984497f3f98409a9545776
+    sha256: 416d1d9318f3267325ad7e2b8a575df20ff9031197b30c0222c3d3b023877260
+  category: main
+  optional: false
+- name: tqdm
+  version: 4.66.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     colorama: ''
@@ -16078,6 +24627,18 @@ package:
 - name: traitlets
   version: 5.14.2
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: af5fa2d2186003472e766a23c46cae04
+    sha256: 9ea6073091c130470a51b51703c8d2d959434992e29c4aa4abeba07cd56533a3
+  category: main
+  optional: false
+- name: traitlets
+  version: 5.14.2
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
@@ -16088,37 +24649,63 @@ package:
   category: main
   optional: false
 - name: typeguard
-  version: 4.1.5
+  version: 4.2.1
   manager: conda
   platform: linux-64
   dependencies:
     importlib_metadata: '>=3.6'
     python: '>=3.8'
     typing_extensions: '>=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.1.5-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 59d22e0ca481b057b94d54fc9ebacb13
-    sha256: df63f90625d2eaefcb6990437b941c1c90ec3c224bc65a2becac928542d0aa5f
+    md5: 47102c2390ebdc73a8a1843e77dab61e
+    sha256: dd140e850215c729a50cbface4a1fc640dcc91f8da43ce467977a298c4dfe89a
   category: main
   optional: false
 - name: typeguard
-  version: 4.1.5
+  version: 4.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    importlib_metadata: '>=3.6'
+    typing_extensions: '>=4.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.2.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 47102c2390ebdc73a8a1843e77dab61e
+    sha256: dd140e850215c729a50cbface4a1fc640dcc91f8da43ce467977a298c4dfe89a
+  category: main
+  optional: false
+- name: typeguard
+  version: 4.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib_metadata: '>=3.6'
     python: '>=3.8'
+    importlib_metadata: '>=3.6'
     typing_extensions: '>=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.1.5-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 59d22e0ca481b057b94d54fc9ebacb13
-    sha256: df63f90625d2eaefcb6990437b941c1c90ec3c224bc65a2becac928542d0aa5f
+    md5: 47102c2390ebdc73a8a1843e77dab61e
+    sha256: dd140e850215c729a50cbface4a1fc640dcc91f8da43ce467977a298c4dfe89a
   category: main
   optional: false
 - name: types-python-dateutil
   version: 2.9.0.20240316
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7831efa91d57475373ee52fb92e8d137
+    sha256: 6630bbc43dfb72339fadafc521db56c9d17af72bfce459af195eecb01163de20
+  category: main
+  optional: false
+- name: types-python-dateutil
+  version: 2.9.0.20240316
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
@@ -16143,6 +24730,18 @@ package:
   version: 4.10.0
   manager: conda
   platform: linux-64
+  dependencies:
+    typing_extensions: 4.10.0
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.10.0-hd8ed1ab_0.conda
+  hash:
+    md5: 091683b9150d2ebaa62fd7e2c86433da
+    sha256: 0698fe2c4e555fb44c27c60f7a21fa0eea7f5bf8186ad109543c5b056e27f96a
+  category: main
+  optional: false
+- name: typing-extensions
+  version: 4.10.0
+  manager: conda
+  platform: osx-64
   dependencies:
     typing_extensions: 4.10.0
   url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.10.0-hd8ed1ab_0.conda
@@ -16167,6 +24766,18 @@ package:
   version: 4.10.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.10.0-pyha770c72_0.conda
+  hash:
+    md5: 16ae769069b380646c47142d719ef466
+    sha256: 4be24d557897b2f6609f5d5f7c437833c62f4d4a96581e39530067e96a2d0451
+  category: main
+  optional: false
+- name: typing_extensions
+  version: 4.10.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.10.0-pyha770c72_0.conda
@@ -16204,11 +24815,25 @@ package:
 - name: typing_inspect
   version: 0.9.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    mypy_extensions: '>=0.3.0'
     python: '>=3.5'
     typing_extensions: '>=3.7.4'
+    mypy_extensions: '>=0.3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9e924b76b91908a17e28a19a0ab88687
+    sha256: 16e0b825c138e14ebc84623248d91d93a8cff29bb93595cc4aa46ca32f24f1de
+  category: main
+  optional: false
+- name: typing_inspect
+  version: 0.9.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.5'
+    typing_extensions: '>=3.7.4'
+    mypy_extensions: '>=0.3.0'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_0.conda
   hash:
     md5: 9e924b76b91908a17e28a19a0ab88687
@@ -16219,6 +24844,18 @@ package:
   version: 0.1.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: eb67e3cace64c66233e2d35949e20f92
+    sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
+  category: main
+  optional: false
+- name: typing_utils
+  version: 0.1.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
@@ -16255,6 +24892,17 @@ package:
 - name: tzcode
   version: 2024a
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/tzcode-2024a-h10d778d_0.conda
+  hash:
+    md5: 8d50ba6668dbd193cd42ccd9099fa2ae
+    sha256: e3ee34b2711500f3b1d38309d47cfd7e4d05c0144f0b2b2bdfbc271a28cfdd76
+  category: main
+  optional: false
+- name: tzcode
+  version: 2024a
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/tzcode-2024a-h93a5062_0.conda
@@ -16267,6 +24915,17 @@ package:
   version: 2024a
   manager: conda
   platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+  hash:
+    md5: 161081fc7cec0bfda0d86d7cb595f8d8
+    sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
+  category: main
+  optional: false
+- name: tzdata
+  version: 2024a
+  manager: conda
+  platform: osx-64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
   hash:
@@ -16301,6 +24960,19 @@ package:
 - name: tzlocal
   version: '5.2'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/tzlocal-5.2-py39h6e9494a_0.conda
+  hash:
+    md5: 828412576e7202ba22e5ee3256c70951
+    sha256: 42971089fa77cb29905c494c78c59e45d554b56ead732966cbe71eea10371751
+  category: main
+  optional: false
+- name: tzlocal
+  version: '5.2'
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -16316,13 +24988,14 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    cuda-cudart: '>=12.0.107,<13.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     rdma-core: '>=50.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-h11edf95_7.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-hf604dca_7.conda
   hash:
-    md5: 20a94f617ad76922f8737ad1fe317f4d
-    sha256: 3e381ec5918045a43e0f349214a4d38e53990897ba07a6abf025f9e0156acaf2
+    md5: 65df290dcf5d4f6d11e98faf6429f392
+    sha256: 0992f449135cb8af2320fbfea2d76f5c543468858e77f35fa39c1048bf2d8782
   category: main
   optional: false
 - name: ukkonen
@@ -16339,6 +25012,21 @@ package:
   hash:
     md5: b66595fbda99771266f042f42c7457be
     sha256: 6ca31e79eeee63ea33e5b18dd81c1bc202c43741b5f0de3bcd4409f9ffd93a95
+  category: main
+  optional: false
+- name: ukkonen
+  version: 1.0.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cffi: ''
+    libcxx: '>=15.0.7'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py39h8ee36c8_4.conda
+  hash:
+    md5: 234e1d8799d93d5d51b3d778019a6db9
+    sha256: 87b17e86e8540aa4a598fd024fd884427557138dceae2ba48d3e99a51dad623a
   category: main
   optional: false
 - name: ukkonen
@@ -16373,6 +25061,19 @@ package:
 - name: unicodedata2
   version: 15.1.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py39hdc70f33_0.conda
+  hash:
+    md5: ede122e9ef2775a8879063d9d3ee819f
+    sha256: 2c3049ec6ffd44beb61964bf109993f654a7316fa6a368c634d603e8347f9fdf
+  category: main
+  optional: false
+- name: unicodedata2
+  version: 15.1.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -16398,6 +25099,18 @@ package:
 - name: unidecode
   version: 1.3.8
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/unidecode-1.3.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: 913724e0dfe2708b7b7d4e35b8cc2e0f
+    sha256: 3f29636a555736983ac2bdeb6e41a5cd85b572fa4f6cc2270d6c6543d8eb8c0b
+  category: main
+  optional: false
+- name: unidecode
+  version: 1.3.8
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -16411,6 +25124,18 @@ package:
   version: 1.3.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0944dc65cb4a9b5b68522c3bb585d41c
+    sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
+  category: main
+  optional: false
+- name: uri-template
+  version: 1.3.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
@@ -16438,10 +25163,22 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.7-h59595ed_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.7-hcb278e6_1.conda
   hash:
-    md5: c5edf07141147789784f89d5b4e4a9ad
-    sha256: ec997599b6dcfef34242c67b695c4704d9ba6cb0b9de8f390defa475a95cdb3f
+    md5: 2c46deb08ba9b10e90d0a6401ad65deb
+    sha256: bc7670384fc3e519b376eab25b2c747afe392b243f17e881075231f4a0f2e5a0
+  category: main
+  optional: false
+- name: uriparser
+  version: 0.9.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.7-hf0c8a7f_1.conda
+  hash:
+    md5: 998073b0ccb5f99d07d2089cf06363b3
+    sha256: faf0f7919851960bbb1d18d977f62082c0e4dc8f26e348d702e8a2dba53a4c37
   category: main
   optional: false
 - name: uriparser
@@ -16449,11 +25186,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.7-h13dd4ca_1.conda
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.7-hb7217d7_1.conda
   hash:
-    md5: df83a53820f413eb8b14045433a2d587
-    sha256: 019103df9eec86c9afa92dec21a849e63d57bfa9125ca811e68b78dab224c4ee
+    md5: 4fe532e3c6b0cfa5365eb01743d32578
+    sha256: bedd03f3bb30b73ae7b0dc9626f1371a8568ce6d41303df3e8299688428dfa94
   category: main
   optional: false
 - name: urllib3
@@ -16473,11 +25210,25 @@ package:
 - name: urllib3
   version: 1.26.18
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+  hash:
+    md5: bf61cfd2a7f212efba378167a07d4a6a
+    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
+  category: main
+  optional: false
+- name: urllib3
+  version: 1.26.18
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     python: '>=3.7'
+    brotli-python: '>=1.0.9'
+    pysocks: '>=1.5.6,<2.0,!=1.5.7'
   url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
   hash:
     md5: bf61cfd2a7f212efba378167a07d4a6a
@@ -16516,6 +25267,39 @@ package:
   hash:
     md5: eb55dbc1f7fb59823b361f92ba73f7fa
     sha256: b85bf700aac63cafae0d728f36ab35848fdb390be973232d74d61edef78fdcea
+  category: main
+  optional: false
+- name: vaex-core
+  version: 4.17.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aplus: ''
+    blake3: ''
+    cloudpickle: ''
+    dask: ''
+    filelock: ''
+    frozendict: ''
+    future: '>=0.15.2'
+    libcxx: '>=15.0.7'
+    nest-asyncio: '>=1.3.3'
+    numpy: '>=1.21.6,<2.0a0'
+    pandas: ''
+    pcre: '>=8.45,<9.0a0'
+    progressbar2: ''
+    pyarrow: '>=3.0'
+    pydantic: '>=1.8.0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+    pyyaml: ''
+    requests: ''
+    rich: ''
+    six: ''
+    tabulate: '>=0.8.3'
+  url: https://conda.anaconda.org/conda-forge/osx-64/vaex-core-4.17.1-py39h49cddf2_0.conda
+  hash:
+    md5: a4e3728d9012ba7b18b734c94b69368b
+    sha256: a15de94253142a6ade7da9ffd3d787560fc1698006946d54c03106d059dda231
   category: main
   optional: false
 - name: vaex-core
@@ -16569,12 +25353,27 @@ package:
 - name: virtualenv
   version: 20.25.1
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
+    python: '>=3.8'
     distlib: <1,>=0.3.7
     filelock: <4,>=3.12.2
     platformdirs: <5,>=3.9.1
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.25.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 8797a4e26be36880a603aba29c785352
+    sha256: 1ced4445cf72cd9dc344ad04bdaf703a08cc428c8c46e4bda928ad79786ee153
+  category: main
+  optional: false
+- name: virtualenv
+  version: 20.25.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
     python: '>=3.8'
+    distlib: <1,>=0.3.7
+    filelock: <4,>=3.12.2
+    platformdirs: <5,>=3.9.1
   url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.25.1-pyhd8ed1ab_0.conda
   hash:
     md5: 8797a4e26be36880a603aba29c785352
@@ -16596,6 +25395,18 @@ package:
 - name: wcwidth
   version: 0.2.13
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+  hash:
+    md5: 68f0738df502a14213624b288c60c9ad
+    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+  category: main
+  optional: false
+- name: wcwidth
+  version: 0.2.13
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
@@ -16620,6 +25431,18 @@ package:
 - name: webcolors
   version: '1.13'
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+  hash:
+    md5: 166212fe82dad8735550030488a01d03
+    sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
+  category: main
+  optional: false
+- name: webcolors
+  version: '1.13'
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.5'
@@ -16644,6 +25467,18 @@ package:
 - name: webencodings
   version: 0.5.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: daf5160ff9cde3a468556965329085b9
+    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  category: main
+  optional: false
+- name: webencodings
+  version: 0.5.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=2.6'
@@ -16668,6 +25503,18 @@ package:
 - name: websocket-client
   version: 1.7.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 50ad31e07d706aae88b14a4ac9c73f23
+    sha256: d9b537d5b7c5aa7a02a4ce4c6b755e458bd8083b67752a73c92d113ccec6c10f
+  category: main
+  optional: false
+- name: websocket-client
+  version: 1.7.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
@@ -16693,10 +25540,23 @@ package:
 - name: werkzeug
   version: 3.0.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    markupsafe: '>=2.1.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: af8d825d93dbe6331ee6d61c69869ca0
+    sha256: b7ac49549d370a411b1d6150d24243a15adcce07f1c61ec2ea1b536346e47aa0
+  category: main
+  optional: false
+- name: werkzeug
+  version: 3.0.1
+  manager: conda
   platform: osx-arm64
   dependencies:
-    markupsafe: '>=2.1.1'
     python: '>=3.8'
+    markupsafe: '>=2.1.1'
   url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
   hash:
     md5: af8d825d93dbe6331ee6d61c69869ca0
@@ -16704,33 +25564,57 @@ package:
   category: main
   optional: false
 - name: wheel
-  version: 0.42.0
+  version: 0.43.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 1cdea58981c5cbc17b51973bcaddcea7
-    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
+    md5: 0b5293a157c2b5cd513dd1b03d8d3aae
+    sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
   category: main
   optional: false
 - name: wheel
-  version: 0.42.0
+  version: 0.43.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 0b5293a157c2b5cd513dd1b03d8d3aae
+    sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
+  category: main
+  optional: false
+- name: wheel
+  version: 0.43.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 1cdea58981c5cbc17b51973bcaddcea7
-    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
+    md5: 0b5293a157c2b5cd513dd1b03d8d3aae
+    sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
   category: main
   optional: false
 - name: widgetsnbextension
   version: 4.0.10
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.10-pyhd8ed1ab_0.conda
+  hash:
+    md5: 521f489e3babeddeec638c2add7e9e64
+    sha256: 981b06c76a1a86bb84be09522768be0458274926b22f4b0225dfcdd30a6593e0
+  category: main
+  optional: false
+- name: widgetsnbextension
+  version: 4.0.10
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.10-pyhd8ed1ab_0.conda
@@ -16768,6 +25652,19 @@ package:
 - name: wrapt
   version: 1.14.1
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.14.1-py39ha30fb19_1.tar.bz2
+  hash:
+    md5: 1f32082a7afac6f4b7255d4d3be520e0
+    sha256: ad1587b6685aebb0e0f912020f3dc02e00626912953f49591f9c7aac230aeaf4
+  category: main
+  optional: false
+- name: wrapt
+  version: 1.14.1
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -16776,6 +25673,72 @@ package:
   hash:
     md5: ed6107ea31f4381e880cec32a5f986d9
     sha256: 83f5c4e8963137f6c0287846d118d9e3baac69cfa86b4734a4ea02f4e276422c
+  category: main
+  optional: false
+- name: xcb-util
+  version: 0.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
+  hash:
+    md5: 9bfac7ccd94d54fd21a0501296d60424
+    sha256: 0c91d87f0efdaadd4e56a5f024f8aab20ec30f90aa2ce9e4ebea05fbc20f71ad
+  category: main
+  optional: false
+- name: xcb-util-image
+  version: 0.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
+    xcb-util: '>=0.4.0,<0.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h8ee46fc_1.conda
+  hash:
+    md5: 9d7bcddf49cbf727730af10e71022c73
+    sha256: 92ffd68d2801dbc27afe223e04ae7e78ef605fc8575f107113c93c7bafbd15b0
+  category: main
+  optional: false
+- name: xcb-util-keysyms
+  version: 0.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
+  hash:
+    md5: 632413adcd8bc16b515cab87a2932913
+    sha256: 8451d92f25d6054a941b962179180728c48c62aab5bf20ac10fef713d5da6a9a
+  category: main
+  optional: false
+- name: xcb-util-renderutil
+  version: 0.3.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
+  hash:
+    md5: e995b155d938b6779da6ace6c6b13816
+    sha256: 6987588e6fff5892056021c2ea52f7a0deefb2c7348e70d24750e2d60dabf009
+  category: main
+  optional: false
+- name: xcb-util-wm
+  version: 0.4.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
+  hash:
+    md5: 90108a432fb5c6150ccfee3f03388656
+    sha256: 08ba7147c7579249b6efd33397dc1a8c2404278053165aaecd39280fee705724
   category: main
   optional: false
 - name: xerces-c
@@ -16797,6 +25760,20 @@ package:
 - name: xerces-c
   version: 3.2.5
   manager: conda
+  platform: osx-64
+  dependencies:
+    icu: '>=73.2,<74.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-hbbe9ea5_0.conda
+  hash:
+    md5: ade166000a13c81d9a75f65281e302b0
+    sha256: 10487c0b28ee2303570c6d0867000587a8c36836fffd4d634d8778c494d16965
+  category: main
+  optional: false
+- name: xerces-c
+  version: 3.2.5
+  manager: conda
   platform: osx-arm64
   dependencies:
     icu: '>=73.2,<74.0a0'
@@ -16808,16 +25785,29 @@ package:
     sha256: 8ad901a5fe535ebd16b469cf8e46cf174f7e6e4d9b432cc8cc02666a87e7e2ee
   category: main
   optional: false
+- name: xkeyboard-config
+  version: '2.41'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    xorg-libx11: '>=1.8.7,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.41-hd590300_0.conda
+  hash:
+    md5: 81f740407b45e3f9047b3174fa94eb9e
+    sha256: 56955610c0747ea7cb026bb8aa9ef165ff41d616e89894538173b8b7dd2ee49a
+  category: main
+  optional: false
 - name: xorg-kbproto
   version: 1.0.7
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+    libgcc-ng: '>=7.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h14c3975_1002.tar.bz2
   hash:
-    md5: 4b230e8381279d76131116660f5a241a
-    sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
+    md5: 6dfe5dbe10d55266e4a5e89287eed578
+    sha256: e0ecf489734baf996703b2b274b0d130485476162ef5aae1d4e74851549a470e
   category: main
   optional: false
 - name: xorg-libice
@@ -16877,6 +25867,17 @@ package:
 - name: xorg-libxau
   version: 1.0.11
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+  hash:
+    md5: 9566b4c29274125b0266d0177b5eb97b
+    sha256: 8a2e398c4f06f10c64e69f56bcf3ddfa30b432201446a0893505e735b346619a
+  category: main
+  optional: false
+- name: xorg-libxau
+  version: 1.0.11
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
@@ -16890,11 +25891,22 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+    libgcc-ng: '>=7.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h516909a_0.tar.bz2
   hash:
-    md5: be93aabceefa2fac576e971aef407908
-    sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+    md5: e95a160e60b2a327309a6d323a4d780e
+    sha256: 6cd3f826a853bb26bf303b26560439b135ebc2a88c9806e70a8d6935cfeeea91
+  category: main
+  optional: false
+- name: xorg-libxdmcp
+  version: 1.1.3
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+  hash:
+    md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
+    sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
   category: main
   optional: false
 - name: xorg-libxdmcp
@@ -16941,11 +25953,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
+    libgcc-ng: '>=7.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h14c3975_1002.tar.bz2
   hash:
-    md5: 06feff3d2634e3097ce2fe681474b534
-    sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
+    md5: fbcb7fa11dee1a5d3df4371cc55bb229
+    sha256: bbed3c5ab97fdde0a0a2d725be15cd9b5fc770086e0afecebc8c155873bfff73
   category: main
   optional: false
 - name: xorg-xextproto
@@ -16960,16 +25972,28 @@ package:
     sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
   category: main
   optional: false
+- name: xorg-xf86vidmodeproto
+  version: 2.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=7.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-h516909a_1002.tar.bz2
+  hash:
+    md5: c3f8431e8a5e0b54f8f2ebd812000516
+    sha256: 88e67824b807173c684988244965982cd9e63f1ddf33c10333b64c55e1768bf9
+  category: main
+  optional: false
 - name: xorg-xproto
   version: 7.0.31
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+    libgcc-ng: '>=7.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h14c3975_1007.tar.bz2
   hash:
-    md5: b4a4381d54784606820704f7b5f05a15
-    sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
+    md5: a45d8cd411bdf8f08ced463f68986b62
+    sha256: d24dfec052d1ed796604caf405d8846a394c7950c60a611ec24a4b91aaa9d56f
   category: main
   optional: false
 - name: xxhash
@@ -16987,6 +26011,17 @@ package:
 - name: xxhash
   version: 0.8.2
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/xxhash-0.8.2-h4140336_0.conda
+  hash:
+    md5: 7e1dd1923f44ab000be63d9e40ed9ed7
+    sha256: 2a4bbe7965b99d405ddafcd05434425d8d57b34982c590eb8036eb870d8d8b86
+  category: main
+  optional: false
+- name: xxhash
+  version: 0.8.2
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/xxhash-0.8.2-hb547adb_0.conda
@@ -16999,6 +26034,18 @@ package:
   version: 2023.10.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1e0d85c0e2fef9539218da185b285f54
+    sha256: da655e2e0a742fddefeeaf2dd828b62a1820a3755d13341e1a555a10fcb9cf81
+  category: main
+  optional: false
+- name: xyzservices
+  version: 2023.10.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
@@ -17034,6 +26081,17 @@ package:
 - name: xz
   version: 5.2.6
   manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  hash:
+    md5: a72f9d4ea13d55d745ff1ed594747f10
+    sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  category: main
+  optional: false
+- name: xz
+  version: 5.2.6
+  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
@@ -17052,6 +26110,17 @@ package:
   hash:
     md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
     sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  category: main
+  optional: false
+- name: yaml
+  version: 0.2.5
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  hash:
+    md5: d7e08fcf8259d742156188e8762b4d20
+    sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
   category: main
   optional: false
 - name: yaml
@@ -17079,6 +26148,21 @@ package:
   hash:
     md5: 7288bccf99dd979dfcf80bb372c3de3f
     sha256: a0370c724d347103ae1a7c8a49166cc69359d80055c11bc5d7222d259efd8f12
+  category: main
+  optional: false
+- name: yarl
+  version: 1.9.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    idna: '>=2.0'
+    multidict: '>=4.0'
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.9.4-py39ha09f3b3_0.conda
+  hash:
+    md5: f6e21fa521a3eb23889768cb5a4cc186
+    sha256: a2e07a7568395f7bf121c5a777f22046dd4870f9a26febb6c3f14c12ba666b92
   category: main
   optional: false
 - name: yarl
@@ -17113,6 +26197,20 @@ package:
 - name: zeromq
   version: 4.3.5
   manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    libsodium: '>=1.0.18,<1.0.19.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
+  hash:
+    md5: 4c055e46b394be36681fe476c1e2ee6e
+    sha256: 19be553b3cc8352b6e842134b8de66ae39fcae80bc575c203076370faab6009c
+  category: main
+  optional: false
+- name: zeromq
+  version: 4.3.5
+  manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=16'
@@ -17138,6 +26236,18 @@ package:
 - name: zict
   version: 3.0.0
   manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: cf30c2c15b82aacb07f9c09e28ff2275
+    sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
+  category: main
+  optional: false
+- name: zict
+  version: 3.0.0
+  manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
@@ -17151,6 +26261,18 @@ package:
   version: 3.17.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  category: main
+  optional: false
+- name: zipp
+  version: 3.17.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
@@ -17187,6 +26309,18 @@ package:
 - name: zlib
   version: 1.2.13
   manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: 1.2.13
+  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+  hash:
+    md5: 75a8a98b1c4671c5d2897975731da42d
+    sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
+  category: main
+  optional: false
+- name: zlib
+  version: 1.2.13
+  manager: conda
   platform: osx-arm64
   dependencies:
     libzlib: 1.2.13
@@ -17208,6 +26342,18 @@ package:
   hash:
     md5: 04b88013080254850d6c01ed54810589
     sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+  hash:
+    md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
+    sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
   category: main
   optional: false
 - name: zstd
@@ -17236,6 +26382,17 @@ package:
 - name: aioboto3
   version: 12.3.0
   manager: pip
+  platform: osx-64
+  dependencies:
+    aiobotocore: 2.11.2
+  url: https://files.pythonhosted.org/packages/2d/69/e375ee955f67eb468d5bc907423bdbdb39cbdd2012652e8abd98ba0bb255/aioboto3-12.3.0-py3-none-any.whl
+  hash:
+    sha256: 268b98046f8e1e303b4bbc553b60643b26c0031b4290ef163caf80c3be5ecf85
+  category: main
+  optional: false
+- name: aioboto3
+  version: 12.3.0
+  manager: pip
   platform: osx-arm64
   dependencies:
     aiobotocore: 2.11.2
@@ -17262,6 +26419,21 @@ package:
 - name: aiobotocore
   version: 2.11.2
   manager: pip
+  platform: osx-64
+  dependencies:
+    botocore: '>=1.33.2,<1.34.35'
+    aiohttp: '>=3.7.4.post0,<4.0.0'
+    wrapt: '>=1.10.10,<2.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    boto3: '>=1.33.2,<1.34.35'
+  url: https://files.pythonhosted.org/packages/25/cf/c695f7f3301117766d778f536082c41ba20fd01b02e14a5c06f92a5ea75e/aiobotocore-2.11.2-py3-none-any.whl
+  hash:
+    sha256: 487fede588040bfa3a43df945275c28c1c73ca75bf705295adb9fbadd2e89be7
+  category: main
+  optional: false
+- name: aiobotocore
+  version: 2.11.2
+  manager: pip
   platform: osx-arm64
   dependencies:
     botocore: '>=1.33.2,<1.34.35'
@@ -17287,6 +26459,16 @@ package:
 - name: annotated-types
   version: 0.6.0
   manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/28/78/d31230046e58c207284c6b2c4e8d96e6d3cb4e52354721b944d3e1ee4aa5/annotated_types-0.6.0-py3-none-any.whl
+  hash:
+    sha256: 0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43
+  category: main
+  optional: false
+- name: annotated-types
+  version: 0.6.0
+  manager: pip
   platform: osx-arm64
   dependencies: {}
   url: https://files.pythonhosted.org/packages/28/78/d31230046e58c207284c6b2c4e8d96e6d3cb4e52354721b944d3e1ee4aa5/annotated_types-0.6.0-py3-none-any.whl
@@ -17310,6 +26492,19 @@ package:
 - name: boto3
   version: 1.34.34
   manager: pip
+  platform: osx-64
+  dependencies:
+    botocore: '>=1.34.34,<1.35.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    s3transfer: '>=0.10.0,<0.11.0'
+  url: https://files.pythonhosted.org/packages/0e/78/d505b8c71139d234e34df1c4a18d0567287494ce63f690337aa2af23219c/boto3-1.34.34-py3-none-any.whl
+  hash:
+    sha256: 33a8b6d9136fa7427160edb92d2e50f2035f04e9d63a2d1027349053e12626aa
+  category: main
+  optional: false
+- name: boto3
+  version: 1.34.34
+  manager: pip
   platform: osx-arm64
   dependencies:
     botocore: '>=1.34.34,<1.35.0'
@@ -17336,6 +26531,19 @@ package:
 - name: botocore
   version: 1.34.34
   manager: pip
+  platform: osx-64
+  dependencies:
+    jmespath: '>=0.7.1,<2.0.0'
+    python-dateutil: '>=2.1,<3.0.0'
+    urllib3: '>=1.25.4,<1.27'
+  url: https://files.pythonhosted.org/packages/6e/71/b81be726c424784858e9b9ccada167dbb19364f37744d9d780c2f79f9e6e/botocore-1.34.34-py3-none-any.whl
+  hash:
+    sha256: cd060b0d88ebb2b893f1411c1db7f2ba66cc18e52dcc57ad029564ef5fec437b
+  category: main
+  optional: false
+- name: botocore
+  version: 1.34.34
+  manager: pip
   platform: osx-arm64
   dependencies:
     jmespath: '>=0.7.1,<2.0.0'
@@ -17359,6 +26567,16 @@ package:
 - name: dacite
   version: 1.8.1
   manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/21/0f/cf0943f4f55f0fbc7c6bd60caf1343061dff818b02af5a0d444e473bb78d/dacite-1.8.1-py3-none-any.whl
+  hash:
+    sha256: cc31ad6fdea1f49962ea42db9421772afe01ac5442380d9a99fcf3d188c61afe
+  category: main
+  optional: false
+- name: dacite
+  version: 1.8.1
+  manager: pip
   platform: osx-arm64
   dependencies: {}
   url: https://files.pythonhosted.org/packages/21/0f/cf0943f4f55f0fbc7c6bd60caf1343061dff818b02af5a0d444e473bb78d/dacite-1.8.1-py3-none-any.whl
@@ -17370,6 +26588,19 @@ package:
   version: 0.1.5
   manager: pip
   platform: linux-64
+  dependencies:
+    pandas: '>=0.25.2'
+    dataclasses-json: '>=0.5.2'
+    doltcli: '>=0.1.6,<0.2.0'
+  url: https://files.pythonhosted.org/packages/a6/24/318bd96f965b8b8c37d38a1b2268029e500718d19913fdc59e569eb14161/dolt_integrations-0.1.5-py3-none-any.whl
+  hash:
+    sha256: d90eb2eb4cae3dbc50f544f37e3a71bf50fdda8428109cfc15056fe94febc1b4
+  category: main
+  optional: false
+- name: dolt-integrations
+  version: 0.1.5
+  manager: pip
+  platform: osx-64
   dependencies:
     pandas: '>=0.25.2'
     dataclasses-json: '>=0.5.2'
@@ -17396,6 +26627,17 @@ package:
   version: 0.1.18
   manager: pip
   platform: linux-64
+  dependencies:
+    typed-ast: '>1.4.3'
+  url: https://files.pythonhosted.org/packages/19/d0/3a3119ca82af8d27c06d2f1fe826f4ae8be2a3bd3e5a4c7a59852e962059/doltcli-0.1.18-py3-none-any.whl
+  hash:
+    sha256: 9d8a8454ef2337d388e40de2fc915fbc6d616e4ac494926488d0d4da9ce1747a
+  category: main
+  optional: false
+- name: doltcli
+  version: 0.1.18
+  manager: pip
+  platform: osx-64
   dependencies:
     typed-ast: '>1.4.3'
   url: https://files.pythonhosted.org/packages/19/d0/3a3119ca82af8d27c06d2f1fe826f4ae8be2a3bd3e5a4c7a59852e962059/doltcli-0.1.18-py3-none-any.whl
@@ -17427,6 +26669,16 @@ package:
 - name: duckdb
   version: 0.9.2
   manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/7f/c6/b822ecfcb10e955bdb9b637af2901df04ac9c8fad6722daf83536adc2f8a/duckdb-0.9.2-cp39-cp39-macosx_10_9_x86_64.whl
+  hash:
+    sha256: e5d0bb845a80aa48ed1fd1d2d285dd352e96dc97f8efced2a7429437ccd1fe1f
+  category: main
+  optional: false
+- name: duckdb
+  version: 0.9.2
+  manager: pip
   platform: osx-arm64
   dependencies: {}
   url: https://files.pythonhosted.org/packages/54/75/701914dae093eeb431e39288c2d39d21f2f2430ed9010977a88890765d45/duckdb-0.9.2-cp39-cp39-macosx_11_0_arm64.whl
@@ -17452,6 +26704,21 @@ package:
 - name: flytekitplugins-deck-standard
   version: 1.10.2
   manager: pip
+  platform: osx-64
+  dependencies:
+    flytekit: '>=1.3.0b2,<2.0.0'
+    markdown: '*'
+    plotly: '*'
+    ydata-profiling: '*'
+    ipywidgets: '*'
+  url: https://files.pythonhosted.org/packages/c4/13/1f7c371031967e541012eb017b95dd266ccd919abe7ed6996a96870e39ea/flytekitplugins_deck_standard-1.10.2-py3-none-any.whl
+  hash:
+    sha256: bb71de7d462b2ca51d42812fb61a2ca3e42ad19866fe973bef1ffa0ce147965c
+  category: main
+  optional: false
+- name: flytekitplugins-deck-standard
+  version: 1.10.2
+  manager: pip
   platform: osx-arm64
   dependencies:
     flytekit: '>=1.3.0b2,<2.0.0'
@@ -17480,6 +26747,19 @@ package:
 - name: flytekitplugins-kfpytorch
   version: 1.10.2
   manager: pip
+  platform: osx-64
+  dependencies:
+    cloudpickle: '*'
+    flyteidl: '>=1.5.1'
+    flytekit: '>=1.6.1'
+  url: https://files.pythonhosted.org/packages/b0/31/64f935cfc7d2784101045fdc9151ab38036057afb8d102793e4f8a76e22d/flytekitplugins_kfpytorch-1.10.2-py3-none-any.whl
+  hash:
+    sha256: baac1698148a63f72478b063ee93ad81346626407f302ea0f6f44b1083e2e723
+  category: main
+  optional: false
+- name: flytekitplugins-kfpytorch
+  version: 1.10.2
+  manager: pip
   platform: osx-arm64
   dependencies:
     cloudpickle: '*'
@@ -17505,6 +26785,18 @@ package:
 - name: flytekitplugins-sqlalchemy
   version: 1.10.2
   manager: pip
+  platform: osx-64
+  dependencies:
+    flytekit: '>=1.3.0b2,<2.0.0'
+    sqlalchemy: '>=1.4.7'
+  url: https://files.pythonhosted.org/packages/99/c3/82bb331973c1ee7fd374e314f209d4bffb63d896a1f345da145cac24a91a/flytekitplugins_sqlalchemy-1.10.2-py3-none-any.whl
+  hash:
+    sha256: 9e19b16edfc7468c94e1e69801a465abe89412e5c46d50a19e283ab717afca3f
+  category: main
+  optional: false
+- name: flytekitplugins-sqlalchemy
+  version: 1.10.2
+  manager: pip
   platform: osx-arm64
   dependencies:
     flytekit: '>=1.3.0b2,<2.0.0'
@@ -17529,6 +26821,18 @@ package:
 - name: google-auth-oauthlib
   version: 0.6.0
   manager: pip
+  platform: osx-64
+  dependencies:
+    google-auth: '>=1.0.0'
+    requests-oauthlib: '>=0.7.0'
+  url: https://files.pythonhosted.org/packages/4d/d1/79277a5c507df72cc22ee2c3949ae384c4af8110bc0b472f0c49fcdcba3b/google_auth_oauthlib-0.6.0-py2.py3-none-any.whl
+  hash:
+    sha256: 69112d0890c075e6ab03950cd9b8e1b953d6e89ba51de5f393e939fb3bc68284
+  category: main
+  optional: false
+- name: google-auth-oauthlib
+  version: 0.6.0
+  manager: pip
   platform: osx-arm64
   dependencies:
     google-auth: '>=1.0.0'
@@ -17542,6 +26846,16 @@ package:
   version: 0.34.0
   manager: pip
   platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/ba/b1/7c54d1950e7808df06642274e677dbcedba57f75307adf2e5ad8d39e5e0e/google_cloud-0.34.0-py2.py3-none-any.whl
+  hash:
+    sha256: fb1ab7b0548fe44b3d538041f0a374505b7f990d448a935ea36649c5ccab5acf
+  category: main
+  optional: false
+- name: google-cloud
+  version: 0.34.0
+  manager: pip
+  platform: osx-64
   dependencies: {}
   url: https://files.pythonhosted.org/packages/ba/b1/7c54d1950e7808df06642274e677dbcedba57f75307adf2e5ad8d39e5e0e/google_cloud-0.34.0-py2.py3-none-any.whl
   hash:
@@ -17572,6 +26886,17 @@ package:
 - name: grpcio
   version: 1.43.0
   manager: pip
+  platform: osx-64
+  dependencies:
+    six: '>=1.5.2'
+  url: https://files.pythonhosted.org/packages/2a/62/902308b06a02a99ac60dc20cad08a2fb223b6b35dfca814d513f195ac770/grpcio-1.43.0-cp39-cp39-macosx_10_10_x86_64.whl
+  hash:
+    sha256: 2f96142d0abc91290a63ba203f01649e498302b1b6007c67bad17f823ecde0cf
+  category: main
+  optional: false
+- name: grpcio
+  version: 1.43.0
+  manager: pip
   platform: osx-arm64
   dependencies:
     six: '>=1.5.2'
@@ -17596,6 +26921,19 @@ package:
 - name: grpcio-status
   version: 1.43.0
   manager: pip
+  platform: osx-64
+  dependencies:
+    protobuf: '>=3.6.0'
+    grpcio: '>=1.43.0'
+    googleapis-common-protos: '>=1.5.5'
+  url: https://files.pythonhosted.org/packages/a3/6b/4d49846da5b5a496658fde7c1315c2ed48b3d98f7460122a19f94af39248/grpcio_status-1.43.0-py3-none-any.whl
+  hash:
+    sha256: 9036b24f5769adafdc3e91d9434c20e9ede0b30f50cc6bff105c0f414bb9e0e0
+  category: main
+  optional: false
+- name: grpcio-status
+  version: 1.43.0
+  manager: pip
   platform: osx-arm64
   dependencies:
     protobuf: '>=3.6.0'
@@ -17619,6 +26957,16 @@ package:
 - name: htmlmin
   version: 0.1.12
   manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/b3/e7/fcd59e12169de19f0131ff2812077f964c6b960e7c09804d30a7bf2ab461/htmlmin-0.1.12.tar.gz
+  hash:
+    sha256: 50c1ef4630374a5d723900096a961cff426dff46b48f34d194a81bbe14eca178
+  category: main
+  optional: false
+- name: htmlmin
+  version: 0.1.12
+  manager: pip
   platform: osx-arm64
   dependencies: {}
   url: https://files.pythonhosted.org/packages/b3/e7/fcd59e12169de19f0131ff2812077f964c6b960e7c09804d30a7bf2ab461/htmlmin-0.1.12.tar.gz
@@ -17643,6 +26991,20 @@ package:
 - name: imagehash
   version: 4.3.1
   manager: pip
+  platform: osx-64
+  dependencies:
+    pywavelets: '*'
+    numpy: '*'
+    pillow: '*'
+    scipy: '*'
+  url: https://files.pythonhosted.org/packages/2d/b4/19a746a986c6e38595fa5947c028b1b8e287773dcad766e648897ad2a4cf/ImageHash-4.3.1-py2.py3-none-any.whl
+  hash:
+    sha256: 5ad9a5cde14fe255745a8245677293ac0d67f09c330986a351f34b614ba62fb5
+  category: main
+  optional: false
+- name: imagehash
+  version: 4.3.1
+  manager: pip
   platform: osx-arm64
   dependencies:
     pywavelets: '*'
@@ -17668,12 +27030,86 @@ package:
 - name: jaraco.classes
   version: 3.3.0
   manager: pip
+  platform: osx-64
+  dependencies:
+    more-itertools: '*'
+  url: https://files.pythonhosted.org/packages/c7/6b/1bc8fa93ea85146e08f0e0883bc579b7c7328364ed7df90b1628dcb36e10/jaraco.classes-3.3.0-py3-none-any.whl
+  hash:
+    sha256: 10afa92b6743f25c0cf5f37c6bb6e18e2c5bb84a16527ccfc0040ea377e7aaeb
+  category: main
+  optional: false
+- name: jaraco.classes
+  version: 3.3.0
+  manager: pip
   platform: osx-arm64
   dependencies:
     more-itertools: '*'
   url: https://files.pythonhosted.org/packages/c7/6b/1bc8fa93ea85146e08f0e0883bc579b7c7328364ed7df90b1628dcb36e10/jaraco.classes-3.3.0-py3-none-any.whl
   hash:
     sha256: 10afa92b6743f25c0cf5f37c6bb6e18e2c5bb84a16527ccfc0040ea377e7aaeb
+  category: main
+  optional: false
+- name: jaraco.context
+  version: 4.3.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/0a/de/3f889cd55e69f0a91b396f6799ca31ea0d6869cde338e7c79335699090cb/jaraco.context-4.3.0-py3-none-any.whl
+  hash:
+    sha256: 5d9e95ca0faa78943ed66f6bc658dd637430f16125d86988e77844c741ff2f11
+  category: main
+  optional: false
+- name: jaraco.context
+  version: 4.3.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/0a/de/3f889cd55e69f0a91b396f6799ca31ea0d6869cde338e7c79335699090cb/jaraco.context-4.3.0-py3-none-any.whl
+  hash:
+    sha256: 5d9e95ca0faa78943ed66f6bc658dd637430f16125d86988e77844c741ff2f11
+  category: main
+  optional: false
+- name: jaraco.context
+  version: 4.3.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/0a/de/3f889cd55e69f0a91b396f6799ca31ea0d6869cde338e7c79335699090cb/jaraco.context-4.3.0-py3-none-any.whl
+  hash:
+    sha256: 5d9e95ca0faa78943ed66f6bc658dd637430f16125d86988e77844c741ff2f11
+  category: main
+  optional: false
+- name: jaraco.functools
+  version: 4.0.0
+  manager: pip
+  platform: linux-64
+  dependencies:
+    more-itertools: '*'
+  url: https://files.pythonhosted.org/packages/4c/57/726a9c80c1b36f98b497debd72f4c81ae444d55abf9647367e5d53e1cc93/jaraco.functools-4.0.0-py3-none-any.whl
+  hash:
+    sha256: daf276ddf234bea897ef14f43c4e1bf9eefeac7b7a82a4dd69228ac20acff68d
+  category: main
+  optional: false
+- name: jaraco.functools
+  version: 4.0.0
+  manager: pip
+  platform: osx-64
+  dependencies:
+    more-itertools: '*'
+  url: https://files.pythonhosted.org/packages/4c/57/726a9c80c1b36f98b497debd72f4c81ae444d55abf9647367e5d53e1cc93/jaraco.functools-4.0.0-py3-none-any.whl
+  hash:
+    sha256: daf276ddf234bea897ef14f43c4e1bf9eefeac7b7a82a4dd69228ac20acff68d
+  category: main
+  optional: false
+- name: jaraco.functools
+  version: 4.0.0
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    more-itertools: '*'
+  url: https://files.pythonhosted.org/packages/4c/57/726a9c80c1b36f98b497debd72f4c81ae444d55abf9647367e5d53e1cc93/jaraco.functools-4.0.0-py3-none-any.whl
+  hash:
+    sha256: daf276ddf234bea897ef14f43c4e1bf9eefeac7b7a82a4dd69228ac20acff68d
   category: main
   optional: false
 - name: llvmlite
@@ -17684,6 +27120,16 @@ package:
   url: https://files.pythonhosted.org/packages/be/a6/55020df7f04666bceb3ccc5dc0cb0812d68d5fdec883ff015a9110928829/llvmlite-0.41.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   hash:
     sha256: 24091a6b31242bcdd56ae2dbea40007f462260bc9bdf947953acc39dffd54f8f
+  category: main
+  optional: false
+- name: llvmlite
+  version: 0.41.1
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/fc/7a/c6741000d767fed4b339fcd4fa65afbc5fe776473d5f9e9c41eceab0a7c6/llvmlite-0.41.1-cp39-cp39-macosx_10_9_x86_64.whl
+  hash:
+    sha256: 04725975e5b2af416d685ea0769f4ecc33f97be541e301054c9f741003085802
   category: main
   optional: false
 - name: llvmlite
@@ -17700,6 +27146,21 @@ package:
   version: 0.22.3
   manager: pip
   platform: linux-64
+  dependencies:
+    pandas: 1.5.3
+    packaging: '*'
+    numpy: '>=1.18.5'
+    fsspec: '*'
+    psutil: '*'
+  url: https://files.pythonhosted.org/packages/79/68/e560890fe0b8b89eb55e30bf7c11c4f43d1975da578e516a0996a7fce562/modin-0.22.3-py3-none-any.whl
+  hash:
+    sha256: e438ead6eb8dc536dbf8c74365e007d88d6187196f2d0756b77d6551bf35a686
+  category: main
+  optional: false
+- name: modin
+  version: 0.22.3
+  manager: pip
+  platform: osx-64
   dependencies:
     pandas: 1.5.3
     packaging: '*'
@@ -17741,6 +27202,18 @@ package:
 - name: numba
   version: 0.58.1
   manager: pip
+  platform: osx-64
+  dependencies:
+    llvmlite: '>=0.41.0dev0,<0.42'
+    numpy: '>=1.22,<1.27'
+  url: https://files.pythonhosted.org/packages/b5/de/e2ef933a99c502d2ec5dda1a43a74ab98b1b606c0ff17422d42c62a6f00f/numba-0.58.1-cp39-cp39-macosx_10_9_x86_64.whl
+  hash:
+    sha256: 5c765aef472a9406a97ea9782116335ad4f9ef5c9f93fc05fd44aab0db486954
+  category: main
+  optional: false
+- name: numba
+  version: 0.58.1
+  manager: pip
   platform: osx-arm64
   dependencies:
     llvmlite: '>=0.41.0dev0,<0.42'
@@ -17766,6 +27239,19 @@ package:
 - name: pandas
   version: 1.5.3
   manager: pip
+  platform: osx-64
+  dependencies:
+    python-dateutil: '>=2.8.1'
+    pytz: '>=2020.1'
+    numpy: '>=1.20.3'
+  url: https://files.pythonhosted.org/packages/02/4a/8e2513db9d15929b833147f975d8424dc6a3e18100ead10aab78756a1aad/pandas-1.5.3-cp39-cp39-macosx_10_9_x86_64.whl
+  hash:
+    sha256: c4c00e0b0597c8e4f59e8d461f797e5d70b4d025880516a8261b2817c47759ee
+  category: main
+  optional: false
+- name: pandas
+  version: 1.5.3
+  manager: pip
   platform: osx-arm64
   dependencies:
     python-dateutil: '>=2.8.1'
@@ -17780,6 +27266,18 @@ package:
   version: 0.5.4
   manager: pip
   platform: linux-64
+  dependencies:
+    six: '*'
+    numpy: '>=1.4'
+  url: https://files.pythonhosted.org/packages/29/ab/373449d6f741732f94e2d15d116a90f050b2857cb727b26d2f7bead50815/patsy-0.5.4-py2.py3-none-any.whl
+  hash:
+    sha256: 0486413077a527db51ddea8fa94a5234d0feb17a4f4dc01b59b6086c58a70f80
+  category: main
+  optional: false
+- name: patsy
+  version: 0.5.4
+  manager: pip
+  platform: osx-64
   dependencies:
     six: '*'
     numpy: '>=1.4'
@@ -17818,6 +27316,21 @@ package:
 - name: phik
   version: 0.12.3
   manager: pip
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.18.0'
+    scipy: '>=1.5.2'
+    pandas: '>=0.25.1'
+    matplotlib: '>=2.2.3'
+    joblib: '>=0.14.1'
+  url: https://files.pythonhosted.org/packages/11/53/b1f8520fc7f90904cfb7dd5765cace015069cacf45953f62f0dccc74a073/phik-0.12.3-cp39-cp39-macosx_10_13_x86_64.whl
+  hash:
+    sha256: dfbb20614288df46970640c9127f500f7e03a66631bb9aa3774a2f5222f19f75
+  category: main
+  optional: false
+- name: phik
+  version: 0.12.3
+  manager: pip
   platform: osx-arm64
   dependencies:
     numpy: '>=1.18.0'
@@ -17834,6 +27347,19 @@ package:
   version: 2.5.2
   manager: pip
   platform: linux-64
+  dependencies:
+    annotated-types: '>=0.4.0'
+    pydantic-core: 2.14.5
+    typing-extensions: '>=4.6.1'
+  url: https://files.pythonhosted.org/packages/0a/2b/64066de1c4cf3d4ed623beeb3bbf3f8d0cc26661f1e7d180ec5eb66b75a5/pydantic-2.5.2-py3-none-any.whl
+  hash:
+    sha256: 80c50fb8e3dcecfddae1adbcc00ec5822918490c99ab31f6cf6140ca1c1429f0
+  category: main
+  optional: false
+- name: pydantic
+  version: 2.5.2
+  manager: pip
+  platform: osx-64
   dependencies:
     annotated-types: '>=0.4.0'
     pydantic-core: 2.14.5
@@ -17870,6 +27396,17 @@ package:
 - name: pydantic-core
   version: 2.14.5
   manager: pip
+  platform: osx-64
+  dependencies:
+    typing-extensions: '>=4.6.0,<4.7.0 || >4.7.0'
+  url: https://files.pythonhosted.org/packages/9a/e1/c33fcdbdad7f5c29376fa2e57f8d60f966c44fc77fc36a70d0ae03bbe813/pydantic_core-2.14.5-cp39-cp39-macosx_10_7_x86_64.whl
+  hash:
+    sha256: a6a16f4a527aae4f49c875da3cdc9508ac7eef26e7977952608610104244e1b7
+  category: main
+  optional: false
+- name: pydantic-core
+  version: 2.14.5
+  manager: pip
   platform: osx-arm64
   dependencies:
     typing-extensions: '>=4.6.0,<4.7.0 || >4.7.0'
@@ -17887,6 +27424,17 @@ package:
   url: https://files.pythonhosted.org/packages/a7/58/1724d6362becfa71eded2dffe145e795786b13c3a66f6523f3aff1b3f3cf/pywavelets-1.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   hash:
     sha256: 49aa6abf9ac941f47f7ea26a3c7dd5c8bfcf0e903dc5ec68ed105b52bfccd4e2
+  category: main
+  optional: false
+- name: pywavelets
+  version: 1.5.0
+  manager: pip
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.22.4,<2.0'
+  url: https://files.pythonhosted.org/packages/b0/a8/787508e85d579d0990b344410acdba4b6f45f19284404d2895cc8a35769d/pywavelets-1.5.0-cp39-cp39-macosx_10_13_x86_64.whl
+  hash:
+    sha256: 34d189aed544687500a2fba5b8970951a76f62f1d140cc5f9440d9b32b14b8f5
   category: main
   optional: false
 - name: pywavelets
@@ -17920,6 +27468,28 @@ package:
   url: https://files.pythonhosted.org/packages/3e/da/9bf3ac45a2e26f8000ea7d48caa308681a742d69d6cc0fb18be82f26692c/ray-2.6.3-cp39-cp39-manylinux2014_x86_64.whl
   hash:
     sha256: 18d033cc468e5171d9995476c33f99a5b79f091c34265c7e9f3d8b1c9042437e
+  category: main
+  optional: false
+- name: ray
+  version: 2.6.3
+  manager: pip
+  platform: osx-64
+  dependencies:
+    click: '>=7.0'
+    filelock: '*'
+    jsonschema: '*'
+    msgpack: '>=1.0.0,<2.0.0'
+    packaging: '*'
+    protobuf: '>=3.15.3,<3.19.5 || >3.19.5'
+    pyyaml: '*'
+    aiosignal: '*'
+    frozenlist: '*'
+    requests: '*'
+    grpcio: '>=1.32.0'
+    numpy: '>=1.19.3'
+  url: https://files.pythonhosted.org/packages/8a/78/7c241d4c34cfb342749158ab483709a65ceae727883261f2f4998b485d9f/ray-2.6.3-cp39-cp39-macosx_10_15_x86_64.whl
+  hash:
+    sha256: 3ccf809e5948333c1c8c81694514b5900259e79cbdc8bddd3680695820cafcf2
   category: main
   optional: false
 - name: ray
@@ -17960,6 +27530,19 @@ package:
 - name: readthedocs-sphinx-ext
   version: 2.2.4
   manager: pip
+  platform: osx-64
+  dependencies:
+    requests: '*'
+    jinja2: '>=2.9'
+    packaging: '*'
+  url: https://files.pythonhosted.org/packages/12/45/c0db0a248a10395a6d8d3cacff3a50279b62f0fe165c2b23341c43db7d18/readthedocs_sphinx_ext-2.2.4-py2.py3-none-any.whl
+  hash:
+    sha256: 77b5b12e9fa6bb7ab623e7be5bfbd7523c83a2ea72c48f6f6f4d5e3df87ac896
+  category: main
+  optional: false
+- name: readthedocs-sphinx-ext
+  version: 2.2.4
+  manager: pip
   platform: osx-arm64
   dependencies:
     requests: '*'
@@ -17974,6 +27557,17 @@ package:
   version: 0.10.1
   manager: pip
   platform: linux-64
+  dependencies:
+    botocore: '>=1.33.2,<2.0a.0'
+  url: https://files.pythonhosted.org/packages/83/37/395cdb6ee92925fa211e55d8f07b9f93cf93f60d7d4ce5e66fd73f1ea986/s3transfer-0.10.1-py3-none-any.whl
+  hash:
+    sha256: ceb252b11bcf87080fb7850a224fb6e05c8a776bab8f2b64b7f25b969464839d
+  category: main
+  optional: false
+- name: s3transfer
+  version: 0.10.1
+  manager: pip
+  platform: osx-64
   dependencies:
     botocore: '>=1.33.2,<2.0a.0'
   url: https://files.pythonhosted.org/packages/83/37/395cdb6ee92925fa211e55d8f07b9f93cf93f60d7d4ce5e66fd73f1ea986/s3transfer-0.10.1-py3-none-any.whl
@@ -18006,6 +27600,17 @@ package:
 - name: scipy
   version: 1.11.4
   manager: pip
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.21.6,<1.28.0'
+  url: https://files.pythonhosted.org/packages/c5/e0/9872b7923c0ff7a420af8f559d0f5c6831143477b4ce57afe1b2a7c59a63/scipy-1.11.4-cp39-cp39-macosx_10_9_x86_64.whl
+  hash:
+    sha256: 6e619aba2df228a9b34718efb023966da781e89dd3d21637b27f2e54db0410d7
+  category: main
+  optional: false
+- name: scipy
+  version: 1.11.4
+  manager: pip
   platform: osx-arm64
   dependencies:
     numpy: '>=1.21.6,<1.28.0'
@@ -18030,6 +27635,19 @@ package:
 - name: seaborn
   version: 0.12.2
   manager: pip
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.17,<1.24.0 || >1.24.0'
+    pandas: '>=0.25'
+    matplotlib: '>=3.1,<3.6.1 || >3.6.1'
+  url: https://files.pythonhosted.org/packages/8f/2e/17bbb83fbf102687bb2aa3d808add39da820a7698159302a1a69bb82e01c/seaborn-0.12.2-py3-none-any.whl
+  hash:
+    sha256: ebf15355a4dba46037dfd65b7350f014ceb1f13c05e814eda2c9f5fd731afc08
+  category: main
+  optional: false
+- name: seaborn
+  version: 0.12.2
+  manager: pip
   platform: osx-arm64
   dependencies:
     numpy: '>=1.17,<1.24.0 || >1.24.0'
@@ -18056,6 +27674,19 @@ package:
 - name: sphinx-code-include
   version: 1.1.1
   manager: pip
+  platform: osx-64
+  dependencies:
+    beautifulsoup4: '>=4.8'
+    six: '>=1.12'
+    sphinx: '>=1.3'
+  url: https://files.pythonhosted.org/packages/89/bf/95e6eb1b9a5cf502684006c9ac8a11f7d543a95a45856dcaf8f7bf9b31f1/sphinx_code_include-1.1.1-py2.py3-none-any.whl
+  hash:
+    sha256: 8c7d680fabb9fe45a74d036c967a61ef574fe1bd49d1539a74f52b9abbe50207
+  category: main
+  optional: false
+- name: sphinx-code-include
+  version: 1.1.1
+  manager: pip
   platform: osx-arm64
   dependencies:
     beautifulsoup4: '>=4.8'
@@ -18080,6 +27711,17 @@ package:
 - name: sphinx-markdown-tables
   version: 0.0.17
   manager: pip
+  platform: osx-64
+  dependencies:
+    markdown: '>=3.4'
+  url: https://files.pythonhosted.org/packages/93/8d/8785a36892992582ef8d87c69ab90e26124ab1059c501d93ebecd99d2323/sphinx_markdown_tables-0.0.17-py3-none-any.whl
+  hash:
+    sha256: 2bd0c30779653e4dd120300cbd9ca412c480738cc2241f6dea477a883f299e04
+  category: main
+  optional: false
+- name: sphinx-markdown-tables
+  version: 0.0.17
+  manager: pip
   platform: osx-arm64
   dependencies:
     markdown: '>=3.4'
@@ -18088,32 +27730,21 @@ package:
     sha256: 2bd0c30779653e4dd120300cbd9ca412c480738cc2241f6dea477a883f299e04
   category: main
   optional: false
-- name: sphinx-new-tab-link
-  version: 0.2.3
+- name: sphinxcontrib-video
+  version: 0.2.0
   manager: pip
   platform: linux-64
   dependencies:
     sphinx: '*'
-  url: https://files.pythonhosted.org/packages/23/b4/8269282568ac9e26dbefdbdb642e89b8f2b211ef9f5f00f50a466c05f0b6/sphinx_new_tab_link-0.2.3-py3-none-any.whl
+  url: https://files.pythonhosted.org/packages/76/7e/d346546cfc532a52c3a3c961100ea023e77a0c1c51b1ab5a500421a285c6/sphinxcontrib_video-0.2.0-py3-none-any.whl
   hash:
-    sha256: 2321b633170d8e33acae8afb96b3d7d9a8b3f081271987ae12a53151e2a0ab56
-  category: main
-  optional: false
-- name: sphinx-new-tab-link
-  version: 0.2.3
-  manager: pip
-  platform: osx-arm64
-  dependencies:
-    sphinx: '*'
-  url: https://files.pythonhosted.org/packages/23/b4/8269282568ac9e26dbefdbdb642e89b8f2b211ef9f5f00f50a466c05f0b6/sphinx_new_tab_link-0.2.3-py3-none-any.whl
-  hash:
-    sha256: 2321b633170d8e33acae8afb96b3d7d9a8b3f081271987ae12a53151e2a0ab56
+    sha256: 8973278316c02547efd0910bfd69205385462c423885cf03edc28b1c66f3b23c
   category: main
   optional: false
 - name: sphinxcontrib-video
   version: 0.2.0
   manager: pip
-  platform: linux-64
+  platform: osx-64
   dependencies:
     sphinx: '*'
   url: https://files.pythonhosted.org/packages/76/7e/d346546cfc532a52c3a3c961100ea023e77a0c1c51b1ab5a500421a285c6/sphinxcontrib_video-0.2.0-py3-none-any.whl
@@ -18136,6 +27767,17 @@ package:
   version: 0.4.0
   manager: pip
   platform: linux-64
+  dependencies:
+    six: '*'
+  url: https://files.pythonhosted.org/packages/13/0d/7e5009f48c33d5fd533dda80b42c4a79fce8dfdd1b617d0a9df9a9836145/sphinxext_remoteliteralinclude-0.4.0-py3-none-any.whl
+  hash:
+    sha256: e91378f07f378e6ca435246e07334c19a8c16b9baf6e180fc3e428a359846ea2
+  category: main
+  optional: false
+- name: sphinxext-remoteliteralinclude
+  version: 0.4.0
+  manager: pip
+  platform: osx-64
   dependencies:
     six: '*'
   url: https://files.pythonhosted.org/packages/13/0d/7e5009f48c33d5fd533dda80b42c4a79fce8dfdd1b617d0a9df9a9836145/sphinxext_remoteliteralinclude-0.4.0-py3-none-any.whl
@@ -18172,6 +27814,21 @@ package:
 - name: statsmodels
   version: 0.14.0
   manager: pip
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.18'
+    scipy: '>=1.4,<1.9.2 || >1.9.2'
+    pandas: '>=1.0'
+    patsy: '>=0.5.2'
+    packaging: '>=21.3'
+  url: https://files.pythonhosted.org/packages/cb/c2/37e017b50ce4f368a904f6b4d753520bd49ccc56aefc4610fc64e383f56c/statsmodels-0.14.0-cp39-cp39-macosx_10_9_x86_64.whl
+  hash:
+    sha256: 1c7724ad573af26139a98393ae64bc318d1b19762b13442d96c7a3e793f495c3
+  category: main
+  optional: false
+- name: statsmodels
+  version: 0.14.0
+  manager: pip
   platform: osx-arm64
   dependencies:
     numpy: '>=1.18'
@@ -18188,6 +27845,16 @@ package:
   version: 0.2.0
   manager: pip
   platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/dd/60/3651960b74aead282ec1ad819e70bdccf3ee73322d13d4339a6e3f5b7ed3/tangled_up_in_unicode-0.2.0-py3-none-any.whl
+  hash:
+    sha256: 154be12605b1687a17133aa741ae951cf9ee531c48a0c19f98d83ec5cb3cc7be
+  category: main
+  optional: false
+- name: tangled-up-in-unicode
+  version: 0.2.0
+  manager: pip
+  platform: osx-64
   dependencies: {}
   url: https://files.pythonhosted.org/packages/dd/60/3651960b74aead282ec1ad819e70bdccf3ee73322d13d4339a6e3f5b7ed3/tangled_up_in_unicode-0.2.0-py3-none-any.whl
   hash:
@@ -18217,6 +27884,16 @@ package:
 - name: typed-ast
   version: 1.5.5
   manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/b1/88/6e7f36f5fab6fbf0586a2dd866ac337924b7d4796a4d1b2b04443a864faf/typed_ast-1.5.5-cp39-cp39-macosx_10_9_x86_64.whl
+  hash:
+    sha256: 042eb665ff6bf020dd2243307d11ed626306b82812aba21836096d229fdc6a10
+  category: main
+  optional: false
+- name: typed-ast
+  version: 1.5.5
+  manager: pip
   platform: osx-arm64
   dependencies: {}
   url: https://files.pythonhosted.org/packages/71/30/09d27e13824495547bcc665bd07afc593b22b9484f143b27565eae4ccaac/typed_ast-1.5.5-cp39-cp39-macosx_11_0_arm64.whl
@@ -18238,6 +27915,17 @@ package:
 - name: types-requests
   version: 2.30.0.0
   manager: pip
+  platform: osx-64
+  dependencies:
+    types-urllib3: '*'
+  url: https://files.pythonhosted.org/packages/fa/c7/024171d587afe75934a6f779922d24fcc6dd468e947c74598eb17840e229/types_requests-2.30.0.0-py3-none-any.whl
+  hash:
+    sha256: c6cf08e120ca9f0dc4fa4e32c3f953c3fba222bcc1db6b97695bce8da1ba9864
+  category: main
+  optional: false
+- name: types-requests
+  version: 2.30.0.0
+  manager: pip
   platform: osx-arm64
   dependencies:
     types-urllib3: '*'
@@ -18259,6 +27947,16 @@ package:
 - name: types-urllib3
   version: 1.26.25.14
   manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl
+  hash:
+    sha256: 9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e
+  category: main
+  optional: false
+- name: types-urllib3
+  version: 1.26.25.14
+  manager: pip
   platform: osx-arm64
   dependencies: {}
   url: https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl
@@ -18270,6 +27968,24 @@ package:
   version: 0.7.5
   manager: pip
   platform: linux-64
+  dependencies:
+    numpy: '*'
+    pandas: '>=0.25.3'
+    attrs: '>=19.3.0'
+    networkx: '>=2.4'
+    tangled-up-in-unicode: '>=0.0.4'
+    multimethod: '>=1.4'
+    imagehash: '*'
+    pillow: '*'
+  url: https://files.pythonhosted.org/packages/62/fa/6a8539c83d2ccbd08d5f0c843b1784af9ff514e77f4c9d5d6800fdd340f6/visions-0.7.5-py3-none-any.whl
+  hash:
+    sha256: 1e57219715255282a909cfb93d25d6e453535aa0c26640a0d6f03e40be6263d7
+  category: main
+  optional: false
+- name: visions
+  version: 0.7.5
+  manager: pip
+  platform: osx-64
   dependencies:
     numpy: '*'
     pandas: '>=0.25.3'
@@ -18306,6 +28022,18 @@ package:
   version: 0.5.9
   manager: pip
   platform: linux-64
+  dependencies:
+    urllib3: '>=1.25.3'
+    python-dateutil: '*'
+  url: https://files.pythonhosted.org/packages/b1/48/a7a8d3d55a4751497c68f2fd1c3da1bfb1145a47870ae571295de8fa329d/whylabs_client-0.5.9-py3-none-any.whl
+  hash:
+    sha256: 540f85f490b00abcd29237a6bf39967fea85cac452f1262a762a6667bf0a5f7a
+  category: main
+  optional: false
+- name: whylabs-client
+  version: 0.5.9
+  manager: pip
+  platform: osx-64
   dependencies:
     urllib3: '>=1.25.3'
     python-dateutil: '*'
@@ -18330,6 +28058,23 @@ package:
   version: 1.3.3
   manager: pip
   platform: linux-64
+  dependencies:
+    platformdirs: '>=3.5.0,<4.0.0'
+    protobuf: '>=3.19.4'
+    requests: '>=2.27,<3.0'
+    types-requests: '>=2.30.0.0,<3.0.0.0'
+    typing-extensions: '>=3.10'
+    whylabs-client: '>=0.5.5,<0.6.0'
+    whylogs-sketching: '>=3.4.1.dev3'
+  url: https://files.pythonhosted.org/packages/91/cc/2c90e7ef06e940bf912d5b0a7373b9f15547efdf07a38ddcc6e739d9981b/whylogs-1.3.3-py3-none-any.whl
+  hash:
+    sha256: 8aeab6ff2634a6bbf2adc5b6ee34b2e29eadecfb64a5f50f1a95b1b28b358531
+  category: main
+  optional: false
+- name: whylogs
+  version: 1.3.3
+  manager: pip
+  platform: osx-64
   dependencies:
     platformdirs: '>=3.5.0,<4.0.0'
     protobuf: '>=3.19.4'
@@ -18373,6 +28118,16 @@ package:
 - name: whylogs-sketching
   version: 3.4.1.dev3
   manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/36/f9/baa5edfc07aa551e951111523d71b207793de843ca5a47bddd93ed0e5047/whylogs_sketching-3.4.1.dev3-cp39-cp39-macosx_10_9_x86_64.whl
+  hash:
+    sha256: 832247fd9d3ecf13791418a75c359db6c3aeffd51d7372d026e95f307ef286cc
+  category: main
+  optional: false
+- name: whylogs-sketching
+  version: 3.4.1.dev3
+  manager: pip
   platform: osx-arm64
   dependencies: {}
   url: https://files.pythonhosted.org/packages/11/50/4d2906066362827bf7b9cc116d6e796760cef9d27ee30230f16075283f09/whylogs_sketching-3.4.1.dev3-cp39-cp39-macosx_11_0_arm64.whl
@@ -18396,6 +28151,19 @@ package:
 - name: wordcloud
   version: 1.9.2
   manager: pip
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.6.1'
+    pillow: '*'
+    matplotlib: '*'
+  url: https://files.pythonhosted.org/packages/6a/cf/4b158a4847515c757398a6762e0c0473278dfe6cfb5dd018e09853b25dba/wordcloud-1.9.2-cp39-cp39-macosx_10_9_x86_64.whl
+  hash:
+    sha256: 139f0dbf6b6aeb32a20ccb383320dde514297c9aeba9b6cc7a82f4bb2502b1f9
+  category: main
+  optional: false
+- name: wordcloud
+  version: 1.9.2
+  manager: pip
   platform: osx-arm64
   dependencies:
     numpy: '>=1.6.1'
@@ -18410,6 +28178,36 @@ package:
   version: 4.6.3
   manager: pip
   platform: linux-64
+  dependencies:
+    scipy: '>=1.4.1,<1.12'
+    pandas: '>1.1,<1.4.0 || >1.4.0,<3'
+    matplotlib: '>=3.2,<3.9'
+    pydantic: '>=2'
+    pyyaml: '>=5.0.0,<6.1'
+    jinja2: '>=2.11.1,<3.2'
+    visions: 0.7.5
+    numpy: '>=1.16.0,<1.26'
+    htmlmin: 0.1.12
+    phik: '>=0.11.1,<0.13'
+    requests: '>=2.24.0,<3'
+    tqdm: '>=4.48.2,<5'
+    seaborn: '>=0.10.1,<0.13'
+    multimethod: '>=1.4,<2'
+    statsmodels: '>=0.13.2,<1'
+    typeguard: '>=4.1.2,<5'
+    imagehash: 4.3.1
+    wordcloud: '>=1.9.1'
+    dacite: '>=1.8'
+    numba: '>=0.56.0,<0.59.0'
+  url: https://files.pythonhosted.org/packages/c6/12/a869b9f81c992a179a27d76154b3ae3c1a65a43c9ec117437762093a75ca/ydata_profiling-4.6.3-py2.py3-none-any.whl
+  hash:
+    sha256: 156d68a20f1a1de4c449177291e4eed07e46429d332d162243d8bf2c61f60903
+  category: main
+  optional: false
+- name: ydata-profiling
+  version: 4.6.3
+  manager: pip
+  platform: osx-64
   dependencies:
     scipy: '>=1.4.1,<1.12'
     pandas: '>1.1,<1.4.0 || >1.4.0,<3'

--- a/monodocs-environment.yaml
+++ b/monodocs-environment.yaml
@@ -76,7 +76,6 @@ dependencies:
     - ray==2.6.3
     - duckdb
     - aioboto3>=12.3.0                    # aws sagemaker inference
-    - sphinx-new-tab-link
 
 platforms:
   - linux-64


### PR DESCRIPTION
This PR removes the `sphinx-new-tab-link` dependency for adding `target="_blank"` to external links in favor of using a simple custom javascript file to achieve the same effect.

## Why are the changes needed?

The `sphinx-new-tab-link` dependency caused an unintended change in the html/css styling of the site (black border on table elements):

<img width="888" alt="image" src="https://github.com/flyteorg/flyte/assets/2816689/c9f4f116-6b40-419f-9401-e696d25083e6">

`sphinx-new-tab-link` depends on `sphinxcontrib-extdevhelper-kasane`, ([repo](https://github.com/ftnext/sphinxcontrib-extdevhelper-kasane)), which seems to modify the way the html docs are rendered in a non-obvious way.

## What changes were proposed in this pull request?

Use sphinx's supported way of customizing docs with a `custom.js` file that achieves the same thing, but without the additional python dependency.

## How was this patch tested?

Docs built locally with `make docs`
