### PR TITLE
docs: add `nested_type` example in `data_types_and_io/structured_dataset.py`

### DIFF
--- a/docs/user_guide/data_types_and_io/structureddataset.md
+++ b/docs/user_guide/data_types_and_io/structureddataset.md
@@ -252,3 +252,13 @@ You can run the code locally as follows:
 ```
 
 [flytesnacks]: https://github.com/flyteorg/flytesnacks/tree/master/examples/data_types_and_io/
+
+### The nested typed columns
+
+Most storage formats have support for nested field structures today (Avro, parquet, bq) and so is StructuredDatasets.
+
+
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/data_types_and_io/data_types_and_io/structured_dataset.py
+:caption: data_types_and_io/structured_dataset.py
+:lines: 158-293
+```

--- a/docs/user_guide/data_types_and_io/structureddataset.md
+++ b/docs/user_guide/data_types_and_io/structureddataset.md
@@ -248,7 +248,7 @@ You can run the code locally as follows:
 
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
-:lines: 151-155
+:lines: 153-157
 ```
 
 ### The nested typed columns
@@ -261,7 +261,7 @@ Nested field StructuredDataset should be run when flytekit version > 1.11.0.
 
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
-:lines: 159-269
+:lines: 159-270
 ```
 
 [flytesnacks]: https://github.com/flyteorg/flytesnacks/tree/master/examples/data_types_and_io/

--- a/docs/user_guide/data_types_and_io/structureddataset.md
+++ b/docs/user_guide/data_types_and_io/structureddataset.md
@@ -251,14 +251,17 @@ You can run the code locally as follows:
 :lines: 151-155
 ```
 
-[flytesnacks]: https://github.com/flyteorg/flytesnacks/tree/master/examples/data_types_and_io/
-
 ### The nested typed columns
 
-Most storage formats have support for nested field structures today (Avro, parquet, bq) and so is StructuredDatasets.
+Like most storage formats (e.g. Avro, Parquet, and BigQuery), StructuredDataset support nested field structures.
 
+:::{note}
+Nested field StructuredDataset should be run  when flytekit version > 1.11.0.
+:::
 
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
 :lines: 158-296
 ```
+
+[flytesnacks]: https://github.com/flyteorg/flytesnacks/tree/master/examples/data_types_and_io/

--- a/docs/user_guide/data_types_and_io/structureddataset.md
+++ b/docs/user_guide/data_types_and_io/structureddataset.md
@@ -261,7 +261,7 @@ Nested field StructuredDataset should be run when flytekit version > 1.11.0.
 
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
-:lines: 158-296
+:lines: 159-269
 ```
 
 [flytesnacks]: https://github.com/flyteorg/flytesnacks/tree/master/examples/data_types_and_io/

--- a/docs/user_guide/data_types_and_io/structureddataset.md
+++ b/docs/user_guide/data_types_and_io/structureddataset.md
@@ -237,7 +237,7 @@ You can now use `numpy.ndarray` to deserialize the parquet file to NumPy and ser
 
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
-:lines: 134-147
+:lines: 134-149
 ```
 
 :::{note}

--- a/docs/user_guide/data_types_and_io/structureddataset.md
+++ b/docs/user_guide/data_types_and_io/structureddataset.md
@@ -256,7 +256,7 @@ You can run the code locally as follows:
 Like most storage formats (e.g. Avro, Parquet, and BigQuery), StructuredDataset support nested field structures.
 
 :::{note}
-Nested field StructuredDataset should be run  when flytekit version > 1.11.0.
+Nested field StructuredDataset should be run when flytekit version > 1.11.0.
 :::
 
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/data_types_and_io/data_types_and_io/structured_dataset.py

--- a/docs/user_guide/data_types_and_io/structureddataset.md
+++ b/docs/user_guide/data_types_and_io/structureddataset.md
@@ -260,5 +260,5 @@ Most storage formats have support for nested field structures today (Avro, parqu
 
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
-:lines: 158-293
+:lines: 158-296
 ```


### PR DESCRIPTION
## Tracking issue

https://github.com/flyteorg/flyte/issues/4241
https://github.com/flyteorg/flytekit/pull/2252
https://github.com/flyteorg/flytesnacks/pull/1657


## Why are the changes needed?

Add `structured_dataset_nested_type` examples in documentation.

https://github.com/flyteorg/flytekit/pull/2252

## What changes were proposed in this pull request?

Demonstrate how to use `nested_types` in `structured_dataset`

## How was this patch tested?

https://github.com/flyteorg/flytekit/pull/2252/files#diff-e78d93a6e6cd2463cd5fc51973434c29ece29d05fe6b36691d6d19860386f938

### Setup process

`make dev-docs`

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flytekit/pull/2252
https://github.com/flyteorg/flytesnacks/pull/1657

## Docs link
https://flyte--5269.org.readthedocs.build/en/5269/user_guide/data_types_and_io/structureddataset.html#structured-dataset
