### PR TITLE
Give flyte binary cluster role permission to create service accounts

### DIFF
--- a/charts/flyte-binary/templates/clusterrole.yaml
+++ b/charts/flyte-binary/templates/clusterrole.yaml
@@ -25,6 +25,7 @@ rules:
     - namespaces
     - resourcequotas
     - secrets
+    - serviceaccounts
     verbs:
     - create
     - get


### PR DESCRIPTION
## Why are the changes needed?
1. Flyte was failing to create service accounts on EKS since it didn't have permissions to do so
2. The service account template in the Single Cluster Simple Cloud Deployment [`eks-starter.yaml`](https://github.com/flyteorg/flyte/blob/master/charts/flyte-binary/eks-starter.yaml) file was failing for the above reason

## What changes were proposed in this pull request?

Give the flyte binary cluster role permissions to create new service accounts.

## How was this patch tested?

Tested on an internal kubernetes cluster.

### Screenshots
Before:
<img width="1501" alt="Screenshot 2024-07-22 at 9 26 05 PM" src="https://github.com/user-attachments/assets/57be231c-e88d-42f6-a285-16362d51883a">

After:
<img width="1502" alt="Screenshot 2024-07-22 at 9 49 23 PM" src="https://github.com/user-attachments/assets/cec48499-0f94-4d47-b68c-5b5ad4990293">
