### PR TITLE
Update FlyterPropeller config to working config for flyte agent

### DIFF
--- a/docs/flyte_agents/developing_agents.md
+++ b/docs/flyte_agents/developing_agents.md
@@ -169,13 +169,26 @@ kubectl set image deployment/flyteagent flyteagent=ghcr.io/flyteorg/flyteagent:l
 2. Update the FlytePropeller configmap:
 
 ```YAML
- tasks:
-   task-plugins:
-     enabled-plugins:
-       - agent-service
-     default-for-task-types:
-       - bigquery_query_job_task: agent-service
-       - custom_task: agent-service
+plugins:
+  agent-service:
+    defaultAgent:
+      endpoint: dns:///flyteagent.<flyteagent namespace>.svc.cluster.local:8000
+    supportedTaskTypes:
+    - sensor
+    - custom_task
+tasks:
+  task-plugins:
+    default-for-task-types:
+      custom_task: agent-service
+      container: container
+      container_array: k8s-array
+      sensor: agent-service
+      sidecar: sidecar
+    enabled-plugins:
+    - container
+    - sidecar
+    - k8s-array
+    - agent-service
 ```
 
 3. Restart FlytePropeller:
@@ -193,7 +206,7 @@ By running agents independently, you can thoroughly test and validate your agent
 controlled environment before deploying them to the production cluster.
 
 By default, all agent requests will be sent to the default agent service. However,
-you can route particular task requests to designated agent services by adjusting the FlytePropeller configuration. 
+you can route particular task requests to designated agent services by adjusting the FlytePropeller configuration.
 
 ```yaml
  plugins:


### PR DESCRIPTION
This pull request updates the flyte agent documentation to include working FlytePropeller configurations when running a custom agent/task. The previous configuration did not configure the agent service endpoint for propeller and attempts to run custom tasks would result in the following log messages. This also formats the YAML to 2 space indent. 

```
❯ kubectl logs flytepropeller-5559db6f4d-bgpr7 -f | grep armada                                                                                                                                                            
{"json":{"exec_id":"f6bf36697f1a84994907","node":"examplesayhello","ns":"flytesnacks-development","res_ver":"32767965","routine":"worker-0","tasktype":"armada","wf":"flytesnacks:development:.flytegen.example.say_hello"},"level":"warning","msg":"No plugin found for Handler-type [armada], defaulting to [container]","ts":"2024-05-16T01:07:14Z"}
{"json":{"exec_id":"f6bf36697f1a84994907","node":"examplesayhello","ns":"flytesnacks-development","res_ver":"32767966","routine":"worker-0","tasktype":"armada","wf":"flytesnacks:development:.flytegen.example.say_hello"},"level":"warning","msg":"No plugin found for Handler-type [armada], defaulting to [container]","ts":"2024-05-16T01:07:14Z"}
```