### PR TITLE
Fix flytectl demo start

### DIFF
--- a/flytectl/pkg/github/githubutil_test.go
+++ b/flytectl/pkg/github/githubutil_test.go
@@ -181,7 +181,7 @@ func TestGetUpgradeMessage(t *testing.T) {
 	stdlibversion.Version = "v0.2.10"
 	message, err := GetUpgradeMessage(version, darwin)
 	assert.Nil(t, err)
-	assert.Equal(t, 163, len(message))
+	assert.Equal(t, 154, len(message))
 
 	version = "v0.2.09"
 	message, err = GetUpgradeMessage(version, darwin)
@@ -196,10 +196,10 @@ func TestGetUpgradeMessage(t *testing.T) {
 	version = "v0.2.20"
 	message, err = GetUpgradeMessage(version, windows)
 	assert.Nil(t, err)
-	assert.Equal(t, 163, len(message))
+	assert.Equal(t, 154, len(message))
 
 	version = "v0.2.20"
 	message, err = GetUpgradeMessage(version, linux)
 	assert.Nil(t, err)
-	assert.Equal(t, 163, len(message))
+	assert.Equal(t, 154, len(message))
 }


### PR DESCRIPTION
## Why are the changes needed?
`flytectl demo start` fails with the newly released flytectl from the monorepo.

## What changes were proposed in this pull request?
Filter out the tags used to release flytectl in the command used to start the demo cluster.

Over the course of this I noticed that the self-upgrade command is no longer working, but this will be fixed in a separate PR as the github API we're using to list tags is not returning the prefixed tags (i.e. https://api.github.com/repos/flyteorg/flyte/tags doesn't return `flytectl/vX.Y.Z`).

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
I built a local binary of flytectl and was able to start sandbox.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
