### PR TITLE
Fix flytectl returning the oldest workflow when using --latest flag

### DIFF
--- a/flytectl/cmd/get/launch_plan.go
+++ b/flytectl/cmd/get/launch_plan.go
@@ -219,7 +219,7 @@ func FetchLPForName(ctx context.Context, fetcher ext.AdminFetcherExtInterface, n
 	var lp *admin.LaunchPlan
 	var err error
 	if launchplan.DefaultConfig.Latest {
-		if lp, err = fetcher.FetchLPLatestVersion(ctx, name, project, domain, launchplan.DefaultConfig.Filter); err != nil {
+		if lp, err = fetcher.FetchLPLatestVersion(ctx, name, project, domain); err != nil {
 			return nil, err
 		}
 		launchPlans = append(launchPlans, lp)

--- a/flytectl/cmd/get/launch_plan_test.go
+++ b/flytectl/cmd/get/launch_plan_test.go
@@ -293,11 +293,10 @@ func TestGetLaunchPlanFuncLatest(t *testing.T) {
 	defer s.TearDown()
 	getLaunchPlanSetup()
 	launchplan.DefaultConfig.Latest = true
-	launchplan.DefaultConfig.Filter = filters.Filters{}
-	s.FetcherExt.OnFetchLPLatestVersionMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(launchPlan2, nil)
+	s.FetcherExt.OnFetchLPLatestVersionMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(launchPlan2, nil)
 	err := getLaunchPlanFunc(s.Ctx, argsLp, s.CmdCtx)
 	assert.Nil(t, err)
-	s.FetcherExt.AssertCalled(t, "FetchLPLatestVersion", s.Ctx, "launchplan1", projectValue, domainValue, launchplan.DefaultConfig.Filter)
+	s.FetcherExt.AssertCalled(t, "FetchLPLatestVersion", s.Ctx, "launchplan1", projectValue, domainValue)
 	s.TearDownAndVerify(t, `{"id": {"name": "launchplan1","version": "v2"},"spec": {"workflowId": {"name": "workflow2"},"defaultInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}}`)
 }
 

--- a/flytectl/cmd/get/workflow.go
+++ b/flytectl/cmd/get/workflow.go
@@ -2,7 +2,6 @@ package get
 
 import (
 	"context"
-
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
 	workflowconfig "github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/workflow"
 	cmdCore "github.com/flyteorg/flyte/flytectl/cmd/core"
@@ -183,7 +182,7 @@ func FetchWorkflowForName(ctx context.Context, fetcher ext.AdminFetcherExtInterf
 	domain string) (workflows []*admin.Workflow, isList bool, err error) {
 	var workflow *admin.Workflow
 	if workflowconfig.DefaultConfig.Latest {
-		if workflow, err = fetcher.FetchWorkflowLatestVersion(ctx, name, project, domain, workflowconfig.DefaultConfig.Filter); err != nil {
+		if workflow, err = fetcher.FetchWorkflowLatestVersion(ctx, name, project, domain); err != nil {
 			return nil, false, err
 		}
 		workflows = append(workflows, workflow)

--- a/flytectl/cmd/get/workflow.go
+++ b/flytectl/cmd/get/workflow.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"context"
+
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
 	workflowconfig "github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/workflow"
 	cmdCore "github.com/flyteorg/flyte/flytectl/cmd/core"

--- a/flytectl/cmd/get/workflow_test.go
+++ b/flytectl/cmd/get/workflow_test.go
@@ -174,9 +174,8 @@ func TestGetWorkflowFuncLatestWithTable(t *testing.T) {
 
 	getWorkflowSetup()
 	workflow.DefaultConfig.Latest = true
-	workflow.DefaultConfig.Filter = filters.Filters{}
 	config.GetConfig().Output = printer.OutputFormatTABLE.String()
-	s.FetcherExt.OnFetchWorkflowLatestVersionMatch(s.Ctx, "workflow1", projectValue, domainValue, filters.Filters{}).Return(workflow1, nil)
+	s.FetcherExt.OnFetchWorkflowLatestVersionMatch(s.Ctx, "workflow1", projectValue, domainValue).Return(workflow1, nil)
 	err := getWorkflowFunc(s.Ctx, argsWf, s.CmdCtx)
 	assert.Nil(t, err)
 	s.TearDownAndVerify(t, `

--- a/flytectl/pkg/ext/fetcher.go
+++ b/flytectl/pkg/ext/fetcher.go
@@ -34,7 +34,7 @@ type AdminFetcherExtInterface interface {
 	FetchAllVerOfLP(ctx context.Context, lpName, project, domain string, filter filters.Filters) ([]*admin.LaunchPlan, error)
 
 	// FetchLPLatestVersion fetches latest version of launch plan in a  project, domain
-	FetchLPLatestVersion(ctx context.Context, name, project, domain string, filter filters.Filters) (*admin.LaunchPlan, error)
+	FetchLPLatestVersion(ctx context.Context, name, project, domain string) (*admin.LaunchPlan, error)
 
 	// FetchLPVersion fetches particular version of launch plan in a  project, domain
 	FetchLPVersion(ctx context.Context, name, version, project, domain string) (*admin.LaunchPlan, error)

--- a/flytectl/pkg/ext/fetcher.go
+++ b/flytectl/pkg/ext/fetcher.go
@@ -55,7 +55,7 @@ type AdminFetcherExtInterface interface {
 	FetchAllVerOfWorkflow(ctx context.Context, name, project, domain string, filter filters.Filters) ([]*admin.Workflow, error)
 
 	// FetchWorkflowLatestVersion fetches latest version of workflow in a  project, domain
-	FetchWorkflowLatestVersion(ctx context.Context, name, project, domain string, filter filters.Filters) (*admin.Workflow, error)
+	FetchWorkflowLatestVersion(ctx context.Context, name, project, domain string) (*admin.Workflow, error)
 
 	// FetchWorkflowVersion fetches particular version of workflow in a  project, domain
 	FetchWorkflowVersion(ctx context.Context, name, version, project, domain string) (*admin.Workflow, error)

--- a/flytectl/pkg/ext/launch_plan_fetcher.go
+++ b/flytectl/pkg/ext/launch_plan_fetcher.go
@@ -26,8 +26,13 @@ func (a *AdminFetcherExtClient) FetchAllVerOfLP(ctx context.Context, lpName, pro
 }
 
 // FetchLPLatestVersion fetches latest version for give launch plan name
-func (a *AdminFetcherExtClient) FetchLPLatestVersion(ctx context.Context, name, project, domain string, filter filters.Filters) (*admin.LaunchPlan, error) {
-	// Fetch the latest version of the task.
+func (a *AdminFetcherExtClient) FetchLPLatestVersion(ctx context.Context, name, project, domain string) (*admin.LaunchPlan, error) {
+	// Fetch the latest version of the LaunchPLan.
+	filter := filters.Filters{
+		SortBy: "created_at",
+		Limit:  1,
+		Asc:    false,
+	}
 	lpVersions, err := a.FetchAllVerOfLP(ctx, name, project, domain, filter)
 	if err != nil {
 		return nil, err

--- a/flytectl/pkg/ext/launch_plan_fetcher_test.go
+++ b/flytectl/pkg/ext/launch_plan_fetcher_test.go
@@ -156,7 +156,7 @@ func TestFetchAllVerOfLPEmptyResponse(t *testing.T) {
 func TestFetchLPLatestVersion(t *testing.T) {
 	getLaunchPlanFetcherSetup()
 	adminClient.OnListLaunchPlansMatch(mock.Anything, mock.Anything).Return(launchPlanListResponse, nil)
-	_, err := adminFetcherExt.FetchLPLatestVersion(ctx, "lpName", "project", "domain", lpFilters)
+	_, err := adminFetcherExt.FetchLPLatestVersion(ctx, "lpName", "project", "domain")
 	assert.Nil(t, err)
 }
 
@@ -164,6 +164,6 @@ func TestFetchLPLatestVersionError(t *testing.T) {
 	launchPlanListResponse := &admin.LaunchPlanList{}
 	getLaunchPlanFetcherSetup()
 	adminClient.OnListLaunchPlansMatch(mock.Anything, mock.Anything).Return(launchPlanListResponse, nil)
-	_, err := adminFetcherExt.FetchLPLatestVersion(ctx, "lpName", "project", "domain", lpFilters)
+	_, err := adminFetcherExt.FetchLPLatestVersion(ctx, "lpName", "project", "domain")
 	assert.Equal(t, fmt.Errorf("no launchplans retrieved for lpName"), err)
 }

--- a/flytectl/pkg/ext/mocks/admin_fetcher_ext_interface.go
+++ b/flytectl/pkg/ext/mocks/admin_fetcher_ext_interface.go
@@ -266,8 +266,8 @@ func (_m AdminFetcherExtInterface_FetchLPLatestVersion) Return(_a0 *admin.Launch
 	return &AdminFetcherExtInterface_FetchLPLatestVersion{Call: _m.Call.Return(_a0, _a1)}
 }
 
-func (_m *AdminFetcherExtInterface) OnFetchLPLatestVersion(ctx context.Context, name string, project string, domain string, filter filters.Filters) *AdminFetcherExtInterface_FetchLPLatestVersion {
-	c_call := _m.On("FetchLPLatestVersion", ctx, name, project, domain, filter)
+func (_m *AdminFetcherExtInterface) OnFetchLPLatestVersion(ctx context.Context, name string, project string, domain string) *AdminFetcherExtInterface_FetchLPLatestVersion {
+	c_call := _m.On("FetchLPLatestVersion", ctx, name, project, domain)
 	return &AdminFetcherExtInterface_FetchLPLatestVersion{Call: c_call}
 }
 
@@ -276,13 +276,13 @@ func (_m *AdminFetcherExtInterface) OnFetchLPLatestVersionMatch(matchers ...inte
 	return &AdminFetcherExtInterface_FetchLPLatestVersion{Call: c_call}
 }
 
-// FetchLPLatestVersion provides a mock function with given fields: ctx, name, project, domain, filter
-func (_m *AdminFetcherExtInterface) FetchLPLatestVersion(ctx context.Context, name string, project string, domain string, filter filters.Filters) (*admin.LaunchPlan, error) {
-	ret := _m.Called(ctx, name, project, domain, filter)
+// FetchLPLatestVersion provides a mock function with given fields: ctx, name, project, domain
+func (_m *AdminFetcherExtInterface) FetchLPLatestVersion(ctx context.Context, name string, project string, domain string) (*admin.LaunchPlan, error) {
+	ret := _m.Called(ctx, name, project, domain)
 
 	var r0 *admin.LaunchPlan
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, filters.Filters) *admin.LaunchPlan); ok {
-		r0 = rf(ctx, name, project, domain, filter)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *admin.LaunchPlan); ok {
+		r0 = rf(ctx, name, project, domain)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*admin.LaunchPlan)
@@ -290,8 +290,8 @@ func (_m *AdminFetcherExtInterface) FetchLPLatestVersion(ctx context.Context, na
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, filters.Filters) error); ok {
-		r1 = rf(ctx, name, project, domain, filter)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, name, project, domain)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/flytectl/pkg/ext/mocks/admin_fetcher_ext_interface.go
+++ b/flytectl/pkg/ext/mocks/admin_fetcher_ext_interface.go
@@ -676,8 +676,8 @@ func (_m AdminFetcherExtInterface_FetchWorkflowLatestVersion) Return(_a0 *admin.
 	return &AdminFetcherExtInterface_FetchWorkflowLatestVersion{Call: _m.Call.Return(_a0, _a1)}
 }
 
-func (_m *AdminFetcherExtInterface) OnFetchWorkflowLatestVersion(ctx context.Context, name string, project string, domain string, filter filters.Filters) *AdminFetcherExtInterface_FetchWorkflowLatestVersion {
-	c_call := _m.On("FetchWorkflowLatestVersion", ctx, name, project, domain, filter)
+func (_m *AdminFetcherExtInterface) OnFetchWorkflowLatestVersion(ctx context.Context, name string, project string, domain string) *AdminFetcherExtInterface_FetchWorkflowLatestVersion {
+	c_call := _m.On("FetchWorkflowLatestVersion", ctx, name, project, domain)
 	return &AdminFetcherExtInterface_FetchWorkflowLatestVersion{Call: c_call}
 }
 

--- a/flytectl/pkg/ext/mocks/admin_fetcher_ext_interface.go
+++ b/flytectl/pkg/ext/mocks/admin_fetcher_ext_interface.go
@@ -686,13 +686,13 @@ func (_m *AdminFetcherExtInterface) OnFetchWorkflowLatestVersionMatch(matchers .
 	return &AdminFetcherExtInterface_FetchWorkflowLatestVersion{Call: c_call}
 }
 
-// FetchWorkflowLatestVersion provides a mock function with given fields: ctx, name, project, domain, filter
-func (_m *AdminFetcherExtInterface) FetchWorkflowLatestVersion(ctx context.Context, name string, project string, domain string, filter filters.Filters) (*admin.Workflow, error) {
-	ret := _m.Called(ctx, name, project, domain, filter)
+// FetchWorkflowLatestVersion provides a mock function with given fields: ctx, name, project, domain
+func (_m *AdminFetcherExtInterface) FetchWorkflowLatestVersion(ctx context.Context, name string, project string, domain string) (*admin.Workflow, error) {
+	ret := _m.Called(ctx, name, project, domain)
 
 	var r0 *admin.Workflow
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, filters.Filters) *admin.Workflow); ok {
-		r0 = rf(ctx, name, project, domain, filter)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *admin.Workflow); ok {
+		r0 = rf(ctx, name, project, domain)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*admin.Workflow)
@@ -700,8 +700,8 @@ func (_m *AdminFetcherExtInterface) FetchWorkflowLatestVersion(ctx context.Conte
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, filters.Filters) error); ok {
-		r1 = rf(ctx, name, project, domain, filter)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, name, project, domain)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/flytectl/pkg/ext/workflow_fetcher.go
+++ b/flytectl/pkg/ext/workflow_fetcher.go
@@ -42,8 +42,13 @@ func (a *AdminFetcherExtClient) FetchAllWorkflows(ctx context.Context, project, 
 }
 
 // FetchWorkflowLatestVersion fetches latest version for given workflow name
-func (a *AdminFetcherExtClient) FetchWorkflowLatestVersion(ctx context.Context, name, project, domain string, filter filters.Filters) (*admin.Workflow, error) {
+func (a *AdminFetcherExtClient) FetchWorkflowLatestVersion(ctx context.Context, name, project, domain string) (*admin.Workflow, error) {
 	// Fetch the latest version of the workflow.
+	filter := filters.Filters{
+		SortBy: "created_at",
+		Limit:  1,
+		Asc:    false,
+	}
 	wVersions, err := a.FetchAllVerOfWorkflow(ctx, name, project, domain, filter)
 	if err != nil {
 		return nil, err

--- a/flytectl/pkg/ext/workflow_fetcher_test.go
+++ b/flytectl/pkg/ext/workflow_fetcher_test.go
@@ -147,7 +147,7 @@ func TestFetchWorkflowLatestVersion(t *testing.T) {
 	getWorkflowFetcherSetup()
 	adminClient.OnGetWorkflowMatch(mock.Anything, mock.Anything).Return(workflowResponse, nil)
 	adminClient.OnListWorkflowsMatch(mock.Anything, mock.Anything).Return(workflowListResponse, nil)
-	_, err := adminFetcherExt.FetchWorkflowLatestVersion(ctx, "workflowName", "project", "domain", workflowFilter)
+	_, err := adminFetcherExt.FetchWorkflowLatestVersion(ctx, "workflowName", "project", "domain")
 	assert.Nil(t, err)
 }
 
@@ -155,6 +155,6 @@ func TestFetchWorkflowLatestVersionError(t *testing.T) {
 	workflowListResponse := &admin.WorkflowList{}
 	getWorkflowFetcherSetup()
 	adminClient.OnListWorkflowsMatch(mock.Anything, mock.Anything).Return(workflowListResponse, nil)
-	_, err := adminFetcherExt.FetchWorkflowLatestVersion(ctx, "workflowName", "project", "domain", workflowFilter)
+	_, err := adminFetcherExt.FetchWorkflowLatestVersion(ctx, "workflowName", "project", "domain")
 	assert.Equal(t, fmt.Errorf("no workflow retrieved for workflowName"), err)
 }


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->
Closes https://github.com/flyteorg/flyte/issues/3972

## Why are the changes needed?

Passing the --latest flag in when getting Workflows are not returning the latest but the opposite. 

## What changes were proposed in this pull request?

We set a default filter for the get `FetchWorkflowLatestVersion` and also `FetchLaunchPlanLatestVersion`. 

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
