### PR TITLE
Add pod name as an environment variable FLYTE_INTERNAL_POD_NAME

### DIFF
--- a/flyteadmin/pkg/manager/impl/execution_manager.go
+++ b/flyteadmin/pkg/manager/impl/execution_manager.go
@@ -592,6 +592,7 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 		WorkflowClosure:          workflow.Closure.CompiledWorkflow,
 		WorkflowClosureReference: storage.DataReference(workflowModel.RemoteClosureIdentifier),
 		ExecutionParameters:      executionParameters,
+		OffloadedInputsReference: inputsURI,
 	})
 
 	if err != nil {
@@ -1032,6 +1033,7 @@ func (m *ExecutionManager) launchExecutionAndPrepareModel(
 		WorkflowClosure:          workflow.Closure.CompiledWorkflow,
 		WorkflowClosureReference: storage.DataReference(workflowModel.RemoteClosureIdentifier),
 		ExecutionParameters:      executionParameters,
+		OffloadedInputsReference: inputsURI,
 	})
 	if execErr != nil {
 		createExecModelInput.Error = execErr

--- a/flyteadmin/pkg/runtime/interfaces/application_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/application_configuration.go
@@ -106,6 +106,9 @@ type ApplicationConfig struct {
 
 	// A URL pointing to the flyteconsole instance used to hit this flyteadmin instance.
 	ConsoleURL string `json:"consoleUrl,omitempty" pflag:",A URL pointing to the flyteconsole instance used to hit this flyteadmin instance."`
+
+	// Enabling this will instruct operator to use storage (s3/gcs/etc) to offload workflow execution inputs instead of storing them inline in the CRD.
+	UseOffloadedInputs bool `json:"useOffloadedInputs" pflag:",Use offloaded inputs for workflows."`
 }
 
 func (a *ApplicationConfig) GetRoleNameKey() string {

--- a/flyteadmin/pkg/workflowengine/impl/k8s_executor.go
+++ b/flyteadmin/pkg/workflowengine/impl/k8s_executor.go
@@ -54,6 +54,10 @@ func (e K8sWorkflowExecutor) Execute(ctx context.Context, data interfaces.Execut
 		flyteWf.SubWorkflows = nil
 		flyteWf.Tasks = nil
 	}
+	if e.config.ApplicationConfiguration().GetTopLevelConfig().UseOffloadedInputs {
+		flyteWf.OffloadedInputs = data.OffloadedInputsReference
+		flyteWf.Inputs = nil
+	}
 
 	if consoleURL := e.config.ApplicationConfiguration().GetTopLevelConfig().ConsoleURL; len(consoleURL) > 0 {
 		flyteWf.ConsoleURL = consoleURL

--- a/flyteadmin/pkg/workflowengine/impl/k8s_executor_test.go
+++ b/flyteadmin/pkg/workflowengine/impl/k8s_executor_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	flyteclient "github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned"
 	v1alpha12 "github.com/flyteorg/flyte/flytepropeller/pkg/client/clientset/versioned/typed/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 var fakeFlyteWF = FakeFlyteWorkflowV1alpha1{}
@@ -416,4 +417,74 @@ func TestExecute_OffloadWorkflowClosure(t *testing.T) {
 	assert.Nil(t, offloadedFlyteWf.WorkflowSpec)
 	assert.Nil(t, offloadedFlyteWf.Tasks)
 	assert.Nil(t, offloadedFlyteWf.SubWorkflows)
+}
+
+func TestExecute_OffloadInputs(t *testing.T) {
+	offloadedFlyteWf := &v1alpha1.FlyteWorkflow{
+		ExecutionID: v1alpha1.ExecutionID{
+			WorkflowExecutionIdentifier: execID,
+		},
+		Inputs: &v1alpha1.Inputs{
+			LiteralMap: testInputs,
+		},
+	}
+	inputsReference := storage.DataReference("inputs")
+
+	mockApplicationConfig := runtimeMocks.MockApplicationProvider{}
+	mockApplicationConfig.SetTopLevelConfig(runtimeInterfaces.ApplicationConfig{
+		UseOffloadedInputs: true,
+	})
+	mockRuntime := runtimeMocks.NewMockConfigurationProvider(&mockApplicationConfig, nil, nil, nil, nil, nil)
+
+	mockBuilder := mocks.FlyteWorkflowBuilder{}
+	workflowClosure := core.CompiledWorkflowClosure{
+		Primary: &core.CompiledWorkflow{
+			Template: &core.WorkflowTemplate{
+				Id: &core.Identifier{
+					Project: "p",
+					Domain:  "d",
+					Name:    "n",
+					Version: "version",
+				},
+			},
+		},
+	}
+	mockBuilder.OnBuildMatch(mock.MatchedBy(func(wfClosure *core.CompiledWorkflowClosure) bool {
+		return proto.Equal(wfClosure, &workflowClosure)
+	}), mock.MatchedBy(func(inputs *core.LiteralMap) bool {
+		return proto.Equal(inputs, testInputs)
+	}), mock.MatchedBy(func(executionID *core.WorkflowExecutionIdentifier) bool {
+		return proto.Equal(executionID, execID)
+	}), namespace).Return(offloadedFlyteWf, nil)
+	executor := K8sWorkflowExecutor{
+		config:           mockRuntime,
+		workflowBuilder:  &mockBuilder,
+		executionCluster: getFakeExecutionCluster(),
+	}
+	assert.NotNil(t, offloadedFlyteWf.Inputs)
+
+	resp, err := executor.Execute(context.TODO(), interfaces.ExecutionData{
+		Namespace:               namespace,
+		ExecutionID:             execID,
+		ReferenceWorkflowName:   "ref_workflow_name",
+		ReferenceLaunchPlanName: "ref_lp_name",
+		WorkflowClosure:         &workflowClosure,
+		ExecutionParameters: interfaces.ExecutionParameters{
+			Inputs: testInputs,
+			ExecutionConfig: &admin.WorkflowExecutionConfig{
+				SecurityContext: &core.SecurityContext{
+					RunAs: &core.Identity{
+						IamRole:           testRoleSc,
+						K8SServiceAccount: testK8sServiceAccountSc,
+					},
+				},
+			},
+		},
+		OffloadedInputsReference: inputsReference,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Cluster, clusterID)
+
+	assert.Nil(t, offloadedFlyteWf.Inputs)
+	assert.Equal(t, inputsReference, offloadedFlyteWf.OffloadedInputs)
 }

--- a/flyteadmin/pkg/workflowengine/interfaces/executor.go
+++ b/flyteadmin/pkg/workflowengine/interfaces/executor.go
@@ -49,6 +49,8 @@ type ExecutionData struct {
 	WorkflowClosureReference storage.DataReference
 	// Additional parameters used to build a workflow execution
 	ExecutionParameters ExecutionParameters
+	// Storage data reference of the execution inputs
+	OffloadedInputsReference storage.DataReference
 }
 
 // ExecutionResponse is returned when a Flyte workflow execution is successfully created.

--- a/flytectl/cmd/demo/exec_test.go
+++ b/flytectl/cmd/demo/exec_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	cmdCore "github.com/flyteorg/flyte/flytectl/cmd/core"
 	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker"
@@ -26,7 +27,7 @@ func TestDemoClusterExec(t *testing.T) {
 	cmdCtx := cmdCore.NewCommandContext(mockClient, *mockOutStream)
 	reader := bufio.NewReader(strings.NewReader("test"))
 
-	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{
 		{
 			ID: docker.FlyteSandboxClusterName,
 			Names: []string{
@@ -54,7 +55,7 @@ func TestSandboxClusterExecWithoutCmd(t *testing.T) {
 
 	ctx := s.Ctx
 
-	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{
 		{
 			ID: docker.FlyteSandboxClusterName,
 			Names: []string{

--- a/flytectl/cmd/demo/reload_test.go
+++ b/flytectl/cmd/demo/reload_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	cmdCore "github.com/flyteorg/flyte/flytectl/cmd/core"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker/mocks"
@@ -33,7 +34,7 @@ var fakePod = corev1.Pod{
 func sandboxSetup(ctx context.Context, legacy bool) {
 	mockDocker := &mocks.Docker{}
 	docker.Client = mockDocker
-	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{
 		{
 			ID: docker.FlyteSandboxClusterName,
 			Names: []string{

--- a/flytectl/cmd/demo/status_test.go
+++ b/flytectl/cmd/demo/status_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker/mocks"
@@ -15,7 +16,7 @@ func TestDemoStatus(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		s := testutils.Setup()
 		defer s.TearDown()
-		mockDocker.OnContainerList(s.Ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerList(s.Ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		docker.Client = mockDocker
 		err := demoClusterStatus(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
@@ -25,7 +26,7 @@ func TestDemoStatus(t *testing.T) {
 		defer s.TearDown()
 		ctx := s.Ctx
 		mockDocker := &mocks.Docker{}
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{
 			{
 				ID: docker.FlyteSandboxClusterName,
 				Names: []string{

--- a/flytectl/cmd/demo/teardown_test.go
+++ b/flytectl/cmd/demo/teardown_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	sandboxCmdConfig "github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/sandbox"
 	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flytectl/pkg/configutil"
@@ -33,8 +34,8 @@ func TestTearDownFunc(t *testing.T) {
 	t.Run("SuccessKeepVolume", func(t *testing.T) {
 		ctx := context.Background()
 		mockDocker := &mocks.Docker{}
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
-		mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(containers, nil)
+		mockDocker.OnContainerRemove(ctx, mock.Anything, container.RemoveOptions{Force: true}).Return(nil)
 		mockK8sContextMgr := &k8sMocks.ContextOps{}
 		k8s.ContextMgr = mockK8sContextMgr
 		mockK8sContextMgr.OnRemoveContextMatch(mock.Anything).Return(nil)
@@ -44,8 +45,8 @@ func TestTearDownFunc(t *testing.T) {
 	t.Run("SuccessRemoveVolume", func(t *testing.T) {
 		ctx := context.Background()
 		mockDocker := &mocks.Docker{}
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
-		mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(containers, nil)
+		mockDocker.OnContainerRemove(ctx, mock.Anything, container.RemoveOptions{Force: true}).Return(nil)
 		mockDocker.OnVolumeRemove(ctx, docker.FlyteSandboxVolumeName, true).Return(nil)
 		mockK8sContextMgr := &k8sMocks.ContextOps{}
 		k8s.ContextMgr = mockK8sContextMgr
@@ -60,8 +61,8 @@ func TestTearDownFunc(t *testing.T) {
 	t.Run("ErrorOnContainerRemove", func(t *testing.T) {
 		ctx := context.Background()
 		mockDocker := &mocks.Docker{}
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
-		mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(fmt.Errorf("err"))
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(containers, nil)
+		mockDocker.OnContainerRemove(ctx, mock.Anything, container.RemoveOptions{Force: true}).Return(fmt.Errorf("err"))
 		err := sandbox.Teardown(ctx, mockDocker, sandboxCmdConfig.DefaultTeardownFlags)
 		assert.NotNil(t, err)
 	})
@@ -69,7 +70,7 @@ func TestTearDownFunc(t *testing.T) {
 	t.Run("ErrorOnContainerList", func(t *testing.T) {
 		ctx := context.Background()
 		mockDocker := &mocks.Docker{}
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(nil, fmt.Errorf("err"))
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(nil, fmt.Errorf("err"))
 		err := sandbox.Teardown(ctx, mockDocker, sandboxCmdConfig.DefaultTeardownFlags)
 		assert.NotNil(t, err)
 	})
@@ -84,8 +85,8 @@ func TestTearDownClusterFunc(t *testing.T) {
 
 	ctx := s.Ctx
 	mockDocker := &mocks.Docker{}
-	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
-	mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(nil)
+	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(containers, nil)
+	mockDocker.OnContainerRemove(ctx, mock.Anything, container.RemoveOptions{Force: true}).Return(nil)
 	docker.Client = mockDocker
 	err := teardownDemoCluster(ctx, []string{}, s.CmdCtx)
 	assert.Nil(t, err)

--- a/flytectl/cmd/sandbox/exec_test.go
+++ b/flytectl/cmd/sandbox/exec_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	cmdCore "github.com/flyteorg/flyte/flytectl/cmd/core"
 	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker"
@@ -26,7 +27,7 @@ func TestSandboxClusterExec(t *testing.T) {
 	cmdCtx := cmdCore.NewCommandContext(mockClient, *mockOutStream)
 	reader := bufio.NewReader(strings.NewReader("test"))
 
-	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{
 		{
 			ID: docker.FlyteSandboxClusterName,
 			Names: []string{
@@ -52,7 +53,7 @@ func TestSandboxClusterExecWithoutCmd(t *testing.T) {
 	s := testutils.Setup()
 	ctx := s.Ctx
 
-	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{
 		{
 			ID: docker.FlyteSandboxClusterName,
 			Names: []string{

--- a/flytectl/cmd/sandbox/status_test.go
+++ b/flytectl/cmd/sandbox/status_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker/mocks"
@@ -14,7 +15,7 @@ func TestSandboxStatus(t *testing.T) {
 	t.Run("Sandbox status with zero result", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		s := testutils.Setup()
-		mockDocker.OnContainerList(s.Ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerList(s.Ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		docker.Client = mockDocker
 		err := sandboxClusterStatus(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
@@ -23,7 +24,7 @@ func TestSandboxStatus(t *testing.T) {
 		s := testutils.Setup()
 		ctx := s.Ctx
 		mockDocker := &mocks.Docker{}
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{
 			{
 				ID: docker.FlyteSandboxClusterName,
 				Names: []string{

--- a/flytectl/cmd/sandbox/teardown_test.go
+++ b/flytectl/cmd/sandbox/teardown_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flytectl/pkg/configutil"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker"
@@ -22,8 +23,8 @@ func TestTearDownClusterFunc(t *testing.T) {
 	s := testutils.Setup()
 	ctx := s.Ctx
 	mockDocker := &mocks.Docker{}
-	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
-	mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(nil)
+	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(containers, nil)
+	mockDocker.OnContainerRemove(ctx, mock.Anything, container.RemoveOptions{Force: true}).Return(nil)
 	mockK8sContextMgr := &k8sMocks.ContextOps{}
 	mockK8sContextMgr.OnRemoveContext(mock.Anything).Return(nil)
 	k8s.ContextMgr = mockK8sContextMgr

--- a/flytectl/go.mod
+++ b/flytectl/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/charmbracelet/bubbletea v0.25.0
 	github.com/charmbracelet/lipgloss v0.10.0
 	github.com/disiqueira/gotree v1.0.0
-	github.com/docker/docker v24.0.9+incompatible
+	github.com/docker/docker v26.1.5+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/enescakir/emoji v1.0.0
 	github.com/flyteorg/flyte/flyteidl v0.0.0-00010101000000-000000000000
@@ -71,11 +71,12 @@ require (
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/containerd/log v0.1.0 // indirect
 	github.com/coocood/freecache v1.1.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/danieljoos/wincred v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/distribution v2.8.2+incompatible // indirect
+	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.0 // indirect
@@ -123,6 +124,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect

--- a/flytectl/go.sum
+++ b/flytectl/go.sum
@@ -106,6 +106,8 @@ github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa h1:jQCWAUqqlij9Pgj2i/P
 github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa/go.mod h1:x/1Gn8zydmfq8dk6e9PdstVsDgu9RuyIIJqAaF//0IM=
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 h1:q2hJAaP1k2wIvVRd/hEHD7lacgqrCPS+k8g1MndzfWY=
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
+github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
+github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/coocood/freecache v1.1.1 h1:uukNF7QKCZEdZ9gAV7WQzvh0SbjwdMF6m3x3rxEkaPc=
 github.com/coocood/freecache v1.1.1/go.mod h1:OKrEjkGVoxZhyWAJoeFi5BMLUJm2Tit0kpGkIr7NGYY=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
@@ -120,10 +122,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/disiqueira/gotree v1.0.0 h1:en5wk87n7/Jyk6gVME3cx3xN9KmUCstJ1IjHr4Se4To=
 github.com/disiqueira/gotree v1.0.0/go.mod h1:7CwL+VWsWAU95DovkdRZAtA7YbtHwGk+tLV/kNi8niU=
-github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
-github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v24.0.9+incompatible h1:HPGzNmwfLZWdxHqK9/II92pyi1EpYKsAqcl4G0Of9v0=
-github.com/docker/docker v24.0.9+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/docker/docker v26.1.5+incompatible h1:NEAxTwEjxV6VbBMBoGG3zPqbiJosIApZjxlbrG9q3/g=
+github.com/docker/docker v26.1.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
@@ -353,6 +355,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zk
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
+github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 h1:rzf0wL0CHVc8CEsgyygG0Mn9CNCCPZqOPaz8RiiHYQk=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/flytectl/pkg/docker/docker.go
+++ b/flytectl/pkg/docker/docker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
@@ -16,16 +17,16 @@ import (
 
 type Docker interface {
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
-	ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error
+	ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error
 	ImagePull(ctx context.Context, refStr string, options types.ImagePullOptions) (io.ReadCloser, error)
 	ContainerWait(ctx context.Context, container string, condition container.WaitCondition) (<-chan container.WaitResponse, <-chan error)
-	ContainerLogs(ctx context.Context, container string, options types.ContainerLogsOptions) (io.ReadCloser, error)
-	ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error
-	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
+	ContainerLogs(ctx context.Context, container string, options container.LogsOptions) (io.ReadCloser, error)
+	ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error
+	ContainerList(ctx context.Context, options container.ListOptions) ([]types.Container, error)
 	ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error)
 	ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
-	ImageList(ctx context.Context, listOption types.ImageListOptions) ([]types.ImageSummary, error)
+	ImageList(ctx context.Context, listOption types.ImageListOptions) ([]image.Summary, error)
 	ContainerStatPath(ctx context.Context, containerID, path string) (types.ContainerPathStat, error)
 	CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	VolumeCreate(ctx context.Context, options volume.CreateOptions) (volume.Volume, error)

--- a/flytectl/pkg/docker/docker_util.go
+++ b/flytectl/pkg/docker/docker_util.go
@@ -74,7 +74,7 @@ func GetDockerClient() (Docker, error) {
 
 // GetSandbox will return sandbox container if it exist
 func GetSandbox(ctx context.Context, cli Docker) (*types.Container, error) {
-	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
+	containers, err := cli.ContainerList(ctx, container.ListOptions{
 		All: true,
 	})
 	if err != nil {
@@ -97,7 +97,7 @@ func RemoveSandbox(ctx context.Context, cli Docker, reader io.Reader) error {
 
 	if c != nil {
 		if docker.DefaultConfig.Force || cmdUtil.AskForConfirmation("delete existing sandbox cluster", reader) {
-			err := cli.ContainerRemove(context.Background(), c.ID, types.ContainerRemoveOptions{
+			err := cli.ContainerRemove(context.Background(), c.ID, container.RemoveOptions{
 				Force: true,
 			})
 			return err
@@ -273,7 +273,7 @@ func StartContainer(ctx context.Context, cli Docker, volumes []mount.Mount, expo
 		return "", err
 	}
 
-	if err := cli.ContainerStart(context.Background(), resp.ID, types.ContainerStartOptions{}); err != nil {
+	if err := cli.ContainerStart(context.Background(), resp.ID, container.StartOptions{}); err != nil {
 		return "", err
 	}
 	return resp.ID, nil
@@ -287,7 +287,7 @@ func CopyContainerFile(ctx context.Context, cli Docker, source, destination, nam
 	}
 	var removeErr error
 	defer func() {
-		removeErr = cli.ContainerRemove(context.Background(), resp.ID, types.ContainerRemoveOptions{
+		removeErr = cli.ContainerRemove(context.Background(), resp.ID, container.RemoveOptions{
 			Force: true,
 		})
 	}()
@@ -320,7 +320,7 @@ func CopyContainerFile(ctx context.Context, cli Docker, source, destination, nam
 
 // ReadLogs will return io scanner for reading the logs of a container
 func ReadLogs(ctx context.Context, cli Docker, id string) (*bufio.Scanner, error) {
-	reader, err := cli.ContainerLogs(ctx, id, types.ContainerLogsOptions{
+	reader, err := cli.ContainerLogs(ctx, id, container.LogsOptions{
 		ShowStderr: true,
 		ShowStdout: true,
 		Timestamps: true,

--- a/flytectl/pkg/docker/docker_util_test.go
+++ b/flytectl/pkg/docker/docker_util_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/docker"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker/mocks"
@@ -52,7 +53,7 @@ func TestGetSandbox(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		ctx := context.Background()
 
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(containers, nil)
 		c, err := GetSandbox(ctx, mockDocker)
 		assert.Equal(t, c.Names[0], FlyteSandboxClusterName)
 		assert.Nil(t, err)
@@ -62,7 +63,7 @@ func TestGetSandbox(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		ctx := context.Background()
 
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		c, err := GetSandbox(ctx, mockDocker)
 		assert.Nil(t, c)
 		assert.Nil(t, err)
@@ -72,8 +73,8 @@ func TestGetSandbox(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		ctx := context.Background()
 
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
-		mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(containers, nil)
+		mockDocker.OnContainerRemove(ctx, mock.Anything, container.RemoveOptions{Force: true}).Return(nil)
 		err := RemoveSandbox(ctx, mockDocker, strings.NewReader("y"))
 		assert.Nil(t, err)
 	})
@@ -87,8 +88,8 @@ func TestRemoveSandboxWithNoReply(t *testing.T) {
 		ctx := context.Background()
 
 		// Verify the attributes
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
-		mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(containers, nil)
+		mockDocker.OnContainerRemove(ctx, mock.Anything, container.RemoveOptions{Force: true}).Return(nil)
 		err := RemoveSandbox(ctx, mockDocker, strings.NewReader("n"))
 		assert.NotNil(t, err)
 
@@ -102,8 +103,8 @@ func TestRemoveSandboxWithNoReply(t *testing.T) {
 		ctx := context.Background()
 
 		// Verify the attributes
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
-		mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerRemove(ctx, mock.Anything, container.RemoveOptions{Force: true}).Return(nil)
 		err := RemoveSandbox(ctx, mockDocker, strings.NewReader("n"))
 		assert.Nil(t, err)
 	})
@@ -116,7 +117,7 @@ func TestPullDockerImage(t *testing.T) {
 		ctx := context.Background()
 		// Verify the attributes
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnImageListMatch(ctx, types.ImageListOptions{}).Return([]types.ImageSummary{{RepoTags: []string{"nginx:latest"}}}, nil)
+		mockDocker.OnImageListMatch(ctx, types.ImageListOptions{}).Return([]image.Summary{{RepoTags: []string{"nginx:latest"}}}, nil)
 		err := PullDockerImage(ctx, mockDocker, "nginx:latest", ImagePullPolicyAlways, ImagePullOptions{}, false)
 		assert.Nil(t, err)
 	})
@@ -126,7 +127,7 @@ func TestPullDockerImage(t *testing.T) {
 		ctx := context.Background()
 		// Verify the attributes
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnImageListMatch(ctx, types.ImageListOptions{}).Return([]types.ImageSummary{}, nil)
+		mockDocker.OnImageListMatch(ctx, types.ImageListOptions{}).Return([]image.Summary{}, nil)
 		err := PullDockerImage(ctx, mockDocker, "nginx:latest", ImagePullPolicyAlways, ImagePullOptions{}, false)
 		assert.Nil(t, err)
 	})
@@ -145,7 +146,7 @@ func TestPullDockerImage(t *testing.T) {
 		ctx := context.Background()
 		// Verify the attributes
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnImageListMatch(ctx, types.ImageListOptions{}).Return([]types.ImageSummary{}, nil)
+		mockDocker.OnImageListMatch(ctx, types.ImageListOptions{}).Return([]image.Summary{}, nil)
 		err := PullDockerImage(ctx, mockDocker, "nginx:latest", ImagePullPolicyIfNotPresent, ImagePullOptions{}, false)
 		assert.Nil(t, err)
 	})
@@ -153,7 +154,7 @@ func TestPullDockerImage(t *testing.T) {
 	t.Run("Success skip existing image with ImagePullPolicyIfNotPresent", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		ctx := context.Background()
-		mockDocker.OnImageListMatch(ctx, types.ImageListOptions{}).Return([]types.ImageSummary{{RepoTags: []string{"nginx:latest"}}}, nil)
+		mockDocker.OnImageListMatch(ctx, types.ImageListOptions{}).Return([]image.Summary{{RepoTags: []string{"nginx:latest"}}}, nil)
 		err := PullDockerImage(ctx, mockDocker, "nginx:latest", ImagePullPolicyIfNotPresent, ImagePullOptions{}, false)
 		assert.Nil(t, err)
 	})
@@ -161,7 +162,7 @@ func TestPullDockerImage(t *testing.T) {
 	t.Run("Success skip existing image with ImagePullPolicyNever", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		ctx := context.Background()
-		mockDocker.OnImageListMatch(ctx, types.ImageListOptions{}).Return([]types.ImageSummary{{RepoTags: []string{"nginx:latest"}}}, nil)
+		mockDocker.OnImageListMatch(ctx, types.ImageListOptions{}).Return([]image.Summary{{RepoTags: []string{"nginx:latest"}}}, nil)
 		err := PullDockerImage(ctx, mockDocker, "nginx:latest", ImagePullPolicyNever, ImagePullOptions{}, false)
 		assert.Nil(t, err)
 	})
@@ -169,7 +170,7 @@ func TestPullDockerImage(t *testing.T) {
 	t.Run("Error non-existent image with ImagePullPolicyNever", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		ctx := context.Background()
-		mockDocker.OnImageListMatch(ctx, types.ImageListOptions{}).Return([]types.ImageSummary{}, nil)
+		mockDocker.OnImageListMatch(ctx, types.ImageListOptions{}).Return([]image.Summary{}, nil)
 		err := PullDockerImage(ctx, mockDocker, "nginx:latest", ImagePullPolicyNever, ImagePullOptions{}, false)
 		assert.ErrorContains(t, err, "Image does not exist, but image pull policy prevents pulling it")
 	})
@@ -197,7 +198,7 @@ func TestStartContainer(t *testing.T) {
 		}, nil, nil, mock.Anything).Return(container.CreateResponse{
 			ID: "Hello",
 		}, nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(nil)
 		id, err := StartContainer(ctx, mockDocker, Volumes, p1, p2, "nginx", imageName, nil, false)
 		assert.Nil(t, err)
 		assert.Greater(t, len(id), 0)
@@ -227,7 +228,7 @@ func TestStartContainer(t *testing.T) {
 		}, nil, nil, mock.Anything).Return(container.CreateResponse{
 			ID: "Hello",
 		}, nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(nil)
 		id, err := StartContainer(ctx, mockDocker, Volumes, p1, p2, "nginx", imageName, additionalEnv, false)
 		assert.Nil(t, err)
 		assert.Greater(t, len(id), 0)
@@ -254,7 +255,7 @@ func TestStartContainer(t *testing.T) {
 		}, nil, nil, mock.Anything).Return(container.CreateResponse{
 			ID: "",
 		}, fmt.Errorf("error"))
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(nil)
 		id, err := StartContainer(ctx, mockDocker, Volumes, p1, p2, "nginx", imageName, nil, false)
 		assert.NotNil(t, err)
 		assert.Equal(t, len(id), 0)
@@ -280,7 +281,7 @@ func TestStartContainer(t *testing.T) {
 		}, nil, nil, mock.Anything).Return(container.CreateResponse{
 			ID: "Hello",
 		}, nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(fmt.Errorf("error"))
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(fmt.Errorf("error"))
 		id, err := StartContainer(ctx, mockDocker, Volumes, p1, p2, "nginx", imageName, nil, false)
 		assert.NotNil(t, err)
 		assert.Equal(t, len(id), 0)
@@ -294,7 +295,7 @@ func TestReadLogs(t *testing.T) {
 	t.Run("Successfully read logs", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		ctx := context.Background()
-		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
+		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, container.LogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,
@@ -307,7 +308,7 @@ func TestReadLogs(t *testing.T) {
 	t.Run("Error in reading logs", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		ctx := context.Background()
-		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
+		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, container.LogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,
@@ -477,7 +478,7 @@ func TestCopyFile(t *testing.T) {
 			container.CreateResponse{ID: containerName}, nil)
 		mockDocker.OnContainerStatPath(ctx, containerName, "some source").Return(types.ContainerPathStat{}, nil)
 		mockDocker.OnCopyFromContainer(ctx, containerName, "some source").Return(reader, types.ContainerPathStat{}, nil)
-		mockDocker.OnContainerRemove(ctx, containerName, types.ContainerRemoveOptions{Force: true}).Return(nil)
+		mockDocker.OnContainerRemove(ctx, containerName, container.RemoveOptions{Force: true}).Return(nil)
 		assert.Nil(t, err)
 
 		// Run
@@ -499,7 +500,7 @@ func TestCopyFile(t *testing.T) {
 			ctx, &container.Config{Image: image}, &container.HostConfig{}, nil, nil, containerName).Return(
 			container.CreateResponse{ID: containerName}, nil)
 		mockDocker.OnContainerStatPath(ctx, containerName, "some source").Return(types.ContainerPathStat{}, myErr)
-		mockDocker.OnContainerRemove(ctx, containerName, types.ContainerRemoveOptions{Force: true}).Return(nil)
+		mockDocker.OnContainerRemove(ctx, containerName, container.RemoveOptions{Force: true}).Return(nil)
 		assert.Nil(t, err)
 
 		// Run

--- a/flytectl/pkg/docker/mocks/docker.go
+++ b/flytectl/pkg/docker/mocks/docker.go
@@ -7,6 +7,8 @@ import (
 
 	container "github.com/docker/docker/api/types/container"
 
+	image "github.com/docker/docker/api/types/image"
+
 	io "io"
 
 	mock "github.com/stretchr/testify/mock"
@@ -189,7 +191,7 @@ func (_m Docker_ContainerList) Return(_a0 []types.Container, _a1 error) *Docker_
 	return &Docker_ContainerList{Call: _m.Call.Return(_a0, _a1)}
 }
 
-func (_m *Docker) OnContainerList(ctx context.Context, options types.ContainerListOptions) *Docker_ContainerList {
+func (_m *Docker) OnContainerList(ctx context.Context, options container.ListOptions) *Docker_ContainerList {
 	c_call := _m.On("ContainerList", ctx, options)
 	return &Docker_ContainerList{Call: c_call}
 }
@@ -200,11 +202,11 @@ func (_m *Docker) OnContainerListMatch(matchers ...interface{}) *Docker_Containe
 }
 
 // ContainerList provides a mock function with given fields: ctx, options
-func (_m *Docker) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+func (_m *Docker) ContainerList(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
 	ret := _m.Called(ctx, options)
 
 	var r0 []types.Container
-	if rf, ok := ret.Get(0).(func(context.Context, types.ContainerListOptions) []types.Container); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, container.ListOptions) []types.Container); ok {
 		r0 = rf(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
@@ -213,7 +215,7 @@ func (_m *Docker) ContainerList(ctx context.Context, options types.ContainerList
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.ContainerListOptions) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, container.ListOptions) error); ok {
 		r1 = rf(ctx, options)
 	} else {
 		r1 = ret.Error(1)
@@ -230,7 +232,7 @@ func (_m Docker_ContainerLogs) Return(_a0 io.ReadCloser, _a1 error) *Docker_Cont
 	return &Docker_ContainerLogs{Call: _m.Call.Return(_a0, _a1)}
 }
 
-func (_m *Docker) OnContainerLogs(ctx context.Context, _a1 string, options types.ContainerLogsOptions) *Docker_ContainerLogs {
+func (_m *Docker) OnContainerLogs(ctx context.Context, _a1 string, options container.LogsOptions) *Docker_ContainerLogs {
 	c_call := _m.On("ContainerLogs", ctx, _a1, options)
 	return &Docker_ContainerLogs{Call: c_call}
 }
@@ -241,11 +243,11 @@ func (_m *Docker) OnContainerLogsMatch(matchers ...interface{}) *Docker_Containe
 }
 
 // ContainerLogs provides a mock function with given fields: ctx, _a1, options
-func (_m *Docker) ContainerLogs(ctx context.Context, _a1 string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
+func (_m *Docker) ContainerLogs(ctx context.Context, _a1 string, options container.LogsOptions) (io.ReadCloser, error) {
 	ret := _m.Called(ctx, _a1, options)
 
 	var r0 io.ReadCloser
-	if rf, ok := ret.Get(0).(func(context.Context, string, types.ContainerLogsOptions) io.ReadCloser); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, container.LogsOptions) io.ReadCloser); ok {
 		r0 = rf(ctx, _a1, options)
 	} else {
 		if ret.Get(0) != nil {
@@ -254,7 +256,7 @@ func (_m *Docker) ContainerLogs(ctx context.Context, _a1 string, options types.C
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, types.ContainerLogsOptions) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, container.LogsOptions) error); ok {
 		r1 = rf(ctx, _a1, options)
 	} else {
 		r1 = ret.Error(1)
@@ -271,7 +273,7 @@ func (_m Docker_ContainerRemove) Return(_a0 error) *Docker_ContainerRemove {
 	return &Docker_ContainerRemove{Call: _m.Call.Return(_a0)}
 }
 
-func (_m *Docker) OnContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) *Docker_ContainerRemove {
+func (_m *Docker) OnContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) *Docker_ContainerRemove {
 	c_call := _m.On("ContainerRemove", ctx, containerID, options)
 	return &Docker_ContainerRemove{Call: c_call}
 }
@@ -282,11 +284,11 @@ func (_m *Docker) OnContainerRemoveMatch(matchers ...interface{}) *Docker_Contai
 }
 
 // ContainerRemove provides a mock function with given fields: ctx, containerID, options
-func (_m *Docker) ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error {
+func (_m *Docker) ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error {
 	ret := _m.Called(ctx, containerID, options)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, types.ContainerRemoveOptions) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, container.RemoveOptions) error); ok {
 		r0 = rf(ctx, containerID, options)
 	} else {
 		r0 = ret.Error(0)
@@ -303,7 +305,7 @@ func (_m Docker_ContainerStart) Return(_a0 error) *Docker_ContainerStart {
 	return &Docker_ContainerStart{Call: _m.Call.Return(_a0)}
 }
 
-func (_m *Docker) OnContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) *Docker_ContainerStart {
+func (_m *Docker) OnContainerStart(ctx context.Context, containerID string, options container.StartOptions) *Docker_ContainerStart {
 	c_call := _m.On("ContainerStart", ctx, containerID, options)
 	return &Docker_ContainerStart{Call: c_call}
 }
@@ -314,11 +316,11 @@ func (_m *Docker) OnContainerStartMatch(matchers ...interface{}) *Docker_Contain
 }
 
 // ContainerStart provides a mock function with given fields: ctx, containerID, options
-func (_m *Docker) ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error {
+func (_m *Docker) ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error {
 	ret := _m.Called(ctx, containerID, options)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, types.ContainerStartOptions) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, container.StartOptions) error); ok {
 		r0 = rf(ctx, containerID, options)
 	} else {
 		r0 = ret.Error(0)
@@ -461,11 +463,11 @@ type Docker_ImageList struct {
 	*mock.Call
 }
 
-func (_m Docker_ImageList) Return(_a0 []types.ImageSummary, _a1 error) *Docker_ImageList {
+func (_m Docker_ImageList) Return(_a0 []image.Summary, _a1 error) *Docker_ImageList {
 	return &Docker_ImageList{Call: _m.Call.Return(_a0, _a1)}
 }
 
-func (_m *Docker) OnImageList(ctx context.Context, listOption types.ImageListOptions) *Docker_ImageList {
+func (_m *Docker) OnImageList(ctx context.Context, listOption image.ListOptions) *Docker_ImageList {
 	c_call := _m.On("ImageList", ctx, listOption)
 	return &Docker_ImageList{Call: c_call}
 }
@@ -476,20 +478,20 @@ func (_m *Docker) OnImageListMatch(matchers ...interface{}) *Docker_ImageList {
 }
 
 // ImageList provides a mock function with given fields: ctx, listOption
-func (_m *Docker) ImageList(ctx context.Context, listOption types.ImageListOptions) ([]types.ImageSummary, error) {
+func (_m *Docker) ImageList(ctx context.Context, listOption image.ListOptions) ([]image.Summary, error) {
 	ret := _m.Called(ctx, listOption)
 
-	var r0 []types.ImageSummary
-	if rf, ok := ret.Get(0).(func(context.Context, types.ImageListOptions) []types.ImageSummary); ok {
+	var r0 []image.Summary
+	if rf, ok := ret.Get(0).(func(context.Context, image.ListOptions) []image.Summary); ok {
 		r0 = rf(ctx, listOption)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]types.ImageSummary)
+			r0 = ret.Get(0).([]image.Summary)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.ImageListOptions) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, image.ListOptions) error); ok {
 		r1 = rf(ctx, listOption)
 	} else {
 		r1 = ret.Error(1)
@@ -506,7 +508,7 @@ func (_m Docker_ImagePull) Return(_a0 io.ReadCloser, _a1 error) *Docker_ImagePul
 	return &Docker_ImagePull{Call: _m.Call.Return(_a0, _a1)}
 }
 
-func (_m *Docker) OnImagePull(ctx context.Context, refStr string, options types.ImagePullOptions) *Docker_ImagePull {
+func (_m *Docker) OnImagePull(ctx context.Context, refStr string, options image.PullOptions) *Docker_ImagePull {
 	c_call := _m.On("ImagePull", ctx, refStr, options)
 	return &Docker_ImagePull{Call: c_call}
 }
@@ -517,11 +519,11 @@ func (_m *Docker) OnImagePullMatch(matchers ...interface{}) *Docker_ImagePull {
 }
 
 // ImagePull provides a mock function with given fields: ctx, refStr, options
-func (_m *Docker) ImagePull(ctx context.Context, refStr string, options types.ImagePullOptions) (io.ReadCloser, error) {
+func (_m *Docker) ImagePull(ctx context.Context, refStr string, options image.PullOptions) (io.ReadCloser, error) {
 	ret := _m.Called(ctx, refStr, options)
 
 	var r0 io.ReadCloser
-	if rf, ok := ret.Get(0).(func(context.Context, string, types.ImagePullOptions) io.ReadCloser); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, image.PullOptions) io.ReadCloser); ok {
 		r0 = rf(ctx, refStr, options)
 	} else {
 		if ret.Get(0) != nil {
@@ -530,7 +532,7 @@ func (_m *Docker) ImagePull(ctx context.Context, refStr string, options types.Im
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, types.ImagePullOptions) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, image.PullOptions) error); ok {
 		r1 = rf(ctx, refStr, options)
 	} else {
 		r1 = ret.Error(1)

--- a/flytectl/pkg/sandbox/start_test.go
+++ b/flytectl/pkg/sandbox/start_test.go
@@ -129,10 +129,10 @@ func TestStartFunc(t *testing.T) {
 
 	t.Run("Successfully run demo cluster", func(t *testing.T) {
 		sandboxSetup()
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
-		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(nil)
+		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, container.LogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,
@@ -145,7 +145,7 @@ func TestStartFunc(t *testing.T) {
 	})
 	t.Run("Successfully exit when demo cluster exist", func(t *testing.T) {
 		sandboxSetup()
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{
 			{
 				ID: docker.FlyteSandboxClusterName,
 				Names: []string{
@@ -154,8 +154,8 @@ func TestStartFunc(t *testing.T) {
 			},
 		}, nil)
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
-		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(nil)
+		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, container.LogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,
@@ -169,10 +169,10 @@ func TestStartFunc(t *testing.T) {
 		sandboxCmdConfig.DefaultConfig.DeprecatedSource = f.UserHomeDir()
 		sandboxCmdConfig.DefaultConfig.Version = ""
 		sandboxSetup()
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(nil)
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
+		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, container.LogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,
@@ -185,10 +185,10 @@ func TestStartFunc(t *testing.T) {
 		sandboxCmdConfig.DefaultConfig.DeprecatedSource = "../"
 		sandboxCmdConfig.DefaultConfig.Version = ""
 		sandboxSetup()
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(nil)
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
+		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, container.LogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,
@@ -199,10 +199,10 @@ func TestStartFunc(t *testing.T) {
 	})
 	t.Run("Successfully run demo cluster with specific version", func(t *testing.T) {
 		sandboxSetup()
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(nil)
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
+		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, container.LogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,
@@ -220,7 +220,7 @@ func TestStartFunc(t *testing.T) {
 	})
 	t.Run("Failed run demo cluster with wrong version", func(t *testing.T) {
 		sandboxSetup()
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		sandboxCmdConfig.DefaultConfig.Image = ""
 		githubMock.OnGetReleaseByTagMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, fmt.Errorf("non-existent-tag"))
 		_, err := startSandbox(ctx, mockDocker, githubMock, dummyReader(), sandboxCmdConfig.DefaultConfig, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
@@ -229,7 +229,7 @@ func TestStartFunc(t *testing.T) {
 	})
 	t.Run("Error in pulling image", func(t *testing.T) {
 		sandboxSetup()
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), fmt.Errorf("failed to pull"))
 		sandboxCmdConfig.DefaultConfig.Image = ""
 		tag := "v0.15.0"
@@ -244,7 +244,7 @@ func TestStartFunc(t *testing.T) {
 	})
 	t.Run("Error in  removing existing cluster", func(t *testing.T) {
 		sandboxSetup()
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{
 			{
 				ID: docker.FlyteSandboxClusterName,
 				Names: []string{
@@ -253,26 +253,26 @@ func TestStartFunc(t *testing.T) {
 			},
 		}, nil)
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(fmt.Errorf("failed to remove container"))
+		mockDocker.OnContainerRemove(ctx, mock.Anything, container.RemoveOptions{Force: true}).Return(fmt.Errorf("failed to remove container"))
 		_, err := startSandbox(ctx, mockDocker, githubMock, strings.NewReader("y"), sandboxCmdConfig.DefaultConfig, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
 		assert.NotNil(t, err)
 		assert.Equal(t, "failed to remove container", err.Error())
 	})
 	t.Run("Error in start container", func(t *testing.T) {
 		sandboxSetup()
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(fmt.Errorf("failed to run container"))
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(fmt.Errorf("failed to run container"))
 		_, err := startSandbox(ctx, mockDocker, githubMock, dummyReader(), sandboxCmdConfig.DefaultConfig, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
 		assert.NotNil(t, err)
 		assert.Equal(t, "failed to run container", err.Error())
 	})
 	t.Run("Error in reading logs", func(t *testing.T) {
 		sandboxSetup()
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
-		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(nil)
+		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, container.LogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,
@@ -286,8 +286,8 @@ func TestStartFunc(t *testing.T) {
 		sandboxSetup()
 		mockDocker.OnContainerListMatch(mock.Anything, mock.Anything).Return([]types.Container{}, fmt.Errorf("failed to list containers"))
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
-		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(nil)
+		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, container.LogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,
@@ -312,12 +312,12 @@ func TestStartFunc(t *testing.T) {
 			t.Error(err)
 		}
 		sandboxSetup()
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		mockDocker.OnImagePullMatch(mock.Anything, mock.Anything, mock.Anything).Return(dummyReader(), nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(nil)
 		stringReader := strings.NewReader(docker.SuccessMessage)
 		reader := ioutil.NopCloser(stringReader)
-		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
+		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, container.LogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,
@@ -341,8 +341,8 @@ func TestStartFunc(t *testing.T) {
 		docker.Client = mockDocker
 		mockDocker.OnContainerListMatch(mock.Anything, mock.Anything).Return([]types.Container{}, fmt.Errorf("failed to list containers"))
 		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
-		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
-		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
+		mockDocker.OnContainerStart(ctx, "Hello", container.StartOptions{}).Return(nil)
+		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, container.LogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,

--- a/flytectl/pkg/sandbox/status_test.go
+++ b/flytectl/pkg/sandbox/status_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker/mocks"
@@ -15,7 +16,7 @@ func TestSandboxStatus(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		s := testutils.Setup()
 		defer s.TearDown()
-		mockDocker.OnContainerList(s.Ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
+		mockDocker.OnContainerList(s.Ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		err := PrintStatus(s.Ctx, mockDocker)
 		assert.Nil(t, err)
 	})
@@ -24,7 +25,7 @@ func TestSandboxStatus(t *testing.T) {
 		defer s.TearDown()
 		ctx := s.Ctx
 		mockDocker := &mocks.Docker{}
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{
 			{
 				ID: docker.FlyteSandboxClusterName,
 				Names: []string{

--- a/flytectl/pkg/sandbox/teardown.go
+++ b/flytectl/pkg/sandbox/teardown.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/enescakir/emoji"
 	sandboxCmdConfig "github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/sandbox"
 	"github.com/flyteorg/flyte/flytectl/pkg/configutil"
@@ -19,7 +19,7 @@ func Teardown(ctx context.Context, cli docker.Docker, teardownFlags *sandboxCmdC
 		return err
 	}
 	if c != nil {
-		if err := cli.ContainerRemove(context.Background(), c.ID, types.ContainerRemoveOptions{
+		if err := cli.ContainerRemove(context.Background(), c.ID, container.RemoveOptions{
 			Force: true,
 		}); err != nil {
 			return err

--- a/flytectl/pkg/sandbox/teardown_test.go
+++ b/flytectl/pkg/sandbox/teardown_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	sandboxCmdConfig "github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/sandbox"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker/mocks"
@@ -27,19 +28,19 @@ func TestTearDownFunc(t *testing.T) {
 	ctx := context.Background()
 
 	mockDocker := &mocks.Docker{}
-	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
-	mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(fmt.Errorf("err"))
+	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(containers, nil)
+	mockDocker.OnContainerRemove(ctx, mock.Anything, container.RemoveOptions{Force: true}).Return(fmt.Errorf("err"))
 	err := Teardown(ctx, mockDocker, sandboxCmdConfig.DefaultTeardownFlags)
 	assert.NotNil(t, err)
 
 	mockDocker = &mocks.Docker{}
-	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(nil, fmt.Errorf("err"))
+	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(nil, fmt.Errorf("err"))
 	err = Teardown(ctx, mockDocker, sandboxCmdConfig.DefaultTeardownFlags)
 	assert.NotNil(t, err)
 
 	mockDocker = &mocks.Docker{}
-	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
-	mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(nil)
+	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(containers, nil)
+	mockDocker.OnContainerRemove(ctx, mock.Anything, container.RemoveOptions{Force: true}).Return(nil)
 	mockK8sContextMgr := &k8sMocks.ContextOps{}
 	mockK8sContextMgr.OnRemoveContext(mock.Anything).Return(nil)
 	k8s.ContextMgr = mockK8sContextMgr

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go
@@ -61,6 +61,14 @@ func GetExecutionEnvVars(id pluginsCore.TaskExecutionID, consoleURL string) []v1
 			Value: nodeExecutionID.Domain,
 		},
 		{
+			Name: "FLYTE_INTERNAL_POD_NAME",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
 			Name:  "FLYTE_ATTEMPT_NUMBER",
 			Value: attemptNumber,
 		},

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds_test.go
@@ -27,13 +27,13 @@ func TestGetExecutionEnvVars(t *testing.T) {
 	}{
 		{
 			"no-console-url",
-			12,
+			13,
 			"",
 			nil,
 		},
 		{
 			"with-console-url",
-			13,
+			14,
 			"scheme://host/path",
 			&v12.EnvVar{
 				Name:  "FLYTE_EXECUTION_URL",
@@ -42,7 +42,7 @@ func TestGetExecutionEnvVars(t *testing.T) {
 		},
 		{
 			"with-console-url-ending-in-single-slash",
-			13,
+			14,
 			"scheme://host/path/",
 			&v12.EnvVar{
 				Name:  "FLYTE_EXECUTION_URL",
@@ -51,7 +51,7 @@ func TestGetExecutionEnvVars(t *testing.T) {
 		},
 		{
 			"with-console-url-ending-in-multiple-slashes",
-			13,
+			14,
 			"scheme://host/path////",
 			&v12.EnvVar{
 				Name:  "FLYTE_EXECUTION_URL",
@@ -63,7 +63,7 @@ func TestGetExecutionEnvVars(t *testing.T) {
 		envVars := GetExecutionEnvVars(mock, tt.consoleURL)
 		assert.Len(t, envVars, tt.expectedEnvVars)
 		if tt.expectedEnvVar != nil {
-			assert.True(t, proto.Equal(&envVars[4], tt.expectedEnvVar))
+			assert.True(t, proto.Equal(&envVars[5], tt.expectedEnvVar))
 		}
 	}
 }

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/workflow.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/workflow.go
@@ -79,6 +79,11 @@ type FlyteWorkflow struct {
 
 	// Flyteconsole url
 	ConsoleURL string `json:"consoleUrl,omitempty"`
+
+	// Much like WorkflowClosureReference, this field represents the location of offloaded inputs. If this exists,
+	// then the literal Inputs must not be populated. Flytepropeller must retrieve and parse the static inputs prior to
+	// processing.
+	OffloadedInputs DataReference `json:"offloadedInputs,omitempty"`
 }
 
 func (in *FlyteWorkflow) GetSecurityContext() core.SecurityContext {


### PR DESCRIPTION
## Tracking issue
Part of RFC https://github.com/flyteorg/flyte/blob/b3add894fd879d6b6c11e37ba292ae04bf60afeb/rfc/system/5598-deterministic-errors-distributed-training.md#flytepropeller-backend

## Why are the changes needed?
Deterministic error propagation, see: https://github.com/flyteorg/flyte/blob/b3add894fd879d6b6c11e37ba292ae04bf60afeb/rfc/system/5598-deterministic-errors-distributed-training.md#flytepropeller-backend

## What changes were proposed in this pull request?

Add FLYTE_INTERNAL_POD_NAME as a env variable to pod specs.

## How was this patch tested?

Updates to unit tests

Manual run 

<img width="829" alt="image" src="https://github.com/user-attachments/assets/e476c669-046d-4c5c-942b-c56c52f03ae7">


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [X] All commits are signed-off.

## Related PRs

None

## Docs link

None
