### PR TITLE
Fix doc link to testing agent on local cluster

### DIFF
--- a/docs/flyte_agents/developing_agents.md
+++ b/docs/flyte_agents/developing_agents.md
@@ -133,7 +133,7 @@ class FileSensor(BaseSensor):
 
 ### 2. Test the agent
 
-You can test your agent in a {ref}`local Python environment <testing_agents_locally>` or in a {ref}<local development cluster `testing_agents_in_a_local_development_cluster`>.
+You can test your agent in a {ref}`local Python environment <testing_agents_locally>` or in a {ref}`local development cluster <testing_agents_in_a_local_development_cluster>`.
 
 ### 3. Build a new Docker image
 


### PR DESCRIPTION
Fix minor doc link issue found here: https://docs.flyte.org/en/latest/flyte_agents/developing_agents.html

<img width="813" alt="Screenshot 2024-05-20 at 3 25 40 PM" src="https://github.com/flyteorg/flyte/assets/1274471/3caec605-9dba-41dd-9409-cd6b665627bc">

