### PR TITLE
Added additional port configuration for flyte services

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -139,7 +139,8 @@ helm install gateway bitnami/contour -n flyte
 | datacatalog.replicaCount | int | `1` | Replicas count for Datacatalog deployment |
 | datacatalog.resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Datacatalog deployment |
 | datacatalog.securityContext | object | `{"fsGroup":1001,"fsGroupChangePolicy":"OnRootMismatch","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for datacatalog pod(s). |
-| datacatalog.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"type":"NodePort"}` | Service settings for Datacatalog |
+| datacatalog.service | object | `{"additionalPorts":[],"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"type":"NodePort"}` | Service settings for Datacatalog |
+| datacatalog.service.additionalPorts | list | `[]` | Appends additional ports to the service spec. |
 | datacatalog.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for Datacatalog |
 | datacatalog.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Datacatalog pods |
 | datacatalog.serviceAccount.create | bool | `true` | Should a service account be created for Datacatalog |
@@ -175,7 +176,8 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flyteadmin deployment |
 | flyteadmin.secrets | object | `{}` |  |
 | flyteadmin.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for flyteadmin pod(s). |
-| flyteadmin.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"loadBalancerSourceRanges":[],"type":"ClusterIP"}` | Service settings for Flyteadmin |
+| flyteadmin.service | object | `{"additionalPorts":[],"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"loadBalancerSourceRanges":[],"type":"ClusterIP"}` | Service settings for Flyteadmin |
+| flyteadmin.service.additionalPorts | list | `[]` | Appends additional ports to the service spec. |
 | flyteadmin.serviceAccount | object | `{"alwaysCreate":false,"annotations":{},"clusterRole":{"apiGroups":["","flyte.lyft.com","rbac.authorization.k8s.io"],"resources":["configmaps","flyteworkflows","namespaces","pods","resourcequotas","roles","rolebindings","secrets","services","serviceaccounts","spark-role","limitranges"],"verbs":["*"]},"create":true,"createClusterRole":true,"imagePullSecrets":[]}` | Configuration for service accounts for FlyteAdmin |
 | flyteadmin.serviceAccount.alwaysCreate | bool | `false` | Should a service account always be created for flyteadmin even without an actual flyteadmin deployment running (e.g. for multi-cluster setups) |
 | flyteadmin.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Flyteadmin pods |
@@ -236,7 +238,8 @@ helm install gateway bitnami/contour -n flyte
 | flytepropeller.replicaCount | int | `1` | Replicas count for Flytepropeller deployment |
 | flytepropeller.resources | object | `{"limits":{"cpu":"200m","ephemeral-storage":"100Mi","memory":"200Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"100Mi"}}` | Default resources requests and limits for Flytepropeller deployment |
 | flytepropeller.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsUser":1001}` | Sets securityContext for flytepropeller pod(s). |
-| flytepropeller.service | object | `{"enabled":false}` | Settings for flytepropeller service |
+| flytepropeller.service | object | `{"additionalPorts":[],"enabled":false}` | Settings for flytepropeller service |
+| flytepropeller.service.additionalPorts | list | `[]` | Appends additional ports to the service spec. |
 | flytepropeller.service.enabled | bool | `false` | If enabled create the flytepropeller service |
 | flytepropeller.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for FlytePropeller |
 | flytepropeller.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to FlytePropeller pods |

--- a/charts/flyte-core/templates/admin/service.yaml
+++ b/charts/flyte-core/templates/admin/service.yaml
@@ -35,6 +35,5 @@ spec:
     {{- with .Values.flyteadmin.service.additionalPorts -}}
     {{ tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
-    {{- end }}
   selector: {{ include "flyteadmin.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/flyte-core/templates/admin/service.yaml
+++ b/charts/flyte-core/templates/admin/service.yaml
@@ -32,5 +32,9 @@ spec:
     - name: http-metrics
       protocol: TCP
       port: 10254
+    {{- with .Values.flyteadmin.service.additionalPorts -}}
+    {{ tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- end }}
   selector: {{ include "flyteadmin.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/flyte-core/templates/datacatalog/service.yaml
+++ b/charts/flyte-core/templates/datacatalog/service.yaml
@@ -24,6 +24,5 @@ spec:
   {{- with .Values.datacatalog.service.additionalPorts -}}
   {{ tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
-  {{- end }}
   selector: {{ include "datacatalog.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/flyte-core/templates/datacatalog/service.yaml
+++ b/charts/flyte-core/templates/datacatalog/service.yaml
@@ -21,5 +21,9 @@ spec:
     port: 89
     protocol: TCP
     targetPort: 8089
+  {{- with .Values.datacatalog.service.additionalPorts -}}
+  {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- end }}
   selector: {{ include "datacatalog.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/flyte-core/templates/datacatalog/service.yaml
+++ b/charts/flyte-core/templates/datacatalog/service.yaml
@@ -22,7 +22,7 @@ spec:
     protocol: TCP
     targetPort: 8089
   {{- with .Values.datacatalog.service.additionalPorts -}}
-  {{ tpl (toYaml .) $ | nindent 4 }}
+  {{ tpl (toYaml .) $ | nindent 2 }}
   {{- end }}
   selector: {{ include "datacatalog.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/flyte-core/templates/propeller/service.yaml
+++ b/charts/flyte-core/templates/propeller/service.yaml
@@ -11,5 +11,9 @@ spec:
     - name: http-metrics
       protocol: TCP
       port: 10254
+    {{- with .Values.flytepropeller.service.additionalPorts -}}
+    {{ tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- end }}
   selector: {{ include "flytepropeller.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/flyte-core/templates/propeller/service.yaml
+++ b/charts/flyte-core/templates/propeller/service.yaml
@@ -14,6 +14,5 @@ spec:
     {{- with .Values.flytepropeller.service.additionalPorts -}}
     {{ tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
-    {{- end }}
   selector: {{ include "flytepropeller.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -54,6 +54,8 @@ flyteadmin:
       projectcontour.io/upstream-protocol.h2c: grpc
     type: ClusterIP
     loadBalancerSourceRanges: []
+    # -- Appends additional ports to the service spec.
+    additionalPorts: []
   # -- Configuration for service accounts for FlyteAdmin
   serviceAccount:
     # -- Should a service account be created for flyteadmin
@@ -228,6 +230,8 @@ datacatalog:
     annotations:
       projectcontour.io/upstream-protocol.h2c: grpc
     type: NodePort
+    # -- Appends additional ports to the service spec.
+    additionalPorts: []
   # -- Configuration for service accounts for Datacatalog
   serviceAccount:
     # -- Should a service account be created for Datacatalog
@@ -356,6 +360,8 @@ flytepropeller:
   service:
     # -- If enabled create the flytepropeller service
     enabled: false
+    # -- Appends additional ports to the service spec.
+    additionalPorts: []
 
   # -- Settings for flytepropeller service monitor
   serviceMonitor:


### PR DESCRIPTION
## Tracking issue
_NA_

## Why are the changes needed?
Users may want to expose additional ports through k8s services for Flyte components.

## What changes were proposed in this pull request?
This PR adds configuration for exposing additional ports through helm.

## How was this patch tested?
Updated the values file to include a port in the additional port and generated yaml files using:
```
helm template -n flyte --create-namespace flyte ~/Development/flyte/charts/flyte-core --values ~/Development/flyte/charts/flyte-core/values.yaml --debug > flyte.yaml
```
verified that the services included an additional port.

### Setup process
_NA_

### Screenshots
_NA_

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
_NA_

## Docs link
_NA_