### PR TITLE
Fix support for limit-namespace in FlytePropeller

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_collector.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_collector.go
@@ -9,7 +9,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	cache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"

--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_collector_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_collector_test.go
@@ -11,7 +11,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
@@ -38,34 +38,29 @@ var pods = []interface{}{
 	},
 }
 
-func TestNewResourceLevelMonitor(t *testing.T) {
-	x := v1.Pod{}
-	x.GetObjectMeta()
-	lm := ResourceLevelMonitor{}
-	res := lm.countList(context.Background(), pods)
-	assert.Equal(t, 2, res["ns-a"])
-	assert.Equal(t, 1, res["ns-b"])
+type MyFakeCache struct {
+	cache.Cache
 }
 
-type MyFakeInformer struct {
-	cache.SharedIndexInformer
-	store cache.Store
+func (m MyFakeCache) List(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	objectMetadataList, ok := list.(*metav1.PartialObjectMetadataList)
+	if !ok {
+		return fmt.Errorf("unexpected type %T", list)
+	}
+
+	objectMetadataList.Items = make([]metav1.PartialObjectMetadata, 0)
+	for _, pod := range pods {
+		objectMetadataList.Items = append(objectMetadataList.Items, metav1.PartialObjectMetadata{
+			TypeMeta:   objectMetadataList.TypeMeta,
+			ObjectMeta: pod.(*v1.Pod).ObjectMeta,
+		})
+	}
+
+	return nil
 }
 
-func (m MyFakeInformer) GetStore() cache.Store {
-	return m.store
-}
-
-func (m MyFakeInformer) HasSynced() bool {
+func (m MyFakeCache) WaitForCacheSync(_ context.Context) bool {
 	return true
-}
-
-type MyFakeStore struct {
-	cache.Store
-}
-
-func (m MyFakeStore) List() []interface{} {
-	return pods
 }
 
 func TestResourceLevelMonitor_collect(t *testing.T) {
@@ -74,12 +69,10 @@ func TestResourceLevelMonitor_collect(t *testing.T) {
 
 	kinds, _, err := scheme.Scheme.ObjectKinds(&v1.Pod{})
 	assert.NoError(t, err)
-	myInformer := MyFakeInformer{
-		store: MyFakeStore{},
-	}
+	myCache := MyFakeCache{}
 
 	index := NewResourceMonitorIndex()
-	rm := index.GetOrCreateResourceLevelMonitor(ctx, scope, myInformer, kinds[0])
+	rm := index.GetOrCreateResourceLevelMonitor(ctx, scope, myCache, kinds[0])
 	rm.collect(ctx)
 
 	var expected = `
@@ -99,14 +92,11 @@ func TestResourceLevelMonitorSingletonness(t *testing.T) {
 
 	kinds, _, err := scheme.Scheme.ObjectKinds(&v1.Pod{})
 	assert.NoError(t, err)
-	myInformer := MyFakeInformer{
-		store: MyFakeStore{},
-	}
+	myCache := MyFakeCache{}
 
 	index := NewResourceMonitorIndex()
-	rm := index.GetOrCreateResourceLevelMonitor(ctx, scope, myInformer, kinds[0])
-	fmt.Println(rm)
-	//rm2 := index.GetOrCreateResourceLevelMonitor(ctx, scope, myInformer, kinds[0])
+	rm := index.GetOrCreateResourceLevelMonitor(ctx, scope, myCache, kinds[0])
+	rm2 := index.GetOrCreateResourceLevelMonitor(ctx, scope, myCache, kinds[0])
 
-	//assert.Equal(t, rm, rm2)
+	assert.Equal(t, rm, rm2)
 }

--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_collector_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_collector_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )

--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	//"reflect"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -16,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	//"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -641,12 +639,8 @@ func NewPluginManager(ctx context.Context, iCtx pluginsCore.SetupContext, entry 
 	}
 
 	// Construct the collector that will emit a gauge indicating current levels of the resource that this K8s plugin operates on
-	/*pluginInformer, err := getPluginSharedInformer(ctx, kubeClient, entry.ResourceToWatch)
-	if err != nil {
-		return nil, err
-	}
-	rm := monitorIndex.GetOrCreateResourceLevelMonitor(ctx, metricsScope, pluginInformer, gvk)*/
 	rm := monitorIndex.GetOrCreateResourceLevelMonitor(ctx, metricsScope, kubeClient.GetCache(), gvk)
+
 	// Start the poller and gauge emitter
 	rm.RunCollectorOnce(ctx)
 
@@ -668,17 +662,3 @@ func getPluginGvk(resourceToWatch runtime.Object) (schema.GroupVersionKind, erro
 	}
 	return kinds[0], nil
 }
-
-/*func getPluginSharedInformer(ctx context.Context, kubeClient pluginsCore.KubeClient, resourceToWatch client.Object) (cache.SharedIndexInformer, error) {
-	i, err := kubeClient.GetCache().GetInformer(ctx, resourceToWatch)
-	if err != nil {
-		return nil, errors.Wrapf(errors.PluginInitializationFailed, err, "Error getting informer for %s", reflect.TypeOf(i))
-	}
-
-	si, casted := i.(cache.SharedIndexInformer)
-	if !casted {
-		return nil, errors.Errorf(errors.PluginInitializationFailed, "wrong type. Actual: %v", reflect.TypeOf(i))
-	}
-
-	return si, nil
-}*/

--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"reflect"
+	//"reflect"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/cache"
+	//"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -641,11 +641,12 @@ func NewPluginManager(ctx context.Context, iCtx pluginsCore.SetupContext, entry 
 	}
 
 	// Construct the collector that will emit a gauge indicating current levels of the resource that this K8s plugin operates on
-	pluginInformer, err := getPluginSharedInformer(ctx, kubeClient, entry.ResourceToWatch)
+	/*pluginInformer, err := getPluginSharedInformer(ctx, kubeClient, entry.ResourceToWatch)
 	if err != nil {
 		return nil, err
 	}
-	rm := monitorIndex.GetOrCreateResourceLevelMonitor(ctx, metricsScope, pluginInformer, gvk)
+	rm := monitorIndex.GetOrCreateResourceLevelMonitor(ctx, metricsScope, pluginInformer, gvk)*/
+	rm := monitorIndex.GetOrCreateResourceLevelMonitor(ctx, metricsScope, kubeClient.GetCache(), gvk)
 	// Start the poller and gauge emitter
 	rm.RunCollectorOnce(ctx)
 
@@ -668,7 +669,7 @@ func getPluginGvk(resourceToWatch runtime.Object) (schema.GroupVersionKind, erro
 	return kinds[0], nil
 }
 
-func getPluginSharedInformer(ctx context.Context, kubeClient pluginsCore.KubeClient, resourceToWatch client.Object) (cache.SharedIndexInformer, error) {
+/*func getPluginSharedInformer(ctx context.Context, kubeClient pluginsCore.KubeClient, resourceToWatch client.Object) (cache.SharedIndexInformer, error) {
 	i, err := kubeClient.GetCache().GetInformer(ctx, resourceToWatch)
 	if err != nil {
 		return nil, errors.Wrapf(errors.PluginInitializationFailed, err, "Error getting informer for %s", reflect.TypeOf(i))
@@ -680,4 +681,4 @@ func getPluginSharedInformer(ctx context.Context, kubeClient pluginsCore.KubeCli
 	}
 
 	return si, nil
-}
+}*/

--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager_test.go
@@ -991,10 +991,7 @@ func TestResourceManagerConstruction(t *testing.T) {
 	gvk, err := getPluginGvk(&v1.Pod{})
 	assert.NoError(t, err)
 	assert.Equal(t, gvk.Kind, "Pod")
-	si, err := getPluginSharedInformer(ctx, fakeKubeClient, &v1.Pod{})
-	assert.NotNil(t, si)
-	assert.NoError(t, err)
-	rm := index.GetOrCreateResourceLevelMonitor(ctx, scope, si, gvk)
+	rm := index.GetOrCreateResourceLevelMonitor(ctx, scope, fakeKubeClient.GetCache(), gvk)
 	assert.NotNil(t, rm)
 }
 


### PR DESCRIPTION
## Tracking issue
fixes https://github.com/flyteorg/flyte/issues/5087

## Why are the changes needed?
Refer to issue ^^ for in-depth explanation of problem.

## What changes were proposed in this pull request?
Instead of back-pedaling from the informer to retrieve the object cache for listing k8s objects, this PR updates the plugin object monitoring mechanism to issue queries directly to the cache using the k8s object kind and version.

## How was this patch tested?
locally with varying configuration.

### Setup process
_NA_

### Screenshots
_NA_

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
_NA_

## Docs link
_NA_