### PR TITLE
Include group in apiVersion in plugin_collector

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_collector.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_collector.go
@@ -52,7 +52,7 @@ func (r *ResourceLevelMonitor) collect(ctx context.Context) {
 	list := metav1.PartialObjectMetadataList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       r.gvk.Kind,
-			APIVersion: r.gvk.Version,
+			APIVersion: r.gvk.GroupVersion().String(),
 		},
 	}
 	if err := r.cache.List(ctx, &list); err != nil {


### PR DESCRIPTION
## Tracking issue

Closes #5429
## Why are the changes needed?

Correctly sets apiVersion to include group; fixes the `failed to list objects for ...` warning in `collect`

## What changes were proposed in this pull request?

`ResourceLevelMonitor` includes `schema.GroupVersionKind` (gvk). The changes here correctly set the `apiVersion` in `collect` by utilizing `gvk.GroupVersion().String()`, which puts "group" and "version" into a single "group/version" string 

https://github.com/kubernetes/apimachinery/blob/703232ea6da48aed7ac22260dabc6eac01aab896/pkg/runtime/schema/group_version.go#L178-L182

## How was this patch tested?

Built flytepropeller image with this change, deployed, ensured resources were correctly listed and ensured the aforementioned warning didn't appear.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
