### PR TITLE
Disable agent-service plugin in binary helm chart since service agent is disabled by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ go-tidy:
 
 .PHONY: lint-helm-charts
 lint-helm-charts:
-	# This pressuposes that you have act installed
+	# This presupposes that you have act installed
 	act pull_request -W .github/workflows/validate-helm-charts.yaml --container-architecture linux/amd64 -e charts/event.json
 
 .PHONY: spellcheck

--- a/charts/flyte-binary/README.md
+++ b/charts/flyte-binary/README.md
@@ -111,9 +111,9 @@ Chart for basic single Flyte executable deployment
 | deployment.waitForDB.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.waitForDB.image.repository | string | `"postgres"` |  |
 | deployment.waitForDB.image.tag | string | `"15-alpine"` |  |
-| enabled_plugins.tasks | object | `{"task-plugins":{"default-for-task-types":{"container":"container","container_array":"k8s-array","sidecar":"sidecar"},"enabled-plugins":["container","sidecar","k8s-array","agent-service"]}}` | Tasks specific configuration [structure](https://pkg.go.dev/github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/config#GetConfig) |
-| enabled_plugins.tasks.task-plugins | object | `{"default-for-task-types":{"container":"container","container_array":"k8s-array","sidecar":"sidecar"},"enabled-plugins":["container","sidecar","k8s-array","agent-service"]}` | Plugins configuration, [structure](https://pkg.go.dev/github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/config#TaskPluginConfig) |
-| enabled_plugins.tasks.task-plugins.enabled-plugins | list | `["container","sidecar","k8s-array","agent-service"]` | [Enabled Plugins](https://pkg.go.dev/github.com/lyft/flyteplugins/go/tasks/config#Config). Enable sagemaker*, athena if you install the backend plugins |
+| enabled_plugins.tasks | object | `{"task-plugins":{"default-for-task-types":{"container":"container","container_array":"k8s-array","sidecar":"sidecar"},"enabled-plugins":["container","sidecar","k8s-array"]}}` | Tasks specific configuration [structure](https://pkg.go.dev/github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/config#GetConfig) |
+| enabled_plugins.tasks.task-plugins | object | `{"default-for-task-types":{"container":"container","container_array":"k8s-array","sidecar":"sidecar"},"enabled-plugins":["container","sidecar","k8s-array"]}` | Plugins configuration, [structure](https://pkg.go.dev/github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/config#TaskPluginConfig) |
+| enabled_plugins.tasks.task-plugins.enabled-plugins | list | `["container","sidecar","k8s-array"]` | [Enabled Plugins](https://pkg.go.dev/github.com/lyft/flyteplugins/go/tasks/config#Config). Enable sagemaker*, athena if you install the backend plugins |
 | flyte-core-components.admin.disableClusterResourceManager | bool | `false` |  |
 | flyte-core-components.admin.disableScheduler | bool | `false` |  |
 | flyte-core-components.admin.disabled | bool | `false` |  |

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -398,7 +398,8 @@ enabled_plugins:
         - container
         - sidecar
         - k8s-array
-        - agent-service
+        # -- Uncomment to enable agent service plugin in Propeller
+        # - agent-service
       default-for-task-types:
         container: container
         sidecar: sidecar

--- a/deployment/sandbox-binary/flyte_sandbox_binary_helm_generated.yaml
+++ b/deployment/sandbox-binary/flyte_sandbox_binary_helm_generated.yaml
@@ -108,7 +108,6 @@ data:
         - container
         - sidecar
         - k8s-array
-        - agent-service
     plugins:
       logs:
         kubernetes-enabled: false
@@ -358,7 +357,7 @@ spec:
         app.kubernetes.io/instance: flyte
         app.kubernetes.io/component: flyte-binary
       annotations:
-        checksum/configuration: 7a09cfb8462408d773931b8f8fcf2e3c352c7cdcdfa5909bc04c9661041cf4af
+        checksum/configuration: f28b24eab6ae9fa2034ff90ab6b5a39241ecdaf75db9dbbb24c797b1f2e12727
         checksum/configuration-secret: d5d93f4e67780b21593dc3799f0f6682aab0765e708e4020939975d14d44f929
         checksum/cluster-resource-templates: 7dfa59f3d447e9c099b8f8ffad3af466fecbc9cf9f8c97295d9634254a55d4ae
     spec:

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -448,7 +448,6 @@ data:
         - container
         - sidecar
         - k8s-array
-        - agent-service
     plugins:
       logs:
         kubernetes-enabled: true


### PR DESCRIPTION
## Why are the changes needed?

This fixes an issue found where the Flyte sandbox workflow causes propeller to panic on startup. The cause of this panic is that propeller is attempting to initialize the agent plugin when the agent service is down (by default). Requests to the agent service to retrieve the list of supported tasks fails with a timeout.

```go
{"json":{"src":"entrypoint.go:56"},"level":"info","msg":"Started propeller webhook","ts":"2024-06-08T00:43:17Z"}
panic: failed to initialize agent registry with error: failed to list agent: [&{dns:///flyteagent.flyte.svc.cluster.local:8000 true  map[gettask:10s] 10s}] with error: [rpc error: code = DeadlineExceeded desc = context deadline exceeded]

goroutine 32 [running]:
github.com/flyteorg/flyte/flyteplugins/go/tasks/plugins/webapi/agent.newAgentPlugin()
        /flyteorg/build/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go:378 +0x45a
github.com/flyteorg/flyte/flyteplugins/go/tasks/plugins/webapi/agent.RegisterAgentPlugin()
        /flyteorg/build/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go:403 +0xa5
github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task.WranglePluginsAndGenerateFinalList.func1()
        /flyteorg/build/flytepropeller/pkg/controller/nodes/task/plugin_config.go:28 +0xf
sync.(*Once).doSlow(0x0?, 0x1000100?)
        /usr/local/go/src/sync/once.go:74 +0xbf
sync.(*Once).Do(...)
        /usr/local/go/src/sync/once.go:65
github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task.WranglePluginsAndGenerateFinalList({0x4302f80, 0xc00089ad70}, 0xc000773980, {0x7fc2084a7118, 0x5f3af40}, {0x43359c8?, 0xc00137f520})
        /flyteorg/build/flytepropeller/pkg/controller/nodes/task/plugin_config.go:28 +0xac
github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task.(*Handler).Setup(0xc000903450, {0x4302f80, 0xc00089ad70}, {0x42f6930?, 0xc0009d2600})
        /flyteorg/build/flytepropeller/pkg/controller/nodes/task/handler.go:231 +0x191
github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/factory.(*handlerFactory).Setup(0xc000157b80, {0x4302f80, 0xc00089ad70}, {0x430f480?, 0xc000816320}, {0x42f6930, 0xc0009d2600})
        /flyteorg/build/flytepropeller/pkg/controller/nodes/factory/handler_factory.go:73 +0x81f
github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes.(*recursiveNodeExecutor).Initialize(0xc000816320, {0x4302f80, 0xc00089ad70})
        /flyteorg/build/flytepropeller/pkg/controller/nodes/executor.go:464 +0xbf
github.com/flyteorg/flyte/flytepropeller/pkg/controller/workflow.(*workflowExecutor).Initialize(0xc000482500, {0x4302f80, 0xc00089ad70})
        /flyteorg/build/flytepropeller/pkg/controller/workflow/executor.go:385 +0x59
github.com/flyteorg/flyte/flytepropeller/pkg/controller.(*Propeller).Initialize(0x4302f80?, {0x4302f80?, 0xc00089ad70?})
        /flyteorg/build/flytepropeller/pkg/controller/handler.go:83 +0x26
github.com/flyteorg/flyte/flytepropeller/pkg/controller.(*WorkerPool).Initialize(...)
        /flyteorg/build/flytepropeller/pkg/controller/workers.go:121
github.com/flyteorg/flyte/flytepropeller/pkg/controller.(*Controller).run(0xc0005871f0, {0x4302f80, 0xc00089ad70})
        /flyteorg/build/flytepropeller/pkg/controller/controller.go:109 +0x82
github.com/flyteorg/flyte/flytepropeller/pkg/controller.(*Controller).Run(0xc0005871f0, {0x4302f80?, 0xc00089ad70})
        /flyteorg/build/flytepropeller/pkg/controller/controller.go:96 +0x119
github.com/flyteorg/flyte/flytepropeller/pkg/controller.StartController({0x4302f80?, 0xc00089acd0?}, 0xc000830000, {0x343e1f4, 0x3}, {0x431e3c0?, 0xc00137e680}, 0xc001408000)
        /flyteorg/build/flytepropeller/pkg/controller/controller.go:612 +0x5b4
github.com/flyteorg/flyte/cmd/single.startPropeller.func2()
        /flyteorg/build/cmd/single/start.go:167 +0x94
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:78 +0x56
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 82
        /go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:75 +0x96
```

## What changes were proposed in this pull request?

This change remove the agent service from the enabled plugin list considering that the flyte agent service is disabled by default. 

## How was this patch tested?

See generated Kubernetes manifests.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.
