### PR TITLE
chore: update runllm widget configuration

### DIFF
--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -106,10 +106,9 @@
       });
     </script>
     <!-- RunLLM Configuration -->
-    <script defer id="runllm-widget-script" type="module" src='https://cdn.jsdelivr.net/npm/@runllm/search-widget@stable/dist/run-llm-search-widget.es.js'
+    <script defer id="runllm-widget-script" type="module" src="https://widget.runllm.com"
       runllm-server-address="https://api.runllm.com" runllm-assistant-id="60" runllm-position="BOTTOM_RIGHT"
       runllm-keyboard-shortcut="Mod+j"
-      version="stable"
       runllm-slack-community-url="https://flyte-org.slack.com/join/shared_invite/zt-2eq2fgs5f-UGUWnMYVB9agervilmlyaw#/shared-invite/email"
       runllm-name="RunLLM" />
   </head>


### PR DESCRIPTION
## Why are the changes needed?

This PR updates the RunLLM widget configuration to use our new widget.runllm.com url. 

## How was this patch tested?

Tested by adding URL to the docs site and making sure that the docs widget renders.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

If you would like to test in a staging domain, please let me know so I can add to our ReCAPTCHA validation.

This change is really just updating where you get the latest bits of the runllm widget from.


- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
