### PR TITLE
When there's a triggered LP SubWorkflow use the maxParallelism of LP

### DIFF
--- a/flyteadmin/pkg/manager/impl/execution_manager.go
+++ b/flyteadmin/pkg/manager/impl/execution_manager.go
@@ -506,6 +506,14 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 		return nil, nil, err
 	}
 
+	// If a parentNode launched this execution and it's a launchPlan, respect the maxParallelism set in the launchPlan.
+	if parentNodeExecutionID > 0 {
+		if launchPlan.Spec.MaxParallelism > 0 {
+			logger.Info(ctx, fmt.Sprintf("Max parallelism %d set in the LaunchPlan spec.", launchPlan.Spec.MaxParallelism))
+			requestSpec.MaxParallelism = launchPlan.Spec.MaxParallelism
+		}
+	}
+
 	// Dynamically assign task resource defaults.
 	platformTaskResources := util.GetTaskResources(ctx, workflow.Id, m.resourceManager, m.config.TaskResourceConfiguration())
 	for _, t := range workflow.Closure.CompiledWorkflow.Tasks {
@@ -907,6 +915,14 @@ func (m *ExecutionManager) launchExecutionAndPrepareModel(
 	parentNodeExecutionID, sourceExecutionID, err = m.getInheritedExecMetadata(ctx, requestSpec, &workflowExecutionID)
 	if err != nil {
 		return nil, nil, nil, err
+	}
+
+	// If a parentNode launched this execution and it's a launchPlan, respect the maxParallelism set in the launchPlan.
+	if parentNodeExecutionID > 0 {
+		if launchPlan.Spec.MaxParallelism > 0 {
+			logger.Info(ctx, fmt.Sprintf("Max parallelism %d set in the LaunchPlan spec.", launchPlan.Spec.MaxParallelism))
+			requestSpec.MaxParallelism = launchPlan.Spec.MaxParallelism
+		}
 	}
 
 	// Dynamically assign task resource defaults.


### PR DESCRIPTION
## Tracking issue
Closes #5555 

## Why are the changes needed?

## What changes were proposed in this pull request?

I'm proposing that Sub Executions should respect the limit set of a remote LaunchPlan. The authors of the LaunchPlan might have a reason to have this value set and could cause problems if the Main Execution has a higher limit

## How was this patch tested?
This was tested using a Workflow that triggers a remote launch plan in a test environment


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

