### PR TITLE
OIDC config to allow mismatched discovery / issuer

### DIFF
--- a/flyteadmin/auth/auth_context.go
+++ b/flyteadmin/auth/auth_context.go
@@ -141,6 +141,12 @@ func NewAuthenticationContext(ctx context.Context, sm core.SecretManager, oauth2
 	// Construct an oidc Provider, which needs its own http Client.
 	oidcCtx := oidc.ClientContext(ctx, httpClient)
 	baseURL := options.UserAuth.OpenID.BaseURL.String()
+	// use a different issuer for token validation if configured
+	// this allows discovery to work when issuer_url from upstream is mismatched
+	// see https://github.com/coreos/go-oidc/pull/315
+	if iss := options.UserAuth.OpenID.IssuerURL.String(); iss != "" {
+		oidcCtx = oidc.InsecureIssuerURLContext(oidcCtx, iss)
+	}
 	provider, err := oidc.NewProvider(oidcCtx, baseURL)
 	if err != nil {
 		return Context{}, errors.Wrapf(ErrauthCtx, err, "Error creating oidc provider w/ issuer [%v]", baseURL)

--- a/flyteadmin/auth/config/config.go
+++ b/flyteadmin/auth/config/config.go
@@ -267,6 +267,12 @@ type OpenIDOptions struct {
 	// will look something like https://company.okta.com/oauth2/abcdef123456789/
 	BaseURL config.URL `json:"baseUrl"`
 
+	// Allows discovery to work when the issuer_url reported by upstream is mismatched with baseUrl. This may be the
+	// case with Azure *or* when baseUrl refers to an in-cluster service like https://keycloak/auth/realms/MyRealm but
+	// the issuer is a public ingress address accessible to the OIDC client
+	// Refer to https://github.com/coreos/go-oidc/pull/315 for additional details
+	IssuerURL config.URL `json:"issuerUrl" pflag:",OPTIONAL: Use this issuer URL for request validation rather than baseUrl."`
+
 	// Provides a list of scopes to request from the IDP when authenticating. Default value requests claims that should
 	// be supported by any OIdC server. Refer to https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims for
 	// a complete list. Other providers might support additional scopes that you can define in a config.

--- a/flyteadmin/auth/config/config_flags.go
+++ b/flyteadmin/auth/config/config_flags.go
@@ -60,6 +60,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "userAuth.openId.clientSecretName"), DefaultConfig.UserAuth.OpenID.ClientSecretName, "")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "userAuth.openId.clientSecretFile"), DefaultConfig.UserAuth.OpenID.DeprecatedClientSecretFile, "")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "userAuth.openId.baseUrl"), DefaultConfig.UserAuth.OpenID.BaseURL.String(), "")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "userAuth.openId.issuerUrl"), DefaultConfig.UserAuth.OpenID.IssuerURL.String(), "OPTIONAL: Use this issuer URL for request validation rather than baseUrl.")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "userAuth.openId.scopes"), DefaultConfig.UserAuth.OpenID.Scopes, "")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "userAuth.httpProxyURL"), DefaultConfig.UserAuth.HTTPProxyURL.String(), "OPTIONAL: HTTP Proxy to be used for OAuth requests.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "userAuth.cookieHashKeySecretName"), DefaultConfig.UserAuth.CookieHashKeySecretName, "OPTIONAL: Secret name to use for cookie hash key.")

--- a/flyteadmin/auth/config/config_flags_test.go
+++ b/flyteadmin/auth/config/config_flags_test.go
@@ -239,6 +239,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_userAuth.openId.issuerUrl", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := DefaultConfig.UserAuth.OpenID.IssuerURL.String()
+
+			cmdFlags.Set("userAuth.openId.issuerUrl", testValue)
+			if vString, err := cmdFlags.GetString("userAuth.openId.issuerUrl"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.UserAuth.OpenID.IssuerURL)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_userAuth.openId.scopes", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/flyteadmin/auth/config/config_test.go
+++ b/flyteadmin/auth/config/config_test.go
@@ -50,6 +50,9 @@ func TestParseClientSecretConfig(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, len(DefaultConfig.AppAuth.SelfAuthServer.StaticClients), 3)
 	assert.Equal(t, DefaultConfig.AppAuth.SelfAuthServer.StaticClients["flyte-cli"].ID, "flyte-cli")
+
+	// oidc issuer config should only be used when baseUrl is mismatched
+	assert.Equal(t, DefaultConfig.UserAuth.OpenID.IssuerURL.String(), "")
 }
 
 func TestCompare(t *testing.T) {


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?

 - There are a number of cases where the OIDC discovery url returns one issuer, but its desirable to use a separately configured / named issuer for validation instead.

   There are cases in Azure where this is necessary due to their non-standard OIDC configuration -- which is why this was originally added: https://github.com/coreos/go-oidc/pull/315

   There are also cases where it's necessary to use an in-cluster service address, but browser clients are using the external ingress address. Due to cluster DNS configuration, it's possible that flyteadmin may be unable to resolve or use the public ingress address for an Idp, but the internal service address is available. This configuration change allows for that.

 - Regenerated flyteadmin code through mise with:
 > mise x go@1.22 -- make generate


## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
