### PR TITLE
[flytectl] DataConfig missing from TaskSpec

### DIFF
--- a/flytectl/cmd/register/register_util.go
+++ b/flytectl/cmd/register/register_util.go
@@ -339,8 +339,9 @@ func hydrateTaskSpec(task *admin.TaskSpec, sourceUploadedLocation storage.DataRe
 		}
 		task.Template.Target = &core.TaskTemplate_K8SPod{
 			K8SPod: &core.K8SPod{
-				Metadata: task.Template.GetK8SPod().Metadata,
-				PodSpec:  podSpecStruct,
+				Metadata:   task.Template.GetK8SPod().Metadata,
+				PodSpec:    podSpecStruct,
+				DataConfig: task.Template.GetK8SPod().DataConfig,
 			},
 		}
 	}


### PR DESCRIPTION
## Tracking issue
Slack reported issue.

## Why are the changes needed?
When hydrating the taskspec, the DataLoadingConfig is missing for K8s pod.

## What changes were proposed in this pull request?
Add the field.

## How was this patch tested?
tested by packaging and registering against [development](https://flyte.com/console/projects/flytesnacks/domains/development/task/calculate_ellipse_area_python_template_style/version/dataloadingconfig_ctl2) cluster.


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
