### PR TITLE
Update the example Flyte agent Dockerfile

### DIFF
--- a/docs/flyte_agents/developing_agents.md
+++ b/docs/flyte_agents/developing_agents.md
@@ -140,14 +140,13 @@ You can test your agent in a {ref}`local Python environment <testing_agents_loca
 The following is a sample Dockerfile for building an image for a Flyte agent:
 
 ```Dockerfile
-FROM python:3.9-slim-buster
+FROM python:3.10-slim-bookworm
 
 MAINTAINER Flyte Team <users@flyte.org>
 LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
 
-WORKDIR /root
-ENV PYTHONPATH /root
-
+# additional dependencies for running in k8s
+RUN pip install prometheus-client grpcio-health-checking
 # flytekit will autoload the agent if package is installed.
 RUN pip install flytekitplugins-bigquery
 CMD pyflyte serve agent --port 8000
@@ -193,7 +192,7 @@ By running agents independently, you can thoroughly test and validate your agent
 controlled environment before deploying them to the production cluster.
 
 By default, all agent requests will be sent to the default agent service. However,
-you can route particular task requests to designated agent services by adjusting the FlytePropeller configuration. 
+you can route particular task requests to designated agent services by adjusting the FlytePropeller configuration.
 
 ```yaml
  plugins:


### PR DESCRIPTION
This pull request brings the example agent dockerfile up to date with what is [used on master](https://github.com/flyteorg/flytekit/blob/master/Dockerfile.agent) such that it will run on k8s without blowing up. 

The prometheus-client module is required by the agent code and the health checking service is required for k8s health checking it seems. 