### PR TITLE
Stop admin launcher copying shard key from parent workflow

### DIFF
--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/admin.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/admin.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 	evtErr "github.com/flyteorg/flyte/flytepropeller/events/errors"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/transformers/k8s"
 	"github.com/flyteorg/flyte/flytestdlib/cache"
 	stdErr "github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
@@ -113,6 +114,12 @@ func (a *adminLaunchPlanExecutor) Launch(ctx context.Context, launchCtx LaunchCo
 			Value: v,
 		})
 	}
+
+	// Remove the ShardKeyLabel entry from labels so that the child launch plan can potentially run on a different
+	// flytepropeller shard.
+	logger.Warnf(ctx, "launch labels: %v", launchCtx.Labels)
+	delete(launchCtx.Labels, k8s.ShardKeyLabel)
+	logger.Warnf(ctx, "launch labels: %v", launchCtx.Labels)
 
 	req := &admin.ExecutionCreateRequest{
 		Project: executionID.Project,

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/admin.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/admin.go
@@ -117,8 +117,12 @@ func (a *adminLaunchPlanExecutor) Launch(ctx context.Context, launchCtx LaunchCo
 
 	// Make a copy of the labels with shard-key removed. This ensures that the shard-key is re-computed for each
 	// instead of being copied from the parent.
-	labels := launchCtx.Labels
-	delete(labels, k8s.ShardKeyLabel)
+	labels := make(map[string]string)
+	for key, value := range launchCtx.Labels {
+		if key != k8s.ShardKeyLabel {
+			labels[key] = value
+		}
+	}
 
 	req := &admin.ExecutionCreateRequest{
 		Project: executionID.Project,


### PR DESCRIPTION
## Tracking issue
Closes: #5173 

## Why are the changes needed?
For more uniform distribution of workflows across fltyepropeller shards. 

## What changes were proposed in this pull request?
Specifically delete the `shard-key` label but copy all the other labels from parent to child as before. 

## How was this patch tested?
Added a unit test 
I've been using it in production. 

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly - I don't think its applicable. 
- [x] All new and existing tests passed
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
