### PR TITLE
Set IsDefault to False for echo plugin

### DIFF
--- a/flyteplugins/go/tasks/plugins/testing/echo.go
+++ b/flyteplugins/go/tasks/plugins/testing/echo.go
@@ -181,7 +181,7 @@ func init() {
 					taskStartTimes: make(map[string]time.Time),
 				}, nil
 			},
-			IsDefault: true,
+			IsDefault: false,
 		},
 	)
 }


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
If `IsDefault` is True, the unknown task will always be handled by the echo plugin and always succeed.

```
{"json":{"exec_id":"fd2ed7347cfdb4e338f2","node":"n0","ns":"kk-flyte-dev3","res_ver":"9901776719","routine":"worker-
0","src":"handler.go:340","tasktype":"gnn","wf":"shuliang-
projects:development:gnn_agent_test.wf"},"level":"warning","msg":"No plugin found for Handler-type [gnn], defaulting to 
[echo]","ts":"2024-08-31T05:51:07Z"}
```

## What changes were proposed in this pull request?
Set IsDefault to false

## How was this patch tested?
single binary

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
