### PR TITLE
Inherit execution cluster label from source execution

### DIFF
--- a/flyteadmin/pkg/manager/impl/execution_manager.go
+++ b/flyteadmin/pkg/manager/impl/execution_manager.go
@@ -305,6 +305,12 @@ func (m *ExecutionManager) getInheritedExecMetadata(ctx context.Context, request
 	} else {
 		requestSpec.Metadata.Nesting = 1
 	}
+
+	// If the source execution has a cluster label, inherit it.
+	if sourceExecution.Spec.ExecutionClusterLabel != nil {
+		logger.Infof(ctx, "Inherited execution label from source execution [%+v]", sourceExecution.Spec.ExecutionClusterLabel.Value)
+		requestSpec.ExecutionClusterLabel = sourceExecution.Spec.ExecutionClusterLabel
+	}
 	return parentNodeExecutionID, sourceExecutionID, nil
 }
 

--- a/flyteadmin/pkg/manager/impl/execution_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/execution_manager_test.go
@@ -428,6 +428,7 @@ func TestCreateExecutionFromWorkflowNode(t *testing.T) {
 	)
 
 	getExecutionCalled := false
+	var clusterLabel = &admin.ExecutionClusterLabel{Value: executionClusterLabel}
 	repository.ExecutionRepo().(*repositoryMocks.MockExecutionRepo).SetGetCallback(
 		func(ctx context.Context, input interfaces.Identifier) (models.Execution, error) {
 			assert.EqualValues(t, input.Project, parentNodeExecutionID.ExecutionId.Project)
@@ -437,6 +438,7 @@ func TestCreateExecutionFromWorkflowNode(t *testing.T) {
 				Metadata: &admin.ExecutionMetadata{
 					Nesting: 1,
 				},
+				ExecutionClusterLabel: clusterLabel,
 			}
 			specBytes, _ := proto.Marshal(spec)
 			getExecutionCalled = true
@@ -462,6 +464,7 @@ func TestCreateExecutionFromWorkflowNode(t *testing.T) {
 			assert.EqualValues(t, input.SourceExecutionID, 2)
 			assert.Equal(t, 2, int(spec.Metadata.Nesting))
 			assert.Equal(t, principal, spec.Metadata.Principal)
+			assert.Equal(t, executionClusterLabel, spec.ExecutionClusterLabel.Value)
 			assert.Equal(t, principal, input.User)
 			return nil
 		},


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->
Today if a user creates an execution with the `execution-cluster-label`, then the execution launches in the specified cluster. However, if the workflow has a reference workflow in the workflow, that reference workflow launches in the default cluster since this information isn't passed along. This change fixes that issue by inheriting the cluster label from the source.

## Why are the changes needed?
Without this change, part of the workflow will run in cluster 1 and part in cluster 2.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## How was this patch tested?
In a local cluster, a workflow was launched with a reference workflow and the reference workflow launched in the correct cluster.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
