### PR TITLE
propagate dark/light theme to algolia search bar

### DIFF
--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -62,6 +62,43 @@ function scrollToActive() {
     window.addEventListener("beforeunload", () => {
       sessionStorage.setItem("sidebar-scroll-top", sidebar.scrollTop);
     });
-  }
+}
 
-document.addEventListener('DOMContentLoaded', scrollToActive);
+
+function setHtmlDataTheme() {
+  // Set theme at the root html element
+  setTimeout(() => {
+    const theme = document.body.dataset.theme;
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+    if (theme === "auto") {
+      document.documentElement.dataset.theme = prefersDark ? "dark" : "light";
+    } else {
+      document.documentElement.dataset.theme = theme;
+    }
+  }, 10)
+}
+
+
+function setupAlgoliaTheme() {
+  // To get darkmode in the algolia search modal, we need to set the theme in
+  // the root html element. This function propagates the theme set by furo
+  // that's set in the body element.
+  const buttons = document.getElementsByClassName("theme-toggle");
+
+  // set for initial document load
+  setHtmlDataTheme();
+
+  // listen for when theme button is clicked.
+  Array.from(buttons).forEach((btn) => {
+    btn.addEventListener("click", setHtmlDataTheme);
+  });
+}
+
+
+function main() {
+  scrollToActive()
+  setupAlgoliaTheme()
+}
+
+document.addEventListener('DOMContentLoaded', main);

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -103,6 +103,7 @@ function main() {
 
 document.addEventListener('DOMContentLoaded', main);
 window.addEventListener('keydown', (event) => {
+  console.log(event);
   if (event.code === "Escape") {
     // make sure to prevent default behavior with escape key so that algolia
     // modal can be closed properly.

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -103,7 +103,6 @@ function main() {
 
 document.addEventListener('DOMContentLoaded', main);
 window.addEventListener('keydown', (event) => {
-  console.log(event);
   if (event.code === "Escape") {
     // make sure to prevent default behavior with escape key so that algolia
     // modal can be closed properly.

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -102,3 +102,10 @@ function main() {
 }
 
 document.addEventListener('DOMContentLoaded', main);
+window.addEventListener('keydown', (event) => {
+  if (event.code === "Escape") {
+    // make sure to prevent default behavior with escape key so that algolia
+    // modal can be closed properly.
+    event.preventDefault();
+  }
+});


### PR DESCRIPTION
## Why are the changes needed?

Currently, the algolia search bar maintains the light theme even when dark mode is toggled:
<img width="1673" alt="image" src="https://github.com/flyteorg/flyte/assets/2816689/97f53790-78d0-4fd4-8f97-f1b7e23a82a8">

## What changes were proposed in this pull request?

This PR propogates the `data-theme="light/dark/auto"` setting that the furo sphinx theme handles from the `body` element to the root `html` element.

## How was this patch tested?

Built the docs locally with `make docs`
