### PR TITLE
Respect original task definition retry strategy for single task executions

### DIFF
--- a/flyteadmin/pkg/manager/impl/util/single_task_execution.go
+++ b/flyteadmin/pkg/manager/impl/util/single_task_execution.go
@@ -22,10 +22,6 @@ import (
 
 const maxNodeIDLength = 63
 
-var defaultRetryStrategy = core.RetryStrategy{
-	Retries: 3,
-}
-
 const systemNamePrefix = ".flytegen.%s"
 
 const noInputNodeID = ""
@@ -85,13 +81,6 @@ func CreateOrGetWorkflowModel(
 		Version: workflowIdentifier.Version,
 	})
 
-	var retryStrategy *core.RetryStrategy
-	if task.GetClosure().GetCompiledTask().GetTemplate().GetMetadata().GetRetries().GetRetries() > 0 {
-		retryStrategy = task.GetClosure().GetCompiledTask().GetTemplate().GetMetadata().GetRetries()
-	} else {
-		retryStrategy = &defaultRetryStrategy
-	}
-
 	if err != nil {
 		if ferr, ok := err.(errors.FlyteAdminError); !ok || ferr.Code() != codes.NotFound {
 			return nil, err
@@ -106,7 +95,7 @@ func CreateOrGetWorkflowModel(
 						Id: generateNodeNameFromTask(taskIdentifier.Name),
 						Metadata: &core.NodeMetadata{
 							Name:    generateNodeNameFromTask(taskIdentifier.Name),
-							Retries: retryStrategy,
+							Retries: task.GetClosure().GetCompiledTask().GetTemplate().GetMetadata().GetRetries(),
 						},
 						Inputs: generateBindings(*task.Closure.CompiledTask.Template.Interface.Inputs, noInputNodeID),
 						Target: &core.Node_TaskNode{

--- a/flyteadmin/pkg/manager/impl/util/single_task_execution.go
+++ b/flyteadmin/pkg/manager/impl/util/single_task_execution.go
@@ -22,6 +22,10 @@ import (
 
 const maxNodeIDLength = 63
 
+var defaultRetryStrategy = core.RetryStrategy{
+	Retries: 3,
+}
+
 const systemNamePrefix = ".flytegen.%s"
 
 const noInputNodeID = ""
@@ -81,6 +85,15 @@ func CreateOrGetWorkflowModel(
 		Version: workflowIdentifier.Version,
 	})
 
+	var retryStrategy *core.RetryStrategy
+	if task.GetClosure().GetCompiledTask().GetTemplate() != nil &&
+		task.GetClosure().GetCompiledTask().GetTemplate().GetMetadata() != nil &&
+		task.GetClosure().GetCompiledTask().GetTemplate().GetMetadata().GetRetries() != nil {
+		retryStrategy = task.GetClosure().GetCompiledTask().GetTemplate().GetMetadata().GetRetries()
+	} else {
+		retryStrategy = &defaultRetryStrategy
+	}
+
 	if err != nil {
 		if ferr, ok := err.(errors.FlyteAdminError); !ok || ferr.Code() != codes.NotFound {
 			return nil, err
@@ -95,7 +108,7 @@ func CreateOrGetWorkflowModel(
 						Id: generateNodeNameFromTask(taskIdentifier.Name),
 						Metadata: &core.NodeMetadata{
 							Name:    generateNodeNameFromTask(taskIdentifier.Name),
-							Retries: task.GetClosure().GetCompiledTask().GetTemplate().GetMetadata().GetRetries(),
+							Retries: retryStrategy,
 						},
 						Inputs: generateBindings(*task.Closure.CompiledTask.Template.Interface.Inputs, noInputNodeID),
 						Target: &core.Node_TaskNode{

--- a/flyteadmin/pkg/manager/impl/util/single_task_execution.go
+++ b/flyteadmin/pkg/manager/impl/util/single_task_execution.go
@@ -85,6 +85,13 @@ func CreateOrGetWorkflowModel(
 		Version: workflowIdentifier.Version,
 	})
 
+	var retryStrategy *core.RetryStrategy
+	if task.GetClosure().GetCompiledTask().GetTemplate().GetMetadata().GetRetries().GetRetries() > 0 {
+		retryStrategy = task.GetClosure().GetCompiledTask().GetTemplate().GetMetadata().GetRetries()
+	} else {
+		retryStrategy = &defaultRetryStrategy
+	}
+
 	if err != nil {
 		if ferr, ok := err.(errors.FlyteAdminError); !ok || ferr.Code() != codes.NotFound {
 			return nil, err
@@ -99,7 +106,7 @@ func CreateOrGetWorkflowModel(
 						Id: generateNodeNameFromTask(taskIdentifier.Name),
 						Metadata: &core.NodeMetadata{
 							Name:    generateNodeNameFromTask(taskIdentifier.Name),
-							Retries: &defaultRetryStrategy,
+							Retries: retryStrategy,
 						},
 						Inputs: generateBindings(*task.Closure.CompiledTask.Template.Interface.Inputs, noInputNodeID),
 						Target: &core.Node_TaskNode{

--- a/flyteadmin/pkg/manager/impl/util/single_task_execution_test.go
+++ b/flyteadmin/pkg/manager/impl/util/single_task_execution_test.go
@@ -109,6 +109,9 @@ func TestCreateOrGetWorkflowModel(t *testing.T) {
 			Name:         ".flytegen.app.workflows.MyWorkflow.my_task",
 			Version:      "12345",
 		}), fmt.Sprintf("%+v", request.Id))
+		assert.Len(t, request.GetSpec().GetTemplate().GetNodes(), 1)
+		assert.Equal(t, request.GetSpec().GetTemplate().GetNodes()[0].GetMetadata().GetRetries().GetRetries(), uint32(2))
+
 		return &admin.WorkflowCreateResponse{}, nil
 	})
 	taskIdentifier := &core.Identifier{
@@ -146,6 +149,11 @@ func TestCreateOrGetWorkflowModel(t *testing.T) {
 									},
 								},
 							},
+						},
+					},
+					Metadata: &core.TaskMetadata{
+						Retries: &core.RetryStrategy{
+							Retries: 2,
 						},
 					},
 				},


### PR DESCRIPTION
## Why are the changes needed?
It's counter-intuitive that a single task execution doesn't respect a task spec when creating the system-generated workflow but workflow compilation ordinarily does



## What changes were proposed in this pull request?
See PR title.

## How was this patch tested?
Unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
