### PR TITLE
Flyte core webhook pod settings should be separate

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -296,6 +296,10 @@ helm install gateway bitnami/contour -n flyte
 | storage.s3.secretKey | string | `""` | AWS IAM user secret access key to use for S3 bucket auth, only used if authType is set to accesskey |
 | storage.type | string | `"sandbox"` | Sets the storage type. Supported values are sandbox, s3, gcs and custom. |
 | webhook.enabled | bool | `true` | enable or disable secrets webhook |
+| webhook.nodeSelector | object | `{}` | nodeSelector for webhook deployment |
+| webhook.podAnnotations | object | `{}` | Annotations for webhook pods |
+| webhook.podEnv | object | `{}` | Additional webhook container environment variables |
+| webhook.podLabels | object | `{}` | Labels for webhook pods |
 | webhook.priorityClassName | string | `""` | Sets priorityClassName for webhook pod |
 | webhook.resources.requests.cpu | string | `"200m"` |  |
 | webhook.resources.requests.ephemeral-storage | string | `"500Mi"` |  |

--- a/charts/flyte-core/templates/propeller/webhook.yaml
+++ b/charts/flyte-core/templates/propeller/webhook.yaml
@@ -26,12 +26,12 @@ spec:
         app: {{ template "flyte-pod-webhook.name" . }}
         app.kubernetes.io/name: {{ template "flyte-pod-webhook.name" . }}
         app.kubernetes.io/version: {{ .Values.flytepropeller.image.tag }}
-        {{- with .Values.flytepropeller.podLabels }}
+        {{- with .Values.webhook.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
         configChecksum: {{ include (print .Template.BasePath "/propeller/configmap.yaml") . | sha256sum | trunc 63 | quote }}
-        {{- with .Values.flytepropeller.podAnnotations }}
+        {{- with .Values.webhook.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -63,8 +63,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-        {{- if .Values.flytepropeller.podEnv -}}
-        {{- with .Values.flytepropeller.podEnv -}}
+        {{- if .Values.webhook.podEnv -}}
+        {{- with .Values.webhook.podEnv -}}
         {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- end }}
@@ -95,8 +95,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-        {{- if .Values.flytepropeller.podEnv -}}
-        {{- with .Values.flytepropeller.podEnv -}}
+        {{- if .Values.webhook.podEnv -}}
+        {{- with .Values.webhook.podEnv -}}
         {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- end }}
@@ -123,7 +123,7 @@ spec:
         - name: webhook-certs
           secret:
             secretName: flyte-pod-webhook
-      {{- with .Values.flytepropeller.nodeSelector }}
+      {{- with .Values.webhook.nodeSelector }}
       nodeSelector: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
 ---

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -477,6 +477,14 @@ webhook:
     annotations:
       projectcontour.io/upstream-protocol.h2c: grpc
     type: ClusterIP
+  # -- Annotations for webhook pods
+  podAnnotations: {}
+  # -- Additional webhook container environment variables
+  podEnv: {}
+  # -- Labels for webhook pods
+  podLabels: {}
+  # -- nodeSelector for webhook deployment
+  nodeSelector: {}
   # -- Sets securityContext for webhook pod(s).
   securityContext:
     fsGroup: 65534


### PR DESCRIPTION
## Why are the changes needed?

 - Previously, the webhook was sharing some pod level settings in the core chart with flytepropeller like:

   * podAnnotations
   * podEnv
   * podLabels
   * nodeSelector

   Since the webhook runs a separate pod, it should have separate
   settings. This allows for independently adding annotations, like for configuring Prometheus. propeller has a /metrics endpoint, while webhook does not.


NOTE: this isn't backwards compatible, but I also think it's a fairly minor issue that can be covered in docs. I suspect there aren't currently many users here and some of these were not introduced not long ago (as part of https://github.com/flyteorg/flyte/pull/4756)

## What changes were proposed in this pull request?

Moves webhook level settings to their own section

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
