### PR TITLE
Doc: Explain how lifetime of logging links is configured

### DIFF
--- a/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
+++ b/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
@@ -88,7 +88,7 @@ However, not all task types use the log plugin; for example, the Snowflake plugi
 
 ### Configure lifetime of logging links
 
-By default, log links are shown once a task starts running and do not disappear when the task finishes. Certain log links might, however, be helpful already when a task is still queued or initializing, for instance, to debug why a task might not be able to start. Other log links might not be valid anymore once the task terminates. You can configure the lifetime of log links in the following way:
+By default, log links are shown once a task starts running and do not disappear when the task finishes. Certain log links might, however, be helpful when a task is still queued or initializing, for instance, to debug why a task might not be able to start. Other log links might not be valid anymore once the task terminates. You can configure the lifetime of log links in the following way:
 
 ```yaml
 task_logs:

--- a/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
+++ b/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
@@ -88,7 +88,7 @@ However, not all task types use the log plugin; for example, the Snowflake plugi
 
 ### Configure lifetime of logging links
 
-By default, log links are shown once a task starts running and do not disappear. Certain log links might be helpful already when a task is still queued or initializing, for instance, to debug why a task might not be able to start. Other log links might not be valid anymore once the task terminates. You can configure the lifetime of log links in the following way:
+By default, log links are shown once a task starts running and do not disappear when the task finishes. Certain log links might, however, be helpful already when a task is still queued or initializing, for instance, to debug why a task might not be able to start. Other log links might not be valid anymore once the task terminates. You can configure the lifetime of log links in the following way:
 
 ```yaml
 task_logs:

--- a/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
+++ b/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
@@ -86,6 +86,22 @@ Flytepropeller pod would be created as:
 This code snippet will output two logs per task that use the log plugin.
 However, not all task types use the log plugin; for example, the Snowflake plugin will use a link to the Snowflake console.
 
+### Configure lifetime of logging links
+
+By default, log links are shown once a task starts running and do not disappear. Certain log links might be helpful already when a task is still queued or initializing, for instance, to debug why a task might not be able to start. Other log links might not be valid anymore once the task terminates. You can configure the lifetime of log links in the following way:
+
+```yaml
+task_logs:
+  plugins:
+    logs:
+      templates:
+        - displayName: <name-to-show>
+          hideOnceFinished: true
+          showWhilePending: true
+          templateUris:
+            - "https://..."
+```
+
 ## Datadog integration
 
 To send your Flyte workflow logs to Datadog, you can follow these steps:


### PR DESCRIPTION
## Why are the changes needed?

In https://github.com/flyteorg/flyte/pull/4726 I added config options to log links to allow showing certain log links during the queueing/initializing phase or to hide them once the task terminates.

This PR documents these configuration options.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
