### PR TITLE
docs: add missing key in auth guide

### DIFF
--- a/docs/deployment/configuration/auth_setup.rst
+++ b/docs/deployment/configuration/auth_setup.rst
@@ -617,14 +617,14 @@ Follow the steps in this section to configure `flyteadmin` to use an external au
       .. code-block:: yaml
 
          secrets:
-         adminOauthClientCredentials:
-            enabled: true
-            clientSecret: <client secret>
-            clientId: <client id>
+           adminOauthClientCredentials:
+             enabled: true
+             clientSecret: <client secret>
+             clientId: <client id>
          ---
          configmap:
-         admin:
-            admin:
+           admin:
+             admin:
                endpoint: <admin endpoint>
                insecure: true
                clientId: <client id>
@@ -633,28 +633,30 @@ Follow the steps in this section to configure `flyteadmin` to use an external au
                - api://<client id>/.default
                useAudienceFromAdmin: true
          ---
-         auth:
-            appAuth:
-               authServerType: External
-               externalAuthServer:
-                  baseUrl: https://login.microsoftonline.com/<tenant id>/v2.0/
-                  metadataUrl: .well-known/openid-configuration
-                  AllowedAudience:
-                     - api://<client id>
-               thirdPartyConfig:
-                  flyteClient:
+         configmap:
+           adminServer:
+             auth:
+               appAuth:
+                 authServerType: External
+                 externalAuthServer:
+                   baseUrl: https://login.microsoftonline.com/<tenant id>/v2.0/
+                   metadataUrl: .well-known/openid-configuration
+                   AllowedAudience:
+                   - api://<client id>
+                 thirdPartyConfig:
+                   flyteClient:
                      clientId: <client id>
                      redirectUri: http://localhost:53593/callback
                      scopes:
                      - api://<client id>/<custom-scope>
 
-            userAuth:
-               openId:
-                  baseUrl: https://login.microsoftonline.com/<tenant id>/v2.0
-                  scopes:
-                     - openid
-                     - profile
-                  clientId: <client id>
+               userAuth:
+                 openId:
+                 baseUrl: https://login.microsoftonline.com/<tenant id>/v2.0
+                 scopes:
+                 - openid
+                 - profile
+                 clientId: <client id>
 
 .. note::
 

--- a/docs/deployment/configuration/auth_setup.rst
+++ b/docs/deployment/configuration/auth_setup.rst
@@ -558,42 +558,43 @@ Follow the steps in this section to configure `flyteadmin` to use an external au
       .. code-block:: yaml
 
          configmap:
-           auth:
-             appAuth:
+           adminServer:
+             auth:
+               appAuth:
 
-               authServerType: External
+                 authServerType: External
 
-               # 2. Optional: Set external auth server baseUrl if different from OpenId baseUrl.
-               externalAuthServer:
-               # baseUrl: https://<keycloak-url>/auth/realms/<keycloak-realm> # Uncomment for Keycloak and update with your installation host and realm name
-               # baseUrl: https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize # Uncomment for Azure AD
-               # For Okta, use the Issuer URI of the custom auth server:
-                 baseUrl: https://dev-<org-id>.okta.com/oauth2/<auth-server-id>
+                 # 2. Optional: Set external auth server baseUrl if different from OpenId baseUrl.
+                 externalAuthServer:
+                 # baseUrl: https://<keycloak-url>/auth/realms/<keycloak-realm> # Uncomment for Keycloak and update with your installation host and realm name
+                 # baseUrl: https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize # Uncomment for Azure AD
+                 # For Okta, use the Issuer URI of the custom auth server:
+                   baseUrl: https://dev-<org-id>.okta.com/oauth2/<auth-server-id>
 
-                 metadataUrl: .well-known/openid-configuration
+                   metadataUrl: .well-known/openid-configuration
 
-               thirdPartyConfig:
-                  flyteClient:
-                     # 3. Replace with a new Native/Public Client ID provisioned in the custom authorization server.
-                     clientId: flytectl
-                     # This should not change
-                     redirectUri: http://localhost:53593/callback
-                     # 4. "all" is a required scope and must be configured in the custom authorization server.
-                     scopes:
-                     - offline
-                     - all
+                 thirdPartyConfig:
+                    flyteClient:
+                       # 3. Replace with a new Native/Public Client ID provisioned in the custom authorization server.
+                       clientId: flytectl
+                       # This should not change
+                       redirectUri: http://localhost:53593/callback
+                       # 4. "all" is a required scope and must be configured in the custom authorization server.
+                       scopes:
+                       - offline
+                       - all
 
-             userAuth:
-               openId:
-               # baseUrl: https://<keycloak-url>/auth/realms/<keycloak-realm> # Uncomment for Keycloak and update with your installation host and realm name
-               # baseUrl: https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize # Uncomment for Azure AD
-               # For Okta, use the Issuer URI of the custom auth server:
-                 baseUrl: https://dev-<org-id>.okta.com/oauth2/<auth-server-id>
-                 scopes:
-                 - profile
-                 - openid
-                 # - offline_access # Uncomment if OIdC supports issuing refresh tokens.
-                 clientId: <client id>
+               userAuth:
+                 openId:
+                 # baseUrl: https://<keycloak-url>/auth/realms/<keycloak-realm> # Uncomment for Keycloak and update with your installation host and realm name
+                 # baseUrl: https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize # Uncomment for Azure AD
+                 # For Okta, use the Issuer URI of the custom auth server:
+                   baseUrl: https://dev-<org-id>.okta.com/oauth2/<auth-server-id>
+                   scopes:
+                   - profile
+                   - openid
+                   # - offline_access # Uncomment if OIdC supports issuing refresh tokens.
+                   clientId: <client id>
 
 
          secrets:


### PR DESCRIPTION
## Why are the changes needed?

The authentication and authorization guides for `flyte-core` are slightly wrong and led to some confusion on our side.

## What changes were proposed in this pull request?

This PR should fix missing keys and improve some formatting for the AzureAD guide.

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
