### PR TITLE
Fix rli number ranges in Snowflake plugin example doc

### DIFF
--- a/docs/deprecated_integrations/snowflake_plugin/snowflake_plugin_example.md
+++ b/docs/deprecated_integrations/snowflake_plugin/snowflake_plugin_example.md
@@ -18,7 +18,7 @@ Incorporate {py:class}`~flytekitplugins.snowflake.SnowflakeConfig` within the ta
 
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/snowflake_plugin/snowflake_plugin/snowflake_plugin_example.py
 :caption: snowflake_plugin/snowflake_plugin_example.py
-:lines: 5-16
+:lines: 4-15
 ```
 
 :::{note}
@@ -56,7 +56,7 @@ This country will be provided as user input, using a nation key to specify it.
 
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/snowflake_plugin/snowflake_plugin/snowflake_plugin_example.py
 :caption: snowflake_plugin/snowflake_plugin_example.py
-:lines: 19-35
+:lines: 18-34
 ```
 
 To review the query results, access the Snowflake console at:
@@ -66,7 +66,7 @@ You can also execute the task and workflow locally.
 
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/snowflake_plugin/snowflake_plugin/snowflake_plugin_example.py
 :caption: snowflake_plugin/snowflake_plugin_example.py
-:lines: 42-44
+:lines: 41-43
 ```
 
 [flytesnacks]: https://github.com/flyteorg/flytesnacks/tree/master/examples/snowflake_plugin


### PR DESCRIPTION
## Why are the changes needed?

Line number ranges are off by one in Snowflake plugin example doc.

## What changes were proposed in this pull request?

Update line numbers in `rli` directive in Snowflake plugin example doc.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Docs link

TK
