### PR TITLE
Remove source code renderer section from Decks article

### DIFF
--- a/docs/user_guide/development_lifecycle/decks.md
+++ b/docs/user_guide/development_lifecycle/decks.md
@@ -186,20 +186,6 @@ Converts a Pandas dataframe into an HTML table.
 :class: with-shadow
 :::
 
-#### Source code renderer
-
-Converts source code to HTML and renders it as a Unicode string on the deck.
-
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/master/examples/development_lifecycle/development_lifecycle/decks.py
-:caption: development_lifecycle/decks.py
-:lines: 128-141
-```
-
-:::{figure} https://raw.githubusercontent.com/flyteorg/static-resources/main/flytesnacks/user_guide/flyte_decks_source_code_renderer.png
-:alt: Source code renderer
-:class: with-shadow
-:::
-
 ### Contribute to renderers
 
 Don't hesitate to integrate a new renderer into


### PR DESCRIPTION
## Why are the changes needed?

Removes reference to source code renderer from Decks doc since it was removed from flytesnacks example code in https://github.com/flyteorg/flytesnacks/pull/1674

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flytesnacks/pull/1674

## Docs link

TK
