### PR TITLE
Fix: replace `uctl` with  `flytectl` in OSS docs

### DIFF
--- a/flytectl/cmd/update/project.go
+++ b/flytectl/cmd/update/project.go
@@ -73,7 +73,7 @@ For example, to archive a project:
 
 ::
 
-    $ uctl update project --file update.yaml --archive
+    $ flytectl update project --file update.yaml --archive
 
 And to activate (unarchive) the same project:
 
@@ -85,7 +85,7 @@ And to activate (unarchive) the same project:
 
 ::
 
-    $ uctl update project --file update.yaml --archive
+    $ flytectl update project --file update.yaml --archive
 
 Note that when using a *yaml* file, the *activate* flag is not used.
 Instead, the *archive* flag is used for *both* archiving and activating (unarchiving) with the difference being in the *state* field of the *yaml* file.

--- a/flytectl/docs/source/gen/flytectl_update_project.rst
+++ b/flytectl/docs/source/gen/flytectl_update_project.rst
@@ -67,7 +67,7 @@ For example, to archive a project:
 
 ::
 
-    $ uctl update project --file update.yaml --archive
+    $ flytectl update project --file update.yaml --archive
 
 And to activate (unarchive) the same project:
 
@@ -79,7 +79,7 @@ And to activate (unarchive) the same project:
 
 ::
 
-    $ uctl update project --file update.yaml --archive
+    $ flytectl update project --file update.yaml --archive
 
 Note that when using a *yaml* file, the *activate* flag is not used.
 Instead, the *archive* flag is used for *both* archiving and activating (unarchiving) with the difference being in the *state* field of the *yaml* file.


### PR DESCRIPTION
## Why are the changes needed?

OSS docs mention `uctl` ([cli for Union.ai](https://github.com/unionai/uctl)) instead of `flytectl` in two locations.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
