### PR TITLE
Make BaseURL insensitive to trailing slashes for metadata endpoint redirect.

### DIFF
--- a/flyteadmin/auth/handlers.go
+++ b/flyteadmin/auth/handlers.go
@@ -484,7 +484,7 @@ func QueryUserInfoUsingAccessToken(ctx context.Context, originalRequest *http.Re
 // See https://tools.ietf.org/html/rfc8414 for more information.
 func GetOIdCMetadataEndpointRedirectHandler(ctx context.Context, authCtx interfaces.AuthenticationContext) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		metadataURL := authCtx.Options().UserAuth.OpenID.BaseURL.ResolveReference(authCtx.GetOIdCMetadataURL())
+		metadataURL := authCtx.Options().UserAuth.OpenID.BaseURL.JoinPath("/").ResolveReference(authCtx.GetOIdCMetadataURL())
 		http.Redirect(writer, request, metadataURL.String(), http.StatusSeeOther)
 	}
 }

--- a/flyteadmin/auth/handlers_test.go
+++ b/flyteadmin/auth/handlers_test.go
@@ -449,24 +449,60 @@ func TestGetHTTPRequestCookieToMetadataHandler_CustomHeader(t *testing.T) {
 
 func TestGetOIdCMetadataEndpointRedirectHandler(t *testing.T) {
 	ctx := context.Background()
-	metadataPath := mustParseURL(t, OIdCMetadataEndpoint)
-	mockAuthCtx := mocks.AuthenticationContext{}
-	mockAuthCtx.OnOptions().Return(&config.Config{
-		UserAuth: config.UserAuthConfig{
-			OpenID: config.OpenIDOptions{
-				BaseURL: stdConfig.URL{URL: mustParseURL(t, "http://www.google.com")},
-			},
+	type test struct {
+		name                     string
+		baseUrl                  string
+		metadataPath             string
+		expectedRedirectLocation string
+	}
+	tests := []test{
+		{
+			name:                     "base_url_without_path",
+			baseUrl:                  "http://www.google.com",
+			metadataPath:             OIdCMetadataEndpoint,
+			expectedRedirectLocation: "http://www.google.com/.well-known/openid-configuration",
 		},
-	})
+		{
+			name:                     "base_url_with_path",
+			baseUrl:                  "https://login.microsoftonline.com/abc/v2.0",
+			metadataPath:             OIdCMetadataEndpoint,
+			expectedRedirectLocation: "https://login.microsoftonline.com/abc/v2.0/.well-known/openid-configuration",
+		},
+		{
+			name:                     "base_url_with_trailing_slash_path",
+			baseUrl:                  "https://login.microsoftonline.com/abc/v2.0/",
+			metadataPath:             OIdCMetadataEndpoint,
+			expectedRedirectLocation: "https://login.microsoftonline.com/abc/v2.0/.well-known/openid-configuration",
+		},
+		{
+			name:                     "absolute_metadata_path",
+			baseUrl:                  "https://login.microsoftonline.com/abc/v2.0/",
+			metadataPath:             "/.well-known/openid-configuration",
+			expectedRedirectLocation: "https://login.microsoftonline.com/.well-known/openid-configuration",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadataPath := mustParseURL(t, tt.metadataPath)
+			mockAuthCtx := mocks.AuthenticationContext{}
+			mockAuthCtx.OnOptions().Return(&config.Config{
+				UserAuth: config.UserAuthConfig{
+					OpenID: config.OpenIDOptions{
+						BaseURL: stdConfig.URL{URL: mustParseURL(t, tt.baseUrl)},
+					},
+				},
+			})
 
-	mockAuthCtx.OnGetOIdCMetadataURL().Return(&metadataPath)
-	handler := GetOIdCMetadataEndpointRedirectHandler(ctx, &mockAuthCtx)
-	req, err := http.NewRequest("GET", "/xyz", nil)
-	assert.NoError(t, err)
-	w := httptest.NewRecorder()
-	handler(w, req)
-	assert.Equal(t, http.StatusSeeOther, w.Code)
-	assert.Equal(t, "http://www.google.com/.well-known/openid-configuration", w.Header()["Location"][0])
+			mockAuthCtx.OnGetOIdCMetadataURL().Return(&metadataPath)
+			handler := GetOIdCMetadataEndpointRedirectHandler(ctx, &mockAuthCtx)
+			req, err := http.NewRequest("GET", "/xyz", nil)
+			assert.NoError(t, err)
+			w := httptest.NewRecorder()
+			handler(w, req)
+			assert.Equal(t, http.StatusSeeOther, w.Code)
+			assert.Equal(t, tt.expectedRedirectLocation, w.Header()["Location"][0])
+		})
+	}
 }
 
 func TestUserInfoForwardResponseHander(t *testing.T) {

--- a/flyteadmin/auth/handlers_test.go
+++ b/flyteadmin/auth/handlers_test.go
@@ -451,32 +451,32 @@ func TestGetOIdCMetadataEndpointRedirectHandler(t *testing.T) {
 	ctx := context.Background()
 	type test struct {
 		name                     string
-		baseUrl                  string
+		baseURL                  string
 		metadataPath             string
 		expectedRedirectLocation string
 	}
 	tests := []test{
 		{
 			name:                     "base_url_without_path",
-			baseUrl:                  "http://www.google.com",
+			baseURL:                  "http://www.google.com",
 			metadataPath:             OIdCMetadataEndpoint,
 			expectedRedirectLocation: "http://www.google.com/.well-known/openid-configuration",
 		},
 		{
 			name:                     "base_url_with_path",
-			baseUrl:                  "https://login.microsoftonline.com/abc/v2.0",
+			baseURL:                  "https://login.microsoftonline.com/abc/v2.0",
 			metadataPath:             OIdCMetadataEndpoint,
 			expectedRedirectLocation: "https://login.microsoftonline.com/abc/v2.0/.well-known/openid-configuration",
 		},
 		{
 			name:                     "base_url_with_trailing_slash_path",
-			baseUrl:                  "https://login.microsoftonline.com/abc/v2.0/",
+			baseURL:                  "https://login.microsoftonline.com/abc/v2.0/",
 			metadataPath:             OIdCMetadataEndpoint,
 			expectedRedirectLocation: "https://login.microsoftonline.com/abc/v2.0/.well-known/openid-configuration",
 		},
 		{
 			name:                     "absolute_metadata_path",
-			baseUrl:                  "https://login.microsoftonline.com/abc/v2.0/",
+			baseURL:                  "https://login.microsoftonline.com/abc/v2.0/",
 			metadataPath:             "/.well-known/openid-configuration",
 			expectedRedirectLocation: "https://login.microsoftonline.com/.well-known/openid-configuration",
 		},
@@ -488,7 +488,7 @@ func TestGetOIdCMetadataEndpointRedirectHandler(t *testing.T) {
 			mockAuthCtx.OnOptions().Return(&config.Config{
 				UserAuth: config.UserAuthConfig{
 					OpenID: config.OpenIDOptions{
-						BaseURL: stdConfig.URL{URL: mustParseURL(t, tt.baseUrl)},
+						BaseURL: stdConfig.URL{URL: mustParseURL(t, tt.baseURL)},
 					},
 				},
 			})


### PR DESCRIPTION
## Tracking issue

Example: Closes #5456


## Why are the changes needed?

Fixes resolution of OpenID metadata URL redirect.

Without the change tests would fail:
```
expected: "https://login.microsoftonline.com/abc/v2.0/.well-known/openid-configuration"
actual  : "https://login.microsoftonline.com/abc/.well-known/openid-configuration"
```

## What changes were proposed in this pull request?

Append a trailing slash to `BaseURL` before running `ResolveReference`

## How was this patch tested?

Unit tests only.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
