### PR TITLE
Fix issues with helm chart release process

### DIFF
--- a/script/prepare_artifacts.sh
+++ b/script/prepare_artifacts.sh
@@ -30,6 +30,7 @@ grep -rlZ "version:[^P]*# VERSION" ./charts/flyteagent/Chart.yaml | xargs -0 sed
 sed "s/v0.1.10/${VERSION}/g" ./charts/flyteagent/README.md > temp.txt && mv temp.txt ./charts/flyteagent/README.md
 
 helm dep update ./charts/flyte
+helm dep update ./charts/flyte-core
 helm dep update ./charts/flyte-deps
 
 # bump latest release of flyte component in helm

--- a/script/prepare_artifacts.sh
+++ b/script/prepare_artifacts.sh
@@ -21,10 +21,13 @@ grep -rlZ "version:[^P]*# VERSION" ./charts/flyte-core/Chart.yaml | xargs -0 sed
 sed "s/v0.1.10/${VERSION}/g" ./charts/flyte-core/README.md  > temp.txt && mv temp.txt ./charts/flyte-core/README.md
 
 grep -rlZ "version:[^P]*# VERSION" ./charts/flyte-deps/Chart.yaml | xargs -0 sed -i "s/version:[^P]*# VERSION/version: ${VERSION} # VERSION/g"
-sed "s/v0.1.10/${VERSION}/g" ./charts/flyte-deps/README.md  > temp.txt && mv temp.txt ./charts/flyte-core/README.md
+sed "s/v0.1.10/${VERSION}/g" ./charts/flyte-deps/README.md  > temp.txt && mv temp.txt ./charts/flyte-deps/README.md
 
 grep -rlZ "version:[^P]*# VERSION" ./charts/flyte-binary/Chart.yaml | xargs -0 sed -i "s/version:[^P]*# VERSION/version: ${VERSION} # VERSION/g"
-sed "s/v0.1.10/${VERSION}/g" ./charts/flyte-binary/README.md > temp.txt && mv temp.txt ./charts/flyte-core/README.md
+sed "s/v0.1.10/${VERSION}/g" ./charts/flyte-binary/README.md > temp.txt && mv temp.txt ./charts/flyte-binary/README.md
+
+grep -rlZ "version:[^P]*# VERSION" ./charts/flyteagent/Chart.yaml | xargs -0 sed -i "s/version:[^P]*# VERSION/version: ${VERSION} # VERSION/g"
+sed "s/v0.1.10/${VERSION}/g" ./charts/flyteagent/README.md > temp.txt && mv temp.txt ./charts/flyteagent/README.md
 
 helm dep update ./charts/flyte
 helm dep update ./charts/flyte-deps


### PR DESCRIPTION
I am currently attempting to get our fork of Flyte to push helm charts to our artifact store and I ran into some issues. This pull request fixes two issues.
1. Updates the script to find/replace the version of the flyteagent helm chart such that `flyte-core` is able to find a matching version of the relative helm chart reference when doing `helm dependency update`. This should publish an actual updated version of the `flyteagent` helm chart instead of overwriting it (and potentially breaking peoples deployments) : https://artifacthub.io/packages/helm/flyte/flyteagent
3. Updates the script to patch each respective README instead of continuously overwriting the `flyte-core` README. This should fix the broken README that is currently live for `flyte-core`: https://artifacthub.io/packages/helm/flyte/flyte-core