### PR TITLE
Remove upper bound on flyteidl's protobuf dependency

### DIFF
--- a/flyteidl/pyproject.toml
+++ b/flyteidl/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.8,<3.13"
 dependencies = [
     'googleapis-common-protos',
     'protoc-gen-openapiv2',
-    'protobuf>=4.21.1,<5.0.0',
+    'protobuf>=4.21.1',
 ]
 classifiers = [
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
## Why are the changes needed?

flyteidl claims Python 3.12 support, as does flytekit, but protobuf<5.0.0 only supports up to Python 3.11.

## What changes were proposed in this pull request?

Remove the upper bound on flyteidl's protobuf dependency to enable Python 3.12 support.

## How was this patch tested?

Existing/standard CI tests.

### Setup process

n/a

### Screenshots

n/a

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

n/a

## Docs link

n/a
