### PR TITLE
Re-apply changes  to dataclass docs from flytesnacks#1553

### DIFF
--- a/docs/getting_started_with_workflow_development/flyte_project_components.md
+++ b/docs/getting_started_with_workflow_development/flyte_project_components.md
@@ -32,7 +32,7 @@ manage your project's Python requirements.
 
 ````{dropdown} See requirements.txt
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytekit-python-template/main/simple-example/%7B%7Bcookiecutter.project_name%7D%7D/requirements.txt
+```{rli} https://raw.githubusercontent.com/flyteorg/flytekit-python-template/main/basic-template-imagespec/%7B%7Bcookiecutter.project_name%7D%7D/requirements.txt
 :caption: requirements.txt
 ```
 

--- a/docs/user_guide/data_types_and_io/dataclass.md
+++ b/docs/user_guide/data_types_and_io/dataclass.md
@@ -35,6 +35,9 @@ If you're using Flytekit version below v1.10, you'll need to decorate with `@dat
 `from dataclass_json import dataclass_json` instead of inheriting from Mashumaro's `DataClassJSONMixin`.
 :::
 
+If you're using Flytekit version >= v1.11.1, you don't need to decorate with `@dataclass_json` or
+inherit from Mashumaro's `DataClassJSONMixin`.
+
 To begin, import the necessary dependencies.
 
 ```{code-cell}

--- a/docs/user_guide/data_types_and_io/dataclass.md
+++ b/docs/user_guide/data_types_and_io/dataclass.md
@@ -33,10 +33,10 @@ to serialize and deserialize dataclasses.
 :::{important}
 If you're using Flytekit version below v1.10, you'll need to decorate with `@dataclass_json` using
 `from dataclass_json import dataclass_json` instead of inheriting from Mashumaro's `DataClassJSONMixin`.
-:::
 
 If you're using Flytekit version >= v1.11.1, you don't need to decorate with `@dataclass_json` or
 inherit from Mashumaro's `DataClassJSONMixin`.
+:::
 
 To begin, import the necessary dependencies.
 

--- a/docs/user_guide/data_types_and_io/index.md
+++ b/docs/user_guide/data_types_and_io/index.md
@@ -99,8 +99,7 @@ Here's a breakdown of these mappings:
     * - ``@dataclass``
       - ``Struct``
       - Automatic
-      - The class should be a pure value class that inherits from Mashumaro's DataClassJSONMixin,
-        and be annotated with the ``@dataclass`` decorator.
+      - The class should be a pure value class annotated with the ``@dataclass`` decorator.
     * - ``np.ndarray``
       - File
       - Automatic


### PR DESCRIPTION
## Why are the changes needed?

The user guide docs have been moved to Flyte, so we need to re-apply changes from https://github.com/flyteorg/flytesnacks/pull/1553/.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flytesnacks/pull/1553/

## Docs link

TK
