### PR TITLE
Fix flyteidl release  checkout all tags

### DIFF
--- a/.github/workflows/flyteidl-release.yml
+++ b/.github/workflows/flyteidl-release.yml
@@ -34,6 +34,8 @@ jobs:
         working-directory: flyteidl
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
@@ -65,7 +67,7 @@ jobs:
       - name: Set version in npm package
         run: |
           # from refs/tags/v1.2.3 get 1.2.3
-          VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
+          VERSION=$(echo ${{ inputs.version }} | sed 's#.*/v##')
           VERSION=$VERSION make update_npmversion
         shell: bash
       - run: |

--- a/.github/workflows/flyteidl-release.yml
+++ b/.github/workflows/flyteidl-release.yml
@@ -66,8 +66,8 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Set version in npm package
         run: |
-          # from refs/tags/v1.2.3 get 1.2.3
-          VERSION=$(echo ${{ inputs.version }} | sed 's#.*/v##')
+          # v1.2.3 get 1.2.3
+          VERSION=$(echo ${{ inputs.version }} | sed 's#.*v##')
           VERSION=$VERSION make update_npmversion
         shell: bash
       - run: |


### PR DESCRIPTION
## Why are the changes needed?
We moved to a manual gh workflow in https://github.com/flyteorg/flyte/pull/5635, but the downstream gh jobs to the job that creates the git tag do not have access to it. This PR adds it.
 
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Beta release `v1.13.1b1` tested in https://github.com/flyteorg/flyte/actions/runs/10309586794. 
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
