### PR TITLE
Increase more memory limits in flyteagent

### DIFF
--- a/charts/flyteagent/README.md
+++ b/charts/flyteagent/README.md
@@ -32,7 +32,7 @@ A Helm chart for Flyte agent
 | priorityClassName | string | `""` | Sets priorityClassName for datacatalog pod(s). |
 | readinessProbe | object | `{"grpc":{"port":8000},"initialDelaySeconds":1,"periodSeconds":3}` | https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/#trying-the-feature-out |
 | replicaCount | int | `1` | Replicas count for flyteagent deployment |
-| resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"200Mi","memory":"200Mi"},"requests":{"cpu":"500m","ephemeral-storage":"200Mi","memory":"200Mi"}}` | Default resources requests and limits for flyteagent deployment |
+| resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"200Mi","memory":"300Mi"},"requests":{"cpu":"500m","ephemeral-storage":"200Mi","memory":"200Mi"}}` | Default resources requests and limits for flyteagent deployment |
 | securityContext | object | `{"allowPrivilegeEscalation":false}` | Security context for container |
 | service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"type":"ClusterIP"}` | Service settings for flyteagent |
 | serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for flyteagent |

--- a/charts/flyteagent/values.yaml
+++ b/charts/flyteagent/values.yaml
@@ -34,7 +34,7 @@ resources:
   limits:
     cpu: 500m
     ephemeral-storage: 200Mi
-    memory: 200Mi
+    memory: 300Mi
   requests:
     cpu: 500m
     ephemeral-storage: 200Mi

--- a/deployment/agent/flyte_agent_helm_generated.yaml
+++ b/deployment/agent/flyte_agent_helm_generated.yaml
@@ -99,7 +99,7 @@ spec:
           limits:
             cpu: 500m
             ephemeral-storage: 200Mi
-            memory: 200Mi
+            memory: 300Mi
           requests:
             cpu: 500m
             ephemeral-storage: 200Mi

--- a/docker/sandbox-bundled/manifests/complete-agent.yaml
+++ b/docker/sandbox-bundled/manifests/complete-agent.yaml
@@ -816,7 +816,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: VmlJYW1VZUVnRmdPRlpBMg==
+  haSharedSecret: N0UzdzZRdHl3d3BrTEJiSA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1413,7 +1413,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 7b3511fcf4990e8af9648ce0e2a906ec48f528c2f284b412f12d74fc4b656700
+        checksum/secret: c93bd6fe573f912d3b4f9a513f9167aba07ec884ffe278546cb406b53e3eafbe
       labels:
         app: docker-registry
         release: flyte-sandbox
@@ -1771,7 +1771,7 @@ spec:
           limits:
             cpu: 500m
             ephemeral-storage: 200Mi
-            memory: 200Mi
+            memory: 300Mi
           requests:
             cpu: 500m
             ephemeral-storage: 200Mi

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -796,7 +796,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: ZFpwYnNuWEVvWDlDSk9pSA==
+  haSharedSecret: SVVWTlJreURYWWZZcGNBUA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1360,7 +1360,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 0ded6dcac5c615b4ba549828986d3503b2d57fe98d120b17347047a62397f1d4
+        checksum/secret: 48c67eb5c362bb0c6b92ceacc41ce47b685a2b4eb19aff1c2b03a664d6c5f97e
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: ZXkzazVaelQ5RllQR3BUUg==
+  haSharedSecret: aGQwMldpbkk1Z2dqYXlySw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 6dc14ff0b0570f1d991e696b23fb2bdc5c2e0013af403ba73f35b63c20936650
+        checksum/secret: 06ea84484f8efbe84f8aeb732d856ce9b2927d432ca6cef754effbc15208bbf8
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
I got OOM killed When I started the flyte sandbox with the agent pod.
It is not a good user experience for agent users when we run lots os agent tasks concurrently. 
As we support more agents in flytekit, we will get OOM killed.

## What changes were proposed in this pull request?
Add more memory limits for `flyteagent` pod.

## How was this patch tested?
build an image of flyte sandbox.
```zsh
cd docker/sandbox-bundled
make build
```
### Setup process

### Screenshots
#### Agent Pod has to restart due to OOM Killed
<img width="744" alt="image" src="https://github.com/flyteorg/flyte/assets/76461262/201a50e8-aa7d-4ebf-abda-d763082ba9a7">

#### Agent Pod doesn't have to restart after giving more memories
<img width="791" alt="image" src="https://github.com/flyteorg/flyte/assets/76461262/20d1bc0e-1505-49b6-b91e-04482549ac0c">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
