### PR TITLE
Doc: Fix link to install scheduler plugins as gang scheduler for kubeflow plugins

### DIFF
--- a/docs/deployment/plugins/k8s/index.rst
+++ b/docs/deployment/plugins/k8s/index.rst
@@ -32,7 +32,7 @@ Select the integration you need and follow the steps to install the correspondin
     To enable gang scheduling for the ``training-operator``:
 
     a. Select a second scheduler from 
-    `Kubernetes scheduler plugins with co-scheduling <https://www.kubeflow.org/docs/components/training/job-scheduling/#running-jobs-with-gang-scheduling>`__
+    `Kubernetes scheduler plugins with co-scheduling <https://www.kubeflow.org/docs/components/training/user-guides/job-scheduling/#scheduler-plugins-with-coscheduling>`__
     or `Apache YuniKorn <https://yunikorn.apache.org/docs/next/user_guide/workloads/run_tf/>`__ .
 
     b. Configure a Flyte ``PodTemplate`` to use the gang scheduler for your Tasks:


### PR DESCRIPTION
The current link gives 404.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

