### PR TITLE
[Core feature] Allow flyteadmin to start even if OIDC is unavailable (Improve flyteadmin startup resiliency)

### DIFF
--- a/flyteadmin/auth/authzserver/initialize_test.go
+++ b/flyteadmin/auth/authzserver/initialize_test.go
@@ -14,7 +14,7 @@ import (
 func TestRegisterHandlers(t *testing.T) {
 	t.Run("No OAuth2 Provider, no registration required", func(t *testing.T) {
 		registerer := &mocks.HandlerRegisterer{}
-		RegisterHandlers(registerer, auth.Context{})
+		RegisterHandlers(registerer, &auth.Context{})
 	})
 
 	t.Run("Register 4 endpoints", func(t *testing.T) {

--- a/flyteadmin/auth/config/config.go
+++ b/flyteadmin/auth/config/config.go
@@ -72,6 +72,7 @@ var (
 					"openid",
 					"profile",
 				},
+				OnlyStartIfOIDCIsAvailable: true,
 			},
 			CookieSetting: CookieSettings{
 				Domain:         "",
@@ -271,6 +272,9 @@ type OpenIDOptions struct {
 	// be supported by any OIdC server. Refer to https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims for
 	// a complete list. Other providers might support additional scopes that you can define in a config.
 	Scopes []string `json:"scopes"`
+
+	// Blocks flyte from starting up until the OIDC provider is healthy and available
+	OnlyStartIfOIDCIsAvailable bool `json:"onlyStartIfOIDCIsAvailable"`
 }
 
 func GetConfig() *Config {


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5701

## Why are the changes needed?

Today, the flyteadmin pod is blocked from starting up until the OIDC provider is healthy and available (the pod gets stuck in Error state). In some Kubernetes configurations, this erroring-pod could cause deployment-wide issues. The current behavior could be made more resilient.

(Note that this applies to configurations using `useAuth=true`)

## What changes were proposed in this pull request?

A better approach in these configurations is to allow flyte to start up, even if the OIDC provider is unavailable. Then, try to re-initialize the OIDC provider later in the deployment lifespan. This is a more resilient approach, and it can be made configurable.

Adds an `onlyStartIfOIDCIsAvailable` config which controls this behavior.

## How was this patch tested?

A writeup is here which shows the "good" flow when `onlyStartIfOIDCIsAvailable` is enabled and OIDC is unhealthy for a period: https://gist.github.com/ddl-rliu/4c09862404f46a5adbc451025160e0eb

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
