### PR TITLE
Validate labels before creating flyte CRD

### DIFF
--- a/flyteadmin/pkg/manager/impl/validation/execution_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/execution_validator.go
@@ -68,6 +68,9 @@ func ValidateExecutionRequest(ctx context.Context, request admin.ExecutionCreate
 			return err
 		}
 	}
+	if err := validateLabels(request.Spec.Labels); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/flyteadmin/pkg/manager/impl/validation/execution_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/execution_validator_test.go
@@ -66,6 +66,25 @@ func TestValidateExecInvalidProjectAndDomain(t *testing.T) {
 	assert.EqualError(t, err, "failed to validate that project [project] and domain [domain] are registered, err: [foo]")
 }
 
+func TestValidateExecInvalidLabels(t *testing.T) {
+	request := testutils.GetExecutionRequest()
+	request.Spec.Labels = &admin.Labels{
+		Values: map[string]string{
+			"foo": "#bar",
+		},
+	}
+	err := ValidateExecutionRequest(context.Background(), request, testutils.GetRepoWithDefaultProject(), execConfig)
+	assert.ErrorContains(t, err, "invalid label value [#bar]:")
+
+	request.Spec.Labels = &admin.Labels{
+		Values: map[string]string{
+			"#foo": "bar",
+		},
+	}
+	err = ValidateExecutionRequest(context.Background(), request, testutils.GetRepoWithDefaultProject(), execConfig)
+	assert.ErrorContains(t, err, "invalid label key [#foo]:")
+}
+
 func TestGetExecutionInputs(t *testing.T) {
 	executionRequest := testutils.GetExecutionRequest()
 	lpRequest := testutils.GetLaunchPlanRequest()


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Admin created the flyte CRD three times when using invalid labels in the execution and showed the error in flyteconsole.

We should validate labels before creating a CRD and return the error message to the client side (flytekit).

## What changes were proposed in this pull request?
Validate labels before creating flyte CRD.

## How was this patch tested?
```bash
pyflyte run --labels flyte=gwllo:123 --remote flyte-example/getting_started.py wf
```

### Setup process

### Screenshots
Before:

<img width="1337" alt="Screenshot 2024-08-19 at 3 24 22 PM" src="https://github.com/user-attachments/assets/dd358786-4d20-47f5-a7b3-81049c03f5e2">

<img width="1635" alt="Screenshot 2024-08-19 at 3 24 33 PM" src="https://github.com/user-attachments/assets/d0a9a01c-219a-4f63-b953-27d58ac3119e">

After:
<img width="1638" alt="Screenshot 2024-08-19 at 3 24 53 PM" src="https://github.com/user-attachments/assets/c7d5afb5-d927-4ce7-8cb4-2fb8d0dd9f8e">



## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
