### PR TITLE
Turn flyteidl and flytectl releases into manual gh workflows

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -28,7 +28,6 @@ jobs:
               "datacatalog",
               "flyteadmin",
               "flytecopilot",
-              "flyteidl",
               "flyteplugins",
               "flytepropeller",
               "flytestdlib",

--- a/.github/workflows/flytectl-release.yml
+++ b/.github/workflows/flytectl-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "version name. example v1.2.3"
+        description: "version. Do *not* use the `flytectl/` prefix, e.g. `flytectl/v1.2.3`, instead use only `v1.2.3` (including the `v`)"
         required: true
 
 jobs:

--- a/.github/workflows/flytectl-release.yml
+++ b/.github/workflows/flytectl-release.yml
@@ -1,13 +1,34 @@
 name: Flytectl release
 
 on:
-  push:
-    tags:
-      - flytectl/v*.*.*
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "version name. example v1.2.3"
+        required: true
 
 jobs:
+  push-flytectl-tag:
+    name: Push git tag containing the `flyteidl/` prefix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.FLYTE_BOT_PAT }}
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/flytectl/${{ github.event.inputs.version }}`,
+              sha: context.sha
+            })
   release:
     name: Goreleaser
+    needs:
+      - push-flytectl-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/flyteidl-release.yml
+++ b/.github/workflows/flyteidl-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "version name. example v1.2.3"
+        description: "version. Do *not* use the `flyteidl/` prefix, e.g. `flyteidl/v1.2.3`, instead use only `v1.2.3` (including the `v`)"
         required: true
 
 jobs:

--- a/.github/workflows/flyteidl-release.yml
+++ b/.github/workflows/flyteidl-release.yml
@@ -1,12 +1,33 @@
-name: Upload flyteidl to PyPI and npm
+name: Release flyteidl
 
 on:
-  push:
-    tags:
-      - flyteidl/v*.*.*
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "version name. example v1.2.3"
+        required: true
 
 jobs:
+  push-flyteidl-tag:
+    name: Push git tag containing the `flyteidl/` prefix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.FLYTE_BOT_PAT }}
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/flyteidl/${{ github.event.inputs.version }}`,
+              sha: context.sha
+            })
   deploy-to-pypi:
+    needs:
+      - push-flyteidl-tag
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -29,6 +50,8 @@ jobs:
           python -m build
           twine upload dist/*
   deploy-to-npm:
+    needs:
+      - push-flyteidl-tag
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/flytectl/RELEASE.md
+++ b/flytectl/RELEASE.md
@@ -2,4 +2,4 @@
 
 Flytectl releases map to git tags with the prefix `flytectl/` followed by a semver string, e.g. [flytectl/v0.9.0](https://github.com/flyteorg/flyte/releases/tag/flytectl%2Fv0.9.0).
 
-To release a new version of flytectl run the <[github workflow](https://github.com/flyteorg/flyte/blob/master/.github/workflows/flytectl-release.yml), which is responsible for releasing this new version. Be careful to use valid semver versions.
+To release a new version of flytectl run the <[github workflow](https://github.com/flyteorg/flyte/blob/master/.github/workflows/flytectl-release.yml), which is responsible for releasing this new version. Remember to use valid semver versions, including adding the prefix `v`, e.g. `v1.2.3`.

--- a/flytectl/RELEASE.md
+++ b/flytectl/RELEASE.md
@@ -2,4 +2,4 @@
 
 Flytectl releases map to git tags with the prefix `flytectl/` followed by a semver string, e.g. [flytectl/v0.9.0](https://github.com/flyteorg/flyte/releases/tag/flytectl%2Fv0.9.0).
 
-To release a new version of flytectl push a new git tag in the format described above. This will kick off a <[github workflow](https://github.com/flyteorg/flyte/blob/master/.github/workflows/flytectl-release.yml) responsible for releasing this new version. Note how the git tag has to be formatted a certain way for the workflow to run.
+To release a new version of flytectl run the <[github workflow](https://github.com/flyteorg/flyte/blob/master/.github/workflows/flytectl-release.yml), which is responsible for releasing this new version. Be careful to use valid semver versions.

--- a/flyteidl/RELEASE.md
+++ b/flyteidl/RELEASE.md
@@ -1,6 +1,4 @@
 # Release Process
 
-Flyteidl releases map to git tags with the prefix `flyteidl/` followed by a semver string, e.g. [flytectl/v0.9.0](https://github.com/flyteorg/flyte/releases/tag/flytectl%2Fv0.9.0).
-
-To release a new version of flytectl run the <[github workflow](https://github.com/flyteorg/flyte/blob/master/.github/workflows/flyteidl-release.yml), which is responsible for releasing this new version. Be careful to use valid semver versions.
+To release a new version of flyteidl run the <[github workflow](https://github.com/flyteorg/flyte/blob/master/.github/workflows/flyteidl-release.yml), which is responsible for releasing this new version. Remember to use valid semver versions, including adding the prefix `v`, e.g. `v1.2.3`.
 

--- a/flyteidl/RELEASE.md
+++ b/flyteidl/RELEASE.md
@@ -1,0 +1,6 @@
+# Release Process
+
+Flyteidl releases map to git tags with the prefix `flyteidl/` followed by a semver string, e.g. [flytectl/v0.9.0](https://github.com/flyteorg/flyte/releases/tag/flytectl%2Fv0.9.0).
+
+To release a new version of flytectl run the <[github workflow](https://github.com/flyteorg/flyte/blob/master/.github/workflows/flyteidl-release.yml), which is responsible for releasing this new version. Be careful to use valid semver versions.
+


### PR DESCRIPTION
## Why are the changes needed?
Since the move to the monorepo we release flyteidl and flytectl by pushing git tags to the flyte repository, e.g. https://github.com/flyteorg/flyte/releases/tag/flyteidl%2Fv1.13.1b0 and https://github.com/flyteorg/flyte/releases/tag/flytectl%2Fv0.9.0. Pushing a git tag to a remote is essentially an untraceable action which is getting fixed in this PR.

## What changes were proposed in this pull request?
We turn the github workflows used to release flyteidl and flytectl into manual workflows that take the version as an input.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
