### PR TITLE
Updates RunLLM chat widget to use Mod + j as shortcut

### DIFF
--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -101,7 +101,7 @@
     <!-- RunLLM Configuration -->
     <script defer id="runllm-widget-script" type="module" src='https://cdn.jsdelivr.net/npm/@runllm/search-widget@stable/dist/run-llm-search-widget.es.js'
       runllm-server-address="https://api.runllm.com" runllm-assistant-id="60" runllm-position="BOTTOM_RIGHT"
-      runllm-keyboard-shortcut="Mod+l"
+      runllm-keyboard-shortcut="Mod+j"
       version="stable"
       runllm-slack-community-url="https://flyte-org.slack.com/join/shared_invite/zt-2eq2fgs5f-UGUWnMYVB9agervilmlyaw#/shared-invite/email"
       runllm-name="RunLLM" />


### PR DESCRIPTION
## Tracking issue
N/A - Happy to file an issue or update with an issue number if needed.

## Why are the changes needed?
This PR updates the RunLLM chat widget to use the hot key Mod + j to activate the chat on the documentation site.

This means that users can use CMD + j on Mac and CTRL + j on Windows to view and interact with the docs chat.

## How was this patch tested?

I've created a Github codespace to set up the project and edit the code here.

If there are preview links available to view documentation I would appreciate some help getting that link so that I can whitelist the domain for our recaptcha based authentication to do a proper test of everything.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
