### PR TITLE
ci: Reduce build times by 40%

### DIFF
--- a/.github/workflows/generate_flyte_manifest.yml
+++ b/.github/workflows/generate_flyte_manifest.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.21"
       - name: Update references

--- a/.github/workflows/go_generate.yml
+++ b/.github/workflows/go_generate.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ secrets.FLYTE_BOT_PAT }}
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ inputs.go-version }}
       - name: Go generate and diff

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           version: "v0.11.1"
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ inputs.go-version }}
       - name: Integration

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ inputs.go-version }}
       - name: Lint

--- a/.github/workflows/single-binary.yml
+++ b/.github/workflows/single-binary.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.21"
       - name: golangci-lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Fetch the code
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: "1.21"
       - name: Compile
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.21"
       - name: Helm and diff

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ inputs.go-version }}
       - name: Unit Tests

--- a/flytectl/.github/workflows/checks.yml
+++ b/flytectl/.github/workflows/checks.yml
@@ -50,7 +50,7 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.19'
       - name: Run GoReleaser dry run
@@ -73,7 +73,7 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19
       - name: Build Flytectl binary
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           lfs: true
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.19'
       - uses: actions/setup-python@v1


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
we didn't cache Go package in the CI

## What changes were proposed in this pull request?
Upgrade `setup-go` to v4. V4 has enabled caching by default.
https://github.blog/changelog/2023-03-24-github-actions-the-setup-go-action-now-enables-caching-by-default/

## How was this patch tested?
CI

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
