### PR TITLE
perf(webapi): Increase maxWorkers limit to 10000

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/internal/webapi/core.go
+++ b/flyteplugins/go/tasks/pluginmachinery/internal/webapi/core.go
@@ -21,7 +21,7 @@ const (
 	minCacheSize       = 10
 	maxCacheSize       = 500000
 	minWorkers         = 1
-	maxWorkers         = 100
+	maxWorkers         = 10000
 	minSyncDuration    = 5 * time.Second
 	maxSyncDuration    = time.Hour
 	minBurst           = 5

--- a/flyteplugins/go/tasks/pluginmachinery/internal/webapi/core_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/internal/webapi/core_test.go
@@ -74,7 +74,7 @@ func Test_validateConfig(t *testing.T) {
 
 		err := validateConfig(cfg)
 		assert.Error(t, err)
-		assert.Equal(t, "\ncache size is expected to be between 10 and 500000. Provided value is 1000000000\nworkers count is expected to be between 1 and 100. Provided value is 1000000000\nresync interval is expected to be between 5 and 3600. Provided value is 3.6e+07\nread burst is expected to be between 5 and 10000. Provided value is 1000000\nwrite burst is expected to be between 5 and 10000. Provided value is 1000000", err.Error())
+		assert.Equal(t, "\ncache size is expected to be between 10 and 500000. Provided value is 1000000000\nworkers count is expected to be between 1 and 10000. Provided value is 1000000000\nresync interval is expected to be between 5 and 3600. Provided value is 3.6e+07\nread burst is expected to be between 5 and 10000. Provided value is 1000000\nwrite burst is expected to be between 5 and 10000. Provided value is 1000000", err.Error())
 	})
 }
 

--- a/flyteplugins/go/tasks/pluginmachinery/internal/webapi/core_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/internal/webapi/core_test.go
@@ -52,7 +52,7 @@ func Test_validateConfig(t *testing.T) {
 
 		err := validateConfig(cfg)
 		assert.Error(t, err)
-		assert.Equal(t, "\ncache size is expected to be between 10 and 500000. Provided value is 0\nworkers count is expected to be between 1 and 100. Provided value is 0\nresync interval is expected to be between 5 and 3600. Provided value is 0\nread burst is expected to be between 5 and 10000. Provided value is 0\nread qps is expected to be between 1 and 100000. Provided value is 0\nwrite burst is expected to be between 5 and 10000. Provided value is 0\nwrite qps is expected to be between 1 and 100000. Provided value is 0", err.Error())
+		assert.Equal(t, "\ncache size is expected to be between 10 and 500000. Provided value is 0\nworkers count is expected to be between 1 and 10000. Provided value is 0\nresync interval is expected to be between 5 and 3600. Provided value is 0\nread burst is expected to be between 5 and 10000. Provided value is 0\nread qps is expected to be between 1 and 100000. Provided value is 0\nwrite burst is expected to be between 5 and 10000. Provided value is 0\nwrite qps is expected to be between 1 and 100000. Provided value is 0", err.Error())
 	})
 
 	t.Run("Above max", func(t *testing.T) {


### PR DESCRIPTION
## Tracking issue
NA

## What changes were proposed in this pull request?
Increase maxWorkers limit to 10000 to run more agent tasks in parallel.

## How was this patch tested?
Remote cluster

### Setup process
```python
from flytekit import workflow, task, LaunchPlan
from flytekitplugins.dummy_agent import Sleep


@task(task_config=Sleep(duration=0.5))
def sleep_task() -> str:
    return "Hello World!"


@workflow()
def sleep_wf():
    for i in range(100):
        sleep_task()


@workflow
def load_test_wf():
    sleep_lp = LaunchPlan.get_or_create(
        name="fixed_inputs", workflow=sleep_wf, max_parallelism=100
    )
    for i in range(50):
        sleep_lp()
```

### Screenshots
<img width="1563" alt="image" src="https://github.com/flyteorg/flyte/assets/37936015/926bcd07-0d9d-48e8-8934-d7432519f065">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
