### PR TITLE
Do not emit execution id label by default in single binary

### DIFF
--- a/cmd/single/start.go
+++ b/cmd/single/start.go
@@ -249,6 +249,6 @@ func init() {
 	RootCmd.AddCommand(startCmd)
 	// Set Keys
 	labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey,
-		contextutils.ExecIDKey, contextutils.WorkflowIDKey, contextutils.NodeIDKey, contextutils.TaskIDKey,
+		contextutils.WorkflowIDKey, contextutils.NodeIDKey, contextutils.TaskIDKey,
 		contextutils.TaskTypeKey, common.RuntimeTypeKey, common.RuntimeVersionKey, storage.FailureTypeLabel)
 }

--- a/flytestdlib/contextutils/context.go
+++ b/flytestdlib/contextutils/context.go
@@ -12,14 +12,15 @@ import (
 type Key string
 
 const (
-	AppNameKey         Key = "app_name"
-	NamespaceKey       Key = "ns"
-	TaskTypeKey        Key = "tasktype"
-	ProjectKey         Key = "project"
-	DomainKey          Key = "domain"
-	WorkflowIDKey      Key = "wf"
-	NodeIDKey          Key = "node"
-	TaskIDKey          Key = "task"
+	AppNameKey    Key = "app_name"
+	NamespaceKey  Key = "ns"
+	TaskTypeKey   Key = "tasktype"
+	ProjectKey    Key = "project"
+	DomainKey     Key = "domain"
+	WorkflowIDKey Key = "wf"
+	NodeIDKey     Key = "node"
+	TaskIDKey     Key = "task"
+	// Adding this label to a metric will cause higher cardinality. Use with caution.
 	ExecIDKey          Key = "exec_id"
 	JobIDKey           Key = "job_id"
 	PhaseKey           Key = "phase"

--- a/flytestdlib/contextutils/context.go
+++ b/flytestdlib/contextutils/context.go
@@ -20,7 +20,7 @@ const (
 	WorkflowIDKey Key = "wf"
 	NodeIDKey     Key = "node"
 	TaskIDKey     Key = "task"
-	// Adding this label to a metric will cause higher cardinality. Use with caution.
+	// Adding the ExecIDKey label to a metric will cause higher cardinality. Use with caution.
 	ExecIDKey          Key = "exec_id"
 	JobIDKey           Key = "job_id"
 	PhaseKey           Key = "phase"


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/3991

## Why are the changes needed?
Single binary emits execution-id labels to a bunch of flytepropeller and flyteadmin metrics, but since the golang prometheus golang client is setup in such a way that no metric is ever dropped (as described in https://github.com/prometheus/client_golang/discussions/920#discussioncomment-1448783), this ends up causing an apparent memory leak due to how these high cardinality metrics are stored in-memory.

## What changes were proposed in this pull request?
This PR removes the execution-id label from the single binary metrics and adds a comment to hint at the potential problems caused by that setting.

I confirmed that the metric is not enabled by default in any component, nor is set in any of the shipped helm charts, while being left as a last resort debugging tool.

One could argue that we should never have had that label in the first place and instead reach out to other debugging means, like open telemetry, etc, but that's a separate discussion.

## How was this patch tested?
I had a local test where I'd have a workflow composed of a single cached task. Running that in a tight loop and confirming that the increase in memory of the single binary executable is now orders of magnitude slower than before the PR.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
