### PR TITLE
Fix flaky auto_refresh_test

### DIFF
--- a/flytestdlib/cache/auto_refresh_test.go
+++ b/flytestdlib/cache/auto_refresh_test.go
@@ -84,13 +84,13 @@ func TestCacheFour(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		// Wait half a second for all resync periods to complete
-		time.Sleep(500 * time.Millisecond)
-		for i := 1; i <= 10; i++ {
-			item, err := cache.Get(fmt.Sprintf("%d", i))
-			assert.NoError(t, err)
-			assert.Equal(t, 10, item.(fakeCacheItem).val)
-		}
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			for i := 1; i <= 10; i++ {
+				item, err := cache.Get(fmt.Sprintf("%d", i))
+				assert.NoError(c, err)
+				assert.Equal(c, 10, item.(fakeCacheItem).val)
+			}
+		}, 3*time.Second, 100*time.Millisecond)
 		cancel()
 	})
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
This test sometimes fail

## What changes were proposed in this pull request?
Use `EventuallyWithT` in the test
https://pkg.go.dev/github.com/stretchr/testify/assert#Assertions.EventuallyWithT

## How was this patch tested?
```bash
cd flytestdlib
go test ./cache/... -count 10
```
<img width="667" alt="Screenshot 2024-05-15 at 12 50 41 AM" src="https://github.com/unionai/flyte/assets/37936015/e3840835-d2ce-4869-9e7d-9f1bc03f58a1">

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
