### PR TITLE
Add CustomHeaderMatcher to pass additional headers

### DIFF
--- a/flyteadmin/pkg/server/service.go
+++ b/flyteadmin/pkg/server/service.go
@@ -219,6 +219,9 @@ func newHTTPServer(ctx context.Context, pluginRegistry *plugins.Registry, cfg *c
 	// This option sets subject in the user info response
 	gwmuxOptions = append(gwmuxOptions, runtime.WithForwardResponseOption(auth.GetUserInfoForwardResponseHandler()))
 
+	// Use custom header matcher to allow additional headers to be passed through
+	gwmuxOptions = append(gwmuxOptions, runtime.WithIncomingHeaderMatcher(auth.GetCustomHeaderMatcher(pluginRegistry)))
+
 	if cfg.Security.UseAuth {
 		// Add HTTP handlers for OIDC endpoints
 		auth.RegisterHandlers(ctx, mux, authCtx, pluginRegistry)

--- a/flyteadmin/plugins/registry.go
+++ b/flyteadmin/plugins/registry.go
@@ -9,12 +9,13 @@ import (
 type PluginID = string
 
 const (
-	PluginIDWorkflowExecutor       PluginID = "WorkflowExecutor"
-	PluginIDDataProxy              PluginID = "DataProxy"
-	PluginIDUnaryServiceMiddleware PluginID = "UnaryServiceMiddleware"
-	PluginIDPreRedirectHook        PluginID = "PreRedirectHook"
-	PluginIDLogoutHook             PluginID = "LogoutHook"
 	PluginIDAdditionalGRPCService  PluginID = "AdditionalGRPCService"
+	PluginIDCustomerHeaderMatcher  PluginID = "CustomerHeaderMatcher"
+	PluginIDDataProxy              PluginID = "DataProxy"
+	PluginIDLogoutHook             PluginID = "LogoutHook"
+	PluginIDPreRedirectHook        PluginID = "PreRedirectHook"
+	PluginIDUnaryServiceMiddleware PluginID = "UnaryServiceMiddleware"
+	PluginIDWorkflowExecutor       PluginID = "WorkflowExecutor"
 )
 
 type AtomicRegistry struct {


### PR DESCRIPTION
## Why are the changes needed?
By default most headers are dropped when invoking grpc, including `X-Request-Id` used for tracing and logging

## What changes were proposed in this pull request?
Adds a grpc gateway CustomHeaderMatcher and optional override via plugin registry. This allows passing through additional request headers as grpc metadata. By default `X-Request-Id` is passed along.

## How was this patch tested?
Deployed to a cluster and verified the request id recorded in ingress is the same used by admin (previously was generated dynamically in admin middleware)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.
