### PR TITLE
[flyte-core] Create separate grpc service for flyteadmin

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -175,7 +175,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flyteadmin deployment |
 | flyteadmin.secrets | object | `{}` |  |
 | flyteadmin.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for flyteadmin pod(s). |
-| flyteadmin.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"loadBalancerSourceRanges":[],"type":"ClusterIP"}` | Service settings for Flyteadmin |
+| flyteadmin.service | object | `{"annotations":{},"grpcAnnotations":{},"httpAnnotations":{},"loadBalancerSourceRanges":[],"type":"ClusterIP"}` | Service settings for Flyteadmin |
 | flyteadmin.serviceAccount | object | `{"alwaysCreate":false,"annotations":{},"clusterRole":{"apiGroups":["","flyte.lyft.com","rbac.authorization.k8s.io"],"resources":["configmaps","flyteworkflows","namespaces","pods","resourcequotas","roles","rolebindings","secrets","services","serviceaccounts","spark-role","limitranges"],"verbs":["*"]},"create":true,"createClusterRole":true,"imagePullSecrets":[]}` | Configuration for service accounts for FlyteAdmin |
 | flyteadmin.serviceAccount.alwaysCreate | bool | `false` | Should a service account always be created for flyteadmin even without an actual flyteadmin deployment running (e.g. for multi-cluster setups) |
 | flyteadmin.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Flyteadmin pods |

--- a/charts/flyte-core/templates/_helpers.tpl
+++ b/charts/flyte-core/templates/_helpers.tpl
@@ -35,6 +35,45 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- end -}}
 
+{{- define "flyteadmin.service.grpc.name" -}}
+{{- if .Values.common.ingress.separateGrpcIngress }}
+{{- printf "%s-grpc" ( include "flyteadmin.name" . ) -}}
+{{- else }}
+{{- template "flyteadmin.name" . -}}
+{{- end}}
+{{- end -}}
+
+{{- define "flyteadmin.service.grpc.port" -}}
+{{- if eq .Values.configmap.adminServer.server.security.secure true -}}
+80
+{{- else -}}
+81
+{{- end }}
+{{- end -}}
+
+{{- define "flyteadmin.service.http.port" -}}
+80
+{{- end -}}
+
+
+{{/*
+Get the Flyte service GRPC paths.
+*/}}
+{{- define "flyteadmin.ingress.grpcPaths" -}}
+- /flyteidl.service.AdminService
+- /flyteidl.service.AdminService/*
+- /flyteidl.service.AuthMetadataService
+- /flyteidl.service.AuthMetadataService/*
+- /flyteidl.service.DataProxyService
+- /flyteidl.service.DataProxyService/*
+- /flyteidl.service.IdentityService
+- /flyteidl.service.IdentityService/*
+- /flyteidl.service.SignalService
+- /flyteidl.service.SignalService/*
+- /grpc.health.v1.Health
+- /grpc.health.v1.Health/*
+{{- end -}}
+
 {{- define "flytescheduler.name" -}}
 flytescheduler
 {{- end -}}

--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -151,9 +151,12 @@ spec:
         imagePullPolicy: "{{ .Values.flyteadmin.image.pullPolicy }}"
         name: flyteadmin
         ports:
-        - containerPort: {{ .Values.configmap.adminServer.server.httpPort }}
-        - containerPort: {{ .Values.configmap.adminServer.server.grpc.port }}
-        - containerPort: {{ .Values.configmap.adminServer.flyteadmin.profilerPort }}
+        - name: http
+          containerPort: {{ .Values.configmap.adminServer.server.httpPort }}
+        - name: grpc
+          containerPort: {{ .Values.configmap.adminServer.server.grpc.port }}
+        - name: profiler
+          containerPort: {{ .Values.configmap.adminServer.flyteadmin.profilerPort }}
         readinessProbe:
           exec:
             command: [ "sh", "-c", "reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \"$reply\" -lt 200 -o \"$reply\" -ge 400 ]; then exit 1; fi;","grpc_health_probe", "-addr=:8089"]

--- a/charts/flyte-core/templates/admin/service-grpc.yaml
+++ b/charts/flyte-core/templates/admin/service-grpc.yaml
@@ -1,17 +1,17 @@
-{{- if .Values.flyteadmin.enabled }}
+{{- if and .Values.flyteadmin.enabled .Values.common.ingress.separateGrpcIngress }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "flyteadmin.name" . }}
+  name: {{ include "flyteadmin.service.grpc.name" .}}
   namespace: {{ template "flyte.namespace" . }}
   labels: {{ include "flyteadmin.labels" . | nindent 4 }}
-  {{- if or .Values.flyteadmin.service.annotations .Values.flyteadmin.service.httpAnnotations }}
+  {{- if or .Values.flyteadmin.service.annotations .Values.flyteadmin.service.grpcAnnotations }}
   annotations:
     {{- if .Values.flyteadmin.service.annotations }}
     {{- tpl ( .Values.flyteadmin.service.annotations | toYaml ) . | nindent 4 }}
     {{- end }}
-    {{- if .Values.flyteadmin.service.httpAnnotations }}
-    {{- tpl ( .Values.flyteadmin.service.httpAnnotations | toYaml ) . | nindent 4 }}
+    {{- if .Values.flyteadmin.service.grpcAnnotations }}
+    {{- tpl ( .Values.flyteadmin.service.grpcAnnotations | toYaml ) . | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:
@@ -23,21 +23,9 @@ spec:
     {{ . }}
   {{- end }}
   ports:
-    - name: http
-      port: {{ include "flyteadmin.service.http.port" . }}
-      protocol: TCP
-      targetPort: http
-    - name: redoc
-      protocol: TCP
-      port: 87
-      targetPort: 8087
-    - name: http-metrics
-      protocol: TCP
-      port: 10254
-    {{- if not .Values.common.ingress.separateGrpcIngress }}
     - name: grpc
       port: {{ include "flyteadmin.service.grpc.port" . }}
+      protocol: TCP
       targetPort: grpc
-    {{- end }}
   selector: {{ include "flyteadmin.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/flyte-core/templates/common/ingress.yaml
+++ b/charts/flyte-core/templates/common/ingress.yaml
@@ -1,95 +1,24 @@
 {{- define "grpcRoutes" -}}
-{{- $grpcPort := 81 -}}
-{{- if eq .Values.configmap.adminServer.server.security.secure true -}}
-  {{- $grpcPort = 80 -}}
-{{- end }}
 # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
-- path: /flyteidl.service.SignalService
+{{- $paths := (include "flyteadmin.ingress.grpcPaths" .) | fromYamlArray }}
+{{- range $path := $paths }}
+- path: {{ $path }}
+  {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
   pathType: ImplementationSpecific
-  backend:
-    service:
-      name: flyteadmin
-      port:
-        number: {{ $grpcPort }}
-- path: /flyteidl.service.SignalService/*
-  pathType: ImplementationSpecific
-  backend:
-    service:
-      name: flyteadmin
-      port:
-        number: {{ $grpcPort }}
-- path: /flyteidl.service.AdminService
-  pathType: ImplementationSpecific
-  backend:
-    service:
-      name: flyteadmin
-      port:
-        number: {{ $grpcPort }}
-- path: /flyteidl.service.AdminService/*
-  pathType: ImplementationSpecific
-  backend:
-    service:
-      name: flyteadmin
-      port:
-        number: {{ $grpcPort }}
-- path: /flyteidl.service.DataProxyService
-  pathType: ImplementationSpecific
-  backend:
-    service:
-      name: flyteadmin
-      port:
-        number: {{ $grpcPort }}
-- path: /flyteidl.service.DataProxyService/*
-  pathType: ImplementationSpecific
-  backend:
-    service:
-      name: flyteadmin
-      port:
-        number: {{ $grpcPort }}
-- path: /flyteidl.service.AuthMetadataService
-  pathType: ImplementationSpecific
-  backend:
-    service:
-      name: flyteadmin
-      port:
-        number: {{ $grpcPort }}
-- path: /flyteidl.service.AuthMetadataService/*
-  pathType: ImplementationSpecific
-  backend:
-    service:
-      name: flyteadmin
-      port:
-        number: {{ $grpcPort }}
-- path: /flyteidl.service.IdentityService
-  pathType: ImplementationSpecific
-  backend:
-    service:
-      name: flyteadmin
-      port:
-        number: {{ $grpcPort }}
-- path: /flyteidl.service.IdentityService/*
-  pathType: ImplementationSpecific
-  backend:
-    service:
-      name: flyteadmin
-      port:
-        number: {{ $grpcPort }}
-- path: /grpc.health.v1.Health
-  pathType: ImplementationSpecific
-  backend:
-    service:
-      name: flyteadmin
-      port:
-        number: {{ $grpcPort }}
-- path: /grpc.health.v1.Health/*
-  pathType: ImplementationSpecific
-  backend:
-    service:
-      name: flyteadmin
-      port:
-        number: {{ $grpcPort }}
   {{- end }}
-  {{- if .Values.common.ingress.enabled }}
+  backend:
+    {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+    service:
+      name: {{ include "flyteadmin.service.grpc.name" $ }}
+      port:
+        number: {{ include "flyteadmin.service.grpc.port" $ }}
+    {{- else }}
+    serviceName: {{ include "flyteadmin.service.grpc.name" $ }}
+    servicePort: {{ include "flyteadmin.service.grpc.port" $ }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.common.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/flyte-core/values-gcp.yaml
+++ b/charts/flyte-core/values-gcp.yaml
@@ -6,9 +6,9 @@ userSettings:
   dbHost: <CLOUD-SQL-IP>
   dbPassword: <DBPASSWORD>
 # These two storage buckets could be the same or you could specify different buckets if required. Both keys are required.
-# Learn more https://docs.flyte.org/en/latest/concepts/data_management.html#understand-how-flyte-handles-data 
-  bucketName: <METADATA_BUCKET_NAME> 
-  rawDataBucketName: <RAW_DATA_BUCKET_NAME> 
+# Learn more https://docs.flyte.org/en/latest/concepts/data_management.html#understand-how-flyte-handles-data
+  bucketName: <METADATA_BUCKET_NAME>
+  rawDataBucketName: <RAW_DATA_BUCKET_NAME>
   hostName: <HOSTNAME>
 
 #
@@ -35,7 +35,7 @@ flyteadmin:
       ephemeral-storage: 2Gi
       memory: 1G
   service:
-    annotations:
+    grpcAnnotations:
       # Required for the ingress to properly route grpc traffic to grpc port
       cloud.google.com/app-protocols: '{"grpc":"HTTP2"}'
   affinity:

--- a/charts/flyte-core/values-keycloak-idp-flyteclients-without-browser.yaml
+++ b/charts/flyte-core/values-keycloak-idp-flyteclients-without-browser.yaml
@@ -52,7 +52,7 @@ flyteadmin:
     - flyteexamples
   # -- Service settings for Flyteadmin
   service:
-    annotations:
+    grpcAnnotations:
       projectcontour.io/upstream-protocol.h2c: grpc
     type: ClusterIP
     loadBalancerSourceRanges: []

--- a/charts/flyte-core/values-sandbox.yaml
+++ b/charts/flyte-core/values-sandbox.yaml
@@ -3,7 +3,7 @@ flyteadmin:
   serviceMonitor:
     enabled: false
   service:
-    annotations:
+    grpcAnnotations:
       projectcontour.io/upstream-protocol.h2c: grpc
     type: ClusterIP
     loadBalancerSourceRanges: []

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -50,8 +50,11 @@ flyteadmin:
     - flyteexamples
   # -- Service settings for Flyteadmin
   service:
-    annotations:
-      projectcontour.io/upstream-protocol.h2c: grpc
+    annotations: {}
+    httpAnnotations: {}
+    grpcAnnotations: {}
+      # projectcontour.io/upstream-protocol.h2c: grpc
+      # traefik.ingress.kubernetes.io/service.serversscheme: h2c
     type: ClusterIP
     loadBalancerSourceRanges: []
   # -- Configuration for service accounts for FlyteAdmin

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -726,6 +726,28 @@ subjects:
     name: flyte-pod-webhook
     namespace: flyte
 ---
+# Source: flyte-core/templates/admin/service-grpc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: flyteadmin-grpc
+  namespace: flyte
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: flyte
+    helm.sh/chart: flyte-core-v0.1.10
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 81
+      protocol: TCP
+      targetPort: grpc
+  selector: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: flyte
+---
 # Source: flyte-core/templates/admin/service.yaml
 apiVersion: v1
 kind: Service
@@ -737,19 +759,13 @@ metadata:
     app.kubernetes.io/instance: flyte
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: ClusterIP
   ports:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: 8088
-    - name: grpc
-      port: 81
-      protocol: TCP
-      targetPort: 8089
+      targetPort: http
     - name: redoc
       protocol: TCP
       port: 87
@@ -957,9 +973,12 @@ spec:
         imagePullPolicy: "IfNotPresent"
         name: flyteadmin
         ports:
-        - containerPort: 8088
-        - containerPort: 8089
-        - containerPort: 10254
+        - name: http
+          containerPort: 8088
+        - name: grpc
+          containerPort: 8089
+        - name: profiler
+          containerPort: 10254
         readinessProbe:
           exec:
             command: [ "sh", "-c", "reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \"$reply\" -lt 200 -o \"$reply\" -ge 400 ]; then exit 1; fi;","grpc_health_probe", "-addr=:8089"]
@@ -1633,89 +1652,88 @@ spec:
           #   path: /*
           #   pathType: ImplementationSpecific
           #
-          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
-          - path: /flyteidl.service.SignalService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.SignalService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -449,6 +449,28 @@ subjects:
   name: flyteadmin
   namespace: flyte
 ---
+# Source: flyte-core/templates/admin/service-grpc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: flyteadmin-grpc
+  namespace: flyte
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: flyte
+    helm.sh/chart: flyte-core-v0.1.10
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 81
+      protocol: TCP
+      targetPort: grpc
+  selector: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: flyte
+---
 # Source: flyte-core/templates/admin/service.yaml
 apiVersion: v1
 kind: Service
@@ -460,19 +482,13 @@ metadata:
     app.kubernetes.io/instance: flyte
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: ClusterIP
   ports:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: 8088
-    - name: grpc
-      port: 81
-      protocol: TCP
-      targetPort: 8089
+      targetPort: http
     - name: redoc
       protocol: TCP
       port: 87
@@ -662,9 +678,12 @@ spec:
         imagePullPolicy: "IfNotPresent"
         name: flyteadmin
         ports:
-        - containerPort: 8088
-        - containerPort: 8089
-        - containerPort: 10254
+        - name: http
+          containerPort: 8088
+        - name: grpc
+          containerPort: 8089
+        - name: profiler
+          containerPort: 10254
         readinessProbe:
           exec:
             command: [ "sh", "-c", "reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \"$reply\" -lt 200 -o \"$reply\" -ge 400 ]; then exit 1; fi;","grpc_health_probe", "-addr=:8089"]
@@ -1253,89 +1272,88 @@ spec:
           #   path: /*
           #   pathType: ImplementationSpecific
           #
-          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
-          - path: /flyteidl.service.SignalService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.SignalService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81

--- a/deployment/eks/flyte_helm_dataplane_generated.yaml
+++ b/deployment/eks/flyte_helm_dataplane_generated.yaml
@@ -792,89 +792,88 @@ spec:
           #   path: /*
           #   pathType: ImplementationSpecific
           #
-          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
-          - path: /flyteidl.service.SignalService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.SignalService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -757,6 +757,28 @@ subjects:
     name: flyte-pod-webhook
     namespace: flyte
 ---
+# Source: flyte-core/templates/admin/service-grpc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: flyteadmin-grpc
+  namespace: flyte
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: flyte
+    helm.sh/chart: flyte-core-v0.1.10
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 81
+      protocol: TCP
+      targetPort: grpc
+  selector: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: flyte
+---
 # Source: flyte-core/templates/admin/service.yaml
 apiVersion: v1
 kind: Service
@@ -768,19 +790,13 @@ metadata:
     app.kubernetes.io/instance: flyte
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: ClusterIP
   ports:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: 8088
-    - name: grpc
-      port: 81
-      protocol: TCP
-      targetPort: 8089
+      targetPort: http
     - name: redoc
       protocol: TCP
       port: 87
@@ -988,9 +1004,12 @@ spec:
         imagePullPolicy: "IfNotPresent"
         name: flyteadmin
         ports:
-        - containerPort: 8088
-        - containerPort: 8089
-        - containerPort: 10254
+        - name: http
+          containerPort: 8088
+        - name: grpc
+          containerPort: 8089
+        - name: profiler
+          containerPort: 10254
         readinessProbe:
           exec:
             command: [ "sh", "-c", "reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \"$reply\" -lt 200 -o \"$reply\" -ge 400 ]; then exit 1; fi;","grpc_health_probe", "-addr=:8089"]
@@ -1763,89 +1782,88 @@ spec:
           #   path: /*
           #   pathType: ImplementationSpecific
           #
-          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
-          - path: /flyteidl.service.SignalService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.SignalService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -462,6 +462,30 @@ subjects:
   name: flyteadmin
   namespace: flyte
 ---
+# Source: flyte-core/templates/admin/service-grpc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: flyteadmin-grpc
+  namespace: flyte
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: flyte
+    helm.sh/chart: flyte-core-v0.1.10
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    cloud.google.com/app-protocols: '{"grpc":"HTTP2"}'
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 81
+      protocol: TCP
+      targetPort: grpc
+  selector: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: flyte
+---
 # Source: flyte-core/templates/admin/service.yaml
 apiVersion: v1
 kind: Service
@@ -473,20 +497,13 @@ metadata:
     app.kubernetes.io/instance: flyte
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
-  annotations: 
-    cloud.google.com/app-protocols: '{"grpc":"HTTP2"}'
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: ClusterIP
   ports:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: 8088
-    - name: grpc
-      port: 81
-      protocol: TCP
-      targetPort: 8089
+      targetPort: http
     - name: redoc
       protocol: TCP
       port: 87
@@ -677,9 +694,12 @@ spec:
         imagePullPolicy: "IfNotPresent"
         name: flyteadmin
         ports:
-        - containerPort: 8088
-        - containerPort: 8089
-        - containerPort: 10254
+        - name: http
+          containerPort: 8088
+        - name: grpc
+          containerPort: 8089
+        - name: profiler
+          containerPort: 10254
         readinessProbe:
           exec:
             command: [ "sh", "-c", "reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \"$reply\" -lt 200 -o \"$reply\" -ge 400 ]; then exit 1; fi;","grpc_health_probe", "-addr=:8089"]
@@ -1247,90 +1267,89 @@ spec:
       http:
         paths:
           #
-          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
-          - path: /flyteidl.service.SignalService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.SignalService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
   tls:

--- a/deployment/gcp/flyte_helm_dataplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_dataplane_generated.yaml
@@ -778,90 +778,89 @@ spec:
       http:
         paths:
           #
-          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
-          - path: /flyteidl.service.SignalService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.SignalService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
   tls:

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -778,6 +778,30 @@ subjects:
     name: flyte-pod-webhook
     namespace: flyte
 ---
+# Source: flyte-core/templates/admin/service-grpc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: flyteadmin-grpc
+  namespace: flyte
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: flyte
+    helm.sh/chart: flyte-core-v0.1.10
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    cloud.google.com/app-protocols: '{"grpc":"HTTP2"}'
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 81
+      protocol: TCP
+      targetPort: grpc
+  selector: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: flyte
+---
 # Source: flyte-core/templates/admin/service.yaml
 apiVersion: v1
 kind: Service
@@ -789,20 +813,13 @@ metadata:
     app.kubernetes.io/instance: flyte
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
-  annotations: 
-    cloud.google.com/app-protocols: '{"grpc":"HTTP2"}'
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: ClusterIP
   ports:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: 8088
-    - name: grpc
-      port: 81
-      protocol: TCP
-      targetPort: 8089
+      targetPort: http
     - name: redoc
       protocol: TCP
       port: 87
@@ -1011,9 +1028,12 @@ spec:
         imagePullPolicy: "IfNotPresent"
         name: flyteadmin
         ports:
-        - containerPort: 8088
-        - containerPort: 8089
-        - containerPort: 10254
+        - name: http
+          containerPort: 8088
+        - name: grpc
+          containerPort: 8089
+        - name: profiler
+          containerPort: 10254
         readinessProbe:
           exec:
             command: [ "sh", "-c", "reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \"$reply\" -lt 200 -o \"$reply\" -ge 400 ]; then exit 1; fi;","grpc_health_probe", "-addr=:8089"]
@@ -1764,90 +1784,89 @@ spec:
       http:
         paths:
           #
-          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
-          - path: /flyteidl.service.SignalService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.SignalService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AdminService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.AuthMetadataService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
           - path: /grpc.health.v1.Health/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: flyteadmin
+                name: flyteadmin-grpc
                 port:
                   number: 81
   tls:

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -6131,7 +6131,7 @@ metadata:
     app.kubernetes.io/instance: flyte
     helm.sh/chart: flyte-v0.1.10
     app.kubernetes.io/managed-by: Helm
-  annotations: 
+  annotations:
     projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: ClusterIP
@@ -6139,11 +6139,7 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: 8088
-    - name: grpc
-      port: 81
-      protocol: TCP
-      targetPort: 8089
+      targetPort: http
     - name: redoc
       protocol: TCP
       port: 87
@@ -6151,6 +6147,9 @@ spec:
     - name: http-metrics
       protocol: TCP
       port: 10254
+    - name: grpc
+      port: 81
+      targetPort: grpc
   selector: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: flyte
@@ -6792,9 +6791,12 @@ spec:
         imagePullPolicy: "IfNotPresent"
         name: flyteadmin
         ports:
-        - containerPort: 8088
-        - containerPort: 8089
-        - containerPort: 10254
+        - name: http
+          containerPort: 8088
+        - name: grpc
+          containerPort: 8089
+        - name: profiler
+          containerPort: 10254
         readinessProbe:
           exec:
             command: [ "sh", "-c", "reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \"$reply\" -lt 200 -o \"$reply\" -ge 400 ]; then exit 1; fi;","grpc_health_probe", "-addr=:8089"]
@@ -7769,22 +7771,7 @@ spec:
                 name: flyteadmin
                 port:
                   number: 80
-          
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
-          - path: /flyteidl.service.SignalService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.SignalService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
           - path: /flyteidl.service.AdminService
             pathType: ImplementationSpecific
             backend:
@@ -7793,20 +7780,6 @@ spec:
                 port:
                   number: 81
           - path: /flyteidl.service.AdminService/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: flyteadmin
-                port:
-                  number: 81
-          - path: /flyteidl.service.DataProxyService/*
             pathType: ImplementationSpecific
             backend:
               service:
@@ -7827,6 +7800,20 @@ spec:
                 name: flyteadmin
                 port:
                   number: 81
+          - path: /flyteidl.service.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
+          - path: /flyteidl.service.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
           - path: /flyteidl.service.IdentityService
             pathType: ImplementationSpecific
             backend:
@@ -7835,6 +7822,20 @@ spec:
                 port:
                   number: 81
           - path: /flyteidl.service.IdentityService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  number: 81
+          - path: /flyteidl.service.SignalService/*
             pathType: ImplementationSpecific
             backend:
               service:


### PR DESCRIPTION
## Tracking issue
_https://github.com/flyteorg/flyte/issues/4962_

## Why are the changes needed?

This allows setting annotations that are required for some ingress controllers for grpc communication only on parts that actually use grpc.
Without this separation, either the console or the grpc endpoints did not work properly with some ingress controllers, e.g. traefik.

## What changes were proposed in this pull request?

This PR splits the existing `flyteadmin` service of the `flyte-core` chart into two separate services (like in the `flyte-binary` chart).
One service for grpc communication and another one for all other communication.
Accordingly, the `annotations` field of the `values.yaml` was extended to also use `httpAnnotations` and `grpcAnnotations`.
Technically, this is a breaking change for contour users, because the `values.yaml` contained a default `annotation` (that I think should not really be there anyway):

```yaml
    annotations:
      projectcontour.io/upstream-protocol.h2c: grpc
```
I removed this default, but we could also keep this for backwards compatibility.

## Docs link

I'm not sure how to regenerate the docs for this chart from the `values.yaml`. Is there some command I can run?
