### PR TITLE
Support offloading workflow CRD inputs

### DIFF
--- a/flyteadmin/pkg/manager/impl/execution_manager.go
+++ b/flyteadmin/pkg/manager/impl/execution_manager.go
@@ -592,6 +592,7 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 		WorkflowClosure:          workflow.Closure.CompiledWorkflow,
 		WorkflowClosureReference: storage.DataReference(workflowModel.RemoteClosureIdentifier),
 		ExecutionParameters:      executionParameters,
+		OffloadedInputsReference: inputsURI,
 	})
 
 	if err != nil {

--- a/flyteadmin/pkg/manager/impl/execution_manager.go
+++ b/flyteadmin/pkg/manager/impl/execution_manager.go
@@ -1033,6 +1033,7 @@ func (m *ExecutionManager) launchExecutionAndPrepareModel(
 		WorkflowClosure:          workflow.Closure.CompiledWorkflow,
 		WorkflowClosureReference: storage.DataReference(workflowModel.RemoteClosureIdentifier),
 		ExecutionParameters:      executionParameters,
+		OffloadedInputsReference: inputsURI,
 	})
 	if execErr != nil {
 		createExecModelInput.Error = execErr

--- a/flyteadmin/pkg/runtime/interfaces/application_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/application_configuration.go
@@ -106,6 +106,9 @@ type ApplicationConfig struct {
 
 	// A URL pointing to the flyteconsole instance used to hit this flyteadmin instance.
 	ConsoleURL string `json:"consoleUrl,omitempty" pflag:",A URL pointing to the flyteconsole instance used to hit this flyteadmin instance."`
+
+	// Enabling this will instruct operator to use storage (s3/gcs/etc) to offload workflow execution inputs instead of storing them inline in the CRD.
+	UseOffloadedInputs bool `json:"useOffloadedInputs" pflag:",Use offloaded inputs for workflows."`
 }
 
 func (a *ApplicationConfig) GetRoleNameKey() string {

--- a/flyteadmin/pkg/workflowengine/impl/k8s_executor.go
+++ b/flyteadmin/pkg/workflowengine/impl/k8s_executor.go
@@ -54,6 +54,10 @@ func (e K8sWorkflowExecutor) Execute(ctx context.Context, data interfaces.Execut
 		flyteWf.SubWorkflows = nil
 		flyteWf.Tasks = nil
 	}
+	if e.config.ApplicationConfiguration().GetTopLevelConfig().UseOffloadedInputs {
+		flyteWf.OffloadedInputs = data.OffloadedInputsReference
+		flyteWf.Inputs = nil
+	}
 
 	if consoleURL := e.config.ApplicationConfiguration().GetTopLevelConfig().ConsoleURL; len(consoleURL) > 0 {
 		flyteWf.ConsoleURL = consoleURL

--- a/flyteadmin/pkg/workflowengine/impl/k8s_executor_test.go
+++ b/flyteadmin/pkg/workflowengine/impl/k8s_executor_test.go
@@ -3,7 +3,6 @@ package impl
 import (
 	"context"
 	"errors"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
 	"regexp"
 	"testing"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	flyteclient "github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned"
 	v1alpha12 "github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned/typed/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 var fakeFlyteWF = FakeFlyteWorkflowV1alpha1{}

--- a/flyteadmin/pkg/workflowengine/interfaces/executor.go
+++ b/flyteadmin/pkg/workflowengine/interfaces/executor.go
@@ -49,6 +49,8 @@ type ExecutionData struct {
 	WorkflowClosureReference storage.DataReference
 	// Additional parameters used to build a workflow execution
 	ExecutionParameters ExecutionParameters
+	// Storage data reference of the execution inputs
+	OffloadedInputsReference storage.DataReference
 }
 
 // ExecutionResponse is returned when a Flyte workflow execution is successfully created.

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/workflow.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/workflow.go
@@ -79,6 +79,11 @@ type FlyteWorkflow struct {
 
 	// Flyteconsole url
 	ConsoleURL string `json:"consoleUrl,omitempty"`
+
+	// Much like WorkflowClosureReference, this field represents the location of offloaded inputs. If this exists,
+	// then the literal Inputs must not be populated. Flytepropeller must retrieve and parse the static inputs prior to
+	// processing.
+	OffloadedInputs DataReference `json:"offloadedInputs,omitempty"`
 }
 
 func (in *FlyteWorkflow) GetSecurityContext() core.SecurityContext {


### PR DESCRIPTION
## Why are the changes needed?
Flyte allows configuring grpc message sizes, so in theory a workflow could be created with excessively large inputs that get stored inline in the CRD. Unfortunately etcd limits object sizes to 1.5Mb which we could potentially run afoul of.

Much in the same vein as the offloaded workflow closure, this change supports triggering a flyte execution with offloaded execution inputs, to reduce the CRD size.

## What changes were proposed in this pull request?
See PR title

## How was this patch tested?

Ran single binary with the offloadInputs config set to `true` and ran an execution E2E. Verified the Flyte CRD had
```
offloadedInputs: s3://my-s3-bucket/metadata/flytesnacks/development/f87f46599099e4a9d9f8/inputs
```
and it succeeded

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
