### PR TITLE
Fix streak length metric reporting

### DIFF
--- a/flytepropeller/pkg/controller/handler.go
+++ b/flytepropeller/pkg/controller/handler.go
@@ -230,7 +230,6 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 	}
 
 	streak := 0
-	defer p.metrics.StreakLength.Add(ctx, float64(streak))
 
 	maxLength := p.cfg.MaxStreakLength
 	if maxLength <= 0 {
@@ -239,16 +238,15 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 
 	for streak = 0; streak < maxLength; streak++ {
 		w, err = p.streak(ctx, w, wfClosureCrdFields)
-		if err != nil {
-			return err
-		} else if w == nil {
+		if err != nil || w == nil {
 			break
 		}
 
 		logger.Infof(ctx, "FastFollow Enabled. Detected State change, we will try another round. StreakLength [%d]", streak)
 	}
 	logger.Infof(ctx, "Streak ended at [%d]/Max: [%d]", streak, maxLength)
-	return nil
+	p.metrics.StreakLength.Add(ctx, float64(streak))
+	return err
 }
 
 // parseWorkflowClosureCrdFields attempts to retrieve offloaded static workflow closure data from the specified

--- a/flytepropeller/pkg/controller/handler.go
+++ b/flytepropeller/pkg/controller/handler.go
@@ -230,7 +230,7 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 	}
 
 	streak := 0
-	defer func() { p.metrics.StreakLength.Add(ctx, float64(streak)) }()  
+	defer func() { p.metrics.StreakLength.Add(ctx, float64(streak)) }()
 
 	maxLength := p.cfg.MaxStreakLength
 	if maxLength <= 0 {


### PR DESCRIPTION
## Tracking issue
Closes #5170

## Why are the changes needed?
Accurate metrics are useful.

## What changes were proposed in this pull request?
Fix the streak length metric reporting by avoiding use of `defer`. Included slightly simplifying the branching logic. 

## How was this patch tested?
I've been using it in production. 
![image](https://github.com/flyteorg/flyte/assets/9131935/b138eefd-d3bd-45da-acf1-901705c99b7e)


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly - not applicable
- [x] All new and existing tests passed
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
