### PR TITLE
Add Google Tag Manager

### DIFF
--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -1,6 +1,13 @@
 <!doctype html>
 <html class="no-js"{% if language is not none %} lang="{{ language }}"{% endif %}>
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5TRD3RK');</script>
+    <!-- End Google Tag Manager -->
     {%- block site_meta -%}
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
@@ -107,6 +114,10 @@
       runllm-name="RunLLM" />
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5TRD3RK"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     {% block body %}
     <script>
       document.body.dataset.theme = localStorage.getItem("theme") || "auto";

--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -6,7 +6,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5TRD3RK');</script>
+    })(window,document,'script','dataLayer','GTM-WC8V9XS');</script>
     <!-- End Google Tag Manager -->
     {%- block site_meta -%}
     <meta charset="utf-8"/>
@@ -115,7 +115,7 @@
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5TRD3RK"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WC8V9XS"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     {% block body %}

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -203,9 +203,7 @@
             {%- endif %}
           </div>
         </div>
-        {% endblock footer %}    
-        <div class="extra_footer">
-        </div>
+        {% endblock footer %}
       </footer>
     </div>
     <aside class="toc-drawer{% if furo_hide_toc %} no-toc{% endif %}">

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -205,7 +205,6 @@
         </div>
         {% endblock footer %}    
         <div class="extra_footer">
-          <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=65df87cf-549c-4711-b01c-ee9e966c931c" />
         </div>
       </footer>
     </div>


### PR DESCRIPTION
## Why are the changes needed?

Instead of using scarf pixel directly, this adds Google GTM to allow us to experiment with different code snippets from the GTM side.

## What changes were proposed in this pull request?

- [X] Remove scarf pixel
- [X] Add GTM to the base page

## How was this patch tested?

Used the deployed change from the PR.
Looked at the source code to confirm GTM is installed
Installed scarf through GTM and noticed it get injected.

