### PR TITLE
Update template to link issue for closing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,13 @@
 ## Tracking issue
-_https://github.com/flyteorg/flyte/issues/<number>_
+<!--
+If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
+Example: Closes flyteorg/flyte#999
 
-<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->
+If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
+Example: Related to flyteorg/flyte#999
 
-<!-- Remove this section if not applicable -->
-
-<!-- Example: Closes #31 -->
+Remove this section if not applicable
+-->
 
 ## Why are the changes needed?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 ## Tracking issue
 <!--
-If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
-Example: Closes flyteorg/flyte#999
+If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
+Example: Closes #999
 
-If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
-Example: Related to flyteorg/flyte#999
+If your PR is related to an issue or PR, use `Related to #999` to link your PR.
+Example: Related to #999
 
 Remove this section if not applicable
 -->


### PR DESCRIPTION
This PR updates the PR template to properly link to issue in `flyteorg/flyte` to auto close the original issue.

REF: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword