### PR TITLE
docs(kubeflow): Fix kubeflow webhook error

### DIFF
--- a/docs/deployment/plugins/k8s/index.rst
+++ b/docs/deployment/plugins/k8s/index.rst
@@ -17,11 +17,11 @@ Select the integration you need and follow the steps to install the correspondin
 
   .. group-tab:: PyTorch/TensorFlow/MPI
 
-    1. Install the `Kubeflow training-operator <https://github.com/kubeflow/training-operator?tab=readme-ov-file#kubeflow-training-operator>`__:
+    1. Install the `Kubeflow training-operator <https://github.com/kubeflow/training-operator?tab=readme-ov-file#stable-release>`__ (Please install the stable release):
 
     .. code-block:: bash
 
-      kubectl apply -k "github.com/kubeflow/training-operator/manifests/overlays/standalone"
+      kubectl apply -k "github.com/kubeflow/training-operator/manifests/overlays/standalone?ref=v1.7.0"
 
     **Optional: Using a gang scheduler**
 


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?

When I tried to run a tensorflow task using `flytectl demo start --dev`, it throws the following exception

![image](https://github.com/flyteorg/flyte/assets/47914085/0c12d446-c512-43a7-99a4-05c471afb467)

## What changes were proposed in this pull request?

Install the stable release of kubeflow operator.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
