### PR TITLE
[easy] [flyteagent] Add `ExecuteTaskSync` function timeout setting

### DIFF
--- a/flyteplugins/go/tasks/plugins/webapi/agent/plugin_test.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/plugin_test.go
@@ -75,15 +75,26 @@ func TestPlugin(t *testing.T) {
 	t.Run("test getFinalTimeout", func(t *testing.T) {
 		timeout := getFinalTimeout("CreateTask", &Deployment{Endpoint: "localhost:8080", Timeouts: map[string]config.Duration{"CreateTask": {Duration: 1 * time.Millisecond}}})
 		assert.Equal(t, 1*time.Millisecond, timeout.Duration)
+		timeout = getFinalTimeout("GetTask", &Deployment{Endpoint: "localhost:8080", Timeouts: map[string]config.Duration{"GetTask": {Duration: 1 * time.Millisecond}}})
+		assert.Equal(t, 1*time.Millisecond, timeout.Duration)
 		timeout = getFinalTimeout("DeleteTask", &Deployment{Endpoint: "localhost:8080", DefaultTimeout: config.Duration{Duration: 10 * time.Second}})
 		assert.Equal(t, 10*time.Second, timeout.Duration)
+		timeout = getFinalTimeout("ExecuteTaskSync", &Deployment{Endpoint: "localhost:8080", Timeouts: map[string]config.Duration{"ExecuteTaskSync": {Duration: 1 * time.Millisecond}}})
+		assert.Equal(t, 1*time.Millisecond, timeout.Duration)
 	})
 
 	t.Run("test getFinalContext", func(t *testing.T) {
-		ctx, _ := getFinalContext(context.TODO(), "DeleteTask", &Deployment{})
+
+		ctx, _ := getFinalContext(context.TODO(), "CreateTask", &Deployment{Endpoint: "localhost:8080", Timeouts: map[string]config.Duration{"CreateTask": {Duration: 1 * time.Millisecond}}})
+		assert.NotEqual(t, context.TODO(), ctx)
+
+		ctx, _ = getFinalContext(context.TODO(), "GetTask", &Deployment{Endpoint: "localhost:8080", Timeouts: map[string]config.Duration{"GetTask": {Duration: 1 * time.Millisecond}}})
+		assert.NotEqual(t, context.TODO(), ctx)
+
+		ctx, _ = getFinalContext(context.TODO(), "DeleteTask", &Deployment{})
 		assert.Equal(t, context.TODO(), ctx)
 
-		ctx, _ = getFinalContext(context.TODO(), "CreateTask", &Deployment{Endpoint: "localhost:8080", Timeouts: map[string]config.Duration{"CreateTask": {Duration: 1 * time.Millisecond}}})
+		ctx, _ = getFinalContext(context.TODO(), "ExecuteTaskSync", &Deployment{Endpoint: "localhost:8080", Timeouts: map[string]config.Duration{"ExecuteTaskSync": {Duration: 10 * time.Second}}})
 		assert.NotEqual(t, context.TODO(), ctx)
 	})
 


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
We want to let users be able to set sync task's timeout, and it should be different apart from `CreateTask`.

## What changes were proposed in this pull request?
Create a new context before executing `ExecuteTaskSync`.
We can set the timeout of `ExecuteTaskSync` function by adding 
`ExecuteTaskSync: 10s` in our flytepropeller config map.
for example.
```yaml
agent-service:
    supportedTaskTypes:
      - chatgpt
      - sensor
    defaultAgent:
      endpoint: "localhost:8000"
      insecure: true
      timeouts:
        ExecuteTaskSync: 10s
      defaultTimeout: 10s
```

## How was this patch tested?
remote execution and unit tests.

### Setup process
single-binary-dev

### Screenshots
<img width="958" alt="image" src="https://github.com/flyteorg/flyte/assets/76461262/eecdf85f-b9cf-4062-ae0b-96616d6d21a7">
<img width="671" alt="image" src="https://github.com/flyteorg/flyte/assets/76461262/54fa80ca-cfa8-424e-baa9-cbcca84844fd">
<img width="667" alt="image" src="https://github.com/flyteorg/flyte/assets/76461262/a0fde5e9-14b8-4072-8845-172b4ddd6ace">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flyte/pull/5208
