### PR TITLE
Update "Creating a Flyte project" with link to new Dockerfile project template

### DIFF
--- a/docs/getting_started_with_workflow_development/creating_a_flyte_project.md
+++ b/docs/getting_started_with_workflow_development/creating_a_flyte_project.md
@@ -23,7 +23,7 @@ conda activate flyte-example
 
 Next, initialize your Flyte project. The [flytekit-python-template GitHub repository](https://github.com/flyteorg/flytekit-python-template) contains Flyte project templates with sample code that you can run as is or modify to suit your needs.
 
-In this example, we will initialize the [basic-example-imagespec project template](https://github.com/flyteorg/flytekit-python-template/tree/main/basic-example-imagespec).
+In this example, we will initialize the [basic-template-imagespec project template](https://github.com/flyteorg/flytekit-python-template/tree/main/basic-template-imagespec).
 
 ```{prompt} bash $
 pyflyte init my_project
@@ -31,9 +31,9 @@ pyflyte init my_project
 
 :::{note}
 
-To initialize a Flyte project with a different template, use the `--template` parameter:
+If you need to use a Dockerfile for your project, you can initialize the Dockerfile template:
 
-`pyflyte init --template hello-world hello-world`
+`pyflyte init --template basic-template-dockerfile my_project`
 :::
 
 ### 3. Install additional requirements

--- a/docs/getting_started_with_workflow_development/flyte_project_components.md
+++ b/docs/getting_started_with_workflow_development/flyte_project_components.md
@@ -1,3 +1,4 @@
+(flyte_project_components)=
 # Flyte project components
 
 A Flyte project is a directory containing task and workflow code, internal Python source code, configuration files, and other artifacts required to package up your code so that it can be run on a Flyte cluster.
@@ -26,13 +27,13 @@ You can specify pip-installable Python dependencies in your project by adding th
 `requirements.txt` file.
 
 ```{note}
-We recommend using [pip-compile](https://pip-tools.readthedocs.io/en/latest/) to
+We recommend using [pip-compile](https://pip-tools.readthedocs.io/en/stable/) to
 manage your project's Python requirements.
 ```
 
 ````{dropdown} See requirements.txt
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytekit-python-template/main/simple-example/%7B%7Bcookiecutter.project_name%7D%7D/requirements.txt
+```{rli} https://raw.githubusercontent.com/flyteorg/flytekit-python-template/main/basic-template-imagespec/%7B%7Bcookiecutter.project_name%7D%7D/requirements.txt
 :caption: requirements.txt
 ```
 


### PR DESCRIPTION
## Changes in this PR

Updated "Creating a Flyte project" to reference the new [flytekit Dockerfile template](https://github.com/flyteorg/flytekit-python-template/tree/main/basic-template-dockerfile) in "Creating a Flyte project" for users who need to use a Dockerfile instead of ImageSpec. Also fixes link to the basic ImageSpec template.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Docs link

TK
