### PR TITLE
Fix flytectlt tests

### DIFF
--- a/flytectl/Makefile
+++ b/flytectl/Makefile
@@ -40,8 +40,3 @@ test_unit_without_flag:
 	cat coverage.temp.txt  | grep -v "_flags.go" > coverage.txt
 	rm coverage.temp.txt
 	curl -s https://codecov.io/bash > codecov_bash.sh && bash codecov_bash.sh
-
-# TODO - Add the -race flag back
-.PHONY: test_unit
-test_unit:
-	go test -cover ./...

--- a/flytectl/cmd/compile/compile_test.go
+++ b/flytectl/cmd/compile/compile_test.go
@@ -31,6 +31,7 @@ func TestCompileCommand(t *testing.T) {
 	compileCfg.File = "testdata/valid-package.tgz"
 	var setup = u.Setup
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
 	compileCmd := CreateCompileCommand()["compile"]
 	err := compileCmd.CmdFunc(context.Background(), []string{}, s.CmdCtx)
 	assert.Nil(t, err, "compiling via cmd returns err")

--- a/flytectl/cmd/compile/compile_test.go
+++ b/flytectl/cmd/compile/compile_test.go
@@ -31,7 +31,7 @@ func TestCompileCommand(t *testing.T) {
 	compileCfg.File = "testdata/valid-package.tgz"
 	var setup = u.Setup
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 	compileCmd := CreateCompileCommand()["compile"]
 	err := compileCmd.CmdFunc(context.Background(), []string{}, s.CmdCtx)
 	assert.Nil(t, err, "compiling via cmd returns err")

--- a/flytectl/cmd/create/execution_test.go
+++ b/flytectl/cmd/create/execution_test.go
@@ -32,8 +32,7 @@ func (s *createSuite) SetupTest() {
 }
 
 func (s *createSuite) TearDownTest() {
-	// TODO re-enable this
-	// s.RestoreStandardFileDescriptors()
+	defer s.RestoreStandardFileDescriptors()
 	orig := s.originalExecConfig
 	executionConfig = &orig
 	s.MockAdminClient.AssertExpectations(s.T())

--- a/flytectl/cmd/create/execution_test.go
+++ b/flytectl/cmd/create/execution_test.go
@@ -32,6 +32,8 @@ func (s *createSuite) SetupTest() {
 }
 
 func (s *createSuite) TearDownTest() {
+	// TODO re-enable this
+	// s.RestoreStandardFileDescriptors()
 	orig := s.originalExecConfig
 	executionConfig = &orig
 	s.MockAdminClient.AssertExpectations(s.T())

--- a/flytectl/cmd/create/execution_test.go
+++ b/flytectl/cmd/create/execution_test.go
@@ -32,7 +32,7 @@ func (s *createSuite) SetupTest() {
 }
 
 func (s *createSuite) TearDownTest() {
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 	orig := s.originalExecConfig
 	executionConfig = &orig
 	s.MockAdminClient.AssertExpectations(s.T())

--- a/flytectl/cmd/create/execution_util_test.go
+++ b/flytectl/cmd/create/execution_util_test.go
@@ -48,6 +48,8 @@ func createExecutionUtilSetup() {
 
 func TestCreateExecutionForRelaunch(t *testing.T) {
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	createExecutionUtilSetup()
 	s.MockAdminClient.OnRelaunchExecutionMatch(s.Ctx, relaunchRequest).Return(executionCreateResponse, nil)
 	err := relaunchExecution(s.Ctx, "execName", config.GetConfig().Project, config.GetConfig().Domain, s.CmdCtx, executionConfig, "")
@@ -56,6 +58,8 @@ func TestCreateExecutionForRelaunch(t *testing.T) {
 
 func TestCreateExecutionForRelaunchNotFound(t *testing.T) {
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	createExecutionUtilSetup()
 	s.MockAdminClient.OnRelaunchExecutionMatch(s.Ctx, relaunchRequest).Return(nil, errors.New("unknown execution"))
 	err := relaunchExecution(s.Ctx, "execName", config.GetConfig().Project, config.GetConfig().Domain, s.CmdCtx, executionConfig, "")
@@ -66,6 +70,8 @@ func TestCreateExecutionForRelaunchNotFound(t *testing.T) {
 
 func TestCreateExecutionForRecovery(t *testing.T) {
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	createExecutionUtilSetup()
 	s.MockAdminClient.OnRecoverExecutionMatch(s.Ctx, recoverRequest).Return(executionCreateResponse, nil)
 	err := recoverExecution(s.Ctx, "execName", config.GetConfig().Project, config.GetConfig().Domain, s.CmdCtx, executionConfig, "")
@@ -74,6 +80,8 @@ func TestCreateExecutionForRecovery(t *testing.T) {
 
 func TestCreateExecutionForRecoveryNotFound(t *testing.T) {
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	createExecutionUtilSetup()
 	s.MockAdminClient.OnRecoverExecutionMatch(s.Ctx, recoverRequest).Return(nil, errors.New("unknown execution"))
 	err := recoverExecution(s.Ctx, "execName", config.GetConfig().Project, config.GetConfig().Domain, s.CmdCtx, executionConfig, "")
@@ -84,6 +92,8 @@ func TestCreateExecutionForRecoveryNotFound(t *testing.T) {
 func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	t.Run("successful", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{}
 		s.FetcherExt.OnFetchLPVersionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(launchPlan, nil)
@@ -93,6 +103,8 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	})
 	t.Run("successful with envs", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{}
 		s.FetcherExt.OnFetchLPVersionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(launchPlan, nil)
@@ -105,6 +117,8 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	})
 	t.Run("successful with empty envs", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{}
 		s.FetcherExt.OnFetchLPVersionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(launchPlan, nil)
@@ -117,6 +131,8 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	})
 	t.Run("failed literal conversion", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{
 			Spec: &admin.LaunchPlanSpec{
@@ -133,6 +149,8 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	})
 	t.Run("failed fetch", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		createExecutionUtilSetup()
 		s.FetcherExt.OnFetchLPVersionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("failed"))
 		execCreateRequest, err := createExecutionRequestForWorkflow(s.Ctx, "wfName", config.GetConfig().Project, config.GetConfig().Domain, s.CmdCtx, executionConfig, "")
@@ -142,6 +160,8 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	})
 	t.Run("with security context", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		createExecutionUtilSetup()
 		executionConfig.KubeServiceAcct = "default"
 		launchPlan := &admin.LaunchPlan{}
@@ -157,6 +177,8 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 func TestCreateExecutionRequestForTask(t *testing.T) {
 	t.Run("successful", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		createExecutionUtilSetup()
 		task := &admin.Task{
 			Id: &core.Identifier{
@@ -170,6 +192,8 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 	})
 	t.Run("successful with envs", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		createExecutionUtilSetup()
 		task := &admin.Task{
 			Id: &core.Identifier{
@@ -186,6 +210,8 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 	})
 	t.Run("successful with empty envs", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		createExecutionUtilSetup()
 		task := &admin.Task{
 			Id: &core.Identifier{
@@ -202,6 +228,8 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 	})
 	t.Run("failed literal conversion", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		createExecutionUtilSetup()
 		task := &admin.Task{
 			Closure: &admin.TaskClosure{
@@ -226,6 +254,8 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 	})
 	t.Run("failed fetch", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		createExecutionUtilSetup()
 		s.FetcherExt.OnFetchTaskVersionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("failed"))
 		execCreateRequest, err := createExecutionRequestForTask(s.Ctx, "taskName", config.GetConfig().Project, config.GetConfig().Domain, s.CmdCtx, executionConfig, "")
@@ -271,6 +301,8 @@ func Test_resolveOverrides(t *testing.T) {
 
 func TestCreateExecutionForRelaunchOverwritingCache(t *testing.T) {
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	createExecutionUtilSetup()
 	executionConfig.OverwriteCache = true
 	relaunchRequest.OverwriteCache = true // ensure request has overwriteCache param set

--- a/flytectl/cmd/create/execution_util_test.go
+++ b/flytectl/cmd/create/execution_util_test.go
@@ -48,7 +48,7 @@ func createExecutionUtilSetup() {
 
 func TestCreateExecutionForRelaunch(t *testing.T) {
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	createExecutionUtilSetup()
 	s.MockAdminClient.OnRelaunchExecutionMatch(s.Ctx, relaunchRequest).Return(executionCreateResponse, nil)
@@ -58,7 +58,7 @@ func TestCreateExecutionForRelaunch(t *testing.T) {
 
 func TestCreateExecutionForRelaunchNotFound(t *testing.T) {
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	createExecutionUtilSetup()
 	s.MockAdminClient.OnRelaunchExecutionMatch(s.Ctx, relaunchRequest).Return(nil, errors.New("unknown execution"))
@@ -70,7 +70,7 @@ func TestCreateExecutionForRelaunchNotFound(t *testing.T) {
 
 func TestCreateExecutionForRecovery(t *testing.T) {
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	createExecutionUtilSetup()
 	s.MockAdminClient.OnRecoverExecutionMatch(s.Ctx, recoverRequest).Return(executionCreateResponse, nil)
@@ -80,7 +80,7 @@ func TestCreateExecutionForRecovery(t *testing.T) {
 
 func TestCreateExecutionForRecoveryNotFound(t *testing.T) {
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	createExecutionUtilSetup()
 	s.MockAdminClient.OnRecoverExecutionMatch(s.Ctx, recoverRequest).Return(nil, errors.New("unknown execution"))
@@ -92,7 +92,7 @@ func TestCreateExecutionForRecoveryNotFound(t *testing.T) {
 func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	t.Run("successful", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{}
@@ -103,7 +103,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	})
 	t.Run("successful with envs", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{}
@@ -117,7 +117,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	})
 	t.Run("successful with empty envs", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{}
@@ -131,7 +131,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	})
 	t.Run("failed literal conversion", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{
@@ -149,7 +149,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	})
 	t.Run("failed fetch", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		createExecutionUtilSetup()
 		s.FetcherExt.OnFetchLPVersionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("failed"))
@@ -160,7 +160,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	})
 	t.Run("with security context", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		createExecutionUtilSetup()
 		executionConfig.KubeServiceAcct = "default"
@@ -177,7 +177,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 func TestCreateExecutionRequestForTask(t *testing.T) {
 	t.Run("successful", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		createExecutionUtilSetup()
 		task := &admin.Task{
@@ -192,7 +192,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 	})
 	t.Run("successful with envs", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		createExecutionUtilSetup()
 		task := &admin.Task{
@@ -210,7 +210,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 	})
 	t.Run("successful with empty envs", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		createExecutionUtilSetup()
 		task := &admin.Task{
@@ -228,7 +228,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 	})
 	t.Run("failed literal conversion", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		createExecutionUtilSetup()
 		task := &admin.Task{
@@ -254,7 +254,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 	})
 	t.Run("failed fetch", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		createExecutionUtilSetup()
 		s.FetcherExt.OnFetchTaskVersionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("failed"))
@@ -265,7 +265,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 	})
 	t.Run("with security context", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		createExecutionUtilSetup()
 		executionConfig.KubeServiceAcct = "default"
@@ -303,7 +303,7 @@ func Test_resolveOverrides(t *testing.T) {
 
 func TestCreateExecutionForRelaunchOverwritingCache(t *testing.T) {
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	createExecutionUtilSetup()
 	executionConfig.OverwriteCache = true

--- a/flytectl/cmd/create/execution_util_test.go
+++ b/flytectl/cmd/create/execution_util_test.go
@@ -265,6 +265,8 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 	})
 	t.Run("with security context", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		createExecutionUtilSetup()
 		executionConfig.KubeServiceAcct = "default"
 		task := &admin.Task{

--- a/flytectl/cmd/create/project_test.go
+++ b/flytectl/cmd/create/project_test.go
@@ -41,11 +41,11 @@ func createProjectSetup() {
 }
 func TestCreateProjectFunc(t *testing.T) {
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	createProjectSetup()
 	defer s.TearDownAndVerify(t, "project created successfully.")
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 	project.DefaultProjectConfig.ID = projectValue
 	project.DefaultProjectConfig.Name = projectValue
 	project.DefaultProjectConfig.Labels = map[string]string{}
@@ -58,11 +58,11 @@ func TestCreateProjectFunc(t *testing.T) {
 
 func TestEmptyProjectID(t *testing.T) {
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	createProjectSetup()
 	defer s.TearDownAndVerify(t, "")
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 	project.DefaultProjectConfig = &project.ConfigProject{}
 	s.MockAdminClient.OnRegisterProjectMatch(s.Ctx, projectRegisterRequest).Return(nil, nil)
 	err := createProjectsCommand(s.Ctx, []string{}, s.CmdCtx)
@@ -72,11 +72,11 @@ func TestEmptyProjectID(t *testing.T) {
 
 func TestEmptyProjectName(t *testing.T) {
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	createProjectSetup()
 	defer s.TearDownAndVerify(t, "")
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 	project.DefaultProjectConfig.ID = projectValue
 	project.DefaultProjectConfig.Labels = map[string]string{}
 	project.DefaultProjectConfig.Description = ""

--- a/flytectl/cmd/create/project_test.go
+++ b/flytectl/cmd/create/project_test.go
@@ -41,6 +41,8 @@ func createProjectSetup() {
 }
 func TestCreateProjectFunc(t *testing.T) {
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	createProjectSetup()
 	defer s.TearDownAndVerify(t, "project created successfully.")
 	defer s.RestoreStandardFileDescriptors()
@@ -56,6 +58,8 @@ func TestCreateProjectFunc(t *testing.T) {
 
 func TestEmptyProjectID(t *testing.T) {
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	createProjectSetup()
 	defer s.TearDownAndVerify(t, "")
 	defer s.RestoreStandardFileDescriptors()
@@ -68,6 +72,8 @@ func TestEmptyProjectID(t *testing.T) {
 
 func TestEmptyProjectName(t *testing.T) {
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	createProjectSetup()
 	defer s.TearDownAndVerify(t, "")
 	defer s.RestoreStandardFileDescriptors()

--- a/flytectl/cmd/create/project_test.go
+++ b/flytectl/cmd/create/project_test.go
@@ -43,6 +43,7 @@ func TestCreateProjectFunc(t *testing.T) {
 	s := setup()
 	createProjectSetup()
 	defer s.TearDownAndVerify(t, "project created successfully.")
+	defer s.RestoreStandardFileDescriptors()
 	project.DefaultProjectConfig.ID = projectValue
 	project.DefaultProjectConfig.Name = projectValue
 	project.DefaultProjectConfig.Labels = map[string]string{}
@@ -57,6 +58,7 @@ func TestEmptyProjectID(t *testing.T) {
 	s := setup()
 	createProjectSetup()
 	defer s.TearDownAndVerify(t, "")
+	defer s.RestoreStandardFileDescriptors()
 	project.DefaultProjectConfig = &project.ConfigProject{}
 	s.MockAdminClient.OnRegisterProjectMatch(s.Ctx, projectRegisterRequest).Return(nil, nil)
 	err := createProjectsCommand(s.Ctx, []string{}, s.CmdCtx)
@@ -68,6 +70,7 @@ func TestEmptyProjectName(t *testing.T) {
 	s := setup()
 	createProjectSetup()
 	defer s.TearDownAndVerify(t, "")
+	defer s.RestoreStandardFileDescriptors()
 	project.DefaultProjectConfig.ID = projectValue
 	project.DefaultProjectConfig.Labels = map[string]string{}
 	project.DefaultProjectConfig.Description = ""

--- a/flytectl/cmd/demo/exec_test.go
+++ b/flytectl/cmd/demo/exec_test.go
@@ -53,7 +53,7 @@ func TestSandboxClusterExecWithoutCmd(t *testing.T) {
 	mockDocker := &mocks.Docker{}
 	reader := bufio.NewReader(strings.NewReader("test"))
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	ctx := s.Ctx
 

--- a/flytectl/cmd/demo/exec_test.go
+++ b/flytectl/cmd/demo/exec_test.go
@@ -53,6 +53,8 @@ func TestSandboxClusterExecWithoutCmd(t *testing.T) {
 	mockDocker := &mocks.Docker{}
 	reader := bufio.NewReader(strings.NewReader("test"))
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	ctx := s.Ctx
 
 	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{

--- a/flytectl/cmd/demo/status_test.go
+++ b/flytectl/cmd/demo/status_test.go
@@ -15,6 +15,7 @@ func TestDemoStatus(t *testing.T) {
 	t.Run("Demo status with zero result", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		s := testutils.Setup()
+		defer s.RestoreStandardFileDescriptors()
 		mockDocker.OnContainerList(s.Ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
 		docker.Client = mockDocker
 		err := demoClusterStatus(s.Ctx, []string{}, s.CmdCtx)
@@ -22,6 +23,7 @@ func TestDemoStatus(t *testing.T) {
 	})
 	t.Run("Demo status with running", func(t *testing.T) {
 		s := testutils.Setup()
+		defer s.RestoreStandardFileDescriptors()
 		ctx := s.Ctx
 		mockDocker := &mocks.Docker{}
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{

--- a/flytectl/cmd/demo/status_test.go
+++ b/flytectl/cmd/demo/status_test.go
@@ -15,7 +15,7 @@ func TestDemoStatus(t *testing.T) {
 	t.Run("Demo status with zero result", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 		mockDocker.OnContainerList(s.Ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
 		docker.Client = mockDocker
 		err := demoClusterStatus(s.Ctx, []string{}, s.CmdCtx)
@@ -23,7 +23,7 @@ func TestDemoStatus(t *testing.T) {
 	})
 	t.Run("Demo status with running", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 		ctx := s.Ctx
 		mockDocker := &mocks.Docker{}
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{

--- a/flytectl/cmd/demo/teardown_test.go
+++ b/flytectl/cmd/demo/teardown_test.go
@@ -80,7 +80,7 @@ func TestTearDownClusterFunc(t *testing.T) {
 	_ = util.SetupFlyteDir()
 	_ = util.WriteIntoFile([]byte("data"), configutil.FlytectlConfig)
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	ctx := s.Ctx
 	mockDocker := &mocks.Docker{}

--- a/flytectl/cmd/demo/teardown_test.go
+++ b/flytectl/cmd/demo/teardown_test.go
@@ -80,6 +80,8 @@ func TestTearDownClusterFunc(t *testing.T) {
 	_ = util.SetupFlyteDir()
 	_ = util.WriteIntoFile([]byte("data"), configutil.FlytectlConfig)
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	ctx := s.Ctx
 	mockDocker := &mocks.Docker{}
 	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)

--- a/flytectl/cmd/get/execution_test.go
+++ b/flytectl/cmd/get/execution_test.go
@@ -32,6 +32,8 @@ func getExecutionSetup() {
 func TestListExecutionFunc(t *testing.T) {
 	getExecutionSetup()
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	executionResponse := &admin.Execution{
 		Id: &core.WorkflowExecutionIdentifier{
 			Project: projectValue,
@@ -93,6 +95,8 @@ func TestListExecutionFuncWithError(t *testing.T) {
 		},
 	}
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	s.FetcherExt.OnListExecutionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("executions NotFound"))
 	err := getExecutionFunc(s.Ctx, []string{}, s.CmdCtx)
 	assert.NotNil(t, err)
@@ -128,6 +132,7 @@ func TestGetExecutionFunc(t *testing.T) {
 	}
 	args := []string{executionNameValue}
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
 
 	s.FetcherExt.OnFetchExecutionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything).Return(executionResponse, nil)
 	err := getExecutionFunc(s.Ctx, args, s.CmdCtx)
@@ -137,6 +142,7 @@ func TestGetExecutionFunc(t *testing.T) {
 
 func TestGetExecutionFuncForDetails(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
 	getExecutionSetup()
 	ctx := s.Ctx
 	mockCmdCtx := s.CmdCtx
@@ -153,6 +159,8 @@ func TestGetExecutionFuncForDetails(t *testing.T) {
 func TestGetExecutionFuncWithIOData(t *testing.T) {
 	t.Run("successful inputs outputs", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionSetup()
 		ctx := s.Ctx
 		mockCmdCtx := s.CmdCtx
@@ -217,6 +225,8 @@ func TestGetExecutionFuncWithIOData(t *testing.T) {
 	})
 	t.Run("fetch data error from admin", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionSetup()
 		ctx := s.Ctx
 		mockCmdCtx := s.CmdCtx
@@ -257,6 +267,8 @@ func TestGetExecutionFuncWithIOData(t *testing.T) {
 		args := []string{dummyExec}
 		for _, tt := range tests {
 			s := testutils.SetupWithExt()
+			defer s.RestoreStandardFileDescriptors()
+
 			config.GetConfig().Output = tt.outputFormat
 			execution.DefaultConfig.NodeID = tt.nodeID
 
@@ -356,6 +368,8 @@ func TestGetExecutionFuncWithError(t *testing.T) {
 
 	args := []string{executionNameValue}
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	s.FetcherExt.OnFetchExecutionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("execution NotFound"))
 	err := getExecutionFunc(s.Ctx, args, s.CmdCtx)
 	assert.NotNil(t, err)

--- a/flytectl/cmd/get/execution_test.go
+++ b/flytectl/cmd/get/execution_test.go
@@ -32,7 +32,7 @@ func getExecutionSetup() {
 func TestListExecutionFunc(t *testing.T) {
 	getExecutionSetup()
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	executionResponse := &admin.Execution{
 		Id: &core.WorkflowExecutionIdentifier{
@@ -95,7 +95,7 @@ func TestListExecutionFuncWithError(t *testing.T) {
 		},
 	}
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	s.FetcherExt.OnListExecutionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("executions NotFound"))
 	err := getExecutionFunc(s.Ctx, []string{}, s.CmdCtx)
@@ -132,7 +132,7 @@ func TestGetExecutionFunc(t *testing.T) {
 	}
 	args := []string{executionNameValue}
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	s.FetcherExt.OnFetchExecutionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything).Return(executionResponse, nil)
 	err := getExecutionFunc(s.Ctx, args, s.CmdCtx)
@@ -142,7 +142,7 @@ func TestGetExecutionFunc(t *testing.T) {
 
 func TestGetExecutionFuncForDetails(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 	getExecutionSetup()
 	ctx := s.Ctx
 	mockCmdCtx := s.CmdCtx
@@ -159,7 +159,7 @@ func TestGetExecutionFuncForDetails(t *testing.T) {
 func TestGetExecutionFuncWithIOData(t *testing.T) {
 	t.Run("successful inputs outputs", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionSetup()
 		ctx := s.Ctx
@@ -225,7 +225,7 @@ func TestGetExecutionFuncWithIOData(t *testing.T) {
 	})
 	t.Run("fetch data error from admin", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionSetup()
 		ctx := s.Ctx
@@ -267,7 +267,7 @@ func TestGetExecutionFuncWithIOData(t *testing.T) {
 		args := []string{dummyExec}
 		for _, tt := range tests {
 			s := testutils.Setup()
-			defer s.RestoreStandardFileDescriptors()
+			defer s.TearDown()
 
 			config.GetConfig().Output = tt.outputFormat
 			execution.DefaultConfig.NodeID = tt.nodeID
@@ -368,7 +368,7 @@ func TestGetExecutionFuncWithError(t *testing.T) {
 
 	args := []string{executionNameValue}
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	s.FetcherExt.OnFetchExecutionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("execution NotFound"))
 	err := getExecutionFunc(s.Ctx, args, s.CmdCtx)

--- a/flytectl/cmd/get/execution_test.go
+++ b/flytectl/cmd/get/execution_test.go
@@ -141,7 +141,7 @@ func TestGetExecutionFunc(t *testing.T) {
 }
 
 func TestGetExecutionFuncForDetails(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 	getExecutionSetup()
 	ctx := s.Ctx
@@ -158,7 +158,7 @@ func TestGetExecutionFuncForDetails(t *testing.T) {
 
 func TestGetExecutionFuncWithIOData(t *testing.T) {
 	t.Run("successful inputs outputs", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionSetup()
@@ -224,7 +224,7 @@ func TestGetExecutionFuncWithIOData(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("fetch data error from admin", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionSetup()
@@ -266,7 +266,7 @@ func TestGetExecutionFuncWithIOData(t *testing.T) {
 
 		args := []string{dummyExec}
 		for _, tt := range tests {
-			s := testutils.SetupWithExt()
+			s := testutils.Setup()
 			defer s.RestoreStandardFileDescriptors()
 
 			config.GetConfig().Output = tt.outputFormat
@@ -367,7 +367,7 @@ func TestGetExecutionFuncWithError(t *testing.T) {
 	}
 
 	args := []string{executionNameValue}
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	s.FetcherExt.OnFetchExecutionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("execution NotFound"))

--- a/flytectl/cmd/get/launch_plan_test.go
+++ b/flytectl/cmd/get/launch_plan_test.go
@@ -222,7 +222,7 @@ func getLaunchPlanSetup() {
 func TestGetLaunchPlanFuncWithError(t *testing.T) {
 	t.Run("failure fetch latest", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 		getLaunchPlanSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		launchplan.DefaultConfig.Latest = true
@@ -235,7 +235,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching version ", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 		getLaunchPlanSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		launchplan.DefaultConfig.Version = "v1"
@@ -248,7 +248,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching all version ", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 		getLaunchPlanSetup()
 		launchplan.DefaultConfig.Filter = filters.Filters{}
 		launchplan.DefaultConfig.Filter = filters.Filters{}
@@ -261,7 +261,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching ", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "launchplan1", "dummyProject", "dummyDomain", filters.Filters{}).Return(nil, fmt.Errorf("error fetching all version"))
 		s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceGetRequest).Return(nil, fmt.Errorf("error fetching all version"))
@@ -273,7 +273,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching list", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 		getLaunchPlanSetup()
 		argsLp = []string{}
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{}).Return(nil, fmt.Errorf("error fetching all version"))
@@ -285,7 +285,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 
 func TestGetLaunchPlanFunc(t *testing.T) {
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 	getLaunchPlanSetup()
 	s.FetcherExt.OnFetchAllVerOfLPMatch(mock.Anything, mock.Anything, "dummyProject", "dummyDomain", filters.Filters{}).Return(launchPlanListResponse.LaunchPlans, nil)
 	err := getLaunchPlanFunc(s.Ctx, argsLp, s.CmdCtx)
@@ -296,7 +296,7 @@ func TestGetLaunchPlanFunc(t *testing.T) {
 
 func TestGetLaunchPlanFuncLatest(t *testing.T) {
 	s := setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 	getLaunchPlanSetup()
 	launchplan.DefaultConfig.Latest = true
 	launchplan.DefaultConfig.Filter = filters.Filters{}
@@ -309,7 +309,7 @@ func TestGetLaunchPlanFuncLatest(t *testing.T) {
 
 func TestGetLaunchPlanWithVersion(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 	getLaunchPlanSetup()
 	launchplan.DefaultConfig.Version = "v2"
 	s.FetcherExt.OnFetchLPVersion(s.Ctx, "launchplan1", "v2", "dummyProject", "dummyDomain").Return(launchPlan2, nil)
@@ -322,7 +322,7 @@ func TestGetLaunchPlanWithVersion(t *testing.T) {
 func TestGetLaunchPlans(t *testing.T) {
 	t.Run("no workflow filter", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{}).Return(launchPlanListResponse.LaunchPlans, nil)
 		argsLp = []string{}
@@ -332,7 +332,7 @@ func TestGetLaunchPlans(t *testing.T) {
 	})
 	t.Run("workflow filter", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{
 			FieldSelector: "workflow.name=workflow2",
@@ -345,7 +345,7 @@ func TestGetLaunchPlans(t *testing.T) {
 	})
 	t.Run("workflow filter error", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 		getLaunchPlanSetup()
 		argsLp = []string{}
 		launchplan.DefaultConfig.Workflow = "workflow2"
@@ -358,7 +358,7 @@ func TestGetLaunchPlans(t *testing.T) {
 
 func TestGetLaunchPlansWithExecFile(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 	getLaunchPlanSetup()
 	s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceListRequest).Return(launchPlanListResponse, nil)
 	s.MockAdminClient.OnGetLaunchPlanMatch(s.Ctx, objectGetRequest).Return(launchPlan2, nil)
@@ -394,7 +394,7 @@ workflow: launchplan1
 
 func TestGetLaunchPlanTableFunc(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 	getLaunchPlanSetup()
 	s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceGetRequest).Return(launchPlanListResponse, nil)
 	s.MockAdminClient.OnGetLaunchPlanMatch(s.Ctx, objectGetRequest).Return(launchPlan2, nil)

--- a/flytectl/cmd/get/launch_plan_test.go
+++ b/flytectl/cmd/get/launch_plan_test.go
@@ -222,6 +222,7 @@ func getLaunchPlanSetup() {
 func TestGetLaunchPlanFuncWithError(t *testing.T) {
 	t.Run("failure fetch latest", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
 		getLaunchPlanSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		launchplan.DefaultConfig.Latest = true
@@ -234,6 +235,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching version ", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
 		getLaunchPlanSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		launchplan.DefaultConfig.Version = "v1"
@@ -246,6 +248,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching all version ", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
 		getLaunchPlanSetup()
 		launchplan.DefaultConfig.Filter = filters.Filters{}
 		launchplan.DefaultConfig.Filter = filters.Filters{}
@@ -258,6 +261,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching ", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "launchplan1", "dummyProject", "dummyDomain", filters.Filters{}).Return(nil, fmt.Errorf("error fetching all version"))
 		s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceGetRequest).Return(nil, fmt.Errorf("error fetching all version"))
@@ -269,6 +273,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching list", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
 		getLaunchPlanSetup()
 		argsLp = []string{}
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{}).Return(nil, fmt.Errorf("error fetching all version"))
@@ -280,6 +285,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 
 func TestGetLaunchPlanFunc(t *testing.T) {
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
 	getLaunchPlanSetup()
 	s.FetcherExt.OnFetchAllVerOfLPMatch(mock.Anything, mock.Anything, "dummyProject", "dummyDomain", filters.Filters{}).Return(launchPlanListResponse.LaunchPlans, nil)
 	err := getLaunchPlanFunc(s.Ctx, argsLp, s.CmdCtx)
@@ -290,6 +296,7 @@ func TestGetLaunchPlanFunc(t *testing.T) {
 
 func TestGetLaunchPlanFuncLatest(t *testing.T) {
 	s := setup()
+	defer s.RestoreStandardFileDescriptors()
 	getLaunchPlanSetup()
 	launchplan.DefaultConfig.Latest = true
 	launchplan.DefaultConfig.Filter = filters.Filters{}
@@ -302,6 +309,7 @@ func TestGetLaunchPlanFuncLatest(t *testing.T) {
 
 func TestGetLaunchPlanWithVersion(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
 	getLaunchPlanSetup()
 	launchplan.DefaultConfig.Version = "v2"
 	s.FetcherExt.OnFetchLPVersion(s.Ctx, "launchplan1", "v2", "dummyProject", "dummyDomain").Return(launchPlan2, nil)
@@ -314,6 +322,7 @@ func TestGetLaunchPlanWithVersion(t *testing.T) {
 func TestGetLaunchPlans(t *testing.T) {
 	t.Run("no workflow filter", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{}).Return(launchPlanListResponse.LaunchPlans, nil)
 		argsLp = []string{}
@@ -323,6 +332,7 @@ func TestGetLaunchPlans(t *testing.T) {
 	})
 	t.Run("workflow filter", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{
 			FieldSelector: "workflow.name=workflow2",
@@ -335,6 +345,7 @@ func TestGetLaunchPlans(t *testing.T) {
 	})
 	t.Run("workflow filter error", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
 		getLaunchPlanSetup()
 		argsLp = []string{}
 		launchplan.DefaultConfig.Workflow = "workflow2"
@@ -347,6 +358,7 @@ func TestGetLaunchPlans(t *testing.T) {
 
 func TestGetLaunchPlansWithExecFile(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
 	getLaunchPlanSetup()
 	s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceListRequest).Return(launchPlanListResponse, nil)
 	s.MockAdminClient.OnGetLaunchPlanMatch(s.Ctx, objectGetRequest).Return(launchPlan2, nil)
@@ -382,6 +394,7 @@ workflow: launchplan1
 
 func TestGetLaunchPlanTableFunc(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
 	getLaunchPlanSetup()
 	s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceGetRequest).Return(launchPlanListResponse, nil)
 	s.MockAdminClient.OnGetLaunchPlanMatch(s.Ctx, objectGetRequest).Return(launchPlan2, nil)

--- a/flytectl/cmd/get/launch_plan_test.go
+++ b/flytectl/cmd/get/launch_plan_test.go
@@ -308,7 +308,7 @@ func TestGetLaunchPlanFuncLatest(t *testing.T) {
 }
 
 func TestGetLaunchPlanWithVersion(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 	getLaunchPlanSetup()
 	launchplan.DefaultConfig.Version = "v2"
@@ -357,7 +357,7 @@ func TestGetLaunchPlans(t *testing.T) {
 }
 
 func TestGetLaunchPlansWithExecFile(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 	getLaunchPlanSetup()
 	s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceListRequest).Return(launchPlanListResponse, nil)
@@ -393,7 +393,7 @@ workflow: launchplan1
 }
 
 func TestGetLaunchPlanTableFunc(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 	getLaunchPlanSetup()
 	s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceGetRequest).Return(launchPlanListResponse, nil)

--- a/flytectl/cmd/get/matchable_cluster_resource_attribute_test.go
+++ b/flytectl/cmd/get/matchable_cluster_resource_attribute_test.go
@@ -50,6 +50,8 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getClusterResourceAttributeSetup()
 		// No args implying project domain attribute deletion
 		s.FetcherExt.OnFetchProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -62,6 +64,8 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getClusterResourceAttributeSetup()
 		clusterresourceattribute.DefaultFetchConfig.AttrFile = testDataTempFile
 		// No args implying project domain attribute deletion
@@ -75,6 +79,8 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getClusterResourceAttributeSetup()
 		clusterresourceattribute.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
 		// No args implying project domain attribute deletion
@@ -89,6 +95,8 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getClusterResourceAttributeSetup()
 		// No args implying project domain attribute deletion
 		s.FetcherExt.OnFetchProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -102,6 +110,8 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getClusterResourceAttributeSetup()
 		args := []string{"workflow"}
 		s.FetcherExt.OnFetchWorkflowAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -115,6 +125,8 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getClusterResourceAttributeSetup()
 		args := []string{"workflow"}
 		s.FetcherExt.OnFetchWorkflowAttributesMatch(mock.Anything, mock.Anything, mock.Anything,

--- a/flytectl/cmd/get/matchable_cluster_resource_attribute_test.go
+++ b/flytectl/cmd/get/matchable_cluster_resource_attribute_test.go
@@ -50,7 +50,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getClusterResourceAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -64,7 +64,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getClusterResourceAttributeSetup()
 		clusterresourceattribute.DefaultFetchConfig.AttrFile = testDataTempFile
@@ -79,7 +79,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getClusterResourceAttributeSetup()
 		clusterresourceattribute.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
@@ -95,7 +95,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getClusterResourceAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -110,7 +110,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getClusterResourceAttributeSetup()
 		args := []string{"workflow"}
@@ -125,7 +125,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getClusterResourceAttributeSetup()
 		args := []string{"workflow"}

--- a/flytectl/cmd/get/matchable_cluster_resource_attribute_test.go
+++ b/flytectl/cmd/get/matchable_cluster_resource_attribute_test.go
@@ -49,7 +49,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 		},
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getClusterResourceAttributeSetup()
@@ -63,7 +63,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","attributes":{"foo":"bar"}}`)
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getClusterResourceAttributeSetup()
@@ -78,7 +78,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `wrote the config to file temp-output-file`)
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getClusterResourceAttributeSetup()
@@ -94,7 +94,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getClusterResourceAttributeSetup()
@@ -109,7 +109,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getClusterResourceAttributeSetup()
@@ -124,7 +124,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","workflow":"workflow","attributes":{"foo":"bar"}}`)
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getClusterResourceAttributeSetup()

--- a/flytectl/cmd/get/matchable_execution_cluster_label_test.go
+++ b/flytectl/cmd/get/matchable_execution_cluster_label_test.go
@@ -50,6 +50,8 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionClusterLabelSetup()
 		// No args implying project domain attribute deletion
 		s.FetcherExt.OnFetchProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -62,6 +64,8 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionClusterLabelSetup()
 		executionclusterlabel.DefaultFetchConfig.AttrFile = testDataTempFile
 		// No args implying project domain attribute deletion
@@ -75,6 +79,8 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionClusterLabelSetup()
 		executionclusterlabel.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
 		// No args implying project domain attribute deletion
@@ -89,6 +95,8 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 	})
 	t.Run("failed to get project domain attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionClusterLabelSetup()
 		// No args implying project domain attribute deletion
 		s.FetcherExt.OnFetchProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -102,6 +110,8 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionClusterLabelSetup()
 		args := []string{"workflow"}
 		s.FetcherExt.OnFetchWorkflowAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -115,6 +125,8 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 	})
 	t.Run("failed to get workflow attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionClusterLabelSetup()
 		args := []string{"workflow"}
 		s.FetcherExt.OnFetchWorkflowAttributesMatch(mock.Anything, mock.Anything, mock.Anything,

--- a/flytectl/cmd/get/matchable_execution_cluster_label_test.go
+++ b/flytectl/cmd/get/matchable_execution_cluster_label_test.go
@@ -49,7 +49,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 		},
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionClusterLabelSetup()
@@ -63,7 +63,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","value":"foo"}`)
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionClusterLabelSetup()
@@ -78,7 +78,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 		s.TearDownAndVerify(t, `wrote the config to file temp-output-file`)
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionClusterLabelSetup()
@@ -94,7 +94,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("failed to get project domain attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionClusterLabelSetup()
@@ -109,7 +109,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionClusterLabelSetup()
@@ -124,7 +124,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","workflow":"workflow","value":"foo"}`)
 	})
 	t.Run("failed to get workflow attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionClusterLabelSetup()

--- a/flytectl/cmd/get/matchable_execution_cluster_label_test.go
+++ b/flytectl/cmd/get/matchable_execution_cluster_label_test.go
@@ -50,7 +50,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionClusterLabelSetup()
 		// No args implying project domain attribute deletion
@@ -64,7 +64,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionClusterLabelSetup()
 		executionclusterlabel.DefaultFetchConfig.AttrFile = testDataTempFile
@@ -79,7 +79,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionClusterLabelSetup()
 		executionclusterlabel.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
@@ -95,7 +95,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 	})
 	t.Run("failed to get project domain attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionClusterLabelSetup()
 		// No args implying project domain attribute deletion
@@ -110,7 +110,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionClusterLabelSetup()
 		args := []string{"workflow"}
@@ -125,7 +125,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 	})
 	t.Run("failed to get workflow attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionClusterLabelSetup()
 		args := []string{"workflow"}

--- a/flytectl/cmd/get/matchable_execution_queue_attribute_test.go
+++ b/flytectl/cmd/get/matchable_execution_queue_attribute_test.go
@@ -50,7 +50,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionQueueAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -64,7 +64,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionQueueAttributeSetup()
 		executionqueueattribute.DefaultFetchConfig.AttrFile = testDataTempFile
@@ -79,7 +79,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionQueueAttributeSetup()
 		executionqueueattribute.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
@@ -95,7 +95,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionQueueAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -110,7 +110,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionQueueAttributeSetup()
 		args := []string{"workflow"}
@@ -125,7 +125,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getExecutionQueueAttributeSetup()
 		args := []string{"workflow"}

--- a/flytectl/cmd/get/matchable_execution_queue_attribute_test.go
+++ b/flytectl/cmd/get/matchable_execution_queue_attribute_test.go
@@ -50,6 +50,8 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionQueueAttributeSetup()
 		// No args implying project domain attribute deletion
 		s.FetcherExt.OnFetchProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -62,6 +64,8 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionQueueAttributeSetup()
 		executionqueueattribute.DefaultFetchConfig.AttrFile = testDataTempFile
 		// No args implying project domain attribute deletion
@@ -75,6 +79,8 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionQueueAttributeSetup()
 		executionqueueattribute.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
 		// No args implying project domain attribute deletion
@@ -89,6 +95,8 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionQueueAttributeSetup()
 		// No args implying project domain attribute deletion
 		s.FetcherExt.OnFetchProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -102,6 +110,8 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionQueueAttributeSetup()
 		args := []string{"workflow"}
 		s.FetcherExt.OnFetchWorkflowAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -115,6 +125,8 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getExecutionQueueAttributeSetup()
 		args := []string{"workflow"}
 		s.FetcherExt.OnFetchWorkflowAttributesMatch(mock.Anything, mock.Anything, mock.Anything,

--- a/flytectl/cmd/get/matchable_execution_queue_attribute_test.go
+++ b/flytectl/cmd/get/matchable_execution_queue_attribute_test.go
@@ -49,7 +49,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 		},
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionQueueAttributeSetup()
@@ -63,7 +63,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","tags":["foo","bar"]}`)
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionQueueAttributeSetup()
@@ -78,7 +78,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `wrote the config to file temp-output-file`)
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionQueueAttributeSetup()
@@ -94,7 +94,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionQueueAttributeSetup()
@@ -109,7 +109,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionQueueAttributeSetup()
@@ -124,7 +124,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","workflow":"workflow","tags":["foo","bar"]}`)
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getExecutionQueueAttributeSetup()

--- a/flytectl/cmd/get/matchable_plugin_override_test.go
+++ b/flytectl/cmd/get/matchable_plugin_override_test.go
@@ -62,7 +62,7 @@ func TestGetPluginOverride(t *testing.T) {
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getPluginOverrideSetup()
 		// No args implying project domain attribute deletion
@@ -76,7 +76,7 @@ func TestGetPluginOverride(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getPluginOverrideSetup()
 		pluginoverride.DefaultFetchConfig.AttrFile = testDataTempFile
@@ -91,7 +91,7 @@ func TestGetPluginOverride(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getPluginOverrideSetup()
 		pluginoverride.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
@@ -107,7 +107,7 @@ func TestGetPluginOverride(t *testing.T) {
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getPluginOverrideSetup()
 		// No args implying project domain attribute deletion
@@ -122,7 +122,7 @@ func TestGetPluginOverride(t *testing.T) {
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getPluginOverrideSetup()
 		args := []string{"workflow"}
@@ -136,7 +136,7 @@ func TestGetPluginOverride(t *testing.T) {
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getPluginOverrideSetup()
 		args := []string{"workflow"}

--- a/flytectl/cmd/get/matchable_plugin_override_test.go
+++ b/flytectl/cmd/get/matchable_plugin_override_test.go
@@ -61,7 +61,7 @@ func TestGetPluginOverride(t *testing.T) {
 		},
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getPluginOverrideSetup()
@@ -75,7 +75,7 @@ func TestGetPluginOverride(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","overrides":[{"task_type":"python_task","plugin_id":["plugin-override1","plugin-override2"]},{"task_type":"java_task","plugin_id":["plugin-override3","plugin-override3"],"missing_plugin_behavior":1}]}`)
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getPluginOverrideSetup()
@@ -90,7 +90,7 @@ func TestGetPluginOverride(t *testing.T) {
 		s.TearDownAndVerify(t, `wrote the config to file temp-output-file`)
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getPluginOverrideSetup()
@@ -106,7 +106,7 @@ func TestGetPluginOverride(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getPluginOverrideSetup()
@@ -121,7 +121,7 @@ func TestGetPluginOverride(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getPluginOverrideSetup()
@@ -135,7 +135,7 @@ func TestGetPluginOverride(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","workflow":"workflow","overrides":[{"task_type":"python_task","plugin_id":["plugin-override1","plugin-override2"]},{"task_type":"java_task","plugin_id":["plugin-override3","plugin-override3"],"missing_plugin_behavior":1}]}`)
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getPluginOverrideSetup()

--- a/flytectl/cmd/get/matchable_plugin_override_test.go
+++ b/flytectl/cmd/get/matchable_plugin_override_test.go
@@ -62,6 +62,8 @@ func TestGetPluginOverride(t *testing.T) {
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getPluginOverrideSetup()
 		// No args implying project domain attribute deletion
 		s.FetcherExt.OnFetchProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -74,6 +76,8 @@ func TestGetPluginOverride(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getPluginOverrideSetup()
 		pluginoverride.DefaultFetchConfig.AttrFile = testDataTempFile
 		// No args implying project domain attribute deletion
@@ -87,6 +91,8 @@ func TestGetPluginOverride(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getPluginOverrideSetup()
 		pluginoverride.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
 		// No args implying project domain attribute deletion
@@ -101,6 +107,8 @@ func TestGetPluginOverride(t *testing.T) {
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getPluginOverrideSetup()
 		// No args implying project domain attribute deletion
 		s.FetcherExt.OnFetchProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -114,6 +122,8 @@ func TestGetPluginOverride(t *testing.T) {
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getPluginOverrideSetup()
 		args := []string{"workflow"}
 		s.FetcherExt.OnFetchWorkflowAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -126,6 +136,8 @@ func TestGetPluginOverride(t *testing.T) {
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getPluginOverrideSetup()
 		args := []string{"workflow"}
 		s.FetcherExt.OnFetchWorkflowAttributesMatch(mock.Anything, mock.Anything, mock.Anything,

--- a/flytectl/cmd/get/matchable_task_resource_attribute_test.go
+++ b/flytectl/cmd/get/matchable_task_resource_attribute_test.go
@@ -56,7 +56,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 		},
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getTaskResourceAttributeSetup()
@@ -70,7 +70,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","defaults":{"cpu":"1","memory":"150Mi"},"limits":{"cpu":"2","memory":"350Mi"}}`)
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getTaskResourceAttributeSetup()
@@ -85,7 +85,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `wrote the config to file temp-output-file`)
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getTaskResourceAttributeSetup()
@@ -101,7 +101,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getTaskResourceAttributeSetup()
@@ -116,7 +116,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getTaskResourceAttributeSetup()
@@ -131,7 +131,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","workflow":"workflow","defaults":{"cpu":"1","memory":"150Mi"},"limits":{"cpu":"2","memory":"350Mi"}}`)
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getTaskResourceAttributeSetup()

--- a/flytectl/cmd/get/matchable_task_resource_attribute_test.go
+++ b/flytectl/cmd/get/matchable_task_resource_attribute_test.go
@@ -57,7 +57,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getTaskResourceAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -71,7 +71,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getTaskResourceAttributeSetup()
 		taskresourceattribute.DefaultFetchConfig.AttrFile = testDataTempFile
@@ -86,7 +86,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getTaskResourceAttributeSetup()
 		taskresourceattribute.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
@@ -102,7 +102,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getTaskResourceAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -117,7 +117,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getTaskResourceAttributeSetup()
 		args := []string{"workflow"}
@@ -132,7 +132,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getTaskResourceAttributeSetup()
 		args := []string{"workflow"}

--- a/flytectl/cmd/get/matchable_task_resource_attribute_test.go
+++ b/flytectl/cmd/get/matchable_task_resource_attribute_test.go
@@ -57,6 +57,8 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getTaskResourceAttributeSetup()
 		// No args implying project domain attribute deletion
 		s.FetcherExt.OnFetchProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -69,6 +71,8 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getTaskResourceAttributeSetup()
 		taskresourceattribute.DefaultFetchConfig.AttrFile = testDataTempFile
 		// No args implying project domain attribute deletion
@@ -82,6 +86,8 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getTaskResourceAttributeSetup()
 		taskresourceattribute.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
 		// No args implying project domain attribute deletion
@@ -96,6 +102,8 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getTaskResourceAttributeSetup()
 		// No args implying project domain attribute deletion
 		s.FetcherExt.OnFetchProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -109,6 +117,8 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getTaskResourceAttributeSetup()
 		args := []string{"workflow"}
 		s.FetcherExt.OnFetchWorkflowAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -122,6 +132,8 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getTaskResourceAttributeSetup()
 		args := []string{"workflow"}
 		s.FetcherExt.OnFetchWorkflowAttributesMatch(mock.Anything, mock.Anything, mock.Anything,

--- a/flytectl/cmd/get/matchable_workflow_execution_config_test.go
+++ b/flytectl/cmd/get/matchable_workflow_execution_config_test.go
@@ -49,7 +49,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 		},
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getWorkflowExecutionConfigSetup()
@@ -63,7 +63,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","max_parallelism":5}`)
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getWorkflowExecutionConfigSetup()
@@ -78,7 +78,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 		s.TearDownAndVerify(t, `wrote the config to file temp-output-file`)
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getWorkflowExecutionConfigSetup()
@@ -94,7 +94,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getWorkflowExecutionConfigSetup()
@@ -109,7 +109,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getWorkflowExecutionConfigSetup()
@@ -124,7 +124,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","workflow":"workflow","max_parallelism":5}`)
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getWorkflowExecutionConfigSetup()

--- a/flytectl/cmd/get/matchable_workflow_execution_config_test.go
+++ b/flytectl/cmd/get/matchable_workflow_execution_config_test.go
@@ -50,6 +50,8 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getWorkflowExecutionConfigSetup()
 		// No args implying project domain attribute deletion
 		s.FetcherExt.OnFetchProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -62,6 +64,8 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getWorkflowExecutionConfigSetup()
 		workflowexecutionconfig.DefaultFetchConfig.AttrFile = testDataTempFile
 		// No args implying project domain attribute deletion
@@ -75,6 +79,8 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getWorkflowExecutionConfigSetup()
 		workflowexecutionconfig.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
 		// No args implying project domain attribute deletion
@@ -89,6 +95,8 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getWorkflowExecutionConfigSetup()
 		// No args implying project domain attribute deletion
 		s.FetcherExt.OnFetchProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -102,6 +110,8 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getWorkflowExecutionConfigSetup()
 		args := []string{"workflow"}
 		s.FetcherExt.OnFetchWorkflowAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -115,6 +125,8 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getWorkflowExecutionConfigSetup()
 		args := []string{"workflow"}
 		s.FetcherExt.OnFetchWorkflowAttributesMatch(mock.Anything, mock.Anything, mock.Anything,

--- a/flytectl/cmd/get/matchable_workflow_execution_config_test.go
+++ b/flytectl/cmd/get/matchable_workflow_execution_config_test.go
@@ -50,7 +50,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getWorkflowExecutionConfigSetup()
 		// No args implying project domain attribute deletion
@@ -64,7 +64,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getWorkflowExecutionConfigSetup()
 		workflowexecutionconfig.DefaultFetchConfig.AttrFile = testDataTempFile
@@ -79,7 +79,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getWorkflowExecutionConfigSetup()
 		workflowexecutionconfig.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
@@ -95,7 +95,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getWorkflowExecutionConfigSetup()
 		// No args implying project domain attribute deletion
@@ -110,7 +110,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getWorkflowExecutionConfigSetup()
 		args := []string{"workflow"}
@@ -125,7 +125,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getWorkflowExecutionConfigSetup()
 		args := []string{"workflow"}

--- a/flytectl/cmd/get/node_execution_test.go
+++ b/flytectl/cmd/get/node_execution_test.go
@@ -161,6 +161,8 @@ func createDummyTaskExecutionForNode(nodeID string, taskID string) *admin.TaskEx
 func TestGetExecutionDetails(t *testing.T) {
 	t.Run("successful get details default view", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		ctx := s.Ctx
 		mockCmdCtx := s.CmdCtx
 		mockFetcherExt := s.FetcherExt
@@ -227,6 +229,8 @@ func TestGetExecutionDetails(t *testing.T) {
 
 	t.Run("successful get details default view for node-id", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		ctx := s.Ctx
 		mockCmdCtx := s.CmdCtx
 		mockFetcherExt := s.FetcherExt
@@ -290,6 +294,8 @@ func TestGetExecutionDetails(t *testing.T) {
 
 	t.Run("failure task exec fetch", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		ctx := s.Ctx
 		mockCmdCtx := s.CmdCtx
 		mockFetcherExt := s.FetcherExt

--- a/flytectl/cmd/get/node_execution_test.go
+++ b/flytectl/cmd/get/node_execution_test.go
@@ -161,7 +161,7 @@ func createDummyTaskExecutionForNode(nodeID string, taskID string) *admin.TaskEx
 func TestGetExecutionDetails(t *testing.T) {
 	t.Run("successful get details default view", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		ctx := s.Ctx
 		mockCmdCtx := s.CmdCtx
@@ -229,7 +229,7 @@ func TestGetExecutionDetails(t *testing.T) {
 
 	t.Run("successful get details default view for node-id", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		ctx := s.Ctx
 		mockCmdCtx := s.CmdCtx
@@ -294,7 +294,7 @@ func TestGetExecutionDetails(t *testing.T) {
 
 	t.Run("failure task exec fetch", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		ctx := s.Ctx
 		mockCmdCtx := s.CmdCtx

--- a/flytectl/cmd/get/node_execution_test.go
+++ b/flytectl/cmd/get/node_execution_test.go
@@ -160,7 +160,7 @@ func createDummyTaskExecutionForNode(nodeID string, taskID string) *admin.TaskEx
 
 func TestGetExecutionDetails(t *testing.T) {
 	t.Run("successful get details default view", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		ctx := s.Ctx
@@ -228,7 +228,7 @@ func TestGetExecutionDetails(t *testing.T) {
 	})
 
 	t.Run("successful get details default view for node-id", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		ctx := s.Ctx
@@ -293,7 +293,7 @@ func TestGetExecutionDetails(t *testing.T) {
 	})
 
 	t.Run("failure task exec fetch", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		ctx := s.Ctx

--- a/flytectl/cmd/get/project_test.go
+++ b/flytectl/cmd/get/project_test.go
@@ -54,6 +54,8 @@ func getProjectSetup() {
 
 func TestListProjectFunc(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	getProjectSetup()
 	project.DefaultConfig.Filter = filters.Filters{}
 	s.MockAdminClient.OnListProjectsMatch(s.Ctx, resourceListRequestProject).Return(projectListResponse, nil)
@@ -66,6 +68,8 @@ func TestListProjectFunc(t *testing.T) {
 
 func TestGetProjectFunc(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	getProjectSetup()
 	argsProject = []string{}
 
@@ -79,6 +83,8 @@ func TestGetProjectFunc(t *testing.T) {
 
 func TestGetProjectFuncError(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	getProjectSetup()
 	project.DefaultConfig.Filter = filters.Filters{
 		FieldSelector: "hello=",

--- a/flytectl/cmd/get/project_test.go
+++ b/flytectl/cmd/get/project_test.go
@@ -53,7 +53,7 @@ func getProjectSetup() {
 }
 
 func TestListProjectFunc(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	getProjectSetup()
@@ -67,7 +67,7 @@ func TestListProjectFunc(t *testing.T) {
 }
 
 func TestGetProjectFunc(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	getProjectSetup()
@@ -82,7 +82,7 @@ func TestGetProjectFunc(t *testing.T) {
 }
 
 func TestGetProjectFuncError(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	getProjectSetup()

--- a/flytectl/cmd/get/project_test.go
+++ b/flytectl/cmd/get/project_test.go
@@ -54,7 +54,7 @@ func getProjectSetup() {
 
 func TestListProjectFunc(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	getProjectSetup()
 	project.DefaultConfig.Filter = filters.Filters{}
@@ -68,7 +68,7 @@ func TestListProjectFunc(t *testing.T) {
 
 func TestGetProjectFunc(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	getProjectSetup()
 	argsProject = []string{}
@@ -83,7 +83,7 @@ func TestGetProjectFunc(t *testing.T) {
 
 func TestGetProjectFuncError(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	getProjectSetup()
 	project.DefaultConfig.Filter = filters.Filters{

--- a/flytectl/cmd/get/task_test.go
+++ b/flytectl/cmd/get/task_test.go
@@ -248,7 +248,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 }
 
 func TestGetTaskFunc(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	getTaskSetup()
@@ -335,7 +335,7 @@ func TestGetTaskFunc(t *testing.T) {
 }
 
 func TestGetTaskFuncWithTable(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	getTaskSetup()
@@ -361,7 +361,7 @@ func TestGetTaskFuncWithTable(t *testing.T) {
 }
 
 func TestGetTaskFuncLatest(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	getTaskSetup()
@@ -412,7 +412,7 @@ func TestGetTaskFuncLatest(t *testing.T) {
 }
 
 func TestGetTaskWithVersion(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	getTaskSetup()
@@ -464,7 +464,7 @@ func TestGetTaskWithVersion(t *testing.T) {
 }
 
 func TestGetTasks(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	getTaskSetup()
@@ -479,7 +479,7 @@ func TestGetTasks(t *testing.T) {
 }
 
 func TestGetTasksFilters(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	getTaskSetup()
@@ -504,7 +504,7 @@ func TestGetTasksFilters(t *testing.T) {
 }
 
 func TestGetTaskWithExecFile(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	getTaskSetup()

--- a/flytectl/cmd/get/task_test.go
+++ b/flytectl/cmd/get/task_test.go
@@ -177,7 +177,7 @@ func getTaskSetup() {
 func TestGetTaskFuncWithError(t *testing.T) {
 	t.Run("failure fetch latest", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getTaskSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -191,7 +191,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching version ", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getTaskSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -205,7 +205,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching all version ", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getTaskSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -218,7 +218,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching ", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getLaunchPlanSetup()
 		s.MockAdminClient.OnListTasksMatch(s.Ctx, resourceListRequestTask).Return(nil, fmt.Errorf("error fetching all version"))
@@ -232,7 +232,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching list task", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getLaunchPlanSetup()
 		taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -249,7 +249,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 
 func TestGetTaskFunc(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -336,7 +336,7 @@ func TestGetTaskFunc(t *testing.T) {
 
 func TestGetTaskFuncWithTable(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -362,7 +362,7 @@ func TestGetTaskFuncWithTable(t *testing.T) {
 
 func TestGetTaskFuncLatest(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -413,7 +413,7 @@ func TestGetTaskFuncLatest(t *testing.T) {
 
 func TestGetTaskWithVersion(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -465,7 +465,7 @@ func TestGetTaskWithVersion(t *testing.T) {
 
 func TestGetTasks(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -480,7 +480,7 @@ func TestGetTasks(t *testing.T) {
 
 func TestGetTasksFilters(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{
@@ -505,7 +505,7 @@ func TestGetTasksFilters(t *testing.T) {
 
 func TestGetTaskWithExecFile(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	getTaskSetup()
 	s.MockAdminClient.OnListTasksMatch(s.Ctx, resourceListRequestTask).Return(taskListResponse, nil)

--- a/flytectl/cmd/get/task_test.go
+++ b/flytectl/cmd/get/task_test.go
@@ -177,6 +177,8 @@ func getTaskSetup() {
 func TestGetTaskFuncWithError(t *testing.T) {
 	t.Run("failure fetch latest", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		getTaskSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		taskConfig.DefaultConfig.Latest = true
@@ -189,6 +191,8 @@ func TestGetTaskFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching version ", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		getTaskSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		taskConfig.DefaultConfig.Version = "v1"
@@ -201,6 +205,8 @@ func TestGetTaskFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching all version ", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		getTaskSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -212,6 +218,8 @@ func TestGetTaskFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching ", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		getLaunchPlanSetup()
 		s.MockAdminClient.OnListTasksMatch(s.Ctx, resourceListRequestTask).Return(nil, fmt.Errorf("error fetching all version"))
 		s.MockAdminClient.OnGetTaskMatch(s.Ctx, objectGetRequestTask).Return(nil, fmt.Errorf("error fetching task"))
@@ -224,6 +232,8 @@ func TestGetTaskFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching list task", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		getLaunchPlanSetup()
 		taskConfig.DefaultConfig.Filter = filters.Filters{}
 		argsTask = []string{}
@@ -239,6 +249,8 @@ func TestGetTaskFuncWithError(t *testing.T) {
 
 func TestGetTaskFunc(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
 	s.MockAdminClient.OnListTasksMatch(s.Ctx, resourceListRequestTask).Return(taskListResponse, nil)
@@ -324,6 +336,8 @@ func TestGetTaskFunc(t *testing.T) {
 
 func TestGetTaskFuncWithTable(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
 	s.MockAdminClient.OnListTasksMatch(s.Ctx, resourceListRequestTask).Return(taskListResponse, nil)
@@ -348,6 +362,8 @@ func TestGetTaskFuncWithTable(t *testing.T) {
 
 func TestGetTaskFuncLatest(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
 	s.MockAdminClient.OnListTasksMatch(s.Ctx, resourceListRequestTask).Return(taskListResponse, nil)
@@ -397,6 +413,8 @@ func TestGetTaskFuncLatest(t *testing.T) {
 
 func TestGetTaskWithVersion(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
 	s.MockAdminClient.OnListTasksMatch(s.Ctx, resourceListRequestTask).Return(taskListResponse, nil)
@@ -447,6 +465,8 @@ func TestGetTaskWithVersion(t *testing.T) {
 
 func TestGetTasks(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
 	s.MockAdminClient.OnListTasksMatch(s.Ctx, resourceListRequestTask).Return(taskListResponse, nil)
@@ -460,6 +480,8 @@ func TestGetTasks(t *testing.T) {
 
 func TestGetTasksFilters(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{
 		FieldSelector: "task.name=task1,task.version=v1",
@@ -483,6 +505,8 @@ func TestGetTasksFilters(t *testing.T) {
 
 func TestGetTaskWithExecFile(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	getTaskSetup()
 	s.MockAdminClient.OnListTasksMatch(s.Ctx, resourceListRequestTask).Return(taskListResponse, nil)
 	s.MockAdminClient.OnGetTaskMatch(s.Ctx, objectGetRequestTask).Return(task2, nil)

--- a/flytectl/cmd/get/workflow_test.go
+++ b/flytectl/cmd/get/workflow_test.go
@@ -135,7 +135,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching ", func(t *testing.T) {
-		s := testutils.SetupWithExt()
+		s := testutils.Setup()
 		defer s.RestoreStandardFileDescriptors()
 
 		getWorkflowSetup()
@@ -174,7 +174,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 }
 
 func TestGetWorkflowFuncLatestWithTable(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	getWorkflowSetup()
@@ -195,7 +195,7 @@ func TestGetWorkflowFuncLatestWithTable(t *testing.T) {
 }
 
 func TestListWorkflowFuncWithTable(t *testing.T) {
-	s := testutils.SetupWithExt()
+	s := testutils.Setup()
 	defer s.RestoreStandardFileDescriptors()
 
 	getWorkflowSetup()

--- a/flytectl/cmd/get/workflow_test.go
+++ b/flytectl/cmd/get/workflow_test.go
@@ -99,7 +99,7 @@ func getWorkflowSetup() {
 func TestGetWorkflowFuncWithError(t *testing.T) {
 	t.Run("failure fetch latest", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getWorkflowSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -111,7 +111,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching version ", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getWorkflowSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -124,7 +124,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching all version ", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getWorkflowSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -136,7 +136,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching ", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getWorkflowSetup()
 		workflow.DefaultConfig.Latest = true
@@ -149,7 +149,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 
 	t.Run("fetching all workflow success", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getWorkflowSetup()
 		var args []string
@@ -161,7 +161,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 
 	t.Run("fetching all workflow error", func(t *testing.T) {
 		s := setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 
 		getWorkflowSetup()
 		var args []string
@@ -175,7 +175,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 
 func TestGetWorkflowFuncLatestWithTable(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	getWorkflowSetup()
 	workflow.DefaultConfig.Latest = true
@@ -196,7 +196,7 @@ func TestGetWorkflowFuncLatestWithTable(t *testing.T) {
 
 func TestListWorkflowFuncWithTable(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	getWorkflowSetup()
 	workflow.DefaultConfig.Filter = filters.Filters{}

--- a/flytectl/cmd/get/workflow_test.go
+++ b/flytectl/cmd/get/workflow_test.go
@@ -99,6 +99,8 @@ func getWorkflowSetup() {
 func TestGetWorkflowFuncWithError(t *testing.T) {
 	t.Run("failure fetch latest", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		getWorkflowSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		workflow.DefaultConfig.Latest = true
@@ -109,6 +111,8 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching version ", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		getWorkflowSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		workflow.DefaultConfig.Version = "v1"
@@ -120,6 +124,8 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching all version ", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		getWorkflowSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		mockFetcher.OnFetchAllVerOfWorkflowMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -130,6 +136,8 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 
 	t.Run("failure fetching ", func(t *testing.T) {
 		s := testutils.SetupWithExt()
+		defer s.RestoreStandardFileDescriptors()
+
 		getWorkflowSetup()
 		workflow.DefaultConfig.Latest = true
 		args := []string{"workflowName"}
@@ -141,6 +149,8 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 
 	t.Run("fetching all workflow success", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		getWorkflowSetup()
 		var args []string
 		s.FetcherExt.OnFetchAllWorkflowsMatch(mock.Anything, mock.Anything,
@@ -151,6 +161,8 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 
 	t.Run("fetching all workflow error", func(t *testing.T) {
 		s := setup()
+		defer s.RestoreStandardFileDescriptors()
+
 		getWorkflowSetup()
 		var args []string
 		s.FetcherExt.OnFetchAllWorkflowsMatch(mock.Anything, mock.Anything,
@@ -163,6 +175,8 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 
 func TestGetWorkflowFuncLatestWithTable(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	getWorkflowSetup()
 	workflow.DefaultConfig.Latest = true
 	workflow.DefaultConfig.Filter = filters.Filters{}
@@ -182,6 +196,8 @@ func TestGetWorkflowFuncLatestWithTable(t *testing.T) {
 
 func TestListWorkflowFuncWithTable(t *testing.T) {
 	s := testutils.SetupWithExt()
+	defer s.RestoreStandardFileDescriptors()
+
 	getWorkflowSetup()
 	workflow.DefaultConfig.Filter = filters.Filters{}
 	config.GetConfig().Output = printer.OutputFormatTABLE.String()

--- a/flytectl/cmd/testutils/test_utils.go
+++ b/flytectl/cmd/testutils/test_utils.go
@@ -70,6 +70,11 @@ func Setup() (s TestStruct) {
 	return s
 }
 
+func (s *TestStruct) RestoreStandardFileDescriptors() {
+	os.Stdout = s.StdOut
+	os.Stderr = s.Stderr
+}
+
 func SetupWithExt() (s TestStruct) {
 	s.Ctx = context.Background()
 	s.Reader, s.Writer, s.Err = os.Pipe()

--- a/flytectl/cmd/testutils/test_utils.go
+++ b/flytectl/cmd/testutils/test_utils.go
@@ -42,6 +42,7 @@ type TestStruct struct {
 	Stderr          *os.File
 }
 
+// Make sure to call RestoreStandardFileDescriptors after using this function
 func Setup() (s TestStruct) {
 	s.Ctx = context.Background()
 	s.Reader, s.Writer, s.Err = os.Pipe()
@@ -73,34 +74,6 @@ func Setup() (s TestStruct) {
 func (s *TestStruct) RestoreStandardFileDescriptors() {
 	os.Stdout = s.StdOut
 	os.Stderr = s.Stderr
-}
-
-func SetupWithExt() (s TestStruct) {
-	s.Ctx = context.Background()
-	s.Reader, s.Writer, s.Err = os.Pipe()
-	if s.Err != nil {
-		panic(s.Err)
-	}
-	s.StdOut = os.Stdout
-	s.Stderr = os.Stderr
-	os.Stdout = s.Writer
-	os.Stderr = s.Writer
-	log.SetOutput(s.Writer)
-	s.MockClient = admin.InitializeMockClientset()
-	s.FetcherExt = new(extMocks.AdminFetcherExtInterface)
-	s.UpdaterExt = new(extMocks.AdminUpdaterExtInterface)
-	s.DeleterExt = new(extMocks.AdminDeleterExtInterface)
-	s.FetcherExt.OnAdminServiceClient().Return(s.MockClient.AdminClient())
-	s.UpdaterExt.OnAdminServiceClient().Return(s.MockClient.AdminClient())
-	s.DeleterExt.OnAdminServiceClient().Return(s.MockClient.AdminClient())
-	s.MockAdminClient = s.MockClient.AdminClient().(*mocks.AdminServiceClient)
-	s.MockOutStream = s.Writer
-	s.CmdCtx = cmdCore.NewCommandContextWithExt(s.MockClient, s.FetcherExt, s.UpdaterExt, s.DeleterExt, s.MockOutStream)
-	config.GetConfig().Project = projectValue
-	config.GetConfig().Domain = domainValue
-	config.GetConfig().Output = output
-
-	return s
 }
 
 // TearDownAndVerify TODO: Change this to verify log lines from context

--- a/flytectl/cmd/testutils/test_utils.go
+++ b/flytectl/cmd/testutils/test_utils.go
@@ -42,7 +42,7 @@ type TestStruct struct {
 	Stderr          *os.File
 }
 
-// Make sure to call RestoreStandardFileDescriptors after using this function
+// Make sure to call TearDown after using this function
 func Setup() (s TestStruct) {
 	s.Ctx = context.Background()
 	s.Reader, s.Writer, s.Err = os.Pipe()
@@ -71,7 +71,7 @@ func Setup() (s TestStruct) {
 	return s
 }
 
-func (s *TestStruct) RestoreStandardFileDescriptors() {
+func (s *TestStruct) TearDown() {
 	os.Stdout = s.StdOut
 	os.Stderr = s.Stderr
 }

--- a/flytectl/cmd/update/execution_test.go
+++ b/flytectl/cmd/update/execution_test.go
@@ -176,6 +176,8 @@ func TestExecutionUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 func TestExecutionUpdateRequiresExecutionName(t *testing.T) {
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	err := updateExecutionFunc(s.Ctx, nil, s.CmdCtx)
 
 	assert.ErrorContains(t, err, "execution name wasn't passed")
@@ -205,6 +207,8 @@ func testExecutionUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	target := newTestExecution()
 
 	if mockSetup != nil {
@@ -214,6 +218,7 @@ func testExecutionUpdateWithMockSetup(
 	execution.UConfig = &execution.UpdateConfig{}
 	if setup != nil {
 		setup(&s, execution.UConfig, target)
+		defer s.RestoreStandardFileDescriptors()
 	}
 
 	args := []string{target.Id.Name}

--- a/flytectl/cmd/update/execution_test.go
+++ b/flytectl/cmd/update/execution_test.go
@@ -176,7 +176,7 @@ func TestExecutionUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 func TestExecutionUpdateRequiresExecutionName(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	err := updateExecutionFunc(s.Ctx, nil, s.CmdCtx)
 
@@ -207,7 +207,7 @@ func testExecutionUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	target := newTestExecution()
 
@@ -218,7 +218,7 @@ func testExecutionUpdateWithMockSetup(
 	execution.UConfig = &execution.UpdateConfig{}
 	if setup != nil {
 		setup(&s, execution.UConfig, target)
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 	}
 
 	args := []string{target.Id.Name}

--- a/flytectl/cmd/update/launch_plan_meta_test.go
+++ b/flytectl/cmd/update/launch_plan_meta_test.go
@@ -180,6 +180,8 @@ func TestLaunchPlanMetadataUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 func TestLaunchPlanMetadataUpdateRequiresLaunchPlanName(t *testing.T) {
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	config := &NamedEntityConfig{}
 
 	err := getUpdateLPMetaFunc(config)(s.Ctx, nil, s.CmdCtx)

--- a/flytectl/cmd/update/launch_plan_meta_test.go
+++ b/flytectl/cmd/update/launch_plan_meta_test.go
@@ -180,7 +180,7 @@ func TestLaunchPlanMetadataUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 func TestLaunchPlanMetadataUpdateRequiresLaunchPlanName(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	config := &NamedEntityConfig{}
 

--- a/flytectl/cmd/update/launch_plan_test.go
+++ b/flytectl/cmd/update/launch_plan_test.go
@@ -198,7 +198,7 @@ func TestLaunchPlanUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 func TestLaunchPlanUpdateRequiresLaunchPlanName(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	launchplan.UConfig = &launchplan.UpdateConfig{}
 
@@ -213,7 +213,7 @@ func TestLaunchPlanUpdateRequiresLaunchPlanName(t *testing.T) {
 
 func TestLaunchPlanUpdateRequiresLaunchPlanVersion(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	launchplan.UConfig = &launchplan.UpdateConfig{}
 
@@ -252,7 +252,7 @@ func testLaunchPlanUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	target := newTestLaunchPlan()
 
@@ -263,7 +263,7 @@ func testLaunchPlanUpdateWithMockSetup(
 	launchplan.UConfig = &launchplan.UpdateConfig{}
 	if setup != nil {
 		setup(&s, launchplan.UConfig, target)
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 	}
 
 	args := []string{target.Id.Name}

--- a/flytectl/cmd/update/launch_plan_test.go
+++ b/flytectl/cmd/update/launch_plan_test.go
@@ -198,6 +198,8 @@ func TestLaunchPlanUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 func TestLaunchPlanUpdateRequiresLaunchPlanName(t *testing.T) {
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	launchplan.UConfig = &launchplan.UpdateConfig{}
 
 	launchplan.UConfig.Version = testutils.RandomName(2)
@@ -211,6 +213,8 @@ func TestLaunchPlanUpdateRequiresLaunchPlanName(t *testing.T) {
 
 func TestLaunchPlanUpdateRequiresLaunchPlanVersion(t *testing.T) {
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	launchplan.UConfig = &launchplan.UpdateConfig{}
 
 	name := testutils.RandomName(12)
@@ -248,6 +252,8 @@ func testLaunchPlanUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	target := newTestLaunchPlan()
 
 	if mockSetup != nil {
@@ -257,6 +263,7 @@ func testLaunchPlanUpdateWithMockSetup(
 	launchplan.UConfig = &launchplan.UpdateConfig{}
 	if setup != nil {
 		setup(&s, launchplan.UConfig, target)
+		defer s.RestoreStandardFileDescriptors()
 	}
 
 	args := []string{target.Id.Name}

--- a/flytectl/cmd/update/matchable_cluster_resource_attribute_test.go
+++ b/flytectl/cmd/update/matchable_cluster_resource_attribute_test.go
@@ -402,6 +402,8 @@ func testWorkflowClusterResourceAttributeUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	clusterresourceattribute.DefaultUpdateConfig = &clusterresourceattribute.AttrUpdateConfig{}
 	target := newTestWorkflowClusterResourceAttribute()
 
@@ -411,6 +413,7 @@ func testWorkflowClusterResourceAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, clusterresourceattribute.DefaultUpdateConfig, target)
+		defer s.RestoreStandardFileDescriptors()
 	}
 
 	err := updateClusterResourceAttributesFunc(s.Ctx, nil, s.CmdCtx)
@@ -467,6 +470,8 @@ func testProjectClusterResourceAttributeUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	clusterresourceattribute.DefaultUpdateConfig = &clusterresourceattribute.AttrUpdateConfig{}
 	target := newTestProjectClusterResourceAttribute()
 
@@ -476,6 +481,7 @@ func testProjectClusterResourceAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, clusterresourceattribute.DefaultUpdateConfig, target)
+		defer s.RestoreStandardFileDescriptors()
 	}
 
 	err := updateClusterResourceAttributesFunc(s.Ctx, nil, s.CmdCtx)
@@ -539,6 +545,7 @@ func testProjectDomainClusterResourceAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, clusterresourceattribute.DefaultUpdateConfig, target)
+		defer s.RestoreStandardFileDescriptors()
 	}
 
 	err := updateClusterResourceAttributesFunc(s.Ctx, nil, s.CmdCtx)

--- a/flytectl/cmd/update/matchable_cluster_resource_attribute_test.go
+++ b/flytectl/cmd/update/matchable_cluster_resource_attribute_test.go
@@ -402,7 +402,7 @@ func testWorkflowClusterResourceAttributeUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	clusterresourceattribute.DefaultUpdateConfig = &clusterresourceattribute.AttrUpdateConfig{}
 	target := newTestWorkflowClusterResourceAttribute()
@@ -413,7 +413,7 @@ func testWorkflowClusterResourceAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, clusterresourceattribute.DefaultUpdateConfig, target)
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 	}
 
 	err := updateClusterResourceAttributesFunc(s.Ctx, nil, s.CmdCtx)
@@ -470,7 +470,7 @@ func testProjectClusterResourceAttributeUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	clusterresourceattribute.DefaultUpdateConfig = &clusterresourceattribute.AttrUpdateConfig{}
 	target := newTestProjectClusterResourceAttribute()
@@ -481,7 +481,7 @@ func testProjectClusterResourceAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, clusterresourceattribute.DefaultUpdateConfig, target)
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 	}
 
 	err := updateClusterResourceAttributesFunc(s.Ctx, nil, s.CmdCtx)
@@ -545,7 +545,7 @@ func testProjectDomainClusterResourceAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, clusterresourceattribute.DefaultUpdateConfig, target)
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 	}
 
 	err := updateClusterResourceAttributesFunc(s.Ctx, nil, s.CmdCtx)

--- a/flytectl/cmd/update/matchable_execution_queue_attribute_test.go
+++ b/flytectl/cmd/update/matchable_execution_queue_attribute_test.go
@@ -411,6 +411,7 @@ func testWorkflowExecutionQueueAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, executionqueueattribute.DefaultUpdateConfig, target)
+		defer s.RestoreStandardFileDescriptors()
 	}
 
 	err := updateExecutionQueueAttributesFunc(s.Ctx, nil, s.CmdCtx)
@@ -467,6 +468,8 @@ func testProjectExecutionQueueAttributeUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	executionqueueattribute.DefaultUpdateConfig = &executionqueueattribute.AttrUpdateConfig{}
 	target := newTestProjectExecutionQueueAttribute()
 
@@ -476,6 +479,7 @@ func testProjectExecutionQueueAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, executionqueueattribute.DefaultUpdateConfig, target)
+		defer s.RestoreStandardFileDescriptors()
 	}
 
 	err := updateExecutionQueueAttributesFunc(s.Ctx, nil, s.CmdCtx)
@@ -539,6 +543,7 @@ func testProjectDomainExecutionQueueAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, executionqueueattribute.DefaultUpdateConfig, target)
+		defer s.RestoreStandardFileDescriptors()
 	}
 
 	err := updateExecutionQueueAttributesFunc(s.Ctx, nil, s.CmdCtx)

--- a/flytectl/cmd/update/matchable_execution_queue_attribute_test.go
+++ b/flytectl/cmd/update/matchable_execution_queue_attribute_test.go
@@ -411,7 +411,7 @@ func testWorkflowExecutionQueueAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, executionqueueattribute.DefaultUpdateConfig, target)
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 	}
 
 	err := updateExecutionQueueAttributesFunc(s.Ctx, nil, s.CmdCtx)
@@ -468,7 +468,7 @@ func testProjectExecutionQueueAttributeUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	executionqueueattribute.DefaultUpdateConfig = &executionqueueattribute.AttrUpdateConfig{}
 	target := newTestProjectExecutionQueueAttribute()
@@ -479,7 +479,7 @@ func testProjectExecutionQueueAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, executionqueueattribute.DefaultUpdateConfig, target)
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 	}
 
 	err := updateExecutionQueueAttributesFunc(s.Ctx, nil, s.CmdCtx)
@@ -543,7 +543,7 @@ func testProjectDomainExecutionQueueAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, executionqueueattribute.DefaultUpdateConfig, target)
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 	}
 
 	err := updateExecutionQueueAttributesFunc(s.Ctx, nil, s.CmdCtx)

--- a/flytectl/cmd/update/named_entity_test.go
+++ b/flytectl/cmd/update/named_entity_test.go
@@ -42,6 +42,8 @@ func testNamedEntityUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	config := &NamedEntityConfig{}
 	target := newTestNamedEntity(resourceType)
 
@@ -51,6 +53,7 @@ func testNamedEntityUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, config, target)
+		defer s.RestoreStandardFileDescriptors()
 	}
 
 	updateMetadataFactory := getUpdateMetadataFactory(resourceType)

--- a/flytectl/cmd/update/named_entity_test.go
+++ b/flytectl/cmd/update/named_entity_test.go
@@ -42,7 +42,7 @@ func testNamedEntityUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	config := &NamedEntityConfig{}
 	target := newTestNamedEntity(resourceType)
@@ -53,7 +53,7 @@ func testNamedEntityUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, config, target)
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 	}
 
 	updateMetadataFactory := getUpdateMetadataFactory(resourceType)

--- a/flytectl/cmd/update/task_meta_test.go
+++ b/flytectl/cmd/update/task_meta_test.go
@@ -180,7 +180,7 @@ func TestTaskMetadataUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 func TestTaskMetadataUpdateRequiresTaskName(t *testing.T) {
 	s := testutils.Setup()
-	defer s.RestoreStandardFileDescriptors()
+	defer s.TearDown()
 
 	config := &NamedEntityConfig{}
 

--- a/flytectl/cmd/update/task_meta_test.go
+++ b/flytectl/cmd/update/task_meta_test.go
@@ -180,6 +180,8 @@ func TestTaskMetadataUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 func TestTaskMetadataUpdateRequiresTaskName(t *testing.T) {
 	s := testutils.Setup()
+	defer s.RestoreStandardFileDescriptors()
+
 	config := &NamedEntityConfig{}
 
 	err := getUpdateTaskFunc(config)(s.Ctx, nil, s.CmdCtx)

--- a/flytectl/pkg/sandbox/status_test.go
+++ b/flytectl/pkg/sandbox/status_test.go
@@ -15,12 +15,14 @@ func TestSandboxStatus(t *testing.T) {
 	t.Run("Sandbox status with zero result", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		s := testutils.Setup()
+		defer s.RestoreStandardFileDescriptors()
 		mockDocker.OnContainerList(s.Ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
 		err := PrintStatus(s.Ctx, mockDocker)
 		assert.Nil(t, err)
 	})
 	t.Run("Sandbox status with running sandbox", func(t *testing.T) {
 		s := testutils.Setup()
+		defer s.RestoreStandardFileDescriptors()
 		ctx := s.Ctx
 		mockDocker := &mocks.Docker{}
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{

--- a/flytectl/pkg/sandbox/status_test.go
+++ b/flytectl/pkg/sandbox/status_test.go
@@ -15,14 +15,14 @@ func TestSandboxStatus(t *testing.T) {
 	t.Run("Sandbox status with zero result", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 		mockDocker.OnContainerList(s.Ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
 		err := PrintStatus(s.Ctx, mockDocker)
 		assert.Nil(t, err)
 	})
 	t.Run("Sandbox status with running sandbox", func(t *testing.T) {
 		s := testutils.Setup()
-		defer s.RestoreStandardFileDescriptors()
+		defer s.TearDown()
 		ctx := s.Ctx
 		mockDocker := &mocks.Docker{}
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5316

## Why are the changes needed?
We fixed a few of the flytectl issues in https://github.com/flyteorg/flyte/pull/5309, but decided to merge that PR with a few unit tests failing. This PR fixes them.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
We have a few flytectl unit tests that rely on a [TestStruct](https://github.com/flyteorg/flyte/blob/master/flytectl/cmd/testutils/test_utils.go#L29-L43) to capture what's written to standard output and error, but if those file descriptors are not restored then the respective test suites would fail every now and then. In this PR we add a defer statement to ensure that the original file descriptors are restored to the os package.

## How was this patch tested?
Unit tests running in a loop locally (e.g. `seq 100 | xargs -n1 make test_unit`).

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
