### PR TITLE
Use uv in single-binary CI

### DIFF
--- a/.github/workflows/single-binary.yml
+++ b/.github/workflows/single-binary.yml
@@ -174,8 +174,9 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flytekit flytekitplugins-deck-standard flytekitplugins-envd "numpy<2.0.0"
-          pip freeze
+          pip install uv
+          uv pip install --system flytekit flytekitplugins-deck-standard flytekitplugins-envd "numpy<2.0.0"
+          uv pip freeze
       - name: Checkout flytesnacks
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
We spend between 1 and 2 minutes installing python packages to run single-binary tests. Let's cut that to 1 second.

## What changes were proposed in this pull request?
Use uv to install flytekit and other dependencies necessary to run functional tests in single-binary.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
