### PR TITLE
fix(webapi): Ensure cache deletion on abort workflow

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/internal/webapi/core.go
+++ b/flyteplugins/go/tasks/pluginmachinery/internal/webapi/core.go
@@ -121,7 +121,7 @@ func (c CorePlugin) Finalize(ctx context.Context, tCtx core.TaskExecutionContext
 	err := c.cache.DeleteDelayed(cacheItemID)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to delete resource [%v] from cache. Error: %v", cacheItemID, err)
-		return err
+		return fmt.Errorf("failed to delete resource [%v] from cache. Error: %v", cacheItemID, err)
 	}
 
 	if len(c.p.GetConfig().ResourceQuotas) == 0 {


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Propeller keeps sending the requests to agents because propeller didn't remove the item from the async cache when users aborted the workflow.

## What changes were proposed in this pull request?
Delete the item from the cache on abort.

## How was this patch tested?
local sandbox

### Setup process
remote cluster

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
