### PR TITLE
Change phase to WaitingForResources when quota exceeded

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/internal/webapi/allocation_token.go
+++ b/flyteplugins/go/tasks/pluginmachinery/internal/webapi/allocation_token.go
@@ -64,8 +64,8 @@ func (a tokenAllocator) allocateToken(ctx context.Context, p webapi.AsyncPlugin,
 		return &State{
 				AllocationTokenRequestStartTime: startTime,
 				Phase:                           PhaseNotStarted,
-			}, core.PhaseInfoQueued(
-				a.clock.Now(), 0, "Quota for task has exceeded. The request is enqueued."), nil
+			}, core.PhaseInfoWaitingForResourcesInfo(
+				a.clock.Now(), 0, "Quota for task has exceeded. Waiting for the resource.", nil), nil
 	}
 
 	return nil, core.PhaseInfo{}, fmt.Errorf("allocation status undefined [%v]", allocationStatus)

--- a/flyteplugins/go/tasks/plugins/webapi/agent/config.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/config.go
@@ -13,7 +13,7 @@ var (
 	defaultConfig = Config{
 		WebAPI: webapi.PluginConfig{
 			ResourceQuotas: map[core.ResourceNamespace]int{
-				"default": 1,
+				"default": 1000,
 			},
 			ReadRateLimiter: webapi.RateLimiterConfig{
 				Burst: 100,

--- a/flyteplugins/go/tasks/plugins/webapi/agent/config.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/config.go
@@ -13,7 +13,7 @@ var (
 	defaultConfig = Config{
 		WebAPI: webapi.PluginConfig{
 			ResourceQuotas: map[core.ResourceNamespace]int{
-				"default": 1000,
+				"default": 1,
 			},
 			ReadRateLimiter: webapi.RateLimiterConfig{
 				Burst: 100,

--- a/flytepropeller/pkg/controller/nodes/task/resourcemanager/config/config.go
+++ b/flytepropeller/pkg/controller/nodes/task/resourcemanager/config/config.go
@@ -27,7 +27,7 @@ var (
 
 // Configs for Resource Manager
 type Config struct {
-	Type             Type        `json:"type" pflag:"noop,Which resource manager to use"`
+	Type             Type        `json:"type" pflag:"noop, Which resource manager to use, redis or noop. Default is noop."`
 	ResourceMaxQuota int         `json:"resourceMaxQuota" pflag:",Global limit for concurrent Qubole queries"`
 	RedisConfig      RedisConfig `json:"redis" pflag:",Config for Redis resourcemanager."`
 }

--- a/flytepropeller/pkg/controller/nodes/task/resourcemanager/config/config_flags.go
+++ b/flytepropeller/pkg/controller/nodes/task/resourcemanager/config/config_flags.go
@@ -50,7 +50,7 @@ func (Config) mustMarshalJSON(v json.Marshaler) string {
 // flags is json-name.json-sub-name... etc.
 func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "type"), defaultConfig.Type, "Which resource manager to use")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "type"), defaultConfig.Type, " Which resource manager to use,  redis or noop. Default is noop.")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "resourceMaxQuota"), defaultConfig.ResourceMaxQuota, "Global limit for concurrent Qubole queries")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "redis.hostPaths"), defaultConfig.RedisConfig.HostPaths, "Redis hosts locations.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "redis.primaryName"), defaultConfig.RedisConfig.PrimaryName, "Redis primary name,  fill in only if you are connecting to a redis sentinel cluster.")


### PR DESCRIPTION
## Tracking issue
https://flyte-org.slack.com/archives/CP2HDHKE1/p1708818106936209

## Why are the changes needed?
Tasks are stuck in the queue phase when the resource quota is exceeded since the propeller won't send the event to Flyteadmin if the current phase is equal to the [previous](https://github.com/flyteorg/flyte/blob/ea02a22134acb6e548ed034829a2b17361a65c86/flyteplugins/go/tasks/pluginmachinery/internal/webapi/allocation_token.go#L54) phase. Therefore, propeller won't update the state (`PhaseNotStarted` ->`PhaseAllocationTokenAcquired`) as well, and it will always assume that there is no resource available to execute the task.

## What changes were proposed in this pull request?
Change phase to WaitingForResources when the quota is exceeded, so propeller will send the event to flyteadmin.

## How was this patch tested?
local sandbox and enable the resource manager

### Setup process

### Screenshots

Before:

<img width="1899" alt="Screenshot 2024-04-06 at 11 20 03 PM" src="https://github.com/flyteorg/flyte/assets/37936015/64a9ed33-0f06-49c3-b775-ce1a56322fa1">

After:

<img width="1886" alt="Screenshot 2024-04-06 at 11 03 40 PM" src="https://github.com/flyteorg/flyte/assets/37936015/101671dc-7a1d-4e28-8279-48b7a61dda1f">


- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
