### PR TITLE
Fix: Update spark operator helm repository

### DIFF
--- a/docs/deployment/plugins/k8s/index.rst
+++ b/docs/deployment/plugins/k8s/index.rst
@@ -83,7 +83,7 @@ Select the integration you need and follow the steps to install the correspondin
   
     .. code-block:: bash
   
-       helm repo add spark-operator https://googlecloudplatform.github.io/spark-on-k8s-operator
+       helm repo add spark-operator https://kubeflow.github.io/spark-operator
   
     To install the Spark operator, run the following command:
   


### PR DESCRIPTION
## Why are the changes needed?

The helm repository for the spark operator listed in the [Configure Kubernetes Plugins](https://docs.flyte.org/en/latest/deployment/plugins/k8s/index.html#deployment-plugin-setup-k8s) documentation is no longer active.
I'm updating the url as stated in the respective [issue](https://github.com/kubeflow/spark-operator/issues/1929) in the spark operator repository. I tested that this repository works.

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.
