### PR TITLE
Indicate that jq is now required to install flytectl via the script

### DIFF
--- a/flytectl/docs/source/overview.rst
+++ b/flytectl/docs/source/overview.rst
@@ -30,6 +30,9 @@ Flytectl is a Golang binary that can be installed on any platform supported by G
 
     .. tab-item:: Other Operating systems
 
+      .. warning::
+          `jq <https://jqlang.github.io/jq>`_ is a dependency of this script.
+
       .. prompt:: bash $
 
           curl -sL https://ctl.flyte.org/install | bash


### PR DESCRIPTION
## Why are the changes needed?
After we moved flytectl to the monorepo we require `jq` to be installed to be able to filter out unwanted [Flyte releases](https://github.com/flyteorg/flyte/releases).
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
This PR just adds a warning to the "Other Operating Systems" tab in the docs.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
I tried generating the docs locally, but failed.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
