### PR TITLE
Improve flyte-core helm chart

### DIFF
--- a/charts/flyte-core/templates/_helpers.tpl
+++ b/charts/flyte-core/templates/_helpers.tpl
@@ -14,7 +14,7 @@
 
 
 {{- define "flyteadmin.name" -}}
-flyteadmin
+{{- default "flyteadmin" .Values.flyteadmin.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "flyteadmin.selectorLabels" -}}
@@ -36,7 +36,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{- define "flytescheduler.name" -}}
-flytescheduler
+{{- default "flytescheduler" .Values.flytescheduler.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "flytescheduler.selectorLabels" -}}
@@ -59,7 +59,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{- define "flyteclusterresourcesync.name" -}}
-flyteclusterresourcesync
+{{- default "flyteclusterresourcesync" .Values.cluster_resource_manager.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "flyteclusterresourcesync.selectorLabels" -}}
@@ -81,7 +81,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{- define "datacatalog.name" -}}
-datacatalog
+{{- default "datacatalog" .Values.datacatalog.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "datacatalog.selectorLabels" -}}
@@ -125,7 +125,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{- define "flytepropeller-manager.name" -}}
-flytepropeller-manager
+{{- default "flytepropeller-manager" .Values.flytepropeller.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "flytepropeller-manager.selectorLabels" -}}
@@ -147,12 +147,12 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{- define "flyte-pod-webhook.name" -}}
-flyte-pod-webhook
+{{- default "flyte-pod-webhook" .Values.webhook.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 
 {{- define "flyteconsole.name" -}}
-flyteconsole
+{{- default "flyteconsole" .Values.flyteconsole.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "flyteconsole.selectorLabels" -}}

--- a/charts/flyte-core/templates/clusterresourcesync/configmap.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/configmap.yaml
@@ -34,5 +34,4 @@ data:
     clusters:
       {{- tpl (toYaml .) $ | nindent 6 }}
   {{- end }}
-
-  {{- end }}
+{{- end }}

--- a/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: syncresources
+  name: {{ template "flyteclusterresourcesync.name" . }}
   namespace: {{ template "flyte.namespace" . }}
   labels: {{ include "flyteclusterresourcesync.labels" . | nindent 4 }}
 spec:
@@ -55,7 +55,7 @@ spec:
           - mountPath: /var/run/credentials
             name: cluster-secrets
           {{- end }}
-      serviceAccountName: {{ .Values.cluster_resource_manager.service_account_name }}
+      serviceAccountName: {{ .Values.cluster_resource_manager.serviceAccount.create | ternary (include "flyteclusterresourcesync.name" .) .Values.cluster_resource_manager.service_account_name }}
       volumes:  {{- include "databaseSecret.volume" . | nindent 8 }}
         - configMap:
             name: clusterresource-template

--- a/charts/flyte-core/templates/clusterresourcesync/rbac.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/rbac.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.cluster_resource_manager.enabled }}
+{{- if .Values.cluster_resource_manager.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "flyteclusterresourcesync.name" . }}
+  namespace: {{ template "flyte.namespace" . }}
+  labels: {{ include "flyteclusterresourcesync.labels" . | nindent 4 }}
+  {{- with .Values.cluster_resource_manager.serviceAccount.annotations }}
+  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end}}
+{{- with .Values.cluster_resource_manager.serviceAccount.imagePullSecrets }}
+imagePullSecrets: {{ tpl (toYaml .) $ | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/flyte-core/templates/console/deployment.yaml
+++ b/charts/flyte-core/templates/console/deployment.yaml
@@ -59,6 +59,7 @@ spec:
         volumeMounts:
         - mountPath: /srv/flyte
           name: shared-data
+      serviceAccountName: {{ template "flyteconsole.name" . }}
       volumes:
       - emptyDir: {}
         name: shared-data

--- a/charts/flyte-core/templates/console/rbac.yaml
+++ b/charts/flyte-core/templates/console/rbac.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.flyteconsole.enabled }}
+{{- if .Values.flyteconsole.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "flyteconsole.name" . }}
+  namespace: {{ template "flyte.namespace" . }}
+  labels: {{ include "flyteconsole.labels" . | nindent 4 }}
+  {{- with .Values.flyteconsole.serviceAccount.annotations }}
+  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end}}
+{{- with .Values.flyteconsole.serviceAccount.imagePullSecrets }}
+imagePullSecrets: {{ tpl (toYaml .) $ | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -112,5 +112,5 @@ spec:
       {{- with .Values.flytescheduler.tolerations }}
       tolerations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
-{{- end }}
   {{- end }}
+{{- end }}

--- a/charts/flyte-core/templates/flytescheduler/rbac.yaml
+++ b/charts/flyte-core/templates/flytescheduler/rbac.yaml
@@ -17,5 +17,5 @@ imagePullSecrets: {{ tpl (toYaml .) $ | nindent 2 }}
   {{- end }}
 
 ---
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -171,7 +171,7 @@ flytescheduler:
   # -- Annotations for Flytescheduler pods
   podAnnotations: {}
   # -- Additional Flytescheduler container environment variables
-  podEnv: {}
+  podEnv: []
   # -- Labels for Flytescheduler pods
   podLabels: {}
   # -- nodeSelector for Flytescheduler deployment
@@ -243,7 +243,7 @@ datacatalog:
   # -- Annotations for Datacatalog pods
   podAnnotations: {}
   # -- Additional Datacatalog container environment variables
-  podEnv: {}
+  podEnv: []
   # -- Labels for Datacatalog pods
   podLabels: {}
   # -- nodeSelector for Datacatalog deployment
@@ -329,7 +329,7 @@ flytepropeller:
   # -- Annotations for Flytepropeller pods
   podAnnotations: {}
   # -- Additional Flytepropeller container environment variables
-  podEnv: {}
+  podEnv: []
   # -- Labels for Flytepropeller pods
   podLabels: {}
   # -- nodeSelector for Flytepropeller deployment
@@ -926,7 +926,7 @@ cluster_resource_manager:
   # -- Annotations for ClusterResource pods
   podAnnotations: {}
   # -- Additional ClusterResource container environment variables
-  podEnv: {}
+  podEnv: []
   # -- Labels for ClusterResource pods
   podLabels: {}
   # -- nodeSelector for ClusterResource deployment

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -399,10 +399,18 @@ flyteconsole:
   service:
     annotations: {}
     type: ClusterIP
+  # -- Configuration for service accounts for FlyteConsole
+  serviceAccount:
+    # -- Should a service account be created for the console
+    create: true
+    # -- Annotations for ServiceAccount attached to the console
+    annotations: {}
+    # -- ImagePullSecrets to automatically assign to the service console
+    imagePullSecrets: []
   # -- Annotations for Flyteconsole pods
   podAnnotations: {}
   # -- Additional Flyteconsole container environment variables
-  podEnv: {}
+  podEnv: []
   # -- Labels for Flyteconsole pods
   podLabels: {}
   # -- nodeSelector for Flyteconsole deployment
@@ -903,8 +911,18 @@ cluster_resource_manager:
   # -- Enables the Cluster resource manager component
   enabled: true
   standaloneDeployment: false
+  # nameOverride String to override flyteclusterresourcesync.name template
+  nameOverride:
   # -- Service account name to run with
   service_account_name: flyteadmin
+  # -- Configuration for service accounts for ClusterResource, will ignore service_account_name if set
+  serviceAccount:
+    # -- Should a service account be created for the ClusterResource
+    create: true
+    # -- Annotations for ServiceAccount attached to the ClusterResource
+    annotations: { }
+    # -- ImagePullSecrets to automatically assign to the service ClusterResource
+    imagePullSecrets: [ ]
   # -- Annotations for ClusterResource pods
   podAnnotations: {}
   # -- Additional ClusterResource container environment variables

--- a/charts/flyteagent/values.yaml
+++ b/charts/flyteagent/values.yaml
@@ -69,7 +69,7 @@ securityContext:
 # -- Annotations for flyteagent pods
 podAnnotations: {}
 # -- Additional flyteagent pod container environment variables
-podEnv: {}
+podEnv: []
 # -- Labels for flyteagent pods
 podLabels: {}
 # -- nodeSelector for flyteagent deployment


### PR DESCRIPTION
Fixed flyte-core helm chart where ServiceAccounts were missing, incorrect typing, and some naming inconsistencies

## Tracking issue
Closes #5361 

## Why are the changes needed?
Removes error messages in when running the chart
```
coalesce.go:286: warning: cannot overwrite table with non table for flyte-core.flyteagent.podEnv (map[])
```

Adds missing ServiceAccounts to services. 
* This default service account has limited permissions and is generally not recommended for use in production environments
In our production clusters, we have governance that requires all Deployments must have an associated SA, this is currently preventing us from using the chart.

Adds the ability to override the service names.
* This makes it consistent with other charts like flyteagent
  * https://github.com/flyteorg/flyte/blob/master/charts/flyteagent/templates/_helpers.tpl#L17
* Our cluster governance has naming restrictions and this will allow us to use this chart

Changed FlyteClusterResourceSync Deployment name
* The names were hard coded
* There existed a template already in the _helpers file
* Labels did not match the resource names
* This allows for consistency across the services
* Note: Will delete and recreate the Deployment (not backwards compatible)

## What changes were proposed in this pull request?
Helper methods refactored to allow `nameOverride`.
Service Accounts added and applied to Deployments.
values.yaml default values updated to array from map as that is what is expected

## How was this patch tested?
Hand tested, I didn't see unit tests for the helm chart.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
