### PR TITLE
fix(migrations): Correct NULL to empty string in SQL insert

### DIFF
--- a/.github/workflows/single-binary.yml
+++ b/.github/workflows/single-binary.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flytekit flytekitplugins-deck-standard
+          pip install flytekit flytekitplugins-deck-standard "numpy<2.0.0"
           pip freeze
       - name: Checkout flytesnacks
         uses: actions/checkout@v4

--- a/flyteadmin/pkg/repositories/config/migrations.go
+++ b/flyteadmin/pkg/repositories/config/migrations.go
@@ -1250,7 +1250,7 @@ var ContinuedMigrations = []*gormigrate.Migration{
 				// Drop execution_admin_tags and admin_tags tables, and create a new table execution_tags
 				// to store tags associated with executions.
 				sql := "INSERT INTO execution_tags (execution_project, execution_domain, execution_name, created_at, updated_at, deleted_at, key, value)" +
-					" SELECT execution_project, execution_domain, execution_name, created_at, updated_at, deleted_at, name as key, null as value" +
+					" SELECT execution_project, execution_domain, execution_name, created_at, updated_at, deleted_at, name as key, '' as value" +
 					" FROM execution_admin_tags" +
 					" INNER JOIN admin_tags a on execution_admin_tags.admin_tag_id = a.id;"
 				if err := tx.Exec(sql).Error; err != nil {


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
`value` is a primary key in the execution_tag table, so we can't insert a NULL value into that column. 

## What changes were proposed in this pull request?
Insert an empty string instead.

## How was this patch tested?
local sandbox 

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
