### PR TITLE
Change phase to queue on job submit for webapi plugins

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/internal/webapi/monitor.go
+++ b/flyteplugins/go/tasks/pluginmachinery/internal/webapi/monitor.go
@@ -39,7 +39,7 @@ func monitor(ctx context.Context, tCtx core.TaskExecutionContext, p Client, cach
 			}
 			return state, core.PhaseInfoFailure(errors.CacheFailed, cacheItem.ErrorMessage, nil), nil
 		}
-		return state, core.PhaseInfoInitializing(time.Now(), core.DefaultPhaseVersion, "job submitted", nil), nil
+		return state, core.PhaseInfoQueued(time.Now(), core.DefaultPhaseVersion, "job submitted"), nil
 	}
 
 	newPhase, err := p.Status(ctx, newPluginContext(cacheItem.ResourceMeta, cacheItem.Resource, "", tCtx))

--- a/flyteplugins/go/tasks/pluginmachinery/internal/webapi/monitor.go
+++ b/flyteplugins/go/tasks/pluginmachinery/internal/webapi/monitor.go
@@ -2,6 +2,7 @@ package webapi
 
 import (
 	"context"
+	"time"
 
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/errors"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
@@ -38,7 +39,7 @@ func monitor(ctx context.Context, tCtx core.TaskExecutionContext, p Client, cach
 			}
 			return state, core.PhaseInfoFailure(errors.CacheFailed, cacheItem.ErrorMessage, nil), nil
 		}
-		return state, core.PhaseInfoRunning(0, nil), nil
+		return state, core.PhaseInfoInitializing(time.Now(), core.DefaultPhaseVersion, "job submitted", nil), nil
 	}
 
 	newPhase, err := p.Status(ctx, newPluginContext(cacheItem.ResourceMeta, cacheItem.Resource, "", tCtx))


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
log links are not shown up on FlyteConsole when the task status is running.
It will also fix other webAPI plugins.

propeller only sends the event when the current event is not equal to the previous event, so if `ResourceCache` sets the phase to running here without info, the log link will never show up on flyteconsole when the status is running.


## What changes were proposed in this pull request?
The phase should be `PhaseQueue` when there is no resource in the [cacheItem](https://github.com/flyteorg/flyte/blob/328de82f2d81fb4b8fc848d2c178858b49f2c2db/flyteplugins/go/tasks/pluginmachinery/internal/webapi/monitor.go#L33).

The async ResourceCache is empty if the `Get` [request](https://github.com/flyteorg/flyte/blob/ea02a22134acb6e548ed034829a2b17361a65c86/flyteplugins/go/tasks/pluginmachinery/internal/webapi/cache.go#L108) is not yet sent to the agent.

## How was this patch tested?
Local

### Setup process

### Screenshots
<img width="1882" alt="image" src="https://github.com/flyteorg/flyte/assets/37936015/04f04119-5200-4c5b-830d-27b8cbd8c552">

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
