### PR TITLE
perf(cache): Use AddRateLimited for batch enqueue

### DIFF
--- a/flytestdlib/cache/auto_refresh.go
+++ b/flytestdlib/cache/auto_refresh.go
@@ -252,7 +252,7 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 
 	for _, batch := range batches {
 		b := batch
-		w.workqueue.Add(&b)
+		w.workqueue.AddRateLimited(&b)
 	}
 
 	return nil

--- a/flytestdlib/cache/auto_refresh_test.go
+++ b/flytestdlib/cache/auto_refresh_test.go
@@ -35,7 +35,7 @@ func (t terminalCacheItem) IsTerminal() bool {
 	return true
 }
 
-func syncFakeItem(ctx context.Context, batch Batch) ([]ItemSyncResponse, error) {
+func syncFakeItem(_ context.Context, batch Batch) ([]ItemSyncResponse, error) {
 	items := make([]ItemSyncResponse, 0, len(batch))
 	for _, obj := range batch {
 		item := obj.GetItem().(fakeCacheItem)

--- a/flytestdlib/cache/auto_refresh_test.go
+++ b/flytestdlib/cache/auto_refresh_test.go
@@ -19,11 +19,12 @@ import (
 const fakeCacheItemValueLimit = 10
 
 type fakeCacheItem struct {
-	val int
+	val        int
+	isTerminal bool
 }
 
 func (f fakeCacheItem) IsTerminal() bool {
-	return false
+	return f.isTerminal
 }
 
 type terminalCacheItem struct {
@@ -34,7 +35,7 @@ func (t terminalCacheItem) IsTerminal() bool {
 	return true
 }
 
-func syncFakeItem(_ context.Context, batch Batch) ([]ItemSyncResponse, error) {
+func syncFakeItem(ctx context.Context, batch Batch) ([]ItemSyncResponse, error) {
 	items := make([]ItemSyncResponse, 0, len(batch))
 	for _, obj := range batch {
 		item := obj.GetItem().(fakeCacheItem)
@@ -42,11 +43,15 @@ func syncFakeItem(_ context.Context, batch Batch) ([]ItemSyncResponse, error) {
 			// After the item has gone through ten update cycles, leave it unchanged
 			continue
 		}
-
+		isTerminal := false
+		if item.val == fakeCacheItemValueLimit-1 {
+			isTerminal = true
+		}
 		items = append(items, ItemSyncResponse{
 			ID: obj.GetID(),
 			Item: fakeCacheItem{
-				val: item.val + 1,
+				val:        item.val + 1,
+				isTerminal: isTerminal,
 			},
 			Action: Update,
 		})
@@ -60,7 +65,7 @@ func syncTerminalItem(_ context.Context, batch Batch) ([]ItemSyncResponse, error
 }
 
 func TestCacheFour(t *testing.T) {
-	testResyncPeriod := time.Millisecond
+	testResyncPeriod := 10 * time.Millisecond
 	rateLimiter := workqueue.DefaultControllerRateLimiter()
 
 	t.Run("normal operation", func(t *testing.T) {


### PR DESCRIPTION
## Tracking issue
https://flyte-org.slack.com/archives/C05BN3A92SE/p1712926168291449
closed https://github.com/flyteorg/flyte/issues/5202

## Why are the changes needed?
`workqueue.Add` will add all the item in the async cache to the queue at the same time and cause propeller to send N (number of items in the async cache) requests to the external system and some tasks may run into rate limit issue.

## What changes were proposed in this pull request?
Use `workqueue.AddRateLimited` instead of `workqueue.Add`. 

## How was this patch tested?
Local Sandbox

### Setup process

### Screenshots

NA

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
