### PR TITLE
fix: renaming standaloneDeployment variable to be consistent

### DIFF
--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             {{- end }}
             {{- end }}
         {{- end }}
-        {{- if and (.Values.cluster_resource_manager.enabled) (not .Values.cluster_resource_manager.standalone_deploy) }}
+        {{- if and (.Values.cluster_resource_manager.enabled) (not .Values.cluster_resource_manager.standaloneDeployment) }}
         - command:
           - flyteadmin
           - --config

--- a/charts/flyte-core/values-eks.yaml
+++ b/charts/flyte-core/values-eks.yaml
@@ -350,7 +350,7 @@ cluster_resource_manager:
   # -- Enables the Cluster resource manager component
   enabled: true
   # -- Starts the cluster resource manager in standalone mode with requisite auth credentials to call flyteadmin service endpoints
-  standalone_deploy: false
+  standaloneDeployment: false
   config:
     cluster_resources:
       customData:

--- a/charts/flyte-core/values-gcp.yaml
+++ b/charts/flyte-core/values-gcp.yaml
@@ -331,7 +331,7 @@ cluster_resource_manager:
   # -- Enables the Cluster resource manager component
   enabled: true
   # -- Starts the cluster resource manager in standalone mode with requisite auth credentials to call flyteadmin service endpoints
-  standalone_deploy: false
+  standaloneDeployment: false
   config:
     cluster_resources:
       customData:

--- a/docs/deployment/plugins/k8s/index.rst
+++ b/docs/deployment/plugins/k8s/index.rst
@@ -623,7 +623,7 @@ Specify plugin configuration
                           spark: spark
                 cluster_resource_manager:
                   enabled: true 
-                  standalone_deploy: false
+                  standaloneDeployment: false
                   # -- Resource templates that should be applied
                   templates:
                     # -- Template for namespaces resources
@@ -735,7 +735,7 @@ Specify plugin configuration
                             spark: spark 
                     cluster_resource_manager:
                       enabled: true
-                      standalone_deploy: false
+                      standaloneDeployment: false
                       config:
                         cluster_resources:
                           customData:


### PR DESCRIPTION
This PR fixes 2 issues:

1. There was a mismatch with variable naming in the Flyte-Core chart, where standalone_deploy and standaloneDeployment were being used interchangeably
2. cluster_resource_manager could be deployed twice as part of flyteadmin and standalone