### PR TITLE
Remove confusing prometheus configuration options in helm charts 

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -246,8 +246,6 @@ helm install gateway bitnami/contour -n flyte
 | flytepropeller.podLabels | object | `{}` | Labels for Flytepropeller pods |
 | flytepropeller.priorityClassName | string | `""` | Sets priorityClassName for propeller pod(s). |
 | flytepropeller.prometheus.enabled | bool | `false` |  |
-| flytepropeller.prometheus.path | string | `"/metrics"` |  |
-| flytepropeller.prometheus.port | int | `10254` |  |
 | flytepropeller.replicaCount | int | `1` | Replicas count for Flytepropeller deployment |
 | flytepropeller.resources | object | `{"limits":{"cpu":"200m","ephemeral-storage":"100Mi","memory":"200Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"100Mi"}}` | Default resources requests and limits for Flytepropeller deployment |
 | flytepropeller.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsUser":1001}` | Sets securityContext for flytepropeller pod(s). |
@@ -323,8 +321,6 @@ helm install gateway bitnami/contour -n flyte
 | webhook.podLabels | object | `{}` | Labels for webhook pods |
 | webhook.priorityClassName | string | `""` | Sets priorityClassName for webhook pod |
 | webhook.prometheus.enabled | bool | `false` |  |
-| webhook.prometheus.path | string | `"/metrics"` |  |
-| webhook.prometheus.port | int | `10254` |  |
 | webhook.resources.requests.cpu | string | `"200m"` |  |
 | webhook.resources.requests.ephemeral-storage | string | `"500Mi"` |  |
 | webhook.resources.requests.memory | string | `"500Mi"` |  |

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -25,8 +25,8 @@ spec:
         {{- with .Values.flytepropeller.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        prometheus.io/path: {{ .Values.flytepropeller.prometheus.path | quote }}
-        prometheus.io/port: {{ .Values.flytepropeller.prometheus.port | quote }}
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: {{ index .Values.configmap.core.propeller "prof-port" | quote }}
         {{- with .Values.flytepropeller.prometheus.enabled }}
         prometheus.io/scrape: "true"
         {{- end }}
@@ -83,11 +83,6 @@ spec:
         {{- end }}
         ports:
         - containerPort: {{ index .Values.configmap.core.propeller "prof-port" }}
-        {{- if .Values.flytepropeller.prometheus.enabled }}
-        - containerPort: {{ .Values.flytepropeller.prometheus.port }}
-          name: debug
-          protocol: TCP
-        {{- end }}
         resources: {{- toYaml .Values.flytepropeller.resources | nindent 10 }}
         volumeMounts:
         - name: config-volume

--- a/charts/flyte-core/templates/propeller/service.yaml
+++ b/charts/flyte-core/templates/propeller/service.yaml
@@ -10,7 +10,7 @@ spec:
   ports:
     - name: http-metrics
       protocol: TCP
-      port: 10254
+      port: {{ index .Values.configmap.core.propeller "prof-port" }}
     {{- with .Values.flytepropeller.service.additionalPorts -}}
     {{ tpl (toYaml .) $ | nindent 4 }}
     {{- end }}

--- a/charts/flyte-core/templates/propeller/webhook.yaml
+++ b/charts/flyte-core/templates/propeller/webhook.yaml
@@ -34,8 +34,8 @@ spec:
         {{- with .Values.webhook.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        prometheus.io/path: {{ .Values.webhook.prometheus.path | quote }}
-        prometheus.io/port: {{ .Values.webhook.prometheus.port | quote }}
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: {{ index .Values.configmap.core.propeller "prof-port" | quote }}
         {{- with .Values.webhook.prometheus.enabled }}
         prometheus.io/scrape: "true"
         {{- end }}
@@ -108,7 +108,7 @@ spec:
           ports:
           - containerPort: 9443
           {{- if .Values.webhook.prometheus.enabled }}
-          - containerPort: {{ .Values.webhook.prometheus.port }}
+          - containerPort: {{ index .Values.configmap.core.propeller "prof-port" }}
             name: debug
             protocol: TCP
           {{- end }}

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -386,8 +386,6 @@ flytepropeller:
 
   prometheus:
     enabled: false
-    path: "/metrics"
-    port: 10254
 
 #
 # FLYTECONSOLE SETTINGS
@@ -541,8 +539,6 @@ webhook:
 
   prometheus:
     enabled: false
-    path: "/metrics"
-    port: 10254
 
 # ------------------------------------------------
 #

--- a/docker/sandbox-bundled/manifests/complete-agent.yaml
+++ b/docker/sandbox-bundled/manifests/complete-agent.yaml
@@ -816,7 +816,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: N0UzdzZRdHl3d3BrTEJiSA==
+  haSharedSecret: Q0ZnbUcxY3JESlA3STBlMQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1413,7 +1413,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: c93bd6fe573f912d3b4f9a513f9167aba07ec884ffe278546cb406b53e3eafbe
+        checksum/secret: 1555bf28ba6c50774866aa7d150e4ec727928e2015cfaf55f15d1520fc573f8d
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -796,7 +796,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: SVVWTlJreURYWWZZcGNBUA==
+  haSharedSecret: UHhidW1ySTQ1ODg2WWxpVg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1360,7 +1360,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 48c67eb5c362bb0c6b92ceacc41ce47b685a2b4eb19aff1c2b03a664d6c5f97e
+        checksum/secret: 66f5e9e5cffbf4f39ac687f5654abe6bd52c5d1b0c8573b8a563d4d99b025cef
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: aGQwMldpbkk1Z2dqYXlySw==
+  haSharedSecret: ajE5UzNINEh0NUJNOEE5Qg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 06ea84484f8efbe84f8aeb732d856ce9b2927d432ca6cef754effbc15208bbf8
+        checksum/secret: 7f88f1980b7aba2c285c9688b96fbc4aca51eac1d0c98ae9433d7bdc728bb522
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## What changes were proposed in this pull request?

We ran into an issue where we lost metrics when we configured propeller's `prof-port` to be different than the default value. There's a couple issues here. 
1. The service monitor is hardcoded to 10254
2. The prometheus configuration gives the illusion that the prometheus server port is configured independently from the `prof-port`, but the prometheus server is always mounted on the `prof-port`. 

So this change simplifies the configuration and makes it less fragile in the event the the `prof-port` changes.

## How was this patch tested?

The rendered helm chart values have no diff.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
