### PR TITLE
Fix ordering for custom template values in cluster resource controller

### DIFF
--- a/flyteadmin/pkg/clusterresource/controller.go
+++ b/flyteadmin/pkg/clusterresource/controller.go
@@ -485,14 +485,13 @@ func (c *controller) createResourceFromTemplate(ctx context.Context, templateDir
 	templateValues[fmt.Sprintf(templateVariableFormat, domainVariable)] = domain.Id
 
 	var k8sManifest = string(template)
-	for templateKey, templateValue := range templateValues {
-		k8sManifest = strings.Replace(k8sManifest, templateKey, templateValue, replaceAllInstancesOfString)
-	}
-	// Replace remaining template variables from domain specific defaults.
 	for templateKey, templateValue := range customTemplateValues {
 		k8sManifest = strings.Replace(k8sManifest, templateKey, templateValue, replaceAllInstancesOfString)
 	}
-
+	// Replace remaining template variables from domain specific defaults.
+	for templateKey, templateValue := range templateValues {
+		k8sManifest = strings.Replace(k8sManifest, templateKey, templateValue, replaceAllInstancesOfString)
+	}
 	return k8sManifest, nil
 }
 

--- a/flyteadmin/pkg/clusterresource/controller_test.go
+++ b/flyteadmin/pkg/clusterresource/controller_test.go
@@ -296,6 +296,38 @@ metadata:
 `,
 			wantErr: false,
 		},
+		{
+			name: "test create resource from templatized imagepullsecrets.yaml",
+			args: args{
+				ctx:              context.Background(),
+				templateDir:      "testdata",
+				templateFileName: "imagepullsecrets_templatized.yaml",
+				project: &admin.Project{
+					Name: "my-project",
+					Id:   "my-project",
+				},
+				domain: &admin.Domain{
+					Id:   "dev",
+					Name: "dev",
+				},
+				namespace: "my-project-dev",
+				templateValues: templateValuesType{
+					"{{ imagePullSecretsName }}": "default",
+				},
+				customTemplateValues: templateValuesType{
+					"{{ imagePullSecretsName }}": "custom",
+				},
+			},
+			wantK8sManifest: `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: my-project-dev
+imagePullSecrets:
+  - name: custom
+`,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/flyteadmin/pkg/clusterresource/testdata/imagepullsecrets_templatized.yaml
+++ b/flyteadmin/pkg/clusterresource/testdata/imagepullsecrets_templatized.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: {{ namespace }}
+imagePullSecrets:
+  - name: {{ imagePullSecretsName }}


### PR DESCRIPTION
## Why are the changes needed?

Previously the domain-specific defaults were applies first, such that any templatized string

e.g. 
```
imagePullSecrets
  - name: {{ imagePullSecrets }}
```

got rendered with the _domain_ specific default, e.g.
 ```
imagePullSecrets
  - name: default
```
and string substitution therefore found no eligible candidates for replacement in the subsequent custom template values loop.


## What changes were proposed in this pull request?

Fixes ordering of custom template value substitution.

## How was this patch tested?

Tested on flyte sandbox and flyte deployment

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
