### PR TITLE
Refactor flyteadmin to pass proto structs as pointers

### DIFF
--- a/flyteadmin/.golangci.yml
+++ b/flyteadmin/.golangci.yml
@@ -36,5 +36,6 @@ linters-settings:
       - prefix(github.com/flyteorg)
     skip-generated: true
 issues:
-  exclude:
-    - copylocks
+  exclude-rules:
+    - path: pkg/workflowengine/impl/prepare_execution.go
+      text: "copies lock"

--- a/flyteadmin/dataproxy/service_test.go
+++ b/flyteadmin/dataproxy/service_test.go
@@ -160,7 +160,7 @@ func TestCreateUploadLocationMore(t *testing.T) {
 func TestCreateDownloadLink(t *testing.T) {
 	dataStore := commonMocks.GetMockStorageClient()
 	nodeExecutionManager := &mocks.MockNodeExecutionManager{}
-	nodeExecutionManager.SetGetNodeExecutionFunc(func(ctx context.Context, request admin.NodeExecutionGetRequest) (*admin.NodeExecution, error) {
+	nodeExecutionManager.SetGetNodeExecutionFunc(func(ctx context.Context, request *admin.NodeExecutionGetRequest) (*admin.NodeExecution, error) {
 		return &admin.NodeExecution{
 			Closure: &admin.NodeExecutionClosure{
 				DeckUri: "s3://something/something",
@@ -282,14 +282,14 @@ func TestService_GetData(t *testing.T) {
 	}
 
 	nodeExecutionManager.SetGetNodeExecutionDataFunc(
-		func(ctx context.Context, request admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error) {
+		func(ctx context.Context, request *admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error) {
 			return &admin.NodeExecutionGetDataResponse{
 				FullInputs:  inputsLM,
 				FullOutputs: outputsLM,
 			}, nil
 		},
 	)
-	taskExecutionManager.SetListTaskExecutionsCallback(func(ctx context.Context, request admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error) {
+	taskExecutionManager.SetListTaskExecutionsCallback(func(ctx context.Context, request *admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error) {
 		return &admin.TaskExecutionList{
 			TaskExecutions: []*admin.TaskExecution{
 				{
@@ -315,7 +315,7 @@ func TestService_GetData(t *testing.T) {
 			},
 		}, nil
 	})
-	taskExecutionManager.SetGetTaskExecutionDataCallback(func(ctx context.Context, request admin.TaskExecutionGetDataRequest) (*admin.TaskExecutionGetDataResponse, error) {
+	taskExecutionManager.SetGetTaskExecutionDataCallback(func(ctx context.Context, request *admin.TaskExecutionGetDataRequest) (*admin.TaskExecutionGetDataResponse, error) {
 		return &admin.TaskExecutionGetDataResponse{
 			FullInputs:  inputsLM,
 			FullOutputs: outputsLM,
@@ -388,10 +388,10 @@ func TestService_Error(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("get a working set of urls without retry attempt", func(t *testing.T) {
-		taskExecutionManager.SetListTaskExecutionsCallback(func(ctx context.Context, request admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error) {
+		taskExecutionManager.SetListTaskExecutionsCallback(func(ctx context.Context, request *admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error) {
 			return nil, errors.NewFlyteAdminErrorf(1, "not found")
 		})
-		nodeExecID := core.NodeExecutionIdentifier{
+		nodeExecID := &core.NodeExecutionIdentifier{
 			NodeId: "n0",
 			ExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "proj",
@@ -404,13 +404,13 @@ func TestService_Error(t *testing.T) {
 	})
 
 	t.Run("get a working set of urls without retry attempt", func(t *testing.T) {
-		taskExecutionManager.SetListTaskExecutionsCallback(func(ctx context.Context, request admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error) {
+		taskExecutionManager.SetListTaskExecutionsCallback(func(ctx context.Context, request *admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error) {
 			return &admin.TaskExecutionList{
 				TaskExecutions: nil,
 				Token:          "",
 			}, nil
 		})
-		nodeExecID := core.NodeExecutionIdentifier{
+		nodeExecID := &core.NodeExecutionIdentifier{
 			NodeId: "n0",
 			ExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "proj",

--- a/flyteadmin/pkg/async/events/implementations/node_execution_event_writer.go
+++ b/flyteadmin/pkg/async/events/implementations/node_execution_event_writer.go
@@ -14,10 +14,10 @@ import (
 // events, node execution processing doesn't have to wait on these to be committed.
 type nodeExecutionEventWriter struct {
 	db     repositoryInterfaces.Repository
-	events chan admin.NodeExecutionEventRequest
+	events chan *admin.NodeExecutionEventRequest
 }
 
-func (w *nodeExecutionEventWriter) Write(event admin.NodeExecutionEventRequest) {
+func (w *nodeExecutionEventWriter) Write(event *admin.NodeExecutionEventRequest) {
 	w.events <- event
 }
 
@@ -40,6 +40,6 @@ func (w *nodeExecutionEventWriter) Run() {
 func NewNodeExecutionEventWriter(db repositoryInterfaces.Repository, bufferSize int) interfaces.NodeExecutionEventWriter {
 	return &nodeExecutionEventWriter{
 		db:     db,
-		events: make(chan admin.NodeExecutionEventRequest, bufferSize),
+		events: make(chan *admin.NodeExecutionEventRequest, bufferSize),
 	}
 }

--- a/flyteadmin/pkg/async/events/implementations/node_execution_event_writer_test.go
+++ b/flyteadmin/pkg/async/events/implementations/node_execution_event_writer_test.go
@@ -12,7 +12,7 @@ import (
 func TestNodeExecutionEventWriter(t *testing.T) {
 	db := mocks.NewMockRepository()
 
-	event := admin.NodeExecutionEventRequest{
+	event := &admin.NodeExecutionEventRequest{
 		RequestId: "request_id",
 		Event: &event2.NodeExecutionEvent{
 			Id: &core.NodeExecutionIdentifier{

--- a/flyteadmin/pkg/async/events/implementations/workflow_execution_event_writer.go
+++ b/flyteadmin/pkg/async/events/implementations/workflow_execution_event_writer.go
@@ -14,10 +14,10 @@ import (
 // events, workflow execution processing doesn't have to wait on these to be committed.
 type workflowExecutionEventWriter struct {
 	db     repositoryInterfaces.Repository
-	events chan admin.WorkflowExecutionEventRequest
+	events chan *admin.WorkflowExecutionEventRequest
 }
 
-func (w *workflowExecutionEventWriter) Write(event admin.WorkflowExecutionEventRequest) {
+func (w *workflowExecutionEventWriter) Write(event *admin.WorkflowExecutionEventRequest) {
 	w.events <- event
 }
 
@@ -40,6 +40,6 @@ func (w *workflowExecutionEventWriter) Run() {
 func NewWorkflowExecutionEventWriter(db repositoryInterfaces.Repository, bufferSize int) interfaces.WorkflowExecutionEventWriter {
 	return &workflowExecutionEventWriter{
 		db:     db,
-		events: make(chan admin.WorkflowExecutionEventRequest, bufferSize),
+		events: make(chan *admin.WorkflowExecutionEventRequest, bufferSize),
 	}
 }

--- a/flyteadmin/pkg/async/events/implementations/workflow_execution_event_writer_test.go
+++ b/flyteadmin/pkg/async/events/implementations/workflow_execution_event_writer_test.go
@@ -12,7 +12,7 @@ import (
 func TestWorkflowExecutionEventWriter(t *testing.T) {
 	db := mocks.NewMockRepository()
 
-	event := admin.WorkflowExecutionEventRequest{
+	event := &admin.WorkflowExecutionEventRequest{
 		RequestId: "request_id",
 		Event: &event2.WorkflowExecutionEvent{
 			ExecutionId: &core.WorkflowExecutionIdentifier{

--- a/flyteadmin/pkg/async/events/interfaces/node_execution.go
+++ b/flyteadmin/pkg/async/events/interfaces/node_execution.go
@@ -8,5 +8,5 @@ import (
 
 type NodeExecutionEventWriter interface {
 	Run()
-	Write(nodeExecutionEvent admin.NodeExecutionEventRequest)
+	Write(nodeExecutionEvent *admin.NodeExecutionEventRequest)
 }

--- a/flyteadmin/pkg/async/events/interfaces/workflow_execution.go
+++ b/flyteadmin/pkg/async/events/interfaces/workflow_execution.go
@@ -8,5 +8,5 @@ import (
 
 type WorkflowExecutionEventWriter interface {
 	Run()
-	Write(workflowExecutionEvent admin.WorkflowExecutionEventRequest)
+	Write(workflowExecutionEvent *admin.WorkflowExecutionEventRequest)
 }

--- a/flyteadmin/pkg/async/events/mocks/node_execution_event_writer.go
+++ b/flyteadmin/pkg/async/events/mocks/node_execution_event_writer.go
@@ -19,6 +19,6 @@ func (_m *NodeExecutionEventWriter) Run() {
 }
 
 // Write provides a mock function with given fields: nodeExecutionEvent
-func (_m *NodeExecutionEventWriter) Write(nodeExecutionEvent admin.NodeExecutionEventRequest) {
+func (_m *NodeExecutionEventWriter) Write(nodeExecutionEvent *admin.NodeExecutionEventRequest) {
 	_m.Called(nodeExecutionEvent)
 }

--- a/flyteadmin/pkg/async/events/mocks/workflow_execution_event_writer.go
+++ b/flyteadmin/pkg/async/events/mocks/workflow_execution_event_writer.go
@@ -19,6 +19,6 @@ func (_m *WorkflowExecutionEventWriter) Run() {
 }
 
 // Write provides a mock function with given fields: workflowExecutionEvent
-func (_m *WorkflowExecutionEventWriter) Write(workflowExecutionEvent admin.WorkflowExecutionEventRequest) {
+func (_m *WorkflowExecutionEventWriter) Write(workflowExecutionEvent *admin.WorkflowExecutionEventRequest) {
 	_m.Called(workflowExecutionEvent)
 }

--- a/flyteadmin/pkg/async/notifications/email.go
+++ b/flyteadmin/pkg/async/notifications/email.go
@@ -8,7 +8,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-type GetTemplateValue func(admin.WorkflowExecutionEventRequest, *admin.Execution) string
+type GetTemplateValue func(*admin.WorkflowExecutionEventRequest, *admin.Execution) string
 
 const executionError = " The execution failed with error: [%s]."
 
@@ -29,58 +29,58 @@ const launchPlanName = "launch_plan.name"
 const launchPlanVersion = "launch_plan.version"
 const replaceAllInstances = -1
 
-func getProject(_ admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
+func getProject(_ *admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
 	return exec.Id.Project
 }
 
-func getDomain(_ admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
+func getDomain(_ *admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
 	return exec.Id.Domain
 }
 
-func getName(_ admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
+func getName(_ *admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
 	return exec.Id.Name
 }
 
-func getPhase(request admin.WorkflowExecutionEventRequest, _ *admin.Execution) string {
+func getPhase(request *admin.WorkflowExecutionEventRequest, _ *admin.Execution) string {
 	return strings.ToLower(request.Event.Phase.String())
 }
 
-func getError(request admin.WorkflowExecutionEventRequest, _ *admin.Execution) string {
+func getError(request *admin.WorkflowExecutionEventRequest, _ *admin.Execution) string {
 	if request.Event.GetError() != nil {
 		return fmt.Sprintf(executionError, request.Event.GetError().Message)
 	}
 	return ""
 }
 
-func getWorkflowProject(_ admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
+func getWorkflowProject(_ *admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
 	return exec.Closure.WorkflowId.Project
 }
 
-func getWorkflowDomain(_ admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
+func getWorkflowDomain(_ *admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
 	return exec.Closure.WorkflowId.Domain
 }
 
-func getWorkflowName(_ admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
+func getWorkflowName(_ *admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
 	return exec.Closure.WorkflowId.Name
 }
 
-func getWorkflowVersion(_ admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
+func getWorkflowVersion(_ *admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
 	return exec.Closure.WorkflowId.Version
 }
 
-func getLaunchPlanProject(_ admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
+func getLaunchPlanProject(_ *admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
 	return exec.Spec.LaunchPlan.Project
 }
 
-func getLaunchPlanDomain(_ admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
+func getLaunchPlanDomain(_ *admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
 	return exec.Spec.LaunchPlan.Domain
 }
 
-func getLaunchPlanName(_ admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
+func getLaunchPlanName(_ *admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
 	return exec.Spec.LaunchPlan.Name
 }
 
-func getLaunchPlanVersion(_ admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
+func getLaunchPlanVersion(_ *admin.WorkflowExecutionEventRequest, exec *admin.Execution) string {
 	return exec.Spec.LaunchPlan.Version
 }
 
@@ -100,7 +100,7 @@ var getTemplateValueFuncs = map[string]GetTemplateValue{
 	launchPlanVersion: getLaunchPlanVersion,
 }
 
-func substituteEmailParameters(message string, request admin.WorkflowExecutionEventRequest, execution *admin.Execution) string {
+func substituteEmailParameters(message string, request *admin.WorkflowExecutionEventRequest, execution *admin.Execution) string {
 	for template, function := range getTemplateValueFuncs {
 		message = strings.Replace(message, fmt.Sprintf(substitutionParam, template), function(request, execution), replaceAllInstances)
 		message = strings.Replace(message, fmt.Sprintf(substitutionParamNoSpaces, template), function(request, execution), replaceAllInstances)
@@ -112,8 +112,8 @@ func substituteEmailParameters(message string, request admin.WorkflowExecutionEv
 // in customizable email fields set in the flyteadmin application notifications config.
 func ToEmailMessageFromWorkflowExecutionEvent(
 	config runtimeInterfaces.NotificationsConfig,
-	emailNotification admin.EmailNotification,
-	request admin.WorkflowExecutionEventRequest,
+	emailNotification *admin.EmailNotification,
+	request *admin.WorkflowExecutionEventRequest,
 	execution *admin.Execution) *admin.EmailMessage {
 
 	return &admin.EmailMessage{

--- a/flyteadmin/pkg/async/notifications/email_test.go
+++ b/flyteadmin/pkg/async/notifications/email_test.go
@@ -52,7 +52,7 @@ var workflowExecution = &admin.Execution{
 
 func TestSubstituteEmailParameters(t *testing.T) {
 	message := "{{ unused }}. {{project }} and {{ domain }} and {{ name }} ended up in {{ phase }}.{{ error }}"
-	request := admin.WorkflowExecutionEventRequest{
+	request := &admin.WorkflowExecutionEventRequest{
 		Event: &event.WorkflowExecutionEvent{
 			Phase: core.WorkflowExecution_SUCCEEDED,
 		},
@@ -88,7 +88,7 @@ func TestSubstituteAllTemplates(t *testing.T) {
 		messageTemplate = append(messageTemplate, template)
 		desiredResult = append(desiredResult, result)
 	}
-	request := admin.WorkflowExecutionEventRequest{
+	request := &admin.WorkflowExecutionEventRequest{
 		Event: &event.WorkflowExecutionEvent{
 			Phase: core.WorkflowExecution_SUCCEEDED,
 		},
@@ -117,7 +117,7 @@ func TestSubstituteAllTemplatesNoSpaces(t *testing.T) {
 		messageTemplate = append(messageTemplate, template)
 		desiredResult = append(desiredResult, result)
 	}
-	request := admin.WorkflowExecutionEventRequest{
+	request := &admin.WorkflowExecutionEventRequest{
 		Event: &event.WorkflowExecutionEvent{
 			Phase: core.WorkflowExecution_SUCCEEDED,
 		},
@@ -136,12 +136,12 @@ func TestToEmailMessageFromWorkflowExecutionEvent(t *testing.T) {
 			Subject: "Notice: Execution \"{{ name }}\" has succeeded in \"{{ domain }}\".",
 		},
 	}
-	emailNotification := admin.EmailNotification{
+	emailNotification := &admin.EmailNotification{
 		RecipientsEmail: []string{
 			"a@example.com", "b@example.org",
 		},
 	}
-	request := admin.WorkflowExecutionEventRequest{
+	request := &admin.WorkflowExecutionEventRequest{
 		Event: &event.WorkflowExecutionEvent{
 			Phase: core.WorkflowExecution_ABORTED,
 		},

--- a/flyteadmin/pkg/async/notifications/implementations/aws_emailer.go
+++ b/flyteadmin/pkg/async/notifications/implementations/aws_emailer.go
@@ -21,7 +21,7 @@ type AwsEmailer struct {
 	awsEmail      sesiface.SESAPI
 }
 
-func FlyteEmailToSesEmailInput(email admin.EmailMessage) ses.SendEmailInput {
+func FlyteEmailToSesEmailInput(email *admin.EmailMessage) ses.SendEmailInput {
 	var toAddress []*string
 	for _, toEmail := range email.RecipientsEmail {
 		// SES email input takes an array of pointers to strings so we have to create a new one for each email
@@ -51,7 +51,7 @@ func FlyteEmailToSesEmailInput(email admin.EmailMessage) ses.SendEmailInput {
 	}
 }
 
-func (e *AwsEmailer) SendEmail(ctx context.Context, email admin.EmailMessage) error {
+func (e *AwsEmailer) SendEmail(ctx context.Context, email *admin.EmailMessage) error {
 	emailInput := FlyteEmailToSesEmailInput(email)
 	_, err := e.awsEmail.SendEmail(&emailInput)
 	e.systemMetrics.SendTotal.Inc()

--- a/flyteadmin/pkg/async/notifications/implementations/aws_emailer_test.go
+++ b/flyteadmin/pkg/async/notifications/implementations/aws_emailer_test.go
@@ -32,7 +32,7 @@ func TestAwsEmailer_SendEmail(t *testing.T) {
 	mockAwsEmail := mocks.SESClient{}
 	var awsSES sesiface.SESAPI = &mockAwsEmail
 	expectedSenderEmail := "no-reply@example.com"
-	emailNotification := admin.EmailMessage{
+	emailNotification := &admin.EmailMessage{
 		SubjectLine: "Notice: Execution \"name\" has succeeded in \"domain\".",
 		SenderEmail: "no-reply@example.com",
 		RecipientsEmail: []string{
@@ -67,7 +67,7 @@ func TestAwsEmailer_SendEmail(t *testing.T) {
 }
 
 func TestFlyteEmailToSesEmailInput(t *testing.T) {
-	emailNotification := admin.EmailMessage{
+	emailNotification := &admin.EmailMessage{
 		SubjectLine: "Notice: Execution \"name\" has succeeded in \"domain\".",
 		SenderEmail: "no-reply@example.com",
 		RecipientsEmail: []string{
@@ -97,7 +97,7 @@ func TestAwsEmailer_SendEmailError(t *testing.T) {
 
 	testEmail := NewAwsEmailer(getNotificationsConfig(), promutils.NewTestScope(), awsSES)
 
-	emailNotification := admin.EmailMessage{
+	emailNotification := &admin.EmailMessage{
 		SubjectLine: "Notice: Execution \"name\" has succeeded in \"domain\".",
 		SenderEmail: "no-reply@example.com",
 		RecipientsEmail: []string{
@@ -125,7 +125,7 @@ func TestAwsEmailer_SendEmailEmailOutput(t *testing.T) {
 
 	testEmail := NewAwsEmailer(getNotificationsConfig(), promutils.NewTestScope(), awsSES)
 
-	emailNotification := admin.EmailMessage{
+	emailNotification := &admin.EmailMessage{
 		SubjectLine: "Notice: Execution \"name\" has succeeded in \"domain\".",
 		SenderEmail: "no-reply@example.com",
 		RecipientsEmail: []string{

--- a/flyteadmin/pkg/async/notifications/implementations/aws_processor.go
+++ b/flyteadmin/pkg/async/notifications/implementations/aws_processor.go
@@ -36,7 +36,7 @@ func (p *Processor) StartProcessing() {
 }
 
 func (p *Processor) run() error {
-	var emailMessage admin.EmailMessage
+	emailMessage := &admin.EmailMessage{}
 	var err error
 	for msg := range p.sub.Start() {
 		p.systemMetrics.MessageTotal.Inc()
@@ -83,7 +83,7 @@ func (p *Processor) run() error {
 			continue
 		}
 
-		if err = proto.Unmarshal(notificationBytes, &emailMessage); err != nil {
+		if err = proto.Unmarshal(notificationBytes, emailMessage); err != nil {
 			logger.Debugf(context.Background(), "failed to unmarshal to notification object from decoded string[%s] from message [%s] with err: %v", valueString, stringMsg, err)
 			p.systemMetrics.MessageDecodingError.Inc()
 			p.markMessageDone(msg)

--- a/flyteadmin/pkg/async/notifications/implementations/aws_processor_test.go
+++ b/flyteadmin/pkg/async/notifications/implementations/aws_processor_test.go
@@ -30,7 +30,7 @@ func TestProcessor_StartProcessing(t *testing.T) {
 	// Because the message stored in Amazon SQS is a JSON of the SNS output, store the test output in the JSON Messages.
 	testSubscriber.JSONMessages = append(testSubscriber.JSONMessages, testSubscriberMessage)
 
-	sendEmailValidationFunc := func(ctx context.Context, email admin.EmailMessage) error {
+	sendEmailValidationFunc := func(ctx context.Context, email *admin.EmailMessage) error {
 		assert.Equal(t, email.Body, testEmail.Body)
 		assert.Equal(t, email.RecipientsEmail, testEmail.RecipientsEmail)
 		assert.Equal(t, email.SubjectLine, testEmail.SubjectLine)
@@ -115,7 +115,7 @@ func TestProcessor_StartProcessingError(t *testing.T) {
 func TestProcessor_StartProcessingEmailError(t *testing.T) {
 	initializeProcessor()
 	emailError := errors.New("error sending email")
-	sendEmailErrorFunc := func(ctx context.Context, email admin.EmailMessage) error {
+	sendEmailErrorFunc := func(ctx context.Context, email *admin.EmailMessage) error {
 		return emailError
 	}
 	mockEmailer.SetSendEmailFunc(sendEmailErrorFunc)

--- a/flyteadmin/pkg/async/notifications/implementations/gcp_processor.go
+++ b/flyteadmin/pkg/async/notifications/implementations/gcp_processor.go
@@ -39,12 +39,12 @@ func (p *GcpProcessor) StartProcessing() {
 }
 
 func (p *GcpProcessor) run() error {
-	var emailMessage admin.EmailMessage
+	emailMessage := &admin.EmailMessage{}
 
 	for msg := range p.sub.Start() {
 		p.systemMetrics.MessageTotal.Inc()
 
-		if err := proto.Unmarshal(msg.Message(), &emailMessage); err != nil {
+		if err := proto.Unmarshal(msg.Message(), emailMessage); err != nil {
 			logger.Debugf(context.Background(), "failed to unmarshal to notification object message [%s] with err: %v", string(msg.Message()), err)
 			p.systemMetrics.MessageDecodingError.Inc()
 			p.markMessageDone(msg)

--- a/flyteadmin/pkg/async/notifications/implementations/gcp_processor_test.go
+++ b/flyteadmin/pkg/async/notifications/implementations/gcp_processor_test.go
@@ -34,7 +34,7 @@ func TestGcpProcessor_StartProcessing(t *testing.T) {
 
 	testGcpProcessor := NewGcpProcessor(&testGcpSubscriber, &mockGcpEmailer, promutils.NewTestScope())
 
-	sendEmailValidationFunc := func(ctx context.Context, email admin.EmailMessage) error {
+	sendEmailValidationFunc := func(ctx context.Context, email *admin.EmailMessage) error {
 		assert.Equal(t, email.Body, testEmail.Body)
 		assert.Equal(t, email.RecipientsEmail, testEmail.RecipientsEmail)
 		assert.Equal(t, email.SubjectLine, testEmail.SubjectLine)
@@ -81,7 +81,7 @@ func TestGcpProcessor_StartProcessingError(t *testing.T) {
 func TestGcpProcessor_StartProcessingEmailError(t *testing.T) {
 	initializeGcpSubscriber()
 	emailError := errors.New("error sending email")
-	sendEmailErrorFunc := func(ctx context.Context, email admin.EmailMessage) error {
+	sendEmailErrorFunc := func(ctx context.Context, email *admin.EmailMessage) error {
 		return emailError
 	}
 	mockGcpEmailer.SetSendEmailFunc(sendEmailErrorFunc)

--- a/flyteadmin/pkg/async/notifications/implementations/noop_notifications.go
+++ b/flyteadmin/pkg/async/notifications/implementations/noop_notifications.go
@@ -14,7 +14,7 @@ import (
 // Email to use when there is no email configuration.
 type NoopEmail struct{}
 
-func (n *NoopEmail) SendEmail(ctx context.Context, email admin.EmailMessage) error {
+func (n *NoopEmail) SendEmail(ctx context.Context, email *admin.EmailMessage) error {
 	logger.Debugf(ctx, "received noop SendEmail request with subject [%s] and recipient [%s]",
 		email.SubjectLine, strings.Join(email.RecipientsEmail, ","))
 	return nil

--- a/flyteadmin/pkg/async/notifications/implementations/sandbox_processor.go
+++ b/flyteadmin/pkg/async/notifications/implementations/sandbox_processor.go
@@ -27,12 +27,12 @@ func (p *SandboxProcessor) StartProcessing() {
 }
 
 func (p *SandboxProcessor) run() error {
-	var emailMessage admin.EmailMessage
+	emailMessage := &admin.EmailMessage{}
 
 	for {
 		select {
 		case msg := <-p.subChan:
-			err := proto.Unmarshal(msg, &emailMessage)
+			err := proto.Unmarshal(msg, emailMessage)
 			if err != nil {
 				logger.Errorf(context.Background(), "error with unmarshalling message [%v]", err)
 				return err

--- a/flyteadmin/pkg/async/notifications/implementations/sandbox_processor_test.go
+++ b/flyteadmin/pkg/async/notifications/implementations/sandbox_processor_test.go
@@ -19,7 +19,7 @@ func TestSandboxProcessor_StartProcessingSuccess(t *testing.T) {
 	msgChan <- msg
 	testSandboxProcessor := NewSandboxProcessor(msgChan, &mockSandboxEmailer)
 
-	sendEmailValidationFunc := func(ctx context.Context, email admin.EmailMessage) error {
+	sendEmailValidationFunc := func(ctx context.Context, email *admin.EmailMessage) error {
 		assert.Equal(t, testEmail.Body, email.Body)
 		assert.Equal(t, testEmail.RecipientsEmail, email.RecipientsEmail)
 		assert.Equal(t, testEmail.SubjectLine, email.SubjectLine)
@@ -43,7 +43,7 @@ func TestSandboxProcessor_StartProcessingError(t *testing.T) {
 	msgChan <- msg
 
 	emailError := errors.New("error running processor")
-	sendEmailValidationFunc := func(ctx context.Context, email admin.EmailMessage) error {
+	sendEmailValidationFunc := func(ctx context.Context, email *admin.EmailMessage) error {
 		return emailError
 	}
 	mockSandboxEmailer.SetSendEmailFunc(sendEmailValidationFunc)
@@ -70,7 +70,7 @@ func TestSandboxProcessor_StartProcessingEmailError(t *testing.T) {
 	testSandboxProcessor := NewSandboxProcessor(msgChan, &mockSandboxEmailer)
 
 	emailError := errors.New("error sending email")
-	sendEmailValidationFunc := func(ctx context.Context, email admin.EmailMessage) error {
+	sendEmailValidationFunc := func(ctx context.Context, email *admin.EmailMessage) error {
 		return emailError
 	}
 

--- a/flyteadmin/pkg/async/notifications/implementations/sendgrid_emailer.go
+++ b/flyteadmin/pkg/async/notifications/implementations/sendgrid_emailer.go
@@ -30,7 +30,7 @@ func getEmailAddresses(addresses []string) []*mail.Email {
 	return sendgridAddresses
 }
 
-func getSendgridEmail(adminEmail admin.EmailMessage) *mail.SGMailV3 {
+func getSendgridEmail(adminEmail *admin.EmailMessage) *mail.SGMailV3 {
 	m := mail.NewV3Mail()
 	// This from email address is really here as a formality. For sendgrid specifically, the sender email is determined
 	// from the api key that's used, not what you send along here.
@@ -60,7 +60,7 @@ func getAPIKey(config runtimeInterfaces.EmailServerConfig) string {
 	return strings.TrimSpace(string(apiKeyFile))
 }
 
-func (s SendgridEmailer) SendEmail(ctx context.Context, email admin.EmailMessage) error {
+func (s SendgridEmailer) SendEmail(ctx context.Context, email *admin.EmailMessage) error {
 	m := getSendgridEmail(email)
 	s.systemMetrics.SendTotal.Inc()
 	response, err := s.client.Send(m)

--- a/flyteadmin/pkg/async/notifications/implementations/sendgrid_emailer_test.go
+++ b/flyteadmin/pkg/async/notifications/implementations/sendgrid_emailer_test.go
@@ -21,7 +21,7 @@ func TestAddresses(t *testing.T) {
 }
 
 func TestGetEmail(t *testing.T) {
-	emailNotification := admin.EmailMessage{
+	emailNotification := &admin.EmailMessage{
 		SubjectLine: "Notice: Execution \"name\" has succeeded in \"domain\".",
 		SenderEmail: "no-reply@example.com",
 		RecipientsEmail: []string{

--- a/flyteadmin/pkg/async/notifications/interfaces/emailer.go
+++ b/flyteadmin/pkg/async/notifications/interfaces/emailer.go
@@ -9,5 +9,5 @@ import (
 // The implementation of Emailer needs to be passed to the implementation of Processor
 // in order for emails to be sent.
 type Emailer interface {
-	SendEmail(ctx context.Context, email admin.EmailMessage) error
+	SendEmail(ctx context.Context, email *admin.EmailMessage) error
 }

--- a/flyteadmin/pkg/async/notifications/mocks/processor.go
+++ b/flyteadmin/pkg/async/notifications/mocks/processor.go
@@ -29,7 +29,7 @@ func (m *MockSubscriber) Stop() error {
 	return nil
 }
 
-type SendEmailFunc func(ctx context.Context, email admin.EmailMessage) error
+type SendEmailFunc func(ctx context.Context, email *admin.EmailMessage) error
 
 type MockEmailer struct {
 	sendEmailFunc SendEmailFunc
@@ -39,7 +39,7 @@ func (m *MockEmailer) SetSendEmailFunc(sendEmail SendEmailFunc) {
 	m.sendEmailFunc = sendEmail
 }
 
-func (m *MockEmailer) SendEmail(ctx context.Context, email admin.EmailMessage) error {
+func (m *MockEmailer) SendEmail(ctx context.Context, email *admin.EmailMessage) error {
 	if m.sendEmailFunc != nil {
 		return m.sendEmailFunc(ctx, email)
 	}

--- a/flyteadmin/pkg/async/schedule/aws/cloud_watch_scheduler.go
+++ b/flyteadmin/pkg/async/schedule/aws/cloud_watch_scheduler.go
@@ -68,7 +68,7 @@ type cloudWatchScheduler struct {
 	metrics cloudWatchSchedulerMetrics
 }
 
-func getScheduleName(scheduleNamePrefix string, identifier core.Identifier) string {
+func getScheduleName(scheduleNamePrefix string, identifier *core.Identifier) string {
 	hashedIdentifier := hashIdentifier(identifier)
 	if len(scheduleNamePrefix) > 0 {
 		return fmt.Sprintf(scheduleNameFormat, scheduleNamePrefix, hashedIdentifier)
@@ -76,12 +76,12 @@ func getScheduleName(scheduleNamePrefix string, identifier core.Identifier) stri
 	return fmt.Sprintf("%d", hashedIdentifier)
 }
 
-func getScheduleDescription(identifier core.Identifier) string {
+func getScheduleDescription(identifier *core.Identifier) string {
 	return fmt.Sprintf(scheduleDescriptionFormat,
 		identifier.Project, identifier.Domain, identifier.Name)
 }
 
-func getScheduleExpression(schedule admin.Schedule) (string, error) {
+func getScheduleExpression(schedule *admin.Schedule) (string, error) {
 	if schedule.GetCronExpression() != "" {
 		return fmt.Sprintf(cronExpression, schedule.GetCronExpression()), nil
 	}
@@ -171,11 +171,11 @@ func (s *cloudWatchScheduler) AddSchedule(ctx context.Context, input scheduleInt
 }
 
 func (s *cloudWatchScheduler) CreateScheduleInput(ctx context.Context, appConfig *appInterfaces.SchedulerConfig,
-	identifier core.Identifier, schedule *admin.Schedule) (scheduleInterfaces.AddScheduleInput, error) {
+	identifier *core.Identifier, schedule *admin.Schedule) (scheduleInterfaces.AddScheduleInput, error) {
 
 	payload, err := SerializeScheduleWorkflowPayload(
 		schedule.GetKickoffTimeInputArg(),
-		admin.NamedEntityIdentifier{
+		&admin.NamedEntityIdentifier{
 			Project: identifier.Project,
 			Domain:  identifier.Domain,
 			Name:    identifier.Name,
@@ -194,7 +194,7 @@ func (s *cloudWatchScheduler) CreateScheduleInput(ctx context.Context, appConfig
 
 	addScheduleInput := scheduleInterfaces.AddScheduleInput{
 		Identifier:         identifier,
-		ScheduleExpression: *schedule,
+		ScheduleExpression: schedule,
 		Payload:            payload,
 		ScheduleNamePrefix: scheduleNamePrefix,
 	}

--- a/flyteadmin/pkg/async/schedule/aws/cloud_watch_scheduler_test.go
+++ b/flyteadmin/pkg/async/schedule/aws/cloud_watch_scheduler_test.go
@@ -26,7 +26,7 @@ var expectedError = flyteAdminErrors.NewFlyteAdminError(codes.Internal, "foo")
 
 var testSerializedPayload = fmt.Sprintf("event triggered at '%s'", awsTimestampPlaceholder)
 
-var testSchedulerIdentifier = core.Identifier{
+var testSchedulerIdentifier = &core.Identifier{
 	Project: "project",
 	Domain:  "domain",
 	Name:    "name",
@@ -55,7 +55,7 @@ func TestGetScheduleDescription(t *testing.T) {
 }
 
 func TestGetScheduleExpression(t *testing.T) {
-	expression, err := getScheduleExpression(admin.Schedule{
+	expression, err := getScheduleExpression(&admin.Schedule{
 		ScheduleExpression: &admin.Schedule_CronExpression{
 			CronExpression: "foo",
 		},
@@ -63,7 +63,7 @@ func TestGetScheduleExpression(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "cron(foo)", expression)
 
-	expression, err = getScheduleExpression(admin.Schedule{
+	expression, err = getScheduleExpression(&admin.Schedule{
 		ScheduleExpression: &admin.Schedule_Rate{
 			Rate: &admin.FixedRate{
 				Value: 1,
@@ -74,7 +74,7 @@ func TestGetScheduleExpression(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "rate(1 day)", expression)
 
-	expression, err = getScheduleExpression(admin.Schedule{
+	expression, err = getScheduleExpression(&admin.Schedule{
 		ScheduleExpression: &admin.Schedule_Rate{
 			Rate: &admin.FixedRate{
 				Value: 2,
@@ -85,7 +85,7 @@ func TestGetScheduleExpression(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "rate(2 hours)", expression)
 
-	_, err = getScheduleExpression(admin.Schedule{})
+	_, err = getScheduleExpression(&admin.Schedule{})
 	assert.Equal(t, codes.InvalidArgument, err.(flyteAdminErrors.FlyteAdminError).Code())
 }
 
@@ -133,7 +133,7 @@ func TestAddSchedule(t *testing.T) {
 	assert.Nil(t, scheduler.AddSchedule(context.Background(),
 		scheduleInterfaces.AddScheduleInput{
 			Identifier: testSchedulerIdentifier,
-			ScheduleExpression: admin.Schedule{
+			ScheduleExpression: &admin.Schedule{
 				ScheduleExpression: &admin.Schedule_Rate{
 					Rate: &admin.FixedRate{
 						Value: 1,
@@ -168,7 +168,7 @@ func TestAddSchedule_PutRuleError(t *testing.T) {
 	err := scheduler.AddSchedule(context.Background(),
 		scheduleInterfaces.AddScheduleInput{
 			Identifier: testSchedulerIdentifier,
-			ScheduleExpression: admin.Schedule{
+			ScheduleExpression: &admin.Schedule{
 				ScheduleExpression: &admin.Schedule_Rate{
 					Rate: &admin.FixedRate{
 						Value: 1,
@@ -195,7 +195,7 @@ func TestAddSchedule_PutTargetsError(t *testing.T) {
 	err := scheduler.AddSchedule(context.Background(),
 		scheduleInterfaces.AddScheduleInput{
 			Identifier: testSchedulerIdentifier,
-			ScheduleExpression: admin.Schedule{
+			ScheduleExpression: &admin.Schedule{
 				ScheduleExpression: &admin.Schedule_Rate{
 					Rate: &admin.FixedRate{
 						Value: 1,

--- a/flyteadmin/pkg/async/schedule/aws/serialization.go
+++ b/flyteadmin/pkg/async/schedule/aws/serialization.go
@@ -35,13 +35,13 @@ type ScheduledWorkflowExecutionRequest struct {
 	// The name of the kickoff time input argument in the workflow definition. This will be filled with kickoff time.
 	KickoffTimeArg string
 	// The desired launch plan identifier to trigger on schedule event firings.
-	LaunchPlanIdentifier admin.NamedEntityIdentifier
+	LaunchPlanIdentifier *admin.NamedEntityIdentifier
 }
 
 // This produces a function that is used to serialize messages enqueued on the cloudwatch scheduler.
 func SerializeScheduleWorkflowPayload(
-	kickoffTimeArg string, launchPlanIdentifier admin.NamedEntityIdentifier) (*string, error) {
-	payload, err := proto.Marshal(&launchPlanIdentifier)
+	kickoffTimeArg string, launchPlanIdentifier *admin.NamedEntityIdentifier) (*string, error) {
+	payload, err := proto.Marshal(launchPlanIdentifier)
 	if err != nil {
 		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "failed to marshall launch plan with err: %v", err)
 	}
@@ -81,6 +81,6 @@ func DeserializeScheduleWorkflowPayload(payload []byte) (ScheduledWorkflowExecut
 	return ScheduledWorkflowExecutionRequest{
 		KickoffTime:          kickoffTime,
 		KickoffTimeArg:       scheduleWorkflowPayload.KickoffTimeArg,
-		LaunchPlanIdentifier: launchPlanIdentifier,
+		LaunchPlanIdentifier: &launchPlanIdentifier,
 	}, nil
 }

--- a/flyteadmin/pkg/async/schedule/aws/serialization_test.go
+++ b/flyteadmin/pkg/async/schedule/aws/serialization_test.go
@@ -15,7 +15,7 @@ import (
 
 const testKickoffTimeArg = "kickoff time arg"
 
-var testLaunchPlanIdentifier = admin.NamedEntityIdentifier{
+var testLaunchPlanIdentifier = &admin.NamedEntityIdentifier{
 	Name:    "name",
 	Project: "project",
 	Domain:  "domain",
@@ -38,7 +38,7 @@ func TestDeserializeScheduleWorkflowPayload(t *testing.T) {
 		time.Date(2017, 12, 22, 18, 43, 48, 0, time.UTC),
 		scheduledWorkflowExecutionRequest.KickoffTime)
 	assert.Equal(t, testKickoffTimeArg, scheduledWorkflowExecutionRequest.KickoffTimeArg)
-	assert.True(t, proto.Equal(&testLaunchPlanIdentifier, &scheduledWorkflowExecutionRequest.LaunchPlanIdentifier),
+	assert.True(t, proto.Equal(testLaunchPlanIdentifier, scheduledWorkflowExecutionRequest.LaunchPlanIdentifier),
 		fmt.Sprintf("scheduledWorkflowExecutionRequest.LaunchPlanIdentifier %v", &scheduledWorkflowExecutionRequest.LaunchPlanIdentifier))
 }
 

--- a/flyteadmin/pkg/async/schedule/aws/shared.go
+++ b/flyteadmin/pkg/async/schedule/aws/shared.go
@@ -9,7 +9,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
-func hashIdentifier(identifier core.Identifier) uint64 {
+func hashIdentifier(identifier *core.Identifier) uint64 {
 	h := fnv.New64()
 	_, err := h.Write([]byte(fmt.Sprintf(scheduleNameInputsFormat,
 		identifier.Project, identifier.Domain, identifier.Name)))

--- a/flyteadmin/pkg/async/schedule/aws/shared_test.go
+++ b/flyteadmin/pkg/async/schedule/aws/shared_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHashIdentifier(t *testing.T) {
-	identifier := core.Identifier{
+	identifier := &core.Identifier{
 		Project: "project",
 		Domain:  "domain",
 		Name:    "name",

--- a/flyteadmin/pkg/async/schedule/interfaces/event_scheduler.go
+++ b/flyteadmin/pkg/async/schedule/interfaces/event_scheduler.go
@@ -11,9 +11,9 @@ import (
 
 type AddScheduleInput struct {
 	// Defines the unique identifier associated with the schedule
-	Identifier core.Identifier
+	Identifier *core.Identifier
 	// Defines the schedule expression.
-	ScheduleExpression admin.Schedule
+	ScheduleExpression *admin.Schedule
 	// Message payload encoded as an CloudWatch event rule InputTemplate.
 	Payload *string
 	// Optional: The application-wide prefix to be applied for schedule names.
@@ -22,7 +22,7 @@ type AddScheduleInput struct {
 
 type RemoveScheduleInput struct {
 	// Defines the unique identifier associated with the schedule
-	Identifier core.Identifier
+	Identifier *core.Identifier
 	// Optional: The application-wide prefix to be applied for schedule names.
 	ScheduleNamePrefix string
 }
@@ -32,7 +32,7 @@ type EventScheduler interface {
 	AddSchedule(ctx context.Context, input AddScheduleInput) error
 
 	// CreateScheduleInput using the scheduler config and launch plan identifier and schedule
-	CreateScheduleInput(ctx context.Context, appConfig *appInterfaces.SchedulerConfig, identifier core.Identifier,
+	CreateScheduleInput(ctx context.Context, appConfig *appInterfaces.SchedulerConfig, identifier *core.Identifier,
 		schedule *admin.Schedule) (AddScheduleInput, error)
 
 	// Removes an existing schedule.

--- a/flyteadmin/pkg/async/schedule/mocks/mock_event_scheduler.go
+++ b/flyteadmin/pkg/async/schedule/mocks/mock_event_scheduler.go
@@ -18,15 +18,15 @@ type MockEventScheduler struct {
 }
 
 func (s *MockEventScheduler) CreateScheduleInput(ctx context.Context, appConfig *runtimeInterfaces.SchedulerConfig,
-	identifier core.Identifier, schedule *admin.Schedule) (interfaces.AddScheduleInput, error) {
+	identifier *core.Identifier, schedule *admin.Schedule) (interfaces.AddScheduleInput, error) {
 	payload, _ := aws.SerializeScheduleWorkflowPayload(
 		schedule.GetKickoffTimeInputArg(),
-		admin.NamedEntityIdentifier{
+		&admin.NamedEntityIdentifier{
 			Project: identifier.Project,
 			Domain:  identifier.Domain,
 			Name:    identifier.Name,
 		})
-	return interfaces.AddScheduleInput{Identifier: identifier, ScheduleExpression: *schedule, Payload: payload}, nil
+	return interfaces.AddScheduleInput{Identifier: identifier, ScheduleExpression: schedule, Payload: payload}, nil
 }
 
 func (s *MockEventScheduler) AddSchedule(ctx context.Context, input interfaces.AddScheduleInput) error {

--- a/flyteadmin/pkg/async/schedule/noop/event_scheduler.go
+++ b/flyteadmin/pkg/async/schedule/noop/event_scheduler.go
@@ -13,7 +13,7 @@ import (
 
 type EventScheduler struct{}
 
-func (s *EventScheduler) CreateScheduleInput(ctx context.Context, appConfig *runtimeInterfaces.SchedulerConfig, identifier core.Identifier, schedule *admin.Schedule) (interfaces.AddScheduleInput, error) {
+func (s *EventScheduler) CreateScheduleInput(ctx context.Context, appConfig *runtimeInterfaces.SchedulerConfig, identifier *core.Identifier, schedule *admin.Schedule) (interfaces.AddScheduleInput, error) {
 	panic("implement me")
 }
 

--- a/flyteadmin/pkg/common/flyte_url.go
+++ b/flyteadmin/pkg/common/flyte_url.go
@@ -125,7 +125,7 @@ func ParseFlyteURLToExecution(flyteURL string) (ParsedExecution, error) {
 
 }
 
-func FlyteURLsFromNodeExecutionID(nodeExecutionID core.NodeExecutionIdentifier, deck bool) *admin.FlyteURLs {
+func FlyteURLsFromNodeExecutionID(nodeExecutionID *core.NodeExecutionIdentifier, deck bool) *admin.FlyteURLs {
 	base := fmt.Sprintf("flyte://v1/%s/%s/%s/%s", nodeExecutionID.ExecutionId.Project,
 		nodeExecutionID.ExecutionId.Domain, nodeExecutionID.ExecutionId.Name, nodeExecutionID.NodeId)
 
@@ -142,7 +142,7 @@ func FlyteURLsFromNodeExecutionID(nodeExecutionID core.NodeExecutionIdentifier, 
 // FlyteURLKeyFromNodeExecutionID is a modified version of the function above.
 // This constructs a fully unique prefix, and when post-pended with the output name, forms a fully unique name for
 // the artifact service (including the project/domain of course, which the artifact service will add).
-func FlyteURLKeyFromNodeExecutionID(nodeExecutionID core.NodeExecutionIdentifier) string {
+func FlyteURLKeyFromNodeExecutionID(nodeExecutionID *core.NodeExecutionIdentifier) string {
 	res := fmt.Sprintf("%s/%s", nodeExecutionID.ExecutionId.Name, nodeExecutionID.NodeId)
 
 	return res
@@ -150,13 +150,13 @@ func FlyteURLKeyFromNodeExecutionID(nodeExecutionID core.NodeExecutionIdentifier
 
 // FlyteURLKeyFromNodeExecutionIDRetry is a modified version of the function above.
 // See the uniqueness comment above.
-func FlyteURLKeyFromNodeExecutionIDRetry(nodeExecutionID core.NodeExecutionIdentifier, retry int) string {
+func FlyteURLKeyFromNodeExecutionIDRetry(nodeExecutionID *core.NodeExecutionIdentifier, retry int) string {
 	res := fmt.Sprintf("%s/%s/%s", nodeExecutionID.ExecutionId.Name, nodeExecutionID.NodeId, strconv.Itoa(retry))
 
 	return res
 }
 
-func FlyteURLsFromTaskExecutionID(taskExecutionID core.TaskExecutionIdentifier, deck bool) *admin.FlyteURLs {
+func FlyteURLsFromTaskExecutionID(taskExecutionID *core.TaskExecutionIdentifier, deck bool) *admin.FlyteURLs {
 	base := fmt.Sprintf("flyte://v1/%s/%s/%s/%s/%s", taskExecutionID.NodeExecutionId.ExecutionId.Project,
 		taskExecutionID.NodeExecutionId.ExecutionId.Domain, taskExecutionID.NodeExecutionId.ExecutionId.Name, taskExecutionID.NodeExecutionId.NodeId, strconv.Itoa(int(taskExecutionID.RetryAttempt)))
 

--- a/flyteadmin/pkg/common/flyte_url_test.go
+++ b/flyteadmin/pkg/common/flyte_url_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestFlyteURLsFromNodeExecutionID(t *testing.T) {
 	t.Run("with deck", func(t *testing.T) {
-		ne := core.NodeExecutionIdentifier{
+		ne := &core.NodeExecutionIdentifier{
 			NodeId: "n0-dn0-n1",
 			ExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "fs",
@@ -25,7 +25,7 @@ func TestFlyteURLsFromNodeExecutionID(t *testing.T) {
 	})
 
 	t.Run("without deck", func(t *testing.T) {
-		ne := core.NodeExecutionIdentifier{
+		ne := &core.NodeExecutionIdentifier{
 			NodeId: "n0-dn0-n1",
 			ExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "fs",
@@ -42,7 +42,7 @@ func TestFlyteURLsFromNodeExecutionID(t *testing.T) {
 
 func TestFlyteURLsFromTaskExecutionID(t *testing.T) {
 	t.Run("with deck", func(t *testing.T) {
-		te := core.TaskExecutionIdentifier{
+		te := &core.TaskExecutionIdentifier{
 			TaskId: &core.Identifier{
 				ResourceType: core.ResourceType_TASK,
 				Project:      "fs",
@@ -67,7 +67,7 @@ func TestFlyteURLsFromTaskExecutionID(t *testing.T) {
 	})
 
 	t.Run("without deck", func(t *testing.T) {
-		te := core.TaskExecutionIdentifier{
+		te := &core.TaskExecutionIdentifier{
 			TaskId: &core.Identifier{
 				ResourceType: core.ResourceType_TASK,
 				Project:      "fs",

--- a/flyteadmin/pkg/data/implementations/gcp_remote_url.go
+++ b/flyteadmin/pkg/data/implementations/gcp_remote_url.go
@@ -118,19 +118,19 @@ func (g *GCPRemoteURL) signURL(ctx context.Context, gcsURI GCPGCSObject) (string
 	return gcs.SignedURL(gcsURI.bucket, gcsURI.object, opts)
 }
 
-func (g *GCPRemoteURL) Get(ctx context.Context, uri string) (admin.UrlBlob, error) {
+func (g *GCPRemoteURL) Get(ctx context.Context, uri string) (*admin.UrlBlob, error) {
 	logger.Debugf(ctx, "Getting signed url for - %s", uri)
 	gcsURI, err := g.splitURI(ctx, uri)
 	if err != nil {
 		logger.Debugf(ctx, "failed to extract gcs bucket and object from uri: %s", uri)
-		return admin.UrlBlob{}, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "invalid uri: %s", uri)
+		return &admin.UrlBlob{}, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "invalid uri: %s", uri)
 	}
 
 	// First, get the size of the url blob.
 	attrs, err := g.gcsClient.Bucket(gcsURI.bucket).Object(gcsURI.object).Attrs(ctx)
 	if err != nil {
 		logger.Debugf(ctx, "failed to get object size for %s with %v", uri, err)
-		return admin.UrlBlob{}, errors.NewFlyteAdminErrorf(
+		return &admin.UrlBlob{}, errors.NewFlyteAdminErrorf(
 			codes.Internal, "failed to get object size for %s with %v", uri, err)
 	}
 
@@ -138,10 +138,10 @@ func (g *GCPRemoteURL) Get(ctx context.Context, uri string) (admin.UrlBlob, erro
 	if err != nil {
 		logger.Warning(ctx,
 			"failed to presign url for uri [%s] for %v with err %v", uri, g.signDuration, err)
-		return admin.UrlBlob{}, errors.NewFlyteAdminErrorf(codes.Internal,
+		return &admin.UrlBlob{}, errors.NewFlyteAdminErrorf(codes.Internal,
 			"failed to presign url for uri [%s] for %v with err %v", uri, g.signDuration, err)
 	}
-	return admin.UrlBlob{
+	return &admin.UrlBlob{
 		Url:   urlStr,
 		Bytes: attrs.Size,
 	}, nil

--- a/flyteadmin/pkg/data/implementations/noop_remote_url.go
+++ b/flyteadmin/pkg/data/implementations/noop_remote_url.go
@@ -16,13 +16,13 @@ type NoopRemoteURL struct {
 	remoteDataStoreClient storage.DataStore
 }
 
-func (n *NoopRemoteURL) Get(ctx context.Context, uri string) (admin.UrlBlob, error) {
+func (n *NoopRemoteURL) Get(ctx context.Context, uri string) (*admin.UrlBlob, error) {
 	metadata, err := n.remoteDataStoreClient.Head(ctx, storage.DataReference(uri))
 	if err != nil {
-		return admin.UrlBlob{}, errors.NewFlyteAdminErrorf(codes.Internal,
+		return &admin.UrlBlob{}, errors.NewFlyteAdminErrorf(codes.Internal,
 			"failed to get metadata for uri: %s with err: %v", uri, err)
 	}
-	return admin.UrlBlob{
+	return &admin.UrlBlob{
 		Url:   uri,
 		Bytes: metadata.Size(),
 	}, nil

--- a/flyteadmin/pkg/data/interfaces/remote.go
+++ b/flyteadmin/pkg/data/interfaces/remote.go
@@ -9,5 +9,5 @@ import (
 // Defines an interface for fetching pre-signed URLs.
 type RemoteURLInterface interface {
 	// TODO: Refactor for URI to be of type DataReference. We should package a FromString-like function in flytestdlib
-	Get(ctx context.Context, uri string) (admin.UrlBlob, error)
+	Get(ctx context.Context, uri string) (*admin.UrlBlob, error)
 }

--- a/flyteadmin/pkg/data/mocks/remote.go
+++ b/flyteadmin/pkg/data/mocks/remote.go
@@ -9,14 +9,14 @@ import (
 
 // Mock implementation of a RemoteURLInterface
 type MockRemoteURL struct {
-	GetCallback func(ctx context.Context, uri string) (admin.UrlBlob, error)
+	GetCallback func(ctx context.Context, uri string) (*admin.UrlBlob, error)
 }
 
-func (m *MockRemoteURL) Get(ctx context.Context, uri string) (admin.UrlBlob, error) {
+func (m *MockRemoteURL) Get(ctx context.Context, uri string) (*admin.UrlBlob, error) {
 	if m.GetCallback != nil {
 		return m.GetCallback(ctx, uri)
 	}
-	return admin.UrlBlob{}, nil
+	return &admin.UrlBlob{}, nil
 }
 
 func NewMockRemoteURL() interfaces.RemoteURLInterface {

--- a/flyteadmin/pkg/manager/impl/description_entity_manager.go
+++ b/flyteadmin/pkg/manager/impl/description_entity_manager.go
@@ -32,17 +32,17 @@ type DescriptionEntityManager struct {
 	metrics DescriptionEntityMetrics
 }
 
-func (d *DescriptionEntityManager) GetDescriptionEntity(ctx context.Context, request admin.ObjectGetRequest) (
+func (d *DescriptionEntityManager) GetDescriptionEntity(ctx context.Context, request *admin.ObjectGetRequest) (
 	*admin.DescriptionEntity, error) {
 	if err := validation.ValidateDescriptionEntityGetRequest(request); err != nil {
 		logger.Errorf(ctx, "invalid request [%+v]: %v", request, err)
 		return nil, err
 	}
 	ctx = contextutils.WithProjectDomain(ctx, request.Id.Project, request.Id.Domain)
-	return util.GetDescriptionEntity(ctx, d.db, *request.Id)
+	return util.GetDescriptionEntity(ctx, d.db, request.Id)
 }
 
-func (d *DescriptionEntityManager) ListDescriptionEntity(ctx context.Context, request admin.DescriptionEntityListRequest) (*admin.DescriptionEntityList, error) {
+func (d *DescriptionEntityManager) ListDescriptionEntity(ctx context.Context, request *admin.DescriptionEntityListRequest) (*admin.DescriptionEntityList, error) {
 	// Check required fields
 	if err := validation.ValidateDescriptionEntityListRequest(request); err != nil {
 		return nil, err

--- a/flyteadmin/pkg/manager/impl/description_entity_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/description_entity_manager_test.go
@@ -46,13 +46,13 @@ func TestDescriptionEntityManager_Get(t *testing.T) {
 	repository := getMockRepositoryForDETest()
 	manager := NewDescriptionEntityManager(repository, getMockConfigForDETest(), mockScope.NewTestScope())
 
-	response, err := manager.GetDescriptionEntity(context.Background(), admin.ObjectGetRequest{
+	response, err := manager.GetDescriptionEntity(context.Background(), &admin.ObjectGetRequest{
 		Id: &descriptionEntityIdentifier,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
 
-	response, err = manager.GetDescriptionEntity(context.Background(), admin.ObjectGetRequest{
+	response, err = manager.GetDescriptionEntity(context.Background(), &admin.ObjectGetRequest{
 		Id: &badDescriptionEntityIdentifier,
 	})
 	assert.Error(t, err)
@@ -64,7 +64,7 @@ func TestDescriptionEntityManager_List(t *testing.T) {
 	manager := NewDescriptionEntityManager(repository, getMockConfigForDETest(), mockScope.NewTestScope())
 
 	t.Run("failed to validate a request", func(t *testing.T) {
-		response, err := manager.ListDescriptionEntity(context.Background(), admin.DescriptionEntityListRequest{
+		response, err := manager.ListDescriptionEntity(context.Background(), &admin.DescriptionEntityListRequest{
 			Id: &admin.NamedEntityIdentifier{
 				Name: "flyte",
 			},
@@ -74,7 +74,7 @@ func TestDescriptionEntityManager_List(t *testing.T) {
 	})
 
 	t.Run("failed to sort description entity", func(t *testing.T) {
-		response, err := manager.ListDescriptionEntity(context.Background(), admin.DescriptionEntityListRequest{
+		response, err := manager.ListDescriptionEntity(context.Background(), &admin.DescriptionEntityListRequest{
 			ResourceType: core.ResourceType_TASK,
 			Id: &admin.NamedEntityIdentifier{
 				Name:    "flyte",
@@ -89,7 +89,7 @@ func TestDescriptionEntityManager_List(t *testing.T) {
 	})
 
 	t.Run("failed to validate token", func(t *testing.T) {
-		response, err := manager.ListDescriptionEntity(context.Background(), admin.DescriptionEntityListRequest{
+		response, err := manager.ListDescriptionEntity(context.Background(), &admin.DescriptionEntityListRequest{
 			ResourceType: core.ResourceType_TASK,
 			Id: &admin.NamedEntityIdentifier{
 				Name:    "flyte",
@@ -104,7 +104,7 @@ func TestDescriptionEntityManager_List(t *testing.T) {
 	})
 
 	t.Run("list description entities in the task", func(t *testing.T) {
-		response, err := manager.ListDescriptionEntity(context.Background(), admin.DescriptionEntityListRequest{
+		response, err := manager.ListDescriptionEntity(context.Background(), &admin.DescriptionEntityListRequest{
 			ResourceType: core.ResourceType_TASK,
 			Id: &admin.NamedEntityIdentifier{
 				Name:    "flyte",
@@ -118,7 +118,7 @@ func TestDescriptionEntityManager_List(t *testing.T) {
 	})
 
 	t.Run("list description entities in the workflow", func(t *testing.T) {
-		response, err := manager.ListDescriptionEntity(context.Background(), admin.DescriptionEntityListRequest{
+		response, err := manager.ListDescriptionEntity(context.Background(), &admin.DescriptionEntityListRequest{
 			ResourceType: core.ResourceType_WORKFLOW,
 			Id: &admin.NamedEntityIdentifier{
 				Name:    "flyte",
@@ -132,7 +132,7 @@ func TestDescriptionEntityManager_List(t *testing.T) {
 	})
 
 	t.Run("failed to get filter", func(t *testing.T) {
-		response, err := manager.ListDescriptionEntity(context.Background(), admin.DescriptionEntityListRequest{
+		response, err := manager.ListDescriptionEntity(context.Background(), &admin.DescriptionEntityListRequest{
 			ResourceType: core.ResourceType_WORKFLOW,
 			Id: &admin.NamedEntityIdentifier{
 				Name:    "flyte",

--- a/flyteadmin/pkg/manager/impl/executions/quality_of_service_test.go
+++ b/flyteadmin/pkg/manager/impl/executions/quality_of_service_test.go
@@ -38,7 +38,7 @@ func getQualityOfServiceWithDuration(duration time.Duration) *core.QualityOfServ
 func getMockConfig() runtimeInterfaces.Configuration {
 	mockConfig := mocks.NewMockConfigurationProvider(nil, nil, nil, nil, nil, nil)
 	provider := &runtimeIFaceMocks.QualityOfServiceConfiguration{}
-	provider.OnGetTierExecutionValues().Return(map[core.QualityOfService_Tier]core.QualityOfServiceSpec{
+	provider.OnGetTierExecutionValues().Return(map[core.QualityOfService_Tier]*core.QualityOfServiceSpec{
 		core.QualityOfService_HIGH: {
 			QueueingBudget: ptypes.DurationProto(10 * time.Minute),
 		},

--- a/flyteadmin/pkg/manager/impl/executions/queues.go
+++ b/flyteadmin/pkg/manager/impl/executions/queues.go
@@ -25,7 +25,7 @@ type queues = []singleQueueConfiguration
 type queueConfig = map[tag]queues
 
 type QueueAllocator interface {
-	GetQueue(ctx context.Context, identifier core.Identifier) singleQueueConfiguration
+	GetQueue(ctx context.Context, identifier *core.Identifier) singleQueueConfiguration
 }
 
 type queueAllocatorImpl struct {
@@ -52,7 +52,7 @@ func (q *queueAllocatorImpl) refreshExecutionQueues(executionQueues []runtimeInt
 	q.queueConfigMap = queueConfigMap
 }
 
-func (q *queueAllocatorImpl) GetQueue(ctx context.Context, identifier core.Identifier) singleQueueConfiguration {
+func (q *queueAllocatorImpl) GetQueue(ctx context.Context, identifier *core.Identifier) singleQueueConfiguration {
 	// NOTE: If refreshing the execution queues & workflow configs on every call to GetQueue becomes too slow we should
 	// investigate caching the computed queue assignments.
 	executionQueues := q.config.QueueConfiguration().GetExecutionQueues()

--- a/flyteadmin/pkg/manager/impl/executions/queues_test.go
+++ b/flyteadmin/pkg/manager/impl/executions/queues_test.go
@@ -67,22 +67,22 @@ func TestGetQueue(t *testing.T) {
 	queueConfig := singleQueueConfiguration{
 		DynamicQueue: "queue dynamic",
 	}
-	assert.Equal(t, queueConfig, queueAllocator.GetQueue(context.Background(), core.Identifier{
+	assert.Equal(t, queueConfig, queueAllocator.GetQueue(context.Background(), &core.Identifier{
 		Project: "project",
 		Domain:  "domain",
 		Name:    "name",
 	}))
-	assert.EqualValues(t, singleQueueConfiguration{}, queueAllocator.GetQueue(context.Background(), core.Identifier{
+	assert.EqualValues(t, singleQueueConfiguration{}, queueAllocator.GetQueue(context.Background(), &core.Identifier{
 		Project: "project",
 		Domain:  "domain",
 		Name:    "name2",
 	}))
-	assert.EqualValues(t, singleQueueConfiguration{}, queueAllocator.GetQueue(context.Background(), core.Identifier{
+	assert.EqualValues(t, singleQueueConfiguration{}, queueAllocator.GetQueue(context.Background(), &core.Identifier{
 		Project: "project",
 		Domain:  "domain2",
 		Name:    "name",
 	}))
-	assert.EqualValues(t, singleQueueConfiguration{}, queueAllocator.GetQueue(context.Background(), core.Identifier{
+	assert.EqualValues(t, singleQueueConfiguration{}, queueAllocator.GetQueue(context.Background(), &core.Identifier{
 		Project: "project2",
 		Domain:  "domain",
 		Name:    "name",
@@ -174,7 +174,7 @@ func TestGetQueueDefaults(t *testing.T) {
 	assert.Equal(t, singleQueueConfiguration{
 		DynamicQueue: "default dynamic",
 	}, queueAllocator.GetQueue(
-		context.Background(), core.Identifier{
+		context.Background(), &core.Identifier{
 			Project: "unmatched",
 			Domain:  "domain",
 			Name:    "workflow",
@@ -182,7 +182,7 @@ func TestGetQueueDefaults(t *testing.T) {
 	assert.EqualValues(t, singleQueueConfiguration{
 		DynamicQueue: "queue1 dynamic",
 	}, queueAllocator.GetQueue(
-		context.Background(), core.Identifier{
+		context.Background(), &core.Identifier{
 			Project: "project",
 			Domain:  "UNMATCHED",
 			Name:    "workflow",
@@ -190,7 +190,7 @@ func TestGetQueueDefaults(t *testing.T) {
 	assert.EqualValues(t, singleQueueConfiguration{
 		DynamicQueue: "queue2 dynamic",
 	}, queueAllocator.GetQueue(
-		context.Background(), core.Identifier{
+		context.Background(), &core.Identifier{
 			Project: "project",
 			Domain:  "domain",
 			Name:    "UNMATCHED",
@@ -198,7 +198,7 @@ func TestGetQueueDefaults(t *testing.T) {
 	assert.Equal(t, singleQueueConfiguration{
 		DynamicQueue: "queue3 dynamic",
 	}, queueAllocator.GetQueue(
-		context.Background(), core.Identifier{
+		context.Background(), &core.Identifier{
 			Project: "project",
 			Domain:  "domain",
 			Name:    "workflow",

--- a/flyteadmin/pkg/manager/impl/launch_plan_manager.go
+++ b/flyteadmin/pkg/manager/impl/launch_plan_manager.go
@@ -52,15 +52,15 @@ func (m *LaunchPlanManager) getNamedEntityContext(ctx context.Context, identifie
 
 func (m *LaunchPlanManager) CreateLaunchPlan(
 	ctx context.Context,
-	request admin.LaunchPlanCreateRequest) (*admin.LaunchPlanCreateResponse, error) {
+	request *admin.LaunchPlanCreateRequest) (*admin.LaunchPlanCreateResponse, error) {
 	if err := validation.ValidateIdentifier(request.GetSpec().GetWorkflowId(), common.Workflow); err != nil {
 		logger.Debugf(ctx, "Failed to validate provided workflow ID for CreateLaunchPlan with err: %v", err)
 		return nil, err
 	}
-	workflowModel, err := util.GetWorkflowModel(ctx, m.db, *request.Spec.WorkflowId)
+	workflowModel, err := util.GetWorkflowModel(ctx, m.db, request.Spec.WorkflowId)
 	if err != nil {
 		logger.Debugf(ctx, "Failed to get workflow with id [%+v] for CreateLaunchPlan with id [%+v] with err %v",
-			*request.Spec.WorkflowId, request.Id)
+			request.Spec.WorkflowId, request.Id)
 		return nil, err
 	}
 	var workflowInterface core.TypedInterface
@@ -69,7 +69,7 @@ func (m *LaunchPlanManager) CreateLaunchPlan(
 		if err != nil {
 			logger.Errorf(ctx,
 				"Failed to unmarshal TypedInterface for workflow [%+v] with err: %v",
-				*request.Spec.WorkflowId, err)
+				request.Spec.WorkflowId, err)
 			return nil, errors.NewFlyteAdminErrorf(codes.Internal, "failed to unmarshal workflow inputs")
 		}
 	}
@@ -79,16 +79,16 @@ func (m *LaunchPlanManager) CreateLaunchPlan(
 	}
 	ctx = getLaunchPlanContext(ctx, request.Id)
 	launchPlan := transformers.CreateLaunchPlan(request, workflowInterface.Outputs)
-	launchPlanDigest, err := util.GetLaunchPlanDigest(ctx, &launchPlan)
+	launchPlanDigest, err := util.GetLaunchPlanDigest(ctx, launchPlan)
 	if err != nil {
 		logger.Errorf(ctx, "failed to compute launch plan digest for [%+v] with err: %v", launchPlan.Id, err)
 		return nil, err
 	}
 
-	existingLaunchPlanModel, err := util.GetLaunchPlanModel(ctx, m.db, *request.Id)
+	existingLaunchPlanModel, err := util.GetLaunchPlanModel(ctx, m.db, request.Id)
 	if err == nil {
 		if bytes.Equal(existingLaunchPlanModel.Digest, launchPlanDigest) {
-			return nil, errors.NewLaunchPlanExistsIdenticalStructureError(ctx, &request)
+			return nil, errors.NewLaunchPlanExistsIdenticalStructureError(ctx, request)
 		}
 		existingLaunchPlan, transformerErr := transformers.FromLaunchPlanModel(existingLaunchPlanModel)
 		if transformerErr != nil {
@@ -96,7 +96,7 @@ func (m *LaunchPlanManager) CreateLaunchPlan(
 			return nil, transformerErr
 		}
 		// A launch plan exists with different structure
-		return nil, errors.NewLaunchPlanExistsDifferentStructureError(ctx, &request, existingLaunchPlan.Spec, launchPlan.Spec)
+		return nil, errors.NewLaunchPlanExistsDifferentStructureError(ctx, request, existingLaunchPlan.Spec, launchPlan.Spec)
 	}
 
 	launchPlanModel, err :=
@@ -138,7 +138,7 @@ func (m *LaunchPlanManager) updateLaunchPlanModelState(launchPlan *models.Launch
 	return nil
 }
 
-func isScheduleEmpty(launchPlanSpec admin.LaunchPlanSpec) bool {
+func isScheduleEmpty(launchPlanSpec *admin.LaunchPlanSpec) bool {
 	schedule := launchPlanSpec.GetEntityMetadata().GetSchedule()
 	if schedule == nil {
 		return true
@@ -155,8 +155,8 @@ func isScheduleEmpty(launchPlanSpec admin.LaunchPlanSpec) bool {
 	return true
 }
 
-func (m *LaunchPlanManager) enableSchedule(ctx context.Context, launchPlanIdentifier core.Identifier,
-	launchPlanSpec admin.LaunchPlanSpec) error {
+func (m *LaunchPlanManager) enableSchedule(ctx context.Context, launchPlanIdentifier *core.Identifier,
+	launchPlanSpec *admin.LaunchPlanSpec) error {
 
 	addScheduleInput, err := m.scheduler.CreateScheduleInput(ctx,
 		m.config.ApplicationConfiguration().GetSchedulerConfig(), launchPlanIdentifier,
@@ -169,7 +169,7 @@ func (m *LaunchPlanManager) enableSchedule(ctx context.Context, launchPlanIdenti
 }
 
 func (m *LaunchPlanManager) disableSchedule(
-	ctx context.Context, launchPlanIdentifier core.Identifier) error {
+	ctx context.Context, launchPlanIdentifier *core.Identifier) error {
 	return m.scheduler.RemoveSchedule(ctx, scheduleInterfaces.RemoveScheduleInput{
 		Identifier:         launchPlanIdentifier,
 		ScheduleNamePrefix: m.config.ApplicationConfiguration().GetSchedulerConfig().EventSchedulerConfig.ScheduleNamePrefix,
@@ -178,21 +178,21 @@ func (m *LaunchPlanManager) disableSchedule(
 
 func (m *LaunchPlanManager) updateSchedules(
 	ctx context.Context, newlyActiveLaunchPlan models.LaunchPlan, formerlyActiveLaunchPlan *models.LaunchPlan) error {
-	var newlyActiveLaunchPlanSpec admin.LaunchPlanSpec
-	err := proto.Unmarshal(newlyActiveLaunchPlan.Spec, &newlyActiveLaunchPlanSpec)
+	newlyActiveLaunchPlanSpec := &admin.LaunchPlanSpec{}
+	err := proto.Unmarshal(newlyActiveLaunchPlan.Spec, newlyActiveLaunchPlanSpec)
 	if err != nil {
 		logger.Errorf(ctx, "failed to unmarshal newly enabled launch plan spec")
 		return errors.NewFlyteAdminErrorf(codes.Internal, "failed to unmarshal newly enabled launch plan spec")
 	}
-	launchPlanIdentifier := core.Identifier{
+	launchPlanIdentifier := &core.Identifier{
 		Project: newlyActiveLaunchPlan.Project,
 		Domain:  newlyActiveLaunchPlan.Domain,
 		Name:    newlyActiveLaunchPlan.Name,
 		Version: newlyActiveLaunchPlan.Version,
 	}
-	var formerlyActiveLaunchPlanSpec admin.LaunchPlanSpec
+	formerlyActiveLaunchPlanSpec := &admin.LaunchPlanSpec{}
 	if formerlyActiveLaunchPlan != nil {
-		err = proto.Unmarshal(formerlyActiveLaunchPlan.Spec, &formerlyActiveLaunchPlanSpec)
+		err = proto.Unmarshal(formerlyActiveLaunchPlan.Spec, formerlyActiveLaunchPlanSpec)
 		if err != nil {
 			return errors.NewFlyteAdminErrorf(codes.Internal, "failed to unmarshal formerly enabled launch plan spec")
 		}
@@ -200,7 +200,7 @@ func (m *LaunchPlanManager) updateSchedules(
 
 	if !isScheduleEmpty(formerlyActiveLaunchPlanSpec) {
 		// Disable previous schedule
-		formerlyActiveLaunchPlanIdentifier := core.Identifier{
+		formerlyActiveLaunchPlanIdentifier := &core.Identifier{
 			Project: formerlyActiveLaunchPlan.Project,
 			Domain:  formerlyActiveLaunchPlan.Domain,
 			Name:    formerlyActiveLaunchPlan.Name,
@@ -221,13 +221,13 @@ func (m *LaunchPlanManager) updateSchedules(
 	return nil
 }
 
-func (m *LaunchPlanManager) disableLaunchPlan(ctx context.Context, request admin.LaunchPlanUpdateRequest) (
+func (m *LaunchPlanManager) disableLaunchPlan(ctx context.Context, request *admin.LaunchPlanUpdateRequest) (
 	*admin.LaunchPlanUpdateResponse, error) {
 	if err := validation.ValidateIdentifier(request.Id, common.LaunchPlan); err != nil {
 		logger.Debugf(ctx, "can't disable launch plan [%+v] with invalid identifier: %v", request.Id, err)
 		return nil, err
 	}
-	launchPlanModel, err := util.GetLaunchPlanModel(ctx, m.db, *request.Id)
+	launchPlanModel, err := util.GetLaunchPlanModel(ctx, m.db, request.Id)
 	if err != nil {
 		logger.Debugf(ctx, "couldn't find launch plan [%+v] to disable with err: %v", request.Id, err)
 		return nil, err
@@ -247,7 +247,7 @@ func (m *LaunchPlanManager) disableLaunchPlan(ctx context.Context, request admin
 			"failed to unmarshal launch plan spec when disabling schedule for %+v", request.Id)
 	}
 	if launchPlanSpec.EntityMetadata != nil && launchPlanSpec.EntityMetadata.Schedule != nil {
-		err = m.disableSchedule(ctx, core.Identifier{
+		err = m.disableSchedule(ctx, &core.Identifier{
 			Project: launchPlanModel.Project,
 			Domain:  launchPlanModel.Domain,
 			Name:    launchPlanModel.Name,
@@ -266,7 +266,7 @@ func (m *LaunchPlanManager) disableLaunchPlan(ctx context.Context, request admin
 	return &admin.LaunchPlanUpdateResponse{}, nil
 }
 
-func (m *LaunchPlanManager) enableLaunchPlan(ctx context.Context, request admin.LaunchPlanUpdateRequest) (
+func (m *LaunchPlanManager) enableLaunchPlan(ctx context.Context, request *admin.LaunchPlanUpdateRequest) (
 	*admin.LaunchPlanUpdateResponse, error) {
 	newlyActiveLaunchPlanModel, err := m.db.LaunchPlanRepo().Get(ctx, repoInterfaces.Identifier{
 		Project: request.Id.Project,
@@ -329,7 +329,7 @@ func (m *LaunchPlanManager) enableLaunchPlan(ctx context.Context, request admin.
 
 }
 
-func (m *LaunchPlanManager) UpdateLaunchPlan(ctx context.Context, request admin.LaunchPlanUpdateRequest) (
+func (m *LaunchPlanManager) UpdateLaunchPlan(ctx context.Context, request *admin.LaunchPlanUpdateRequest) (
 	*admin.LaunchPlanUpdateResponse, error) {
 	if err := validation.ValidateIdentifier(request.Id, common.LaunchPlan); err != nil {
 		logger.Debugf(ctx, "can't update launch plan [%+v] state, invalid identifier: %v", request.Id, err)
@@ -347,17 +347,17 @@ func (m *LaunchPlanManager) UpdateLaunchPlan(ctx context.Context, request admin.
 	}
 }
 
-func (m *LaunchPlanManager) GetLaunchPlan(ctx context.Context, request admin.ObjectGetRequest) (
+func (m *LaunchPlanManager) GetLaunchPlan(ctx context.Context, request *admin.ObjectGetRequest) (
 	*admin.LaunchPlan, error) {
 	if err := validation.ValidateIdentifier(request.Id, common.LaunchPlan); err != nil {
 		logger.Debugf(ctx, "can't get launch plan [%+v] with invalid identifier: %v", request.Id, err)
 		return nil, err
 	}
 	ctx = getLaunchPlanContext(ctx, request.Id)
-	return util.GetLaunchPlan(ctx, m.db, *request.Id)
+	return util.GetLaunchPlan(ctx, m.db, request.Id)
 }
 
-func (m *LaunchPlanManager) GetActiveLaunchPlan(ctx context.Context, request admin.ActiveLaunchPlanRequest) (
+func (m *LaunchPlanManager) GetActiveLaunchPlan(ctx context.Context, request *admin.ActiveLaunchPlanRequest) (
 	*admin.LaunchPlan, error) {
 	if err := validation.ValidateActiveLaunchPlanRequest(request); err != nil {
 		logger.Debugf(ctx, "can't get active launch plan [%+v] with invalid request: %v", request.Id, err)
@@ -389,7 +389,7 @@ func (m *LaunchPlanManager) GetActiveLaunchPlan(ctx context.Context, request adm
 	return transformers.FromLaunchPlanModel(output.LaunchPlans[0])
 }
 
-func (m *LaunchPlanManager) ListLaunchPlans(ctx context.Context, request admin.ResourceListRequest) (
+func (m *LaunchPlanManager) ListLaunchPlans(ctx context.Context, request *admin.ResourceListRequest) (
 	*admin.LaunchPlanList, error) {
 
 	// Check required fields
@@ -447,7 +447,7 @@ func (m *LaunchPlanManager) ListLaunchPlans(ctx context.Context, request admin.R
 	}, nil
 }
 
-func (m *LaunchPlanManager) ListActiveLaunchPlans(ctx context.Context, request admin.ActiveLaunchPlanListRequest) (
+func (m *LaunchPlanManager) ListActiveLaunchPlans(ctx context.Context, request *admin.ActiveLaunchPlanListRequest) (
 	*admin.LaunchPlanList, error) {
 
 	// Check required fields
@@ -501,7 +501,7 @@ func (m *LaunchPlanManager) ListActiveLaunchPlans(ctx context.Context, request a
 }
 
 // At least project name and domain must be specified along with limit.
-func (m *LaunchPlanManager) ListLaunchPlanIds(ctx context.Context, request admin.NamedEntityIdentifierListRequest) (
+func (m *LaunchPlanManager) ListLaunchPlanIds(ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (
 	*admin.NamedEntityIdentifierList, error) {
 	ctx = contextutils.WithProjectDomain(ctx, request.Project, request.Domain)
 	filters, err := util.GetDbFilters(util.FilterSpec{

--- a/flyteadmin/pkg/manager/impl/metrics_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/metrics_manager_test.go
@@ -36,7 +36,7 @@ func addTimestamp(ts *timestamp.Timestamp, seconds int64) *timestamp.Timestamp {
 func getMockExecutionManager(execution *admin.Execution) interfaces.ExecutionInterface {
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.SetGetCallback(
-		func(ctx context.Context, request admin.WorkflowExecutionGetRequest) (*admin.Execution, error) {
+		func(ctx context.Context, request *admin.WorkflowExecutionGetRequest) (*admin.Execution, error) {
 			return execution, nil
 		})
 
@@ -48,13 +48,13 @@ func getMockNodeExecutionManager(nodeExecutions []*admin.NodeExecution,
 
 	mockNodeExecutionManager := mocks.MockNodeExecutionManager{}
 	mockNodeExecutionManager.SetListNodeExecutionsFunc(
-		func(ctx context.Context, request admin.NodeExecutionListRequest) (*admin.NodeExecutionList, error) {
+		func(ctx context.Context, request *admin.NodeExecutionListRequest) (*admin.NodeExecutionList, error) {
 			return &admin.NodeExecutionList{
 				NodeExecutions: nodeExecutions,
 			}, nil
 		})
 	mockNodeExecutionManager.SetGetNodeExecutionDataFunc(
-		func(ctx context.Context, request admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error) {
+		func(ctx context.Context, request *admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error) {
 			return &admin.NodeExecutionGetDataResponse{
 				DynamicWorkflow: dynamicWorkflow,
 			}, nil
@@ -66,7 +66,7 @@ func getMockNodeExecutionManager(nodeExecutions []*admin.NodeExecution,
 func getMockTaskExecutionManager(taskExecutions []*admin.TaskExecution) interfaces.TaskExecutionInterface {
 	mockTaskExecutionManager := mocks.MockTaskExecutionManager{}
 	mockTaskExecutionManager.SetListTaskExecutionsCallback(
-		func(ctx context.Context, request admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error) {
+		func(ctx context.Context, request *admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error) {
 			return &admin.TaskExecutionList{
 				TaskExecutions: taskExecutions,
 			}, nil
@@ -78,7 +78,7 @@ func getMockTaskExecutionManager(taskExecutions []*admin.TaskExecution) interfac
 func getMockWorkflowManager(workflow *admin.Workflow) interfaces.WorkflowInterface {
 	mockWorkflowManager := mocks.MockWorkflowManager{}
 	mockWorkflowManager.SetGetCallback(
-		func(ctx context.Context, request admin.ObjectGetRequest) (*admin.Workflow, error) {
+		func(ctx context.Context, request *admin.ObjectGetRequest) (*admin.Workflow, error) {
 			return workflow, nil
 		})
 

--- a/flyteadmin/pkg/manager/impl/named_entity_manager.go
+++ b/flyteadmin/pkg/manager/impl/named_entity_manager.go
@@ -42,7 +42,7 @@ type NamedEntityManager struct {
 	metrics NamedEntityMetrics
 }
 
-func (m *NamedEntityManager) UpdateNamedEntity(ctx context.Context, request admin.NamedEntityUpdateRequest) (
+func (m *NamedEntityManager) UpdateNamedEntity(ctx context.Context, request *admin.NamedEntityUpdateRequest) (
 	*admin.NamedEntityUpdateResponse, error) {
 	if err := validation.ValidateNamedEntityUpdateRequest(request); err != nil {
 		logger.Debugf(ctx, "invalid request [%+v]: %v", request, err)
@@ -51,12 +51,12 @@ func (m *NamedEntityManager) UpdateNamedEntity(ctx context.Context, request admi
 	ctx = contextutils.WithProjectDomain(ctx, request.Id.Project, request.Id.Domain)
 
 	// Ensure entity exists before trying to update it
-	_, err := util.GetNamedEntity(ctx, m.db, request.ResourceType, *request.Id)
+	_, err := util.GetNamedEntity(ctx, m.db, request.ResourceType, request.Id)
 	if err != nil {
 		return nil, err
 	}
 
-	metadataModel := transformers.CreateNamedEntityModel(&request)
+	metadataModel := transformers.CreateNamedEntityModel(request)
 	err = m.db.NamedEntityRepo().Update(ctx, metadataModel)
 	if err != nil {
 		logger.Debugf(ctx, "Failed to update named_entity for [%+v] with err %v", request.Id, err)
@@ -65,14 +65,14 @@ func (m *NamedEntityManager) UpdateNamedEntity(ctx context.Context, request admi
 	return &admin.NamedEntityUpdateResponse{}, nil
 }
 
-func (m *NamedEntityManager) GetNamedEntity(ctx context.Context, request admin.NamedEntityGetRequest) (
+func (m *NamedEntityManager) GetNamedEntity(ctx context.Context, request *admin.NamedEntityGetRequest) (
 	*admin.NamedEntity, error) {
 	if err := validation.ValidateNamedEntityGetRequest(request); err != nil {
 		logger.Debugf(ctx, "invalid request [%+v]: %v", request, err)
 		return nil, err
 	}
 	ctx = contextutils.WithProjectDomain(ctx, request.Id.Project, request.Id.Domain)
-	return util.GetNamedEntity(ctx, m.db, request.ResourceType, *request.Id)
+	return util.GetNamedEntity(ctx, m.db, request.ResourceType, request.Id)
 }
 
 func (m *NamedEntityManager) getQueryFilters(referenceEntity core.ResourceType, requestFilters string) ([]common.InlineFilter, error) {
@@ -103,7 +103,7 @@ func (m *NamedEntityManager) getQueryFilters(referenceEntity core.ResourceType, 
 	return filters, nil
 }
 
-func (m *NamedEntityManager) ListNamedEntities(ctx context.Context, request admin.NamedEntityListRequest) (
+func (m *NamedEntityManager) ListNamedEntities(ctx context.Context, request *admin.NamedEntityListRequest) (
 	*admin.NamedEntityList, error) {
 	if err := validation.ValidateNamedEntityListRequest(request); err != nil {
 		logger.Debugf(ctx, "invalid request [%+v]: %v", request, err)

--- a/flyteadmin/pkg/manager/impl/named_entity_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/named_entity_manager_test.go
@@ -57,7 +57,7 @@ func TestNamedEntityManager_Get(t *testing.T) {
 		}, nil
 	}
 	repository.NamedEntityRepo().(*repositoryMocks.MockNamedEntityRepo).SetGetCallback(getFunction)
-	response, err := manager.GetNamedEntity(context.Background(), admin.NamedEntityGetRequest{
+	response, err := manager.GetNamedEntity(context.Background(), &admin.NamedEntityGetRequest{
 		ResourceType: resourceType,
 		Id:           &namedEntityIdentifier,
 	})
@@ -69,14 +69,14 @@ func TestNamedEntityManager_Get_BadRequest(t *testing.T) {
 	repository := getMockRepositoryForNETest()
 	manager := NewNamedEntityManager(repository, getMockConfigForNETest(), mockScope.NewTestScope())
 
-	response, err := manager.GetNamedEntity(context.Background(), admin.NamedEntityGetRequest{
+	response, err := manager.GetNamedEntity(context.Background(), &admin.NamedEntityGetRequest{
 		ResourceType: core.ResourceType_UNSPECIFIED,
 		Id:           &namedEntityIdentifier,
 	})
 	assert.Error(t, err)
 	assert.Nil(t, response)
 
-	response, err = manager.GetNamedEntity(context.Background(), admin.NamedEntityGetRequest{
+	response, err = manager.GetNamedEntity(context.Background(), &admin.NamedEntityGetRequest{
 		ResourceType: resourceType,
 		Id:           &badIdentifier,
 	})
@@ -125,7 +125,7 @@ func TestNamedEntityManager_Update(t *testing.T) {
 	updatedMetadata := admin.NamedEntityMetadata{
 		Description: updatedDescription,
 	}
-	response, err := manager.UpdateNamedEntity(context.Background(), admin.NamedEntityUpdateRequest{
+	response, err := manager.UpdateNamedEntity(context.Background(), &admin.NamedEntityUpdateRequest{
 		Metadata:     &updatedMetadata,
 		ResourceType: resourceType,
 		Id:           &namedEntityIdentifier,
@@ -143,7 +143,7 @@ func TestNamedEntityManager_Update_BadRequest(t *testing.T) {
 	updatedMetadata := admin.NamedEntityMetadata{
 		Description: updatedDescription,
 	}
-	response, err := manager.UpdateNamedEntity(context.Background(), admin.NamedEntityUpdateRequest{
+	response, err := manager.UpdateNamedEntity(context.Background(), &admin.NamedEntityUpdateRequest{
 		Metadata:     &updatedMetadata,
 		ResourceType: core.ResourceType_UNSPECIFIED,
 		Id:           &namedEntityIdentifier,
@@ -151,7 +151,7 @@ func TestNamedEntityManager_Update_BadRequest(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, response)
 
-	response, err = manager.UpdateNamedEntity(context.Background(), admin.NamedEntityUpdateRequest{
+	response, err = manager.UpdateNamedEntity(context.Background(), &admin.NamedEntityUpdateRequest{
 		Metadata:     &updatedMetadata,
 		ResourceType: resourceType,
 		Id:           &badIdentifier,

--- a/flyteadmin/pkg/manager/impl/project_manager.go
+++ b/flyteadmin/pkg/manager/impl/project_manager.go
@@ -28,7 +28,7 @@ var alphabeticalSortParam, _ = common.NewSortParameter(&admin.Sort{
 	Key:       "identifier",
 }, models.ProjectColumns)
 
-func (m *ProjectManager) CreateProject(ctx context.Context, request admin.ProjectRegisterRequest) (
+func (m *ProjectManager) CreateProject(ctx context.Context, request *admin.ProjectRegisterRequest) (
 	*admin.ProjectRegisterResponse, error) {
 	if err := validation.ValidateProjectRegisterRequest(request); err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (m *ProjectManager) CreateProject(ctx context.Context, request admin.Projec
 	return &admin.ProjectRegisterResponse{}, nil
 }
 
-func (m *ProjectManager) ListProjects(ctx context.Context, request admin.ProjectListRequest) (*admin.Projects, error) {
+func (m *ProjectManager) ListProjects(ctx context.Context, request *admin.ProjectListRequest) (*admin.Projects, error) {
 	spec := util.FilterSpec{
 		RequestFilters: request.Filters,
 	}
@@ -75,7 +75,7 @@ func (m *ProjectManager) ListProjects(ctx context.Context, request admin.Project
 	if err != nil {
 		return nil, err
 	}
-	projects := transformers.FromProjectModels(projectModels, m.GetDomains(ctx, admin.GetDomainRequest{}).Domains)
+	projects := transformers.FromProjectModels(projectModels, m.GetDomains(ctx, &admin.GetDomainRequest{}).Domains)
 
 	var token string
 	if len(projects) == int(request.Limit) {
@@ -88,7 +88,7 @@ func (m *ProjectManager) ListProjects(ctx context.Context, request admin.Project
 	}, nil
 }
 
-func (m *ProjectManager) UpdateProject(ctx context.Context, projectUpdate admin.Project) (*admin.ProjectUpdateResponse, error) {
+func (m *ProjectManager) UpdateProject(ctx context.Context, projectUpdate *admin.Project) (*admin.ProjectUpdateResponse, error) {
 	var response admin.ProjectUpdateResponse
 	projectRepo := m.db.ProjectRepo()
 
@@ -104,7 +104,7 @@ func (m *ProjectManager) UpdateProject(ctx context.Context, projectUpdate admin.
 	}
 
 	// Transform the provided project into a model and apply to the DB.
-	projectUpdateModel := transformers.CreateProjectModel(&projectUpdate)
+	projectUpdateModel := transformers.CreateProjectModel(projectUpdate)
 	err = projectRepo.UpdateProject(ctx, projectUpdateModel)
 
 	if err != nil {
@@ -114,7 +114,7 @@ func (m *ProjectManager) UpdateProject(ctx context.Context, projectUpdate admin.
 	return &response, nil
 }
 
-func (m *ProjectManager) GetProject(ctx context.Context, request admin.ProjectGetRequest) (*admin.Project, error) {
+func (m *ProjectManager) GetProject(ctx context.Context, request *admin.ProjectGetRequest) (*admin.Project, error) {
 	if err := validation.ValidateProjectGetRequest(request); err != nil {
 		return nil, err
 	}
@@ -122,12 +122,12 @@ func (m *ProjectManager) GetProject(ctx context.Context, request admin.ProjectGe
 	if err != nil {
 		return nil, err
 	}
-	projectResponse := transformers.FromProjectModel(projectModel, m.GetDomains(ctx, admin.GetDomainRequest{}).Domains)
+	projectResponse := transformers.FromProjectModel(projectModel, m.GetDomains(ctx, &admin.GetDomainRequest{}).Domains)
 
-	return &projectResponse, nil
+	return projectResponse, nil
 }
 
-func (m *ProjectManager) GetDomains(ctx context.Context, request admin.GetDomainRequest) *admin.GetDomainsResponse {
+func (m *ProjectManager) GetDomains(ctx context.Context, request *admin.GetDomainRequest) *admin.GetDomainsResponse {
 	configDomains := m.config.ApplicationConfiguration().GetDomainsConfig()
 	var domains = make([]*admin.Domain, len(*configDomains))
 	for index, configDomain := range *configDomains {

--- a/flyteadmin/pkg/manager/impl/project_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/project_manager_test.go
@@ -46,7 +46,7 @@ func getMockApplicationConfigForProjectManagerTest() runtimeInterfaces.Applicati
 	return &mockApplicationConfig
 }
 
-func testListProjects(request admin.ProjectListRequest, token string, orderExpr string, queryExpr *common.GormQueryExpr, t *testing.T) {
+func testListProjects(request *admin.ProjectListRequest, token string, orderExpr string, queryExpr *common.GormQueryExpr, t *testing.T) {
 	repository := repositoryMocks.NewMockRepository()
 	repository.ProjectRepo().(*repositoryMocks.MockProjectRepo).ListProjectsFunction = func(
 		ctx context.Context, input interfaces.ListResourceInput) ([]models.Project, error) {
@@ -79,14 +79,14 @@ func testListProjects(request admin.ProjectListRequest, token string, orderExpr 
 }
 
 func TestListProjects_NoFilters_LimitOne(t *testing.T) {
-	testListProjects(admin.ProjectListRequest{
+	testListProjects(&admin.ProjectListRequest{
 		Token: "1",
 		Limit: 1,
 	}, "2", "identifier asc", nil, t)
 }
 
 func TestListProjects_HighLimit_SortBy_Filter(t *testing.T) {
-	testListProjects(admin.ProjectListRequest{
+	testListProjects(&admin.ProjectListRequest{
 		Token:   "1",
 		Limit:   999,
 		Filters: "eq(project.name,foo)",
@@ -101,7 +101,7 @@ func TestListProjects_HighLimit_SortBy_Filter(t *testing.T) {
 }
 
 func TestListProjects_NoToken_NoLimit(t *testing.T) {
-	testListProjects(admin.ProjectListRequest{}, "", "identifier asc", nil, t)
+	testListProjects(&admin.ProjectListRequest{}, "", "identifier asc", nil, t)
 }
 
 func TestProjectManager_CreateProject(t *testing.T) {
@@ -118,7 +118,7 @@ func TestProjectManager_CreateProject(t *testing.T) {
 	projectManager := NewProjectManager(mockRepository,
 		runtimeMocks.NewMockConfigurationProvider(
 			getMockApplicationConfigForProjectManagerTest(), nil, nil, nil, nil, nil))
-	_, err := projectManager.CreateProject(context.Background(), admin.ProjectRegisterRequest{
+	_, err := projectManager.CreateProject(context.Background(), &admin.ProjectRegisterRequest{
 		Project: &admin.Project{
 			Id:          "flyte-project-id",
 			Name:        "flyte-project-name",
@@ -138,7 +138,7 @@ func TestProjectManager_CreateProjectError(t *testing.T) {
 	projectManager := NewProjectManager(mockRepository,
 		runtimeMocks.NewMockConfigurationProvider(
 			getMockApplicationConfigForProjectManagerTest(), nil, nil, nil, nil, nil))
-	_, err := projectManager.CreateProject(context.Background(), admin.ProjectRegisterRequest{
+	_, err := projectManager.CreateProject(context.Background(), &admin.ProjectRegisterRequest{
 		Project: &admin.Project{
 			Id:          "flyte-project-id",
 			Name:        "flyte-project-name",
@@ -147,7 +147,7 @@ func TestProjectManager_CreateProjectError(t *testing.T) {
 	})
 	assert.EqualError(t, err, "uh oh")
 
-	_, err = projectManager.CreateProject(context.Background(), admin.ProjectRegisterRequest{
+	_, err = projectManager.CreateProject(context.Background(), &admin.ProjectRegisterRequest{
 		Project: &admin.Project{
 			Id:          "flyte-project-id",
 			Name:        "flyte-project-name",
@@ -171,7 +171,7 @@ func TestProjectManager_CreateProjectErrorDueToBadLabels(t *testing.T) {
 	projectManager := NewProjectManager(mockRepository,
 		runtimeMocks.NewMockConfigurationProvider(
 			getMockApplicationConfigForProjectManagerTest(), nil, nil, nil, nil, nil))
-	_, err := projectManager.CreateProject(context.Background(), admin.ProjectRegisterRequest{
+	_, err := projectManager.CreateProject(context.Background(), &admin.ProjectRegisterRequest{
 		Project: &admin.Project{
 			Id:          "flyte-project-id",
 			Name:        "flyte-project-name",
@@ -180,7 +180,7 @@ func TestProjectManager_CreateProjectErrorDueToBadLabels(t *testing.T) {
 	})
 	assert.EqualError(t, err, "uh oh")
 
-	_, err = projectManager.CreateProject(context.Background(), admin.ProjectRegisterRequest{
+	_, err = projectManager.CreateProject(context.Background(), &admin.ProjectRegisterRequest{
 		Project: &admin.Project{
 			Id:          "flyte-project-id",
 			Name:        "flyte-project-name",
@@ -226,7 +226,7 @@ func TestProjectManager_UpdateProject(t *testing.T) {
 	projectManager := NewProjectManager(mockRepository,
 		runtimeMocks.NewMockConfigurationProvider(
 			getMockApplicationConfigForProjectManagerTest(), nil, nil, nil, nil, nil))
-	_, err := projectManager.UpdateProject(context.Background(), admin.Project{
+	_, err := projectManager.UpdateProject(context.Background(), &admin.Project{
 		Id:          "project-id",
 		Name:        "new-project-name",
 		Description: "new-project-description",
@@ -250,7 +250,7 @@ func TestProjectManager_UpdateProject_ErrorDueToProjectNotFound(t *testing.T) {
 	projectManager := NewProjectManager(mockRepository,
 		runtimeMocks.NewMockConfigurationProvider(
 			getMockApplicationConfigForProjectManagerTest(), nil, nil, nil, nil, nil))
-	_, err := projectManager.UpdateProject(context.Background(), admin.Project{
+	_, err := projectManager.UpdateProject(context.Background(), &admin.Project{
 		Id:          "not-found-project-id",
 		Name:        "not-found-project-name",
 		Description: "not-found-project-description",
@@ -272,7 +272,7 @@ func TestProjectManager_UpdateProject_ErrorDueToInvalidProjectName(t *testing.T)
 	projectManager := NewProjectManager(mockRepository,
 		runtimeMocks.NewMockConfigurationProvider(
 			getMockApplicationConfigForProjectManagerTest(), nil, nil, nil, nil, nil))
-	_, err := projectManager.UpdateProject(context.Background(), admin.Project{
+	_, err := projectManager.UpdateProject(context.Background(), &admin.Project{
 		Id:   "project-id",
 		Name: "longnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamel",
 	})
@@ -298,7 +298,7 @@ func TestProjectManager_TestGetProject(t *testing.T) {
 		getMockApplicationConfigForProjectManagerTest(), nil, nil, nil, nil, nil))
 
 	resp, _ := projectManager.GetProject(context.Background(),
-		*mockedProject)
+		mockedProject)
 
 	assert.Equal(t, mockedProject.Id, resp.Id)
 	assert.Equal(t, "a-mocked-project", resp.Name)
@@ -317,7 +317,7 @@ func TestProjectManager_TestGetProject_ErrorDueToProjectNotFound(t *testing.T) {
 		getMockApplicationConfigForProjectManagerTest(), nil, nil, nil, nil, nil))
 
 	_, err := projectManager.GetProject(context.Background(),
-		*mockedProject)
+		mockedProject)
 
 	assert.EqualError(t, err, "project "+project+" not found")
 }
@@ -330,7 +330,7 @@ func TestProjectManager_TestGetProject_ErrorDueToEmptyProjectGetRequest(t *testi
 		getMockApplicationConfigForProjectManagerTest(), nil, nil, nil, nil, nil))
 
 	_, err := projectManager.GetProject(context.Background(),
-		*mockedProject)
+		mockedProject)
 
 	assert.EqualError(t, err, "missing project_id")
 }

--- a/flyteadmin/pkg/manager/impl/resources/resource_manager.go
+++ b/flyteadmin/pkg/manager/impl/resources/resource_manager.go
@@ -53,7 +53,7 @@ func (m *ResourceManager) GetResource(ctx context.Context, request interfaces.Re
 }
 
 func (m *ResourceManager) createOrMergeUpdateWorkflowAttributes(
-	ctx context.Context, request admin.WorkflowAttributesUpdateRequest, model models.Resource,
+	ctx context.Context, request *admin.WorkflowAttributesUpdateRequest, model models.Resource,
 	resourceType admin.MatchableResource) (*admin.WorkflowAttributesUpdateResponse, error) {
 	resourceID := repo_interface.ResourceID{
 		Project:      model.Project,
@@ -88,7 +88,7 @@ func (m *ResourceManager) createOrMergeUpdateWorkflowAttributes(
 }
 
 func (m *ResourceManager) UpdateWorkflowAttributes(
-	ctx context.Context, request admin.WorkflowAttributesUpdateRequest) (
+	ctx context.Context, request *admin.WorkflowAttributesUpdateRequest) (
 	*admin.WorkflowAttributesUpdateResponse, error) {
 	var resource admin.MatchableResource
 	var err error
@@ -96,7 +96,7 @@ func (m *ResourceManager) UpdateWorkflowAttributes(
 		return nil, err
 	}
 
-	model, err := transformers.WorkflowAttributesToResourceModel(*request.Attributes, resource)
+	model, err := transformers.WorkflowAttributesToResourceModel(request.Attributes, resource)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (m *ResourceManager) UpdateWorkflowAttributes(
 }
 
 func (m *ResourceManager) GetWorkflowAttributes(
-	ctx context.Context, request admin.WorkflowAttributesGetRequest) (
+	ctx context.Context, request *admin.WorkflowAttributesGetRequest) (
 	*admin.WorkflowAttributesGetResponse, error) {
 	if err := validation.ValidateWorkflowAttributesGetRequest(ctx, m.db, m.config, request); err != nil {
 		return nil, err
@@ -132,7 +132,7 @@ func (m *ResourceManager) GetWorkflowAttributes(
 }
 
 func (m *ResourceManager) DeleteWorkflowAttributes(ctx context.Context,
-	request admin.WorkflowAttributesDeleteRequest) (*admin.WorkflowAttributesDeleteResponse, error) {
+	request *admin.WorkflowAttributesDeleteRequest) (*admin.WorkflowAttributesDeleteResponse, error) {
 	if err := validation.ValidateWorkflowAttributesDeleteRequest(ctx, m.db, m.config, request); err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (m *ResourceManager) DeleteWorkflowAttributes(ctx context.Context,
 	return &admin.WorkflowAttributesDeleteResponse{}, nil
 }
 
-func (m *ResourceManager) UpdateProjectAttributes(ctx context.Context, request admin.ProjectAttributesUpdateRequest) (
+func (m *ResourceManager) UpdateProjectAttributes(ctx context.Context, request *admin.ProjectAttributesUpdateRequest) (
 	*admin.ProjectAttributesUpdateResponse, error) {
 
 	var resource admin.MatchableResource
@@ -154,7 +154,7 @@ func (m *ResourceManager) UpdateProjectAttributes(ctx context.Context, request a
 	if resource, err = validation.ValidateProjectAttributesUpdateRequest(ctx, m.db, request); err != nil {
 		return nil, err
 	}
-	model, err := transformers.ProjectAttributesToResourceModel(*request.Attributes, resource)
+	model, err := transformers.ProjectAttributesToResourceModel(request.Attributes, resource)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (m *ResourceManager) UpdateProjectAttributes(ctx context.Context, request a
 	return &admin.ProjectAttributesUpdateResponse{}, nil
 }
 
-func (m *ResourceManager) GetProjectAttributesBase(ctx context.Context, request admin.ProjectAttributesGetRequest) (
+func (m *ResourceManager) GetProjectAttributesBase(ctx context.Context, request *admin.ProjectAttributesGetRequest) (
 	*admin.ProjectAttributesGetResponse, error) {
 
 	if err := validation.ValidateProjectExists(ctx, m.db, request.Project); err != nil {
@@ -201,7 +201,7 @@ func (m *ResourceManager) GetProjectAttributesBase(ctx context.Context, request 
 // Admin server level configuration.
 // Note this merge is only done for WorkflowExecutionConfig
 // This code should be removed pending implementation of a complete settings implementation.
-func (m *ResourceManager) GetProjectAttributes(ctx context.Context, request admin.ProjectAttributesGetRequest) (
+func (m *ResourceManager) GetProjectAttributes(ctx context.Context, request *admin.ProjectAttributesGetRequest) (
 	*admin.ProjectAttributesGetResponse, error) {
 
 	getResponse, err := m.GetProjectAttributesBase(ctx, request)
@@ -215,7 +215,7 @@ func (m *ResourceManager) GetProjectAttributes(ctx context.Context, request admi
 					Project: request.Project,
 					MatchingAttributes: &admin.MatchingAttributes{
 						Target: &admin.MatchingAttributes_WorkflowExecutionConfig{
-							WorkflowExecutionConfig: &configLevelDefaults,
+							WorkflowExecutionConfig: configLevelDefaults,
 						},
 					},
 				},
@@ -230,8 +230,8 @@ func (m *ResourceManager) GetProjectAttributes(ctx context.Context, request admi
 	responseAttributes := getResponse.Attributes.GetMatchingAttributes().GetWorkflowExecutionConfig()
 	if responseAttributes != nil {
 		logger.Warningf(ctx, "Merging response %s with defaults %s", responseAttributes, configLevelDefaults)
-		tmp := util.MergeIntoExecConfig(*responseAttributes, &configLevelDefaults)
-		responseAttributes = &tmp
+		tmp := util.MergeIntoExecConfig(responseAttributes, configLevelDefaults)
+		responseAttributes = tmp
 		return &admin.ProjectAttributesGetResponse{
 			Attributes: &admin.ProjectAttributes{
 				Project: request.Project,
@@ -247,7 +247,7 @@ func (m *ResourceManager) GetProjectAttributes(ctx context.Context, request admi
 	return getResponse, nil
 }
 
-func (m *ResourceManager) DeleteProjectAttributes(ctx context.Context, request admin.ProjectAttributesDeleteRequest) (
+func (m *ResourceManager) DeleteProjectAttributes(ctx context.Context, request *admin.ProjectAttributesDeleteRequest) (
 	*admin.ProjectAttributesDeleteResponse, error) {
 
 	if err := validation.ValidateProjectForUpdate(ctx, m.db, request.Project); err != nil {
@@ -262,7 +262,7 @@ func (m *ResourceManager) DeleteProjectAttributes(ctx context.Context, request a
 }
 
 func (m *ResourceManager) createOrMergeUpdateProjectDomainAttributes(
-	ctx context.Context, request admin.ProjectDomainAttributesUpdateRequest, model models.Resource,
+	ctx context.Context, request *admin.ProjectDomainAttributesUpdateRequest, model models.Resource,
 	resourceType admin.MatchableResource) (*admin.ProjectDomainAttributesUpdateResponse, error) {
 	resourceID := repo_interface.ResourceID{
 		Project:      model.Project,
@@ -297,7 +297,7 @@ func (m *ResourceManager) createOrMergeUpdateProjectDomainAttributes(
 }
 
 func (m *ResourceManager) createOrMergeUpdateProjectAttributes(
-	ctx context.Context, request admin.ProjectAttributesUpdateRequest, model models.Resource,
+	ctx context.Context, request *admin.ProjectAttributesUpdateRequest, model models.Resource,
 	resourceType admin.MatchableResource) (*admin.ProjectAttributesUpdateResponse, error) {
 
 	resourceID := repo_interface.ResourceID{
@@ -333,7 +333,7 @@ func (m *ResourceManager) createOrMergeUpdateProjectAttributes(
 }
 
 func (m *ResourceManager) UpdateProjectDomainAttributes(
-	ctx context.Context, request admin.ProjectDomainAttributesUpdateRequest) (
+	ctx context.Context, request *admin.ProjectDomainAttributesUpdateRequest) (
 	*admin.ProjectDomainAttributesUpdateResponse, error) {
 	var resource admin.MatchableResource
 	var err error
@@ -342,7 +342,7 @@ func (m *ResourceManager) UpdateProjectDomainAttributes(
 	}
 	ctx = contextutils.WithProjectDomain(ctx, request.Attributes.Project, request.Attributes.Domain)
 
-	model, err := transformers.ProjectDomainAttributesToResourceModel(*request.Attributes, resource)
+	model, err := transformers.ProjectDomainAttributesToResourceModel(request.Attributes, resource)
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +357,7 @@ func (m *ResourceManager) UpdateProjectDomainAttributes(
 }
 
 func (m *ResourceManager) GetProjectDomainAttributes(
-	ctx context.Context, request admin.ProjectDomainAttributesGetRequest) (
+	ctx context.Context, request *admin.ProjectDomainAttributesGetRequest) (
 	*admin.ProjectDomainAttributesGetResponse, error) {
 	if err := validation.ValidateProjectDomainAttributesGetRequest(ctx, m.db, m.config, request); err != nil {
 		return nil, err
@@ -377,7 +377,7 @@ func (m *ResourceManager) GetProjectDomainAttributes(
 }
 
 func (m *ResourceManager) DeleteProjectDomainAttributes(ctx context.Context,
-	request admin.ProjectDomainAttributesDeleteRequest) (*admin.ProjectDomainAttributesDeleteResponse, error) {
+	request *admin.ProjectDomainAttributesDeleteRequest) (*admin.ProjectDomainAttributesDeleteResponse, error) {
 	if err := validation.ValidateProjectDomainAttributesDeleteRequest(ctx, m.db, m.config, request); err != nil {
 		return nil, err
 	}
@@ -390,7 +390,7 @@ func (m *ResourceManager) DeleteProjectDomainAttributes(ctx context.Context,
 	return &admin.ProjectDomainAttributesDeleteResponse{}, nil
 }
 
-func (m *ResourceManager) ListAll(ctx context.Context, request admin.ListMatchableAttributesRequest) (
+func (m *ResourceManager) ListAll(ctx context.Context, request *admin.ListMatchableAttributesRequest) (
 	*admin.ListMatchableAttributesResponse, error) {
 	if err := validation.ValidateListAllMatchableAttributesRequest(request); err != nil {
 		return nil, err

--- a/flyteadmin/pkg/manager/impl/resources/resource_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/resources/resource_manager_test.go
@@ -29,7 +29,7 @@ const python = "python"
 const hive = "hive"
 
 func TestUpdateWorkflowAttributes(t *testing.T) {
-	request := admin.WorkflowAttributesUpdateRequest{
+	request := &admin.WorkflowAttributesUpdateRequest{
 		Attributes: &admin.WorkflowAttributes{
 			Project:            project,
 			Domain:             domain,
@@ -57,7 +57,7 @@ func TestUpdateWorkflowAttributes(t *testing.T) {
 }
 
 func TestUpdateWorkflowAttributes_CreateOrMerge(t *testing.T) {
-	request := admin.WorkflowAttributesUpdateRequest{
+	request := &admin.WorkflowAttributesUpdateRequest{
 		Attributes: &admin.WorkflowAttributes{
 			Project:            project,
 			Domain:             domain,
@@ -148,7 +148,7 @@ func TestUpdateWorkflowAttributes_CreateOrMerge(t *testing.T) {
 }
 
 func TestGetWorkflowAttributes(t *testing.T) {
-	request := admin.WorkflowAttributesGetRequest{
+	request := &admin.WorkflowAttributesGetRequest{
 		Project:      project,
 		Domain:       domain,
 		Workflow:     workflow,
@@ -184,7 +184,7 @@ func TestGetWorkflowAttributes(t *testing.T) {
 }
 
 func TestDeleteWorkflowAttributes(t *testing.T) {
-	request := admin.WorkflowAttributesDeleteRequest{
+	request := &admin.WorkflowAttributesDeleteRequest{
 		Project:      project,
 		Domain:       domain,
 		Workflow:     workflow,
@@ -205,7 +205,7 @@ func TestDeleteWorkflowAttributes(t *testing.T) {
 }
 
 func TestUpdateProjectDomainAttributes(t *testing.T) {
-	request := admin.ProjectDomainAttributesUpdateRequest{
+	request := &admin.ProjectDomainAttributesUpdateRequest{
 		Attributes: &admin.ProjectDomainAttributes{
 			Project:            project,
 			Domain:             domain,
@@ -232,7 +232,7 @@ func TestUpdateProjectDomainAttributes(t *testing.T) {
 }
 
 func TestUpdateProjectDomainAttributes_CreateOrMerge(t *testing.T) {
-	request := admin.ProjectDomainAttributesUpdateRequest{
+	request := &admin.ProjectDomainAttributesUpdateRequest{
 		Attributes: &admin.ProjectDomainAttributes{
 			Project:            project,
 			Domain:             domain,
@@ -319,7 +319,7 @@ func TestUpdateProjectDomainAttributes_CreateOrMerge(t *testing.T) {
 }
 
 func TestGetProjectDomainAttributes(t *testing.T) {
-	request := admin.ProjectDomainAttributesGetRequest{
+	request := &admin.ProjectDomainAttributesGetRequest{
 		Project:      project,
 		Domain:       domain,
 		ResourceType: admin.MatchableResource_EXECUTION_QUEUE,
@@ -352,7 +352,7 @@ func TestGetProjectDomainAttributes(t *testing.T) {
 }
 
 func TestDeleteProjectDomainAttributes(t *testing.T) {
-	request := admin.ProjectDomainAttributesDeleteRequest{
+	request := &admin.ProjectDomainAttributesDeleteRequest{
 		Project:      project,
 		Domain:       domain,
 		ResourceType: admin.MatchableResource_EXECUTION_QUEUE,
@@ -371,7 +371,7 @@ func TestDeleteProjectDomainAttributes(t *testing.T) {
 }
 
 func TestUpdateProjectAttributes(t *testing.T) {
-	request := admin.ProjectAttributesUpdateRequest{
+	request := &admin.ProjectAttributesUpdateRequest{
 		Attributes: &admin.ProjectAttributes{
 			Project:            project,
 			MatchingAttributes: testutils.WorkflowExecutionConfigSample,
@@ -396,7 +396,7 @@ func TestUpdateProjectAttributes(t *testing.T) {
 	assert.True(t, createOrUpdateCalled)
 
 	// Test empty attributes
-	request = admin.ProjectAttributesUpdateRequest{Attributes: nil}
+	request = &admin.ProjectAttributesUpdateRequest{Attributes: nil}
 	_, err = manager.UpdateProjectAttributes(context.Background(), request)
 	assert.Error(t, err)
 
@@ -405,7 +405,7 @@ func TestUpdateProjectAttributes(t *testing.T) {
 		ctx context.Context, input models.Resource) error {
 		return errors.NewFlyteAdminErrorf(123, "123")
 	}
-	request = admin.ProjectAttributesUpdateRequest{
+	request = &admin.ProjectAttributesUpdateRequest{
 		Attributes: &admin.ProjectAttributes{
 			Project:            project,
 			MatchingAttributes: testutils.WorkflowExecutionConfigSample,
@@ -416,7 +416,7 @@ func TestUpdateProjectAttributes(t *testing.T) {
 }
 
 func TestUpdateProjectAttributes_CreateOrMerge(t *testing.T) {
-	request := admin.ProjectAttributesUpdateRequest{
+	request := &admin.ProjectAttributesUpdateRequest{
 		Attributes: &admin.ProjectAttributes{
 			Project:            project,
 			MatchingAttributes: commonTestUtils.GetPluginOverridesAttributes(map[string][]string{"python": {"plugin a"}}),
@@ -501,7 +501,7 @@ func TestUpdateProjectAttributes_CreateOrMerge(t *testing.T) {
 }
 
 func TestGetProjectAttributes(t *testing.T) {
-	request := admin.ProjectAttributesGetRequest{
+	request := &admin.ProjectAttributesGetRequest{
 		Project:      project,
 		ResourceType: admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG,
 	}
@@ -543,7 +543,7 @@ func TestGetProjectAttributes(t *testing.T) {
 }
 
 func TestGetProjectAttributes_ConfigLookup(t *testing.T) {
-	request := admin.ProjectAttributesGetRequest{
+	request := &admin.ProjectAttributesGetRequest{
 		Project:      project,
 		ResourceType: admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG,
 	}
@@ -650,7 +650,7 @@ func TestGetProjectAttributes_ConfigLookup(t *testing.T) {
 			OutputLocationPrefix: "s3://test-bucket",
 		}
 		config.SetTopLevelConfig(appConfig)
-		request := admin.ProjectAttributesGetRequest{
+		request := &admin.ProjectAttributesGetRequest{
 			Project:      project,
 			ResourceType: admin.MatchableResource_EXECUTION_QUEUE,
 		}
@@ -664,7 +664,7 @@ func TestGetProjectAttributes_ConfigLookup(t *testing.T) {
 }
 
 func TestDeleteProjectAttributes(t *testing.T) {
-	request := admin.ProjectAttributesDeleteRequest{
+	request := &admin.ProjectAttributesDeleteRequest{
 		Project:      project,
 		ResourceType: admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG,
 	}
@@ -759,7 +759,7 @@ func TestListAllResources(t *testing.T) {
 		}, nil
 	}
 	manager := NewResourceManager(db, testutils.GetApplicationConfigWithDefaultDomains())
-	response, err := manager.ListAll(context.Background(), admin.ListMatchableAttributesRequest{
+	response, err := manager.ListAll(context.Background(), &admin.ListMatchableAttributesRequest{
 		ResourceType: admin.MatchableResource_CLUSTER_RESOURCE,
 	})
 	assert.Nil(t, err)

--- a/flyteadmin/pkg/manager/impl/signal_manager.go
+++ b/flyteadmin/pkg/manager/impl/signal_manager.go
@@ -38,7 +38,7 @@ func getSignalContext(ctx context.Context, identifier *core.SignalIdentifier) co
 	return contextutils.WithSignalID(ctx, identifier.SignalId)
 }
 
-func (s *SignalManager) GetOrCreateSignal(ctx context.Context, request admin.SignalGetOrCreateRequest) (*admin.Signal, error) {
+func (s *SignalManager) GetOrCreateSignal(ctx context.Context, request *admin.SignalGetOrCreateRequest) (*admin.Signal, error) {
 	if err := validation.ValidateSignalGetOrCreateRequest(ctx, request); err != nil {
 		logger.Debugf(ctx, "invalid request [%+v]: %v", request, err)
 		return nil, err
@@ -62,17 +62,17 @@ func (s *SignalManager) GetOrCreateSignal(ctx context.Context, request admin.Sig
 		return nil, err
 	}
 
-	return &signal, nil
+	return signal, nil
 }
 
-func (s *SignalManager) ListSignals(ctx context.Context, request admin.SignalListRequest) (*admin.SignalList, error) {
+func (s *SignalManager) ListSignals(ctx context.Context, request *admin.SignalListRequest) (*admin.SignalList, error) {
 	if err := validation.ValidateSignalListRequest(ctx, request); err != nil {
 		logger.Debugf(ctx, "ListSignals request [%+v] is invalid: %v", request, err)
 		return nil, err
 	}
 	ctx = getExecutionContext(ctx, request.WorkflowExecutionId)
 
-	identifierFilters, err := util.GetWorkflowExecutionIdentifierFilters(ctx, *request.WorkflowExecutionId)
+	identifierFilters, err := util.GetWorkflowExecutionIdentifierFilters(ctx, request.WorkflowExecutionId)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (s *SignalManager) ListSignals(ctx context.Context, request admin.SignalLis
 	}, nil
 }
 
-func (s *SignalManager) SetSignal(ctx context.Context, request admin.SignalSetRequest) (*admin.SignalSetResponse, error) {
+func (s *SignalManager) SetSignal(ctx context.Context, request *admin.SignalSetRequest) (*admin.SignalSetResponse, error) {
 	if err := validation.ValidateSignalSetRequest(ctx, s.db, request); err != nil {
 		return nil, err
 	}

--- a/flyteadmin/pkg/manager/impl/signal_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/signal_manager_test.go
@@ -54,7 +54,7 @@ func TestGetOrCreateSignal(t *testing.T) {
 		mockRepository.SignalRepo().(*repositoryMocks.SignalRepoInterface).OnGetOrCreateMatch(mock.Anything, mock.Anything).Return(nil)
 
 		signalManager := NewSignalManager(mockRepository, mockScope.NewTestScope())
-		request := admin.SignalGetOrCreateRequest{
+		request := &admin.SignalGetOrCreateRequest{
 			Id:   signalID,
 			Type: signalType,
 		}
@@ -71,7 +71,7 @@ func TestGetOrCreateSignal(t *testing.T) {
 	t.Run("ValidationError", func(t *testing.T) {
 		mockRepository := repositoryMocks.NewMockRepository()
 		signalManager := NewSignalManager(mockRepository, mockScope.NewTestScope())
-		request := admin.SignalGetOrCreateRequest{
+		request := &admin.SignalGetOrCreateRequest{
 			Type: signalType,
 		}
 
@@ -84,7 +84,7 @@ func TestGetOrCreateSignal(t *testing.T) {
 		mockRepository.SignalRepo().(*repositoryMocks.SignalRepoInterface).OnGetOrCreateMatch(mock.Anything, mock.Anything).Return(errors.New("foo"))
 
 		signalManager := NewSignalManager(mockRepository, mockScope.NewTestScope())
-		request := admin.SignalGetOrCreateRequest{
+		request := &admin.SignalGetOrCreateRequest{
 			Id:   signalID,
 			Type: signalType,
 		}
@@ -107,7 +107,7 @@ func TestListSignals(t *testing.T) {
 		)
 
 		signalManager := NewSignalManager(mockRepository, mockScope.NewTestScope())
-		request := admin.SignalListRequest{
+		request := &admin.SignalListRequest{
 			WorkflowExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "project",
 				Domain:  "domain",
@@ -135,7 +135,7 @@ func TestListSignals(t *testing.T) {
 	t.Run("ValidationError", func(t *testing.T) {
 		mockRepository := repositoryMocks.NewMockRepository()
 		signalManager := NewSignalManager(mockRepository, mockScope.NewTestScope())
-		request := admin.SignalListRequest{
+		request := &admin.SignalListRequest{
 			WorkflowExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "project",
 				Domain:  "domain",
@@ -153,7 +153,7 @@ func TestListSignals(t *testing.T) {
 			OnListMatch(mock.Anything, mock.Anything).Return(nil, errors.New("foo"))
 
 		signalManager := NewSignalManager(mockRepository, mockScope.NewTestScope())
-		request := admin.SignalListRequest{
+		request := &admin.SignalListRequest{
 			WorkflowExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "project",
 				Domain:  "domain",
@@ -179,7 +179,7 @@ func TestSetSignal(t *testing.T) {
 			OnUpdateMatch(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 		signalManager := NewSignalManager(mockRepository, mockScope.NewTestScope())
-		request := admin.SignalSetRequest{
+		request := &admin.SignalSetRequest{
 			Id:    signalID,
 			Value: signalValue,
 		}
@@ -193,7 +193,7 @@ func TestSetSignal(t *testing.T) {
 	t.Run("ValidationError", func(t *testing.T) {
 		mockRepository := repositoryMocks.NewMockRepository()
 		signalManager := NewSignalManager(mockRepository, mockScope.NewTestScope())
-		request := admin.SignalSetRequest{
+		request := &admin.SignalSetRequest{
 			Value: signalValue,
 		}
 
@@ -210,7 +210,7 @@ func TestSetSignal(t *testing.T) {
 		)
 
 		signalManager := NewSignalManager(mockRepository, mockScope.NewTestScope())
-		request := admin.SignalSetRequest{
+		request := &admin.SignalSetRequest{
 			Id:    signalID,
 			Value: signalValue,
 		}
@@ -227,7 +227,7 @@ func TestSetSignal(t *testing.T) {
 			OnUpdateMatch(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("foo"))
 
 		signalManager := NewSignalManager(mockRepository, mockScope.NewTestScope())
-		request := admin.SignalSetRequest{
+		request := &admin.SignalSetRequest{
 			Id:    signalID,
 			Value: signalValue,
 		}

--- a/flyteadmin/pkg/manager/impl/task_execution_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/task_execution_manager_test.go
@@ -48,7 +48,7 @@ var sampleNodeExecID = &core.NodeExecutionIdentifier{
 	},
 }
 
-var taskEventRequest = admin.TaskExecutionEventRequest{
+var taskEventRequest = &admin.TaskExecutionEventRequest{
 	RequestId: "request id",
 	Event: &event.TaskExecutionEvent{
 		ProducerId:            "propeller",
@@ -554,7 +554,7 @@ func TestGetTaskExecution(t *testing.T) {
 			}, nil
 		})
 	taskExecManager := NewTaskExecutionManager(repository, getMockExecutionsConfigProvider(), getMockStorageForExecTest(context.Background()), mockScope.NewTestScope(), mockTaskExecutionRemoteURL, nil, nil)
-	taskExecution, err := taskExecManager.GetTaskExecution(context.Background(), admin.TaskExecutionGetRequest{
+	taskExecution, err := taskExecManager.GetTaskExecution(context.Background(), &admin.TaskExecutionGetRequest{
 		Id: &core.TaskExecutionIdentifier{
 			TaskId:          sampleTaskID,
 			NodeExecutionId: sampleNodeExecID,
@@ -603,7 +603,7 @@ func TestGetTaskExecution_TransformerError(t *testing.T) {
 			}, nil
 		})
 	taskExecManager := NewTaskExecutionManager(repository, getMockExecutionsConfigProvider(), getMockStorageForExecTest(context.Background()), mockScope.NewTestScope(), mockTaskExecutionRemoteURL, nil, nil)
-	taskExecution, err := taskExecManager.GetTaskExecution(context.Background(), admin.TaskExecutionGetRequest{
+	taskExecution, err := taskExecManager.GetTaskExecution(context.Background(), &admin.TaskExecutionGetRequest{
 		Id: &core.TaskExecutionIdentifier{
 			TaskId:          sampleTaskID,
 			NodeExecutionId: sampleNodeExecID,
@@ -716,7 +716,7 @@ func TestListTaskExecutions(t *testing.T) {
 			}, nil
 		})
 	taskExecManager := NewTaskExecutionManager(repository, getMockExecutionsConfigProvider(), getMockStorageForExecTest(context.Background()), mockScope.NewTestScope(), mockTaskExecutionRemoteURL, nil, nil)
-	taskExecutions, err := taskExecManager.ListTaskExecutions(context.Background(), admin.TaskExecutionListRequest{
+	taskExecutions, err := taskExecManager.ListTaskExecutions(context.Background(), &admin.TaskExecutionListRequest{
 		NodeExecutionId: &core.NodeExecutionIdentifier{
 			NodeId: "nodey b",
 			ExecutionId: &core.WorkflowExecutionIdentifier{
@@ -787,7 +787,7 @@ func TestListTaskExecutions_NoFilters(t *testing.T) {
 			return interfaces.TaskExecutionCollectionOutput{}, nil
 		})
 	taskExecManager := NewTaskExecutionManager(repository, getMockExecutionsConfigProvider(), getMockStorageForExecTest(context.Background()), mockScope.NewTestScope(), mockTaskExecutionRemoteURL, nil, nil)
-	_, err := taskExecManager.ListTaskExecutions(context.Background(), admin.TaskExecutionListRequest{
+	_, err := taskExecManager.ListTaskExecutions(context.Background(), &admin.TaskExecutionListRequest{
 		Token: "1",
 		Limit: 99,
 	})
@@ -805,7 +805,7 @@ func TestListTaskExecutions_NoLimit(t *testing.T) {
 			return interfaces.TaskExecutionCollectionOutput{}, nil
 		})
 	taskExecManager := NewTaskExecutionManager(repository, getMockExecutionsConfigProvider(), getMockStorageForExecTest(context.Background()), mockScope.NewTestScope(), mockTaskExecutionRemoteURL, nil, nil)
-	_, err := taskExecManager.ListTaskExecutions(context.Background(), admin.TaskExecutionListRequest{
+	_, err := taskExecManager.ListTaskExecutions(context.Background(), &admin.TaskExecutionListRequest{
 		Limit: 0,
 	})
 	assert.NotNil(t, err)
@@ -836,7 +836,7 @@ func TestListTaskExecutions_NothingToReturn(t *testing.T) {
 			return interfaces.TaskCollectionOutput{}, nil
 		})
 	taskExecManager := NewTaskExecutionManager(repository, getMockExecutionsConfigProvider(), getMockStorageForExecTest(context.Background()), mockScope.NewTestScope(), mockTaskExecutionRemoteURL, nil, nil)
-	_, err := taskExecManager.ListTaskExecutions(context.Background(), admin.TaskExecutionListRequest{
+	_, err := taskExecManager.ListTaskExecutions(context.Background(), &admin.TaskExecutionListRequest{
 		NodeExecutionId: &core.NodeExecutionIdentifier{
 			ExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "exec project b",
@@ -898,20 +898,20 @@ func TestGetTaskExecutionData(t *testing.T) {
 			}, nil
 		})
 	mockTaskExecutionRemoteURL = dataMocks.NewMockRemoteURL()
-	mockTaskExecutionRemoteURL.(*dataMocks.MockRemoteURL).GetCallback = func(ctx context.Context, uri string) (admin.UrlBlob, error) {
+	mockTaskExecutionRemoteURL.(*dataMocks.MockRemoteURL).GetCallback = func(ctx context.Context, uri string) (*admin.UrlBlob, error) {
 		if uri == "input-uri.pb" {
-			return admin.UrlBlob{
+			return &admin.UrlBlob{
 				Url:   "inputs",
 				Bytes: 100,
 			}, nil
 		} else if uri == "test-output.pb" {
-			return admin.UrlBlob{
+			return &admin.UrlBlob{
 				Url:   "outputs",
 				Bytes: 200,
 			}, nil
 		}
 
-		return admin.UrlBlob{}, errors.New("unexpected input")
+		return &admin.UrlBlob{}, errors.New("unexpected input")
 	}
 	mockStorage := commonMocks.GetMockStorageClient()
 	fullInputs := &core.LiteralMap{
@@ -938,7 +938,7 @@ func TestGetTaskExecutionData(t *testing.T) {
 		return fmt.Errorf("unexpected call to find value in storage [%v]", reference.String())
 	}
 	taskExecManager := NewTaskExecutionManager(repository, getMockExecutionsConfigProvider(), mockStorage, mockScope.NewTestScope(), mockTaskExecutionRemoteURL, nil, nil)
-	dataResponse, err := taskExecManager.GetTaskExecutionData(context.Background(), admin.TaskExecutionGetDataRequest{
+	dataResponse, err := taskExecManager.GetTaskExecutionData(context.Background(), &admin.TaskExecutionGetDataRequest{
 		Id: &core.TaskExecutionIdentifier{
 			TaskId:          sampleTaskID,
 			NodeExecutionId: sampleNodeExecID,

--- a/flyteadmin/pkg/manager/impl/task_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/task_manager_test.go
@@ -168,7 +168,7 @@ func TestGetTask(t *testing.T) {
 	repository.TaskRepo().(*repositoryMocks.MockTaskRepo).SetGetCallback(taskGetFunc)
 	taskManager := NewTaskManager(repository, getMockConfigForTaskTest(), getMockTaskCompiler(), mockScope.NewTestScope())
 
-	task, err := taskManager.GetTask(context.Background(), admin.ObjectGetRequest{
+	task, err := taskManager.GetTask(context.Background(), &admin.ObjectGetRequest{
 		Id: &taskIdentifier,
 	})
 	assert.NoError(t, err)
@@ -187,7 +187,7 @@ func TestGetTask_DatabaseError(t *testing.T) {
 	}
 	repository.TaskRepo().(*repositoryMocks.MockTaskRepo).SetGetCallback(taskGetFunc)
 	taskManager := NewTaskManager(repository, getMockConfigForTaskTest(), getMockTaskCompiler(), mockScope.NewTestScope())
-	task, err := taskManager.GetTask(context.Background(), admin.ObjectGetRequest{
+	task, err := taskManager.GetTask(context.Background(), &admin.ObjectGetRequest{
 		Id: &taskIdentifier,
 	})
 	assert.Nil(t, task)
@@ -214,7 +214,7 @@ func TestGetTask_TransformerError(t *testing.T) {
 	repository.TaskRepo().(*repositoryMocks.MockTaskRepo).SetGetCallback(taskGetFunc)
 	taskManager := NewTaskManager(repository, getMockConfigForTaskTest(), getMockTaskCompiler(), mockScope.NewTestScope())
 
-	task, err := taskManager.GetTask(context.Background(), admin.ObjectGetRequest{
+	task, err := taskManager.GetTask(context.Background(), &admin.ObjectGetRequest{
 		Id: &taskIdentifier,
 	})
 	assert.Nil(t, task)
@@ -273,7 +273,7 @@ func TestListTasks(t *testing.T) {
 	repository.TaskRepo().(*repositoryMocks.MockTaskRepo).SetListCallback(taskListFunc)
 	taskManager := NewTaskManager(repository, getMockConfigForTaskTest(), getMockTaskCompiler(), mockScope.NewTestScope())
 
-	taskList, err := taskManager.ListTasks(context.Background(), admin.ResourceListRequest{
+	taskList, err := taskManager.ListTasks(context.Background(), &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Project: projectValue,
 			Domain:  domainValue,
@@ -304,7 +304,7 @@ func TestListTasks(t *testing.T) {
 func TestListTasks_MissingParameters(t *testing.T) {
 	repository := getMockTaskRepository()
 	taskManager := NewTaskManager(repository, getMockConfigForTaskTest(), getMockTaskCompiler(), mockScope.NewTestScope())
-	_, err := taskManager.ListTasks(context.Background(), admin.ResourceListRequest{
+	_, err := taskManager.ListTasks(context.Background(), &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Domain: domainValue,
 			Name:   nameValue,
@@ -314,7 +314,7 @@ func TestListTasks_MissingParameters(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, err.(adminErrors.FlyteAdminError).Code())
 
-	_, err = taskManager.ListTasks(context.Background(), admin.ResourceListRequest{
+	_, err = taskManager.ListTasks(context.Background(), &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Project: projectValue,
 			Name:    nameValue,
@@ -334,7 +334,7 @@ func TestListTasks_DatabaseError(t *testing.T) {
 
 	repository.TaskRepo().(*repositoryMocks.MockTaskRepo).SetListCallback(taskListFunc)
 	taskManager := NewTaskManager(repository, getMockConfigForTaskTest(), getMockTaskCompiler(), mockScope.NewTestScope())
-	_, err := taskManager.ListTasks(context.Background(), admin.ResourceListRequest{
+	_, err := taskManager.ListTasks(context.Background(), &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Project: projectValue,
 			Domain:  domainValue,
@@ -389,7 +389,7 @@ func TestListUniqueTaskIdentifiers(t *testing.T) {
 
 	repository.TaskRepo().(*repositoryMocks.MockTaskRepo).SetListTaskIdentifiersCallback(listFunc)
 
-	resp, err := taskManager.ListUniqueTaskIdentifiers(context.Background(), admin.NamedEntityIdentifierListRequest{
+	resp, err := taskManager.ListUniqueTaskIdentifiers(context.Background(), &admin.NamedEntityIdentifierListRequest{
 		Project: projectValue,
 		Domain:  domainValue,
 		Limit:   limit,

--- a/flyteadmin/pkg/manager/impl/testutils/mock_requests.go
+++ b/flyteadmin/pkg/manager/impl/testutils/mock_requests.go
@@ -47,8 +47,8 @@ func GetValidTaskRequest() *admin.TaskCreateRequest {
 	}
 }
 
-func GetValidTaskRequestWithOverrides(project string, domain string, name string, version string) admin.TaskCreateRequest {
-	return admin.TaskCreateRequest{
+func GetValidTaskRequestWithOverrides(project string, domain string, name string, version string) *admin.TaskCreateRequest {
+	return &admin.TaskCreateRequest{
 		Id: &core.Identifier{
 			ResourceType: core.ResourceType_TASK,
 			Project:      project,
@@ -76,11 +76,6 @@ func GetValidTaskRequestWithOverrides(project string, domain string, name string
 			},
 		},
 	}
-}
-
-func GetValidTaskSpecBytes() []byte {
-	bytes, _ := proto.Marshal(GetValidTaskRequest().Spec)
-	return bytes
 }
 
 func GetWorkflowRequest() *admin.WorkflowCreateRequest {

--- a/flyteadmin/pkg/manager/impl/testutils/mock_requests.go
+++ b/flyteadmin/pkg/manager/impl/testutils/mock_requests.go
@@ -8,8 +8,8 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
-func GetValidTaskRequest() admin.TaskCreateRequest {
-	return admin.TaskCreateRequest{
+func GetValidTaskRequest() *admin.TaskCreateRequest {
+	return &admin.TaskCreateRequest{
 		Id: &core.Identifier{
 			ResourceType: core.ResourceType_TASK,
 			Project:      "project",
@@ -83,7 +83,7 @@ func GetValidTaskSpecBytes() []byte {
 	return bytes
 }
 
-func GetWorkflowRequest() admin.WorkflowCreateRequest {
+func GetWorkflowRequest() *admin.WorkflowCreateRequest {
 	identifier := core.Identifier{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Project:      "project",
@@ -91,7 +91,7 @@ func GetWorkflowRequest() admin.WorkflowCreateRequest {
 		Name:         "name",
 		Version:      "version",
 	}
-	return admin.WorkflowCreateRequest{
+	return &admin.WorkflowCreateRequest{
 		Id: &identifier,
 		Spec: &admin.WorkflowSpec{
 			Template: &core.WorkflowTemplate{
@@ -126,8 +126,8 @@ func GetWorkflowRequest() admin.WorkflowCreateRequest {
 	}
 }
 
-func GetLaunchPlanRequest() admin.LaunchPlanCreateRequest {
-	return admin.LaunchPlanCreateRequest{
+func GetLaunchPlanRequest() *admin.LaunchPlanCreateRequest {
+	return &admin.LaunchPlanCreateRequest{
 		Id: &core.Identifier{
 			ResourceType: core.ResourceType_LAUNCH_PLAN,
 			Project:      "project",
@@ -164,7 +164,7 @@ func GetLaunchPlanRequest() admin.LaunchPlanCreateRequest {
 	}
 }
 
-func GetLaunchPlanRequestWithDeprecatedCronSchedule(testCronExpr string) admin.LaunchPlanCreateRequest {
+func GetLaunchPlanRequestWithDeprecatedCronSchedule(testCronExpr string) *admin.LaunchPlanCreateRequest {
 	lpRequest := GetLaunchPlanRequest()
 	lpRequest.Spec.EntityMetadata = &admin.LaunchPlanMetadata{
 		Schedule: &admin.Schedule{
@@ -175,7 +175,7 @@ func GetLaunchPlanRequestWithDeprecatedCronSchedule(testCronExpr string) admin.L
 	return lpRequest
 }
 
-func GetLaunchPlanRequestWithCronSchedule(testCronExpr string) admin.LaunchPlanCreateRequest {
+func GetLaunchPlanRequestWithCronSchedule(testCronExpr string) *admin.LaunchPlanCreateRequest {
 	lpRequest := GetLaunchPlanRequest()
 	lpRequest.Spec.EntityMetadata = &admin.LaunchPlanMetadata{
 		Schedule: &admin.Schedule{
@@ -188,7 +188,7 @@ func GetLaunchPlanRequestWithCronSchedule(testCronExpr string) admin.LaunchPlanC
 	return lpRequest
 }
 
-func GetLaunchPlanRequestWithFixedRateSchedule(testRateValue uint32, testRateUnit admin.FixedRateUnit) admin.LaunchPlanCreateRequest {
+func GetLaunchPlanRequestWithFixedRateSchedule(testRateValue uint32, testRateUnit admin.FixedRateUnit) *admin.LaunchPlanCreateRequest {
 	lpRequest := GetLaunchPlanRequest()
 	lpRequest.Spec.EntityMetadata = &admin.LaunchPlanMetadata{
 		Schedule: &admin.Schedule{
@@ -203,8 +203,8 @@ func GetLaunchPlanRequestWithFixedRateSchedule(testRateValue uint32, testRateUni
 	return lpRequest
 }
 
-func GetExecutionRequest() admin.ExecutionCreateRequest {
-	return admin.ExecutionCreateRequest{
+func GetExecutionRequest() *admin.ExecutionCreateRequest {
+	return &admin.ExecutionCreateRequest{
 		Project: "project",
 		Domain:  "domain",
 		Name:    "name",
@@ -246,8 +246,8 @@ func GetExecutionRequest() admin.ExecutionCreateRequest {
 	}
 }
 
-func GetSampleWorkflowSpecForTest() admin.WorkflowSpec {
-	return admin.WorkflowSpec{
+func GetSampleWorkflowSpecForTest() *admin.WorkflowSpec {
+	return &admin.WorkflowSpec{
 		Template: &core.WorkflowTemplate{
 			Interface: &core.TypedInterface{
 				Inputs: &core.VariableMap{
@@ -265,8 +265,8 @@ func GetSampleWorkflowSpecForTest() admin.WorkflowSpec {
 	}
 }
 
-func GetSampleLpSpecForTest() admin.LaunchPlanSpec {
-	return admin.LaunchPlanSpec{
+func GetSampleLpSpecForTest() *admin.LaunchPlanSpec {
+	return &admin.LaunchPlanSpec{
 		WorkflowId: &core.Identifier{
 			ResourceType: core.ResourceType_WORKFLOW,
 			Project:      "project",

--- a/flyteadmin/pkg/manager/impl/util/data.go
+++ b/flyteadmin/pkg/manager/impl/util/data.go
@@ -19,12 +19,12 @@ const (
 	DeckFile    = "deck.html"
 )
 
-func shouldFetchData(config *runtimeInterfaces.RemoteDataConfig, urlBlob admin.UrlBlob) bool {
+func shouldFetchData(config *runtimeInterfaces.RemoteDataConfig, urlBlob *admin.UrlBlob) bool {
 	return config.Scheme == common.Local || config.Scheme == common.None || config.MaxSizeInBytes == 0 ||
 		urlBlob.Bytes < config.MaxSizeInBytes
 }
 
-func shouldFetchOutputData(config *runtimeInterfaces.RemoteDataConfig, urlBlob admin.UrlBlob, outputURI string) bool {
+func shouldFetchOutputData(config *runtimeInterfaces.RemoteDataConfig, urlBlob *admin.UrlBlob, outputURI string) bool {
 	return len(outputURI) > 0 && shouldFetchData(config, urlBlob)
 }
 
@@ -32,11 +32,11 @@ func shouldFetchOutputData(config *runtimeInterfaces.RemoteDataConfig, urlBlob a
 func GetInputs(ctx context.Context, urlData dataInterfaces.RemoteURLInterface,
 	remoteDataConfig *runtimeInterfaces.RemoteDataConfig, storageClient *storage.DataStore, inputURI string) (
 	*core.LiteralMap, *admin.UrlBlob, error) {
-	var inputsURLBlob admin.UrlBlob
+	inputsURLBlob := &admin.UrlBlob{}
 	var fullInputs core.LiteralMap
 
 	if len(inputURI) == 0 {
-		return &fullInputs, &inputsURLBlob, nil
+		return &fullInputs, inputsURLBlob, nil
 	}
 
 	var err error
@@ -55,7 +55,7 @@ func GetInputs(ctx context.Context, urlData dataInterfaces.RemoteURLInterface,
 			logger.Warningf(ctx, "Failed to read inputs from URI [%s] with err: %v", inputURI, err)
 		}
 	}
-	return &fullInputs, &inputsURLBlob, nil
+	return &fullInputs, inputsURLBlob, nil
 }
 
 // ExecutionClosure defines common methods in NodeExecutionClosure and TaskExecutionClosure used to return output data.
@@ -98,10 +98,10 @@ func ToExecutionClosureInterface(closure *admin.ExecutionClosure) ExecutionClosu
 func GetOutputs(ctx context.Context, urlData dataInterfaces.RemoteURLInterface,
 	remoteDataConfig *runtimeInterfaces.RemoteDataConfig, storageClient *storage.DataStore, closure ExecutionClosure) (
 	*core.LiteralMap, *admin.UrlBlob, error) {
-	var outputsURLBlob admin.UrlBlob
+	outputsURLBlob := &admin.UrlBlob{}
 	var fullOutputs = &core.LiteralMap{}
 	if closure == nil {
-		return fullOutputs, &outputsURLBlob, nil
+		return fullOutputs, outputsURLBlob, nil
 	}
 
 	if len(closure.GetOutputUri()) > 0 && remoteDataConfig.SignedURL.Enabled {
@@ -127,5 +127,5 @@ func GetOutputs(ctx context.Context, urlData dataInterfaces.RemoteURLInterface,
 		}
 	}
 
-	return fullOutputs, &outputsURLBlob, nil
+	return fullOutputs, outputsURLBlob, nil
 }

--- a/flyteadmin/pkg/manager/impl/util/data_test.go
+++ b/flyteadmin/pkg/manager/impl/util/data_test.go
@@ -30,7 +30,7 @@ func TestShouldFetchData(t *testing.T) {
 		assert.True(t, shouldFetchData(&interfaces.RemoteDataConfig{
 			Scheme:         common.Local,
 			MaxSizeInBytes: 100,
-		}, admin.UrlBlob{
+		}, &admin.UrlBlob{
 			Url:   "s3://data",
 			Bytes: 200,
 		}))
@@ -39,7 +39,7 @@ func TestShouldFetchData(t *testing.T) {
 		assert.True(t, shouldFetchData(&interfaces.RemoteDataConfig{
 			Scheme:         common.None,
 			MaxSizeInBytes: 100,
-		}, admin.UrlBlob{
+		}, &admin.UrlBlob{
 			Url:   "s3://data",
 			Bytes: 200,
 		}))
@@ -47,7 +47,7 @@ func TestShouldFetchData(t *testing.T) {
 	t.Run("no config", func(t *testing.T) {
 		assert.True(t, shouldFetchData(&interfaces.RemoteDataConfig{
 			Scheme: common.None,
-		}, admin.UrlBlob{
+		}, &admin.UrlBlob{
 			Url:   "s3://data",
 			Bytes: 200,
 		}))
@@ -56,7 +56,7 @@ func TestShouldFetchData(t *testing.T) {
 		assert.True(t, shouldFetchData(&interfaces.RemoteDataConfig{
 			Scheme:         common.AWS,
 			MaxSizeInBytes: 1000,
-		}, admin.UrlBlob{
+		}, &admin.UrlBlob{
 			Url:   "s3://data",
 			Bytes: 200,
 		}))
@@ -65,7 +65,7 @@ func TestShouldFetchData(t *testing.T) {
 		assert.False(t, shouldFetchData(&interfaces.RemoteDataConfig{
 			Scheme:         common.AWS,
 			MaxSizeInBytes: 100,
-		}, admin.UrlBlob{
+		}, &admin.UrlBlob{
 			Url:   "s3://data",
 			Bytes: 200,
 		}))
@@ -74,7 +74,7 @@ func TestShouldFetchData(t *testing.T) {
 		assert.False(t, shouldFetchData(&interfaces.RemoteDataConfig{
 			Scheme:         common.AWS,
 			MaxSizeInBytes: 100,
-		}, admin.UrlBlob{
+		}, &admin.UrlBlob{
 			Bytes: 200,
 		}))
 	})
@@ -85,7 +85,7 @@ func TestShouldFetchOutputData(t *testing.T) {
 		assert.True(t, shouldFetchOutputData(&interfaces.RemoteDataConfig{
 			Scheme:         common.Local,
 			MaxSizeInBytes: 100,
-		}, admin.UrlBlob{
+		}, &admin.UrlBlob{
 			Url:   "s3://data",
 			Bytes: 200,
 		}, "s3://foo/bar.txt"))
@@ -94,7 +94,7 @@ func TestShouldFetchOutputData(t *testing.T) {
 		assert.True(t, shouldFetchOutputData(&interfaces.RemoteDataConfig{
 			Scheme:         common.AWS,
 			MaxSizeInBytes: 1000,
-		}, admin.UrlBlob{
+		}, &admin.UrlBlob{
 			Url:   "s3://data",
 			Bytes: 200,
 		}, "s3://foo/bar.txt"))
@@ -103,7 +103,7 @@ func TestShouldFetchOutputData(t *testing.T) {
 		assert.False(t, shouldFetchOutputData(&interfaces.RemoteDataConfig{
 			Scheme:         common.AWS,
 			MaxSizeInBytes: 1000,
-		}, admin.UrlBlob{
+		}, &admin.UrlBlob{
 			Url:   "s3://data",
 			Bytes: 200,
 		}, ""))
@@ -113,13 +113,13 @@ func TestShouldFetchOutputData(t *testing.T) {
 func TestGetInputs(t *testing.T) {
 	inputsURI := "s3://foo/bar/inputs.pb"
 
-	expectedURLBlob := admin.UrlBlob{
+	expectedURLBlob := &admin.UrlBlob{
 		Url:   "s3://foo/signed/inputs.pb",
 		Bytes: 1000,
 	}
 
 	mockRemoteURL := urlMocks.NewMockRemoteURL()
-	mockRemoteURL.(*urlMocks.MockRemoteURL).GetCallback = func(ctx context.Context, uri string) (admin.UrlBlob, error) {
+	mockRemoteURL.(*urlMocks.MockRemoteURL).GetCallback = func(ctx context.Context, uri string) (*admin.UrlBlob, error) {
 		assert.Equal(t, inputsURI, uri)
 		return expectedURLBlob, nil
 	}
@@ -143,7 +143,7 @@ func TestGetInputs(t *testing.T) {
 		fullInputs, inputURLBlob, err := GetInputs(context.TODO(), mockRemoteURL, &remoteDataConfig, mockStorage, inputsURI)
 		assert.NoError(t, err)
 		assert.True(t, proto.Equal(fullInputs, testLiteralMap))
-		assert.True(t, proto.Equal(inputURLBlob, &expectedURLBlob))
+		assert.True(t, proto.Equal(inputURLBlob, expectedURLBlob))
 	})
 	t.Run("should not sign URL", func(t *testing.T) {
 		remoteDataConfig.SignedURL = interfaces.SignedURL{
@@ -157,13 +157,13 @@ func TestGetInputs(t *testing.T) {
 }
 
 func TestGetOutputs(t *testing.T) {
-	expectedURLBlob := admin.UrlBlob{
+	expectedURLBlob := &admin.UrlBlob{
 		Url:   "s3://foo/signed/outputs.pb",
 		Bytes: 1000,
 	}
 
 	mockRemoteURL := urlMocks.NewMockRemoteURL()
-	mockRemoteURL.(*urlMocks.MockRemoteURL).GetCallback = func(ctx context.Context, uri string) (admin.UrlBlob, error) {
+	mockRemoteURL.(*urlMocks.MockRemoteURL).GetCallback = func(ctx context.Context, uri string) (*admin.UrlBlob, error) {
 		assert.Equal(t, testOutputsURI, uri)
 		return expectedURLBlob, nil
 	}
@@ -192,7 +192,7 @@ func TestGetOutputs(t *testing.T) {
 		fullOutputs, outputURLBlob, err := GetOutputs(context.TODO(), mockRemoteURL, &remoteDataConfig, mockStorage, closure)
 		assert.NoError(t, err)
 		assert.True(t, proto.Equal(fullOutputs, testLiteralMap))
-		assert.True(t, proto.Equal(outputURLBlob, &expectedURLBlob))
+		assert.True(t, proto.Equal(outputURLBlob, expectedURLBlob))
 	})
 	t.Run("offloaded outputs without signed URL", func(t *testing.T) {
 		remoteDataConfig.SignedURL = interfaces.SignedURL{
@@ -206,9 +206,9 @@ func TestGetOutputs(t *testing.T) {
 	})
 	t.Run("inline outputs", func(t *testing.T) {
 		mockRemoteURL := urlMocks.NewMockRemoteURL()
-		mockRemoteURL.(*urlMocks.MockRemoteURL).GetCallback = func(ctx context.Context, uri string) (admin.UrlBlob, error) {
+		mockRemoteURL.(*urlMocks.MockRemoteURL).GetCallback = func(ctx context.Context, uri string) (*admin.UrlBlob, error) {
 			t.Fatal("Should not fetch a remote URL for outputs stored inline for an execution model")
-			return admin.UrlBlob{}, nil
+			return &admin.UrlBlob{}, nil
 		}
 		remoteDataConfig := interfaces.RemoteDataConfig{}
 		remoteDataConfig.MaxSizeInBytes = 2000

--- a/flyteadmin/pkg/manager/impl/util/filters.go
+++ b/flyteadmin/pkg/manager/impl/util/filters.go
@@ -271,7 +271,7 @@ func GetDbFilters(spec FilterSpec, primaryEntity common.Entity) ([]common.Inline
 }
 
 func GetWorkflowExecutionIdentifierFilters(
-	ctx context.Context, workflowExecutionIdentifier core.WorkflowExecutionIdentifier) ([]common.InlineFilter, error) {
+	ctx context.Context, workflowExecutionIdentifier *core.WorkflowExecutionIdentifier) ([]common.InlineFilter, error) {
 	identifierFilters := make([]common.InlineFilter, 3)
 	identifierProjectFilter, err := GetSingleValueEqualityFilter(
 		common.Execution, shared.Project, workflowExecutionIdentifier.Project)
@@ -304,9 +304,9 @@ func GetWorkflowExecutionIdentifierFilters(
 
 // All inputs to this function must be validated.
 func GetNodeExecutionIdentifierFilters(
-	ctx context.Context, nodeExecutionIdentifier core.NodeExecutionIdentifier) ([]common.InlineFilter, error) {
+	ctx context.Context, nodeExecutionIdentifier *core.NodeExecutionIdentifier) ([]common.InlineFilter, error) {
 	workflowExecutionIdentifierFilters, err :=
-		GetWorkflowExecutionIdentifierFilters(ctx, *nodeExecutionIdentifier.ExecutionId)
+		GetWorkflowExecutionIdentifierFilters(ctx, nodeExecutionIdentifier.ExecutionId)
 	if err != nil {
 		return nil, err
 	}

--- a/flyteadmin/pkg/manager/impl/util/filters_test.go
+++ b/flyteadmin/pkg/manager/impl/util/filters_test.go
@@ -172,7 +172,7 @@ func TestGetDbFilters(t *testing.T) {
 
 func TestGetWorkflowExecutionIdentifierFilters(t *testing.T) {
 	identifierFilters, err := GetWorkflowExecutionIdentifierFilters(
-		context.Background(), core.WorkflowExecutionIdentifier{
+		context.Background(), &core.WorkflowExecutionIdentifier{
 			Project: "ex project",
 			Domain:  "ex domain",
 			Name:    "ex name",
@@ -198,7 +198,7 @@ func TestGetWorkflowExecutionIdentifierFilters(t *testing.T) {
 
 func TestGetNodeExecutionIdentifierFilters(t *testing.T) {
 	identifierFilters, err := GetNodeExecutionIdentifierFilters(
-		context.Background(), core.NodeExecutionIdentifier{
+		context.Background(), &core.NodeExecutionIdentifier{
 			ExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "ex project",
 				Domain:  "ex domain",

--- a/flyteadmin/pkg/manager/impl/util/shared.go
+++ b/flyteadmin/pkg/manager/impl/util/shared.go
@@ -22,16 +22,16 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-func GetExecutionName(request admin.ExecutionCreateRequest) string {
+func GetExecutionName(request *admin.ExecutionCreateRequest) string {
 	if request.Name != "" {
 		return request.Name
 	}
 	return naming.GetExecutionName(time.Now().UnixNano())
 }
 
-func GetTask(ctx context.Context, repo repoInterfaces.Repository, identifier core.Identifier) (
+func GetTask(ctx context.Context, repo repoInterfaces.Repository, identifier *core.Identifier) (
 	*admin.Task, error) {
-	taskModel, err := GetTaskModel(ctx, repo, &identifier)
+	taskModel, err := GetTaskModel(ctx, repo, identifier)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func GetTask(ctx context.Context, repo repoInterfaces.Repository, identifier cor
 }
 
 func GetWorkflowModel(
-	ctx context.Context, repo repoInterfaces.Repository, identifier core.Identifier) (models.Workflow, error) {
+	ctx context.Context, repo repoInterfaces.Repository, identifier *core.Identifier) (models.Workflow, error) {
 	workflowModel, err := (repo).WorkflowRepo().Get(ctx, repoInterfaces.Identifier{
 		Project: identifier.Project,
 		Domain:  identifier.Domain,
@@ -75,7 +75,7 @@ func GetWorkflow(
 	ctx context.Context,
 	repo repoInterfaces.Repository,
 	store *storage.DataStore,
-	identifier core.Identifier) (*admin.Workflow, error) {
+	identifier *core.Identifier) (*admin.Workflow, error) {
 	workflowModel, err := GetWorkflowModel(ctx, repo, identifier)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func GetWorkflow(
 }
 
 func GetLaunchPlanModel(
-	ctx context.Context, repo repoInterfaces.Repository, identifier core.Identifier) (models.LaunchPlan, error) {
+	ctx context.Context, repo repoInterfaces.Repository, identifier *core.Identifier) (models.LaunchPlan, error) {
 	launchPlanModel, err := (repo).LaunchPlanRepo().Get(ctx, repoInterfaces.Identifier{
 		Project: identifier.Project,
 		Domain:  identifier.Domain,
@@ -108,7 +108,7 @@ func GetLaunchPlanModel(
 }
 
 func GetLaunchPlan(
-	ctx context.Context, repo repoInterfaces.Repository, identifier core.Identifier) (*admin.LaunchPlan, error) {
+	ctx context.Context, repo repoInterfaces.Repository, identifier *core.Identifier) (*admin.LaunchPlan, error) {
 	launchPlanModel, err := GetLaunchPlanModel(ctx, repo, identifier)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func GetLaunchPlan(
 }
 
 func GetNamedEntityModel(
-	ctx context.Context, repo repoInterfaces.Repository, resourceType core.ResourceType, identifier admin.NamedEntityIdentifier) (models.NamedEntity, error) {
+	ctx context.Context, repo repoInterfaces.Repository, resourceType core.ResourceType, identifier *admin.NamedEntityIdentifier) (models.NamedEntity, error) {
 	metadataModel, err := (repo).NamedEntityRepo().Get(ctx, repoInterfaces.GetNamedEntityInput{
 		ResourceType: resourceType,
 		Project:      identifier.Project,
@@ -131,7 +131,7 @@ func GetNamedEntityModel(
 }
 
 func GetNamedEntity(
-	ctx context.Context, repo repoInterfaces.Repository, resourceType core.ResourceType, identifier admin.NamedEntityIdentifier) (*admin.NamedEntity, error) {
+	ctx context.Context, repo repoInterfaces.Repository, resourceType core.ResourceType, identifier *admin.NamedEntityIdentifier) (*admin.NamedEntity, error) {
 	metadataModel, err := GetNamedEntityModel(ctx, repo, resourceType, identifier)
 	if err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ func GetNamedEntity(
 }
 
 func GetDescriptionEntityModel(
-	ctx context.Context, repo repoInterfaces.Repository, identifier core.Identifier) (models.DescriptionEntity, error) {
+	ctx context.Context, repo repoInterfaces.Repository, identifier *core.Identifier) (models.DescriptionEntity, error) {
 	descriptionEntityModel, err := (repo).DescriptionEntityRepo().Get(ctx, repoInterfaces.GetDescriptionEntityInput{
 		ResourceType: identifier.ResourceType,
 		Project:      identifier.Project,
@@ -156,7 +156,7 @@ func GetDescriptionEntityModel(
 }
 
 func GetDescriptionEntity(
-	ctx context.Context, repo repoInterfaces.Repository, identifier core.Identifier) (*admin.DescriptionEntity, error) {
+	ctx context.Context, repo repoInterfaces.Repository, identifier *core.Identifier) (*admin.DescriptionEntity, error) {
 	descriptionEntityModel, err := GetDescriptionEntityModel(ctx, repo, identifier)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to get description entity [%+v]: %v", identifier, err)
@@ -209,7 +209,7 @@ func ListActiveLaunchPlanVersionsFilters(project, domain string) ([]common.Inlin
 }
 
 func GetExecutionModel(
-	ctx context.Context, repo repoInterfaces.Repository, identifier core.WorkflowExecutionIdentifier) (
+	ctx context.Context, repo repoInterfaces.Repository, identifier *core.WorkflowExecutionIdentifier) (
 	*models.Execution, error) {
 	executionModel, err := repo.ExecutionRepo().Get(ctx, repoInterfaces.Identifier{
 		Project: identifier.Project,
@@ -225,7 +225,7 @@ func GetExecutionModel(
 func GetNodeExecutionModel(ctx context.Context, repo repoInterfaces.Repository, nodeExecutionIdentifier *core.NodeExecutionIdentifier) (
 	*models.NodeExecution, error) {
 	nodeExecutionModel, err := repo.NodeExecutionRepo().Get(ctx, repoInterfaces.NodeExecutionResource{
-		NodeExecutionIdentifier: *nodeExecutionIdentifier,
+		NodeExecutionIdentifier: nodeExecutionIdentifier,
 	})
 
 	if err != nil {
@@ -257,7 +257,7 @@ func GetTaskExecutionModel(
 	}
 
 	taskExecutionModel, err := repo.TaskExecutionRepo().Get(ctx, repoInterfaces.GetTaskExecutionInput{
-		TaskExecutionID: *taskExecutionID,
+		TaskExecutionID: taskExecutionID,
 	})
 	if err != nil {
 		logger.Debugf(ctx, "Failed to get task execution with id [%+v] with err %v", taskExecutionID, err)
@@ -287,7 +287,7 @@ func GetMatchableResource(ctx context.Context, resourceManager interfaces.Resour
 // MergeIntoExecConfig into workflowExecConfig (higher priority) from spec (lower priority) and return the
 // new object with the merged changes.
 // After settings project is done, can move this function back to execution manager. Currently shared with resource.
-func MergeIntoExecConfig(workflowExecConfig admin.WorkflowExecutionConfig, spec shared.WorkflowExecutionConfigInterface) admin.WorkflowExecutionConfig {
+func MergeIntoExecConfig(workflowExecConfig *admin.WorkflowExecutionConfig, spec shared.WorkflowExecutionConfigInterface) *admin.WorkflowExecutionConfig {
 	if workflowExecConfig.GetMaxParallelism() == 0 && spec.GetMaxParallelism() > 0 {
 		workflowExecConfig.MaxParallelism = spec.GetMaxParallelism()
 	}

--- a/flyteadmin/pkg/manager/impl/util/shared_test.go
+++ b/flyteadmin/pkg/manager/impl/util/shared_test.go
@@ -37,7 +37,7 @@ const remoteClosureIdentifier = "remote closure id"
 var errExpected = errors.New("expected error")
 
 func TestPopulateExecutionID(t *testing.T) {
-	name := GetExecutionName(admin.ExecutionCreateRequest{
+	name := GetExecutionName(&admin.ExecutionCreateRequest{
 		Project: "project",
 		Domain:  "domain",
 	})
@@ -46,7 +46,7 @@ func TestPopulateExecutionID(t *testing.T) {
 }
 
 func TestPopulateExecutionID_ExistingName(t *testing.T) {
-	name := GetExecutionName(admin.ExecutionCreateRequest{
+	name := GetExecutionName(&admin.ExecutionCreateRequest{
 		Project: "project",
 		Domain:  "domain",
 		Name:    "name",
@@ -72,7 +72,7 @@ func TestGetTask(t *testing.T) {
 		}, nil
 	}
 	repository.TaskRepo().(*repositoryMocks.MockTaskRepo).SetGetCallback(taskGetFunc)
-	task, err := GetTask(context.Background(), repository, core.Identifier{
+	task, err := GetTask(context.Background(), repository, &core.Identifier{
 		ResourceType: core.ResourceType_TASK,
 		Project:      "project",
 		Domain:       "domain",
@@ -93,7 +93,7 @@ func TestGetTask_DatabaseError(t *testing.T) {
 		return models.Task{}, errExpected
 	}
 	repository.TaskRepo().(*repositoryMocks.MockTaskRepo).SetGetCallback(taskGetFunc)
-	task, err := GetTask(context.Background(), repository, core.Identifier{
+	task, err := GetTask(context.Background(), repository, &core.Identifier{
 		ResourceType: core.ResourceType_TASK,
 		Project:      "project",
 		Domain:       "domain",
@@ -122,7 +122,7 @@ func TestGetTask_TransformerError(t *testing.T) {
 		}, nil
 	}
 	repository.TaskRepo().(*repositoryMocks.MockTaskRepo).SetGetCallback(taskGetFunc)
-	task, err := GetTask(context.Background(), repository, core.Identifier{
+	task, err := GetTask(context.Background(), repository, &core.Identifier{
 		ResourceType: core.ResourceType_TASK,
 		Project:      "project",
 		Domain:       "domain",
@@ -152,7 +152,7 @@ func TestGetWorkflowModel(t *testing.T) {
 		}, nil
 	}
 	repository.WorkflowRepo().(*repositoryMocks.MockWorkflowRepo).SetGetCallback(workflowGetFunc)
-	workflow, err := GetWorkflowModel(context.Background(), repository, core.Identifier{
+	workflow, err := GetWorkflowModel(context.Background(), repository, &core.Identifier{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Project:      "project",
 		Domain:       "domain",
@@ -173,7 +173,7 @@ func TestGetWorkflowModel_DatabaseError(t *testing.T) {
 		return models.Workflow{}, errExpected
 	}
 	repository.WorkflowRepo().(*repositoryMocks.MockWorkflowRepo).SetGetCallback(workflowGetFunc)
-	workflow, err := GetWorkflowModel(context.Background(), repository, core.Identifier{
+	workflow, err := GetWorkflowModel(context.Background(), repository, &core.Identifier{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Project:      "project",
 		Domain:       "domain",
@@ -240,7 +240,7 @@ func TestGetWorkflow(t *testing.T) {
 			return nil
 		}
 	workflow, err := GetWorkflow(
-		context.Background(), repository, mockStorageClient, core.Identifier{
+		context.Background(), repository, mockStorageClient, &core.Identifier{
 			ResourceType: core.ResourceType_WORKFLOW,
 			Project:      "project",
 			Domain:       "domain",
@@ -268,7 +268,7 @@ func TestGetLaunchPlanModel(t *testing.T) {
 		}, nil
 	}
 	repository.LaunchPlanRepo().(*repositoryMocks.MockLaunchPlanRepo).SetGetCallback(getLaunchPlanFunc)
-	launchPlan, err := GetLaunchPlanModel(context.Background(), repository, core.Identifier{
+	launchPlan, err := GetLaunchPlanModel(context.Background(), repository, &core.Identifier{
 		ResourceType: core.ResourceType_LAUNCH_PLAN,
 		Project:      "project",
 		Domain:       "domain",
@@ -289,7 +289,7 @@ func TestGetLaunchPlanModel_DatabaseError(t *testing.T) {
 		return models.LaunchPlan{}, errExpected
 	}
 	repository.LaunchPlanRepo().(*repositoryMocks.MockLaunchPlanRepo).SetGetCallback(getLaunchPlanFunc)
-	launchPlan, err := GetLaunchPlanModel(context.Background(), repository, core.Identifier{
+	launchPlan, err := GetLaunchPlanModel(context.Background(), repository, &core.Identifier{
 		ResourceType: core.ResourceType_LAUNCH_PLAN,
 		Project:      "project",
 		Domain:       "domain",
@@ -317,7 +317,7 @@ func TestGetLaunchPlan(t *testing.T) {
 		}, nil
 	}
 	repository.LaunchPlanRepo().(*repositoryMocks.MockLaunchPlanRepo).SetGetCallback(getLaunchPlanFunc)
-	launchPlan, err := GetLaunchPlan(context.Background(), repository, core.Identifier{
+	launchPlan, err := GetLaunchPlan(context.Background(), repository, &core.Identifier{
 		ResourceType: core.ResourceType_LAUNCH_PLAN,
 		Project:      "project",
 		Domain:       "domain",
@@ -350,7 +350,7 @@ func TestGetLaunchPlan_TransformerError(t *testing.T) {
 		}, nil
 	}
 	repository.LaunchPlanRepo().(*repositoryMocks.MockLaunchPlanRepo).SetGetCallback(getLaunchPlanFunc)
-	launchPlan, err := GetLaunchPlan(context.Background(), repository, core.Identifier{
+	launchPlan, err := GetLaunchPlan(context.Background(), repository, &core.Identifier{
 		ResourceType: core.ResourceType_LAUNCH_PLAN,
 		Project:      "project",
 		Domain:       "domain",
@@ -383,7 +383,7 @@ func TestGetNamedEntityModel(t *testing.T) {
 	repository.NamedEntityRepo().(*repositoryMocks.MockNamedEntityRepo).SetGetCallback(getNamedEntityFunc)
 	entity, err := GetNamedEntityModel(context.Background(), repository,
 		core.ResourceType_WORKFLOW,
-		admin.NamedEntityIdentifier{
+		&admin.NamedEntityIdentifier{
 			Project: "project",
 			Domain:  "domain",
 			Name:    "name",
@@ -405,7 +405,7 @@ func TestGetNamedEntityModel_DatabaseError(t *testing.T) {
 	repository.NamedEntityRepo().(*repositoryMocks.MockNamedEntityRepo).SetGetCallback(getNamedEntityFunc)
 	launchPlan, err := GetNamedEntityModel(context.Background(), repository,
 		core.ResourceType_WORKFLOW,
-		admin.NamedEntityIdentifier{
+		&admin.NamedEntityIdentifier{
 			Project: "project",
 			Domain:  "domain",
 			Name:    "name",
@@ -436,7 +436,7 @@ func TestGetNamedEntity(t *testing.T) {
 	repository.NamedEntityRepo().(*repositoryMocks.MockNamedEntityRepo).SetGetCallback(getNamedEntityFunc)
 	entity, err := GetNamedEntity(context.Background(), repository,
 		core.ResourceType_WORKFLOW,
-		admin.NamedEntityIdentifier{
+		&admin.NamedEntityIdentifier{
 			Project: "project",
 			Domain:  "domain",
 			Name:    "name",
@@ -571,7 +571,7 @@ func TestGetDescriptionEntityModel(t *testing.T) {
 	repository := repositoryMocks.NewMockRepository()
 	t.Run("Get Description Entity model", func(t *testing.T) {
 		entity, err := GetDescriptionEntityModel(context.Background(), repository,
-			core.Identifier{
+			&core.Identifier{
 				ResourceType: core.ResourceType_TASK,
 				Project:      project,
 				Domain:       domain,
@@ -589,7 +589,7 @@ func TestGetDescriptionEntityModel(t *testing.T) {
 		}
 		repository.DescriptionEntityRepo().(*repositoryMocks.MockDescriptionEntityRepo).SetGetCallback(getFunction)
 		entity, err := GetDescriptionEntityModel(context.Background(), repository,
-			core.Identifier{
+			&core.Identifier{
 				ResourceType: core.ResourceType_TASK,
 				Project:      project,
 				Domain:       domain,
@@ -605,7 +605,7 @@ func TestGetDescriptionEntity(t *testing.T) {
 	repository := repositoryMocks.NewMockRepository()
 	t.Run("Get Description Entity", func(t *testing.T) {
 		entity, err := GetDescriptionEntity(context.Background(), repository,
-			core.Identifier{
+			&core.Identifier{
 				ResourceType: core.ResourceType_TASK,
 				Project:      project,
 				Domain:       domain,
@@ -623,7 +623,7 @@ func TestGetDescriptionEntity(t *testing.T) {
 		}
 		repository.DescriptionEntityRepo().(*repositoryMocks.MockDescriptionEntityRepo).SetGetCallback(getFunction)
 		entity, err := GetDescriptionEntity(context.Background(), repository,
-			core.Identifier{
+			&core.Identifier{
 				ResourceType: core.ResourceType_TASK,
 				Project:      project,
 				Domain:       domain,
@@ -638,7 +638,7 @@ func TestGetDescriptionEntity(t *testing.T) {
 		}
 		repository.DescriptionEntityRepo().(*repositoryMocks.MockDescriptionEntityRepo).SetGetCallback(getFunction)
 		entity, err = GetDescriptionEntity(context.Background(), repository,
-			core.Identifier{
+			&core.Identifier{
 				ResourceType: core.ResourceType_TASK,
 				Project:      project,
 				Domain:       domain,
@@ -651,13 +651,13 @@ func TestGetDescriptionEntity(t *testing.T) {
 }
 
 func TestMergeIntoExecConfig(t *testing.T) {
-	var res admin.WorkflowExecutionConfig
+	var res *admin.WorkflowExecutionConfig
 	parameters := []struct {
-		higher, lower, expected admin.WorkflowExecutionConfig
+		higher, lower, expected *admin.WorkflowExecutionConfig
 	}{
 		// Max Parallelism taken from higher
 		{
-			admin.WorkflowExecutionConfig{
+			&admin.WorkflowExecutionConfig{
 				MaxParallelism: 5,
 				RawOutputDataConfig: &admin.RawOutputDataConfig{
 					OutputLocationPrefix: "s3://test-bucket",
@@ -669,7 +669,7 @@ func TestMergeIntoExecConfig(t *testing.T) {
 					Values: map[string]string{"ann1": "annval"},
 				},
 			},
-			admin.WorkflowExecutionConfig{
+			&admin.WorkflowExecutionConfig{
 				MaxParallelism: 0,
 				RawOutputDataConfig: &admin.RawOutputDataConfig{
 					OutputLocationPrefix: "s3://asdf",
@@ -678,7 +678,7 @@ func TestMergeIntoExecConfig(t *testing.T) {
 					Values: map[string]string{"lab1": "oldvalue"},
 				},
 			},
-			admin.WorkflowExecutionConfig{
+			&admin.WorkflowExecutionConfig{
 				MaxParallelism: 5,
 				RawOutputDataConfig: &admin.RawOutputDataConfig{
 					OutputLocationPrefix: "s3://test-bucket",
@@ -694,7 +694,7 @@ func TestMergeIntoExecConfig(t *testing.T) {
 
 		// Values that are set to empty in higher priority get overwritten
 		{
-			admin.WorkflowExecutionConfig{
+			&admin.WorkflowExecutionConfig{
 				RawOutputDataConfig: &admin.RawOutputDataConfig{
 					OutputLocationPrefix: "",
 				},
@@ -705,7 +705,7 @@ func TestMergeIntoExecConfig(t *testing.T) {
 					Values: map[string]string{},
 				},
 			},
-			admin.WorkflowExecutionConfig{
+			&admin.WorkflowExecutionConfig{
 				RawOutputDataConfig: &admin.RawOutputDataConfig{
 					OutputLocationPrefix: "s3://asdf",
 				},
@@ -716,7 +716,7 @@ func TestMergeIntoExecConfig(t *testing.T) {
 					Values: map[string]string{"ann1": "annval"},
 				},
 			},
-			admin.WorkflowExecutionConfig{
+			&admin.WorkflowExecutionConfig{
 				RawOutputDataConfig: &admin.RawOutputDataConfig{
 					OutputLocationPrefix: "s3://asdf",
 				},
@@ -731,8 +731,8 @@ func TestMergeIntoExecConfig(t *testing.T) {
 
 		// Values that are not set at all get merged in
 		{
-			admin.WorkflowExecutionConfig{},
-			admin.WorkflowExecutionConfig{
+			&admin.WorkflowExecutionConfig{},
+			&admin.WorkflowExecutionConfig{
 				RawOutputDataConfig: &admin.RawOutputDataConfig{
 					OutputLocationPrefix: "s3://asdf",
 				},
@@ -743,7 +743,7 @@ func TestMergeIntoExecConfig(t *testing.T) {
 					Values: map[string]string{"ann1": "annval"},
 				},
 			},
-			admin.WorkflowExecutionConfig{
+			&admin.WorkflowExecutionConfig{
 				RawOutputDataConfig: &admin.RawOutputDataConfig{
 					OutputLocationPrefix: "s3://asdf",
 				},
@@ -758,17 +758,17 @@ func TestMergeIntoExecConfig(t *testing.T) {
 
 		// Interruptible
 		{
-			admin.WorkflowExecutionConfig{
+			&admin.WorkflowExecutionConfig{
 				Interruptible: &wrappers.BoolValue{
 					Value: false,
 				},
 			},
-			admin.WorkflowExecutionConfig{
+			&admin.WorkflowExecutionConfig{
 				Interruptible: &wrappers.BoolValue{
 					Value: true,
 				},
 			},
-			admin.WorkflowExecutionConfig{
+			&admin.WorkflowExecutionConfig{
 				Interruptible: &wrappers.BoolValue{
 					Value: false,
 				},
@@ -778,8 +778,8 @@ func TestMergeIntoExecConfig(t *testing.T) {
 
 	for i := range parameters {
 		t.Run(fmt.Sprintf("Testing [%v]", i), func(t *testing.T) {
-			res = MergeIntoExecConfig(parameters[i].higher, &parameters[i].lower)
-			assert.True(t, proto.Equal(&parameters[i].expected, &res))
+			res = MergeIntoExecConfig(parameters[i].higher, parameters[i].lower)
+			assert.True(t, proto.Equal(parameters[i].expected, res))
 		})
 	}
 }

--- a/flyteadmin/pkg/manager/impl/util/single_task_execution_test.go
+++ b/flyteadmin/pkg/manager/impl/util/single_task_execution_test.go
@@ -32,7 +32,7 @@ func TestGenerateWorkflowNameFromTask(t *testing.T) {
 
 func TestGenerateBindings(t *testing.T) {
 	nodeID := "nodeID"
-	outputs := core.VariableMap{
+	outputs := &core.VariableMap{
 		Variables: map[string]*core.Variable{
 			"output1": {},
 			"output2": {},
@@ -87,7 +87,7 @@ func TestCreateOrGetWorkflowModel(t *testing.T) {
 	repository.WorkflowRepo().(*repositoryMocks.MockWorkflowRepo).SetGetCallback(workflowGetFunc)
 
 	mockNamedEntityManager := managerMocks.NamedEntityManager{}
-	mockNamedEntityManager.UpdateNamedEntityFunc = func(ctx context.Context, request admin.NamedEntityUpdateRequest) (*admin.NamedEntityUpdateResponse, error) {
+	mockNamedEntityManager.UpdateNamedEntityFunc = func(ctx context.Context, request *admin.NamedEntityUpdateRequest) (*admin.NamedEntityUpdateResponse, error) {
 		assert.Equal(t, request.ResourceType, core.ResourceType_WORKFLOW)
 		assert.True(t, proto.Equal(request.Id, &admin.NamedEntityIdentifier{
 			Project: "flytekit",
@@ -101,7 +101,7 @@ func TestCreateOrGetWorkflowModel(t *testing.T) {
 	}
 
 	mockWorkflowManager := managerMocks.MockWorkflowManager{}
-	mockWorkflowManager.SetCreateCallback(func(ctx context.Context, request admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error) {
+	mockWorkflowManager.SetCreateCallback(func(ctx context.Context, request *admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error) {
 		assert.True(t, proto.Equal(request.Id, &core.Identifier{
 			ResourceType: core.ResourceType_WORKFLOW,
 			Project:      "flytekit",
@@ -160,7 +160,7 @@ func TestCreateOrGetWorkflowModel(t *testing.T) {
 			},
 		},
 	}
-	workflowModel, err := CreateOrGetWorkflowModel(context.Background(), admin.ExecutionCreateRequest{
+	workflowModel, err := CreateOrGetWorkflowModel(context.Background(), &admin.ExecutionCreateRequest{
 		Project: "flytekit",
 		Domain:  "production",
 		Name:    "SingleTaskExecution",

--- a/flyteadmin/pkg/manager/impl/validation/attributes_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/attributes_validator.go
@@ -40,7 +40,7 @@ func validateMatchingAttributes(attributes *admin.MatchingAttributes, identifier
 
 func ValidateProjectDomainAttributesUpdateRequest(ctx context.Context,
 	db repositoryInterfaces.Repository, config runtimeInterfaces.ApplicationConfiguration,
-	request admin.ProjectDomainAttributesUpdateRequest) (
+	request *admin.ProjectDomainAttributesUpdateRequest) (
 	admin.MatchableResource, error) {
 	if request.Attributes == nil {
 		return defaultMatchableResource, shared.GetMissingArgumentError(shared.Attributes)
@@ -55,7 +55,7 @@ func ValidateProjectDomainAttributesUpdateRequest(ctx context.Context,
 
 func ValidateProjectAttributesUpdateRequest(ctx context.Context,
 	db repositoryInterfaces.Repository,
-	request admin.ProjectAttributesUpdateRequest) (
+	request *admin.ProjectAttributesUpdateRequest) (
 	admin.MatchableResource, error) {
 
 	if request.Attributes == nil {
@@ -69,7 +69,7 @@ func ValidateProjectAttributesUpdateRequest(ctx context.Context,
 }
 
 func ValidateProjectDomainAttributesGetRequest(ctx context.Context, db repositoryInterfaces.Repository,
-	config runtimeInterfaces.ApplicationConfiguration, request admin.ProjectDomainAttributesGetRequest) error {
+	config runtimeInterfaces.ApplicationConfiguration, request *admin.ProjectDomainAttributesGetRequest) error {
 	if err := ValidateProjectAndDomain(ctx, db, config, request.Project, request.Domain); err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func ValidateProjectDomainAttributesGetRequest(ctx context.Context, db repositor
 }
 
 func ValidateProjectDomainAttributesDeleteRequest(ctx context.Context, db repositoryInterfaces.Repository,
-	config runtimeInterfaces.ApplicationConfiguration, request admin.ProjectDomainAttributesDeleteRequest) error {
+	config runtimeInterfaces.ApplicationConfiguration, request *admin.ProjectDomainAttributesDeleteRequest) error {
 	if err := ValidateProjectAndDomain(ctx, db, config, request.Project, request.Domain); err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func ValidateProjectDomainAttributesDeleteRequest(ctx context.Context, db reposi
 }
 
 func ValidateWorkflowAttributesUpdateRequest(ctx context.Context, db repositoryInterfaces.Repository,
-	config runtimeInterfaces.ApplicationConfiguration, request admin.WorkflowAttributesUpdateRequest) (
+	config runtimeInterfaces.ApplicationConfiguration, request *admin.WorkflowAttributesUpdateRequest) (
 	admin.MatchableResource, error) {
 	if request.Attributes == nil {
 		return defaultMatchableResource, shared.GetMissingArgumentError(shared.Attributes)
@@ -104,7 +104,7 @@ func ValidateWorkflowAttributesUpdateRequest(ctx context.Context, db repositoryI
 }
 
 func ValidateWorkflowAttributesGetRequest(ctx context.Context, db repositoryInterfaces.Repository,
-	config runtimeInterfaces.ApplicationConfiguration, request admin.WorkflowAttributesGetRequest) error {
+	config runtimeInterfaces.ApplicationConfiguration, request *admin.WorkflowAttributesGetRequest) error {
 	if err := ValidateProjectAndDomain(ctx, db, config, request.Project, request.Domain); err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func ValidateWorkflowAttributesGetRequest(ctx context.Context, db repositoryInte
 }
 
 func ValidateWorkflowAttributesDeleteRequest(ctx context.Context, db repositoryInterfaces.Repository,
-	config runtimeInterfaces.ApplicationConfiguration, request admin.WorkflowAttributesDeleteRequest) error {
+	config runtimeInterfaces.ApplicationConfiguration, request *admin.WorkflowAttributesDeleteRequest) error {
 	if err := ValidateProjectAndDomain(ctx, db, config, request.Project, request.Domain); err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func ValidateWorkflowAttributesDeleteRequest(ctx context.Context, db repositoryI
 	return nil
 }
 
-func ValidateListAllMatchableAttributesRequest(request admin.ListMatchableAttributesRequest) error {
+func ValidateListAllMatchableAttributesRequest(request *admin.ListMatchableAttributesRequest) error {
 	if _, ok := admin.MatchableResource_name[int32(request.ResourceType)]; !ok {
 		return shared.GetInvalidArgumentError(shared.ResourceType)
 	}

--- a/flyteadmin/pkg/manager/impl/validation/attributes_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/attributes_validator_test.go
@@ -112,18 +112,18 @@ func TestValidateMatchingAttributes(t *testing.T) {
 func TestValidateProjectDomainAttributesUpdateRequest(t *testing.T) {
 	_, err := ValidateProjectDomainAttributesUpdateRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.ProjectDomainAttributesUpdateRequest{})
+		&admin.ProjectDomainAttributesUpdateRequest{})
 	assert.Equal(t, "missing attributes", err.Error())
 
 	_, err = ValidateProjectDomainAttributesUpdateRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.ProjectDomainAttributesUpdateRequest{
+		&admin.ProjectDomainAttributesUpdateRequest{
 			Attributes: &admin.ProjectDomainAttributes{}})
 	assert.Equal(t, "domain [] is unrecognized by system", err.Error())
 
 	_, err = ValidateProjectDomainAttributesUpdateRequest(context.Background(),
 		testutils.GetRepoWithDefaultProjectAndErr(shared.GetMissingArgumentError("project")), attributesApplicationConfigProvider,
-		admin.ProjectDomainAttributesUpdateRequest{
+		&admin.ProjectDomainAttributesUpdateRequest{
 			Attributes: &admin.ProjectDomainAttributes{
 				Domain: "development",
 			}})
@@ -133,7 +133,7 @@ func TestValidateProjectDomainAttributesUpdateRequest(t *testing.T) {
 
 	matchableResource, err := ValidateProjectDomainAttributesUpdateRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.ProjectDomainAttributesUpdateRequest{
+		&admin.ProjectDomainAttributesUpdateRequest{
 			Attributes: &admin.ProjectDomainAttributes{
 				Project: "project",
 				Domain:  "domain",
@@ -154,12 +154,12 @@ func TestValidateProjectDomainAttributesUpdateRequest(t *testing.T) {
 func TestValidateProjectDomainAttributesGetRequest(t *testing.T) {
 	err := ValidateProjectDomainAttributesGetRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.ProjectDomainAttributesGetRequest{})
+		&admin.ProjectDomainAttributesGetRequest{})
 	assert.Equal(t, "domain [] is unrecognized by system", err.Error())
 
 	err = ValidateProjectDomainAttributesGetRequest(context.Background(),
 		testutils.GetRepoWithDefaultProjectAndErr(shared.GetMissingArgumentError("project")),
-		attributesApplicationConfigProvider, admin.ProjectDomainAttributesGetRequest{
+		attributesApplicationConfigProvider, &admin.ProjectDomainAttributesGetRequest{
 			Domain: "development",
 		})
 	assert.Equal(t, "failed to validate that project [] and domain [development] are registered, err: [missing project]",
@@ -167,7 +167,7 @@ func TestValidateProjectDomainAttributesGetRequest(t *testing.T) {
 
 	assert.Nil(t, ValidateProjectDomainAttributesGetRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.ProjectDomainAttributesGetRequest{
+		&admin.ProjectDomainAttributesGetRequest{
 			Project: "project",
 			Domain:  "domain",
 		}))
@@ -176,12 +176,12 @@ func TestValidateProjectDomainAttributesGetRequest(t *testing.T) {
 func TestValidateProjectDomainAttributesDeleteRequest(t *testing.T) {
 	err := ValidateProjectDomainAttributesDeleteRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.ProjectDomainAttributesDeleteRequest{})
+		&admin.ProjectDomainAttributesDeleteRequest{})
 	assert.Equal(t, "domain [] is unrecognized by system", err.Error())
 
 	err = ValidateProjectDomainAttributesDeleteRequest(context.Background(),
 		testutils.GetRepoWithDefaultProjectAndErr(shared.GetMissingArgumentError("project")),
-		attributesApplicationConfigProvider, admin.ProjectDomainAttributesDeleteRequest{
+		attributesApplicationConfigProvider, &admin.ProjectDomainAttributesDeleteRequest{
 			Domain: "development",
 		})
 	assert.Equal(t,
@@ -190,7 +190,7 @@ func TestValidateProjectDomainAttributesDeleteRequest(t *testing.T) {
 
 	assert.Nil(t, ValidateProjectDomainAttributesDeleteRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.ProjectDomainAttributesDeleteRequest{
+		&admin.ProjectDomainAttributesDeleteRequest{
 			Project: "project",
 			Domain:  "domain",
 		}))
@@ -199,18 +199,18 @@ func TestValidateProjectDomainAttributesDeleteRequest(t *testing.T) {
 func TestValidateWorkflowAttributesUpdateRequest(t *testing.T) {
 	_, err := ValidateWorkflowAttributesUpdateRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.WorkflowAttributesUpdateRequest{})
+		&admin.WorkflowAttributesUpdateRequest{})
 	assert.Equal(t, "missing attributes", err.Error())
 
 	_, err = ValidateWorkflowAttributesUpdateRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.WorkflowAttributesUpdateRequest{
+		&admin.WorkflowAttributesUpdateRequest{
 			Attributes: &admin.WorkflowAttributes{}})
 	assert.Equal(t, "domain [] is unrecognized by system", err.Error())
 
 	_, err = ValidateWorkflowAttributesUpdateRequest(context.Background(),
 		testutils.GetRepoWithDefaultProjectAndErr(shared.GetMissingArgumentError("project")),
-		attributesApplicationConfigProvider, admin.WorkflowAttributesUpdateRequest{
+		attributesApplicationConfigProvider, &admin.WorkflowAttributesUpdateRequest{
 			Attributes: &admin.WorkflowAttributes{
 				Domain: "development",
 			}})
@@ -220,7 +220,7 @@ func TestValidateWorkflowAttributesUpdateRequest(t *testing.T) {
 
 	_, err = ValidateWorkflowAttributesUpdateRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.WorkflowAttributesUpdateRequest{
+		&admin.WorkflowAttributesUpdateRequest{
 			Attributes: &admin.WorkflowAttributes{
 				Project: "project",
 				Domain:  "domain",
@@ -229,7 +229,7 @@ func TestValidateWorkflowAttributesUpdateRequest(t *testing.T) {
 
 	matchableResource, err := ValidateWorkflowAttributesUpdateRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.WorkflowAttributesUpdateRequest{
+		&admin.WorkflowAttributesUpdateRequest{
 			Attributes: &admin.WorkflowAttributes{
 				Project:  "project",
 				Domain:   "domain",
@@ -249,12 +249,12 @@ func TestValidateWorkflowAttributesUpdateRequest(t *testing.T) {
 func TestValidateWorkflowAttributesGetRequest(t *testing.T) {
 	err := ValidateWorkflowAttributesGetRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.WorkflowAttributesGetRequest{})
+		&admin.WorkflowAttributesGetRequest{})
 	assert.Equal(t, "domain [] is unrecognized by system", err.Error())
 
 	err = ValidateWorkflowAttributesGetRequest(context.Background(),
 		testutils.GetRepoWithDefaultProjectAndErr(shared.GetMissingArgumentError("project")),
-		attributesApplicationConfigProvider, admin.WorkflowAttributesGetRequest{
+		attributesApplicationConfigProvider, &admin.WorkflowAttributesGetRequest{
 			Domain: "development",
 		})
 	assert.Equal(t,
@@ -263,7 +263,7 @@ func TestValidateWorkflowAttributesGetRequest(t *testing.T) {
 
 	err = ValidateWorkflowAttributesGetRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.WorkflowAttributesGetRequest{
+		&admin.WorkflowAttributesGetRequest{
 			Project: "project",
 			Domain:  "domain",
 		})
@@ -271,7 +271,7 @@ func TestValidateWorkflowAttributesGetRequest(t *testing.T) {
 
 	assert.Nil(t, ValidateWorkflowAttributesGetRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.WorkflowAttributesGetRequest{
+		&admin.WorkflowAttributesGetRequest{
 			Project:  "project",
 			Domain:   "domain",
 			Workflow: "workflow",
@@ -281,12 +281,12 @@ func TestValidateWorkflowAttributesGetRequest(t *testing.T) {
 func TestValidateWorkflowAttributesDeleteRequest(t *testing.T) {
 	err := ValidateWorkflowAttributesDeleteRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.WorkflowAttributesDeleteRequest{})
+		&admin.WorkflowAttributesDeleteRequest{})
 	assert.Equal(t, "domain [] is unrecognized by system", err.Error())
 
 	err = ValidateWorkflowAttributesDeleteRequest(context.Background(),
 		testutils.GetRepoWithDefaultProjectAndErr(shared.GetMissingArgumentError("project")),
-		attributesApplicationConfigProvider, admin.WorkflowAttributesDeleteRequest{
+		attributesApplicationConfigProvider, &admin.WorkflowAttributesDeleteRequest{
 			Domain: "development",
 		})
 	assert.Equal(t,
@@ -295,7 +295,7 @@ func TestValidateWorkflowAttributesDeleteRequest(t *testing.T) {
 
 	err = ValidateWorkflowAttributesDeleteRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.WorkflowAttributesDeleteRequest{
+		&admin.WorkflowAttributesDeleteRequest{
 			Project: "project",
 			Domain:  "domain",
 		})
@@ -303,7 +303,7 @@ func TestValidateWorkflowAttributesDeleteRequest(t *testing.T) {
 
 	assert.Nil(t, ValidateWorkflowAttributesDeleteRequest(context.Background(),
 		testutils.GetRepoWithDefaultProject(), attributesApplicationConfigProvider,
-		admin.WorkflowAttributesDeleteRequest{
+		&admin.WorkflowAttributesDeleteRequest{
 			Project:  "project",
 			Domain:   "domain",
 			Workflow: "workflow",
@@ -311,12 +311,12 @@ func TestValidateWorkflowAttributesDeleteRequest(t *testing.T) {
 }
 
 func TestValidateListAllMatchableAttributesRequest(t *testing.T) {
-	err := ValidateListAllMatchableAttributesRequest(admin.ListMatchableAttributesRequest{
+	err := ValidateListAllMatchableAttributesRequest(&admin.ListMatchableAttributesRequest{
 		ResourceType: 44,
 	})
 	assert.EqualError(t, err, "invalid value for resource_type")
 
-	err = ValidateListAllMatchableAttributesRequest(admin.ListMatchableAttributesRequest{
+	err = ValidateListAllMatchableAttributesRequest(&admin.ListMatchableAttributesRequest{
 		ResourceType: admin.MatchableResource_EXECUTION_QUEUE,
 	})
 	assert.Nil(t, err)

--- a/flyteadmin/pkg/manager/impl/validation/execution_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/execution_validator.go
@@ -26,7 +26,7 @@ var acceptedReferenceLaunchTypes = map[core.ResourceType]interface{}{
 	core.ResourceType_TASK:        nil,
 }
 
-func ValidateExecutionRequest(ctx context.Context, request admin.ExecutionCreateRequest,
+func ValidateExecutionRequest(ctx context.Context, request *admin.ExecutionCreateRequest,
 	db repositoryInterfaces.Repository, config runtimeInterfaces.ApplicationConfiguration) error {
 	if err := ValidateEmptyStringField(request.Project, shared.Project); err != nil {
 		return err
@@ -135,7 +135,7 @@ func CheckValidExecutionID(executionID, fieldName string) error {
 	return nil
 }
 
-func ValidateCreateWorkflowEventRequest(request admin.WorkflowExecutionEventRequest, maxOutputSizeInBytes int64) error {
+func ValidateCreateWorkflowEventRequest(request *admin.WorkflowExecutionEventRequest, maxOutputSizeInBytes int64) error {
 	if request.Event == nil {
 		return errors.NewFlyteAdminErrorf(codes.InvalidArgument,
 			"Workflow event handler was called without event")

--- a/flyteadmin/pkg/manager/impl/validation/execution_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/execution_validator_test.go
@@ -94,7 +94,7 @@ func TestGetExecutionInputs(t *testing.T) {
 		lpRequest.Spec.FixedInputs,
 		lpRequest.Spec.DefaultInputs,
 	)
-	expectedMap := core.LiteralMap{
+	expectedMap := &core.LiteralMap{
 		Literals: map[string]*core.Literal{
 			"foo": coreutils.MustMakeLiteral("foo-value-1"),
 			"bar": coreutils.MustMakeLiteral("bar-value"),
@@ -102,7 +102,7 @@ func TestGetExecutionInputs(t *testing.T) {
 	}
 	assert.Nil(t, err)
 	assert.NotNil(t, actualInputs)
-	assert.EqualValues(t, expectedMap, *actualInputs)
+	assert.EqualValues(t, expectedMap, actualInputs)
 }
 
 func TestValidateExecInputsWrongType(t *testing.T) {
@@ -164,7 +164,7 @@ func TestValidateExecEmptyInputs(t *testing.T) {
 		lpRequest.Spec.FixedInputs,
 		lpRequest.Spec.DefaultInputs,
 	)
-	expectedMap := core.LiteralMap{
+	expectedMap := &core.LiteralMap{
 		Literals: map[string]*core.Literal{
 			"foo": coreutils.MustMakeLiteral("foo-value"),
 			"bar": coreutils.MustMakeLiteral("bar-value"),
@@ -172,7 +172,7 @@ func TestValidateExecEmptyInputs(t *testing.T) {
 	}
 	assert.Nil(t, err)
 	assert.NotNil(t, actualInputs)
-	assert.EqualValues(t, expectedMap, *actualInputs)
+	assert.EqualValues(t, expectedMap, actualInputs)
 }
 
 func TestValidExecutionId(t *testing.T) {
@@ -196,14 +196,14 @@ func TestValidExecutionIdInvalidChars(t *testing.T) {
 }
 
 func TestValidateCreateWorkflowEventRequest(t *testing.T) {
-	request := admin.WorkflowExecutionEventRequest{
+	request := &admin.WorkflowExecutionEventRequest{
 		RequestId: "1",
 	}
 	err := ValidateCreateWorkflowEventRequest(request, maxOutputSizeInBytes)
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "Workflow event handler was called without event")
 
-	request = admin.WorkflowExecutionEventRequest{
+	request = &admin.WorkflowExecutionEventRequest{
 		RequestId: "1",
 		Event: &event.WorkflowExecutionEvent{
 			Phase:        core.WorkflowExecution_FAILED,

--- a/flyteadmin/pkg/manager/impl/validation/launch_plan_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/launch_plan_validator.go
@@ -16,7 +16,7 @@ import (
 )
 
 func ValidateLaunchPlan(ctx context.Context,
-	request admin.LaunchPlanCreateRequest, db repositoryInterfaces.Repository,
+	request *admin.LaunchPlanCreateRequest, db repositoryInterfaces.Repository,
 	config runtimeInterfaces.ApplicationConfiguration, workflowInterface *core.TypedInterface) error {
 	if err := ValidateIdentifier(request.Id, common.LaunchPlan); err != nil {
 		return err
@@ -70,7 +70,7 @@ func ValidateLaunchPlan(ctx context.Context,
 	return nil
 }
 
-func validateSchedule(request admin.LaunchPlanCreateRequest, expectedInputs *core.ParameterMap) error {
+func validateSchedule(request *admin.LaunchPlanCreateRequest, expectedInputs *core.ParameterMap) error {
 	schedule := request.GetSpec().GetEntityMetadata().GetSchedule()
 	if schedule.GetCronExpression() != "" || schedule.GetRate() != nil || schedule.GetCronSchedule() != nil {
 		for key, value := range expectedInputs.Parameters {

--- a/flyteadmin/pkg/manager/impl/validation/launch_plan_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/launch_plan_validator_test.go
@@ -84,7 +84,7 @@ func TestGetLpExpectedInputs(t *testing.T) {
 		},
 		request.GetSpec().GetFixedInputs(), request.GetSpec().GetDefaultInputs(),
 	)
-	expectedMap := core.ParameterMap{
+	expectedMap := &core.ParameterMap{
 		Parameters: map[string]*core.Parameter{
 			"foo": {
 				Var: &core.Variable{
@@ -98,7 +98,7 @@ func TestGetLpExpectedInputs(t *testing.T) {
 	}
 	assert.Nil(t, err)
 	assert.NotNil(t, actualExpectedMap)
-	assert.EqualValues(t, expectedMap, *actualExpectedMap)
+	assert.EqualValues(t, expectedMap, actualExpectedMap)
 }
 
 func TestValidateLpDefaultInputsWrongType(t *testing.T) {
@@ -244,7 +244,7 @@ func TestGetLpExpectedNoFixedInput(t *testing.T) {
 		nil, request.GetSpec().GetDefaultInputs(),
 	)
 
-	expectedMap := core.ParameterMap{
+	expectedMap := &core.ParameterMap{
 		Parameters: map[string]*core.Parameter{
 			"foo": {
 				Var: &core.Variable{
@@ -258,7 +258,7 @@ func TestGetLpExpectedNoFixedInput(t *testing.T) {
 	}
 	assert.Nil(t, err)
 	assert.NotNil(t, actualMap)
-	assert.EqualValues(t, expectedMap, *actualMap)
+	assert.EqualValues(t, expectedMap, actualMap)
 }
 
 func TestGetLpExpectedNoDefaultInput(t *testing.T) {
@@ -274,12 +274,12 @@ func TestGetLpExpectedNoDefaultInput(t *testing.T) {
 		request.GetSpec().GetFixedInputs(), nil,
 	)
 
-	expectedMap := core.ParameterMap{
+	expectedMap := &core.ParameterMap{
 		Parameters: map[string]*core.Parameter{},
 	}
 	assert.Nil(t, err)
 	assert.NotNil(t, actualMap)
-	assert.EqualValues(t, expectedMap, *actualMap)
+	assert.EqualValues(t, expectedMap, actualMap)
 }
 
 func TestValidateSchedule_NoSchedule(t *testing.T) {

--- a/flyteadmin/pkg/manager/impl/validation/named_entity_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/named_entity_validator.go
@@ -12,7 +12,7 @@ import (
 
 var archivableResourceTypes = sets.NewInt32(int32(core.ResourceType_WORKFLOW), int32(core.ResourceType_TASK))
 
-func ValidateNamedEntityGetRequest(request admin.NamedEntityGetRequest) error {
+func ValidateNamedEntityGetRequest(request *admin.NamedEntityGetRequest) error {
 	if err := ValidateResourceType(request.ResourceType); err != nil {
 		return err
 	}
@@ -22,7 +22,7 @@ func ValidateNamedEntityGetRequest(request admin.NamedEntityGetRequest) error {
 	return nil
 }
 
-func ValidateNamedEntityUpdateRequest(request admin.NamedEntityUpdateRequest) error {
+func ValidateNamedEntityUpdateRequest(request *admin.NamedEntityUpdateRequest) error {
 	if err := ValidateResourceType(request.ResourceType); err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func ValidateNamedEntityUpdateRequest(request admin.NamedEntityUpdateRequest) er
 	return nil
 }
 
-func ValidateNamedEntityListRequest(request admin.NamedEntityListRequest) error {
+func ValidateNamedEntityListRequest(request *admin.NamedEntityListRequest) error {
 	if err := ValidateEmptyStringField(request.Project, shared.Project); err != nil {
 		return err
 	}

--- a/flyteadmin/pkg/manager/impl/validation/named_entity_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/named_entity_validator_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestValidateNamedEntityGetRequest(t *testing.T) {
-	assert.Nil(t, ValidateNamedEntityGetRequest(admin.NamedEntityGetRequest{
+	assert.Nil(t, ValidateNamedEntityGetRequest(&admin.NamedEntityGetRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -21,7 +21,7 @@ func TestValidateNamedEntityGetRequest(t *testing.T) {
 		},
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityGetRequest(admin.NamedEntityGetRequest{
+	assert.NotNil(t, ValidateNamedEntityGetRequest(&admin.NamedEntityGetRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Domain: "domain",
@@ -29,7 +29,7 @@ func TestValidateNamedEntityGetRequest(t *testing.T) {
 		},
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityGetRequest(admin.NamedEntityGetRequest{
+	assert.NotNil(t, ValidateNamedEntityGetRequest(&admin.NamedEntityGetRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -37,7 +37,7 @@ func TestValidateNamedEntityGetRequest(t *testing.T) {
 		},
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityGetRequest(admin.NamedEntityGetRequest{
+	assert.NotNil(t, ValidateNamedEntityGetRequest(&admin.NamedEntityGetRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -45,7 +45,7 @@ func TestValidateNamedEntityGetRequest(t *testing.T) {
 		},
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityGetRequest(admin.NamedEntityGetRequest{
+	assert.NotNil(t, ValidateNamedEntityGetRequest(&admin.NamedEntityGetRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
 			Domain:  "domain",
@@ -55,7 +55,7 @@ func TestValidateNamedEntityGetRequest(t *testing.T) {
 }
 
 func TestValidateNamedEntityUpdateRequest(t *testing.T) {
-	assert.Nil(t, ValidateNamedEntityUpdateRequest(admin.NamedEntityUpdateRequest{
+	assert.Nil(t, ValidateNamedEntityUpdateRequest(&admin.NamedEntityUpdateRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -67,7 +67,7 @@ func TestValidateNamedEntityUpdateRequest(t *testing.T) {
 		},
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityUpdateRequest(admin.NamedEntityUpdateRequest{
+	assert.NotNil(t, ValidateNamedEntityUpdateRequest(&admin.NamedEntityUpdateRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Domain: "domain",
@@ -78,7 +78,7 @@ func TestValidateNamedEntityUpdateRequest(t *testing.T) {
 		},
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityUpdateRequest(admin.NamedEntityUpdateRequest{
+	assert.NotNil(t, ValidateNamedEntityUpdateRequest(&admin.NamedEntityUpdateRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -89,7 +89,7 @@ func TestValidateNamedEntityUpdateRequest(t *testing.T) {
 		},
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityUpdateRequest(admin.NamedEntityUpdateRequest{
+	assert.NotNil(t, ValidateNamedEntityUpdateRequest(&admin.NamedEntityUpdateRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -100,7 +100,7 @@ func TestValidateNamedEntityUpdateRequest(t *testing.T) {
 		},
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityUpdateRequest(admin.NamedEntityUpdateRequest{
+	assert.NotNil(t, ValidateNamedEntityUpdateRequest(&admin.NamedEntityUpdateRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -108,7 +108,7 @@ func TestValidateNamedEntityUpdateRequest(t *testing.T) {
 			Name:    "name",
 		},
 	}))
-	assert.Equal(t, codes.InvalidArgument, ValidateNamedEntityUpdateRequest(admin.NamedEntityUpdateRequest{
+	assert.Equal(t, codes.InvalidArgument, ValidateNamedEntityUpdateRequest(&admin.NamedEntityUpdateRequest{
 		ResourceType: core.ResourceType_LAUNCH_PLAN,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -119,7 +119,7 @@ func TestValidateNamedEntityUpdateRequest(t *testing.T) {
 			State: admin.NamedEntityState_NAMED_ENTITY_ARCHIVED,
 		},
 	}).(errors.FlyteAdminError).Code())
-	assert.Nil(t, ValidateNamedEntityUpdateRequest(admin.NamedEntityUpdateRequest{
+	assert.Nil(t, ValidateNamedEntityUpdateRequest(&admin.NamedEntityUpdateRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -130,7 +130,7 @@ func TestValidateNamedEntityUpdateRequest(t *testing.T) {
 			State: admin.NamedEntityState_NAMED_ENTITY_ARCHIVED,
 		},
 	}))
-	assert.Nil(t, ValidateNamedEntityUpdateRequest(admin.NamedEntityUpdateRequest{
+	assert.Nil(t, ValidateNamedEntityUpdateRequest(&admin.NamedEntityUpdateRequest{
 		ResourceType: core.ResourceType_TASK,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -144,32 +144,32 @@ func TestValidateNamedEntityUpdateRequest(t *testing.T) {
 }
 
 func TestValidateNamedEntityListRequest(t *testing.T) {
-	assert.Nil(t, ValidateNamedEntityListRequest(admin.NamedEntityListRequest{
+	assert.Nil(t, ValidateNamedEntityListRequest(&admin.NamedEntityListRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Project:      "project",
 		Domain:       "domain",
 		Limit:        2,
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityListRequest(admin.NamedEntityListRequest{
+	assert.NotNil(t, ValidateNamedEntityListRequest(&admin.NamedEntityListRequest{
 		Project: "project",
 		Domain:  "domain",
 		Limit:   2,
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityListRequest(admin.NamedEntityListRequest{
+	assert.NotNil(t, ValidateNamedEntityListRequest(&admin.NamedEntityListRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Domain:       "domain",
 		Limit:        2,
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityListRequest(admin.NamedEntityListRequest{
+	assert.NotNil(t, ValidateNamedEntityListRequest(&admin.NamedEntityListRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Project:      "project",
 		Limit:        2,
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityListRequest(admin.NamedEntityListRequest{
+	assert.NotNil(t, ValidateNamedEntityListRequest(&admin.NamedEntityListRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Project:      "project",
 		Domain:       "domain",

--- a/flyteadmin/pkg/manager/impl/validation/node_execution_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/node_execution_validator.go
@@ -56,7 +56,7 @@ func ValidateNodeExecutionEventRequest(request *admin.NodeExecutionEventRequest,
 	return nil
 }
 
-func ValidateNodeExecutionListRequest(request admin.NodeExecutionListRequest) error {
+func ValidateNodeExecutionListRequest(request *admin.NodeExecutionListRequest) error {
 	if err := ValidateWorkflowExecutionIdentifier(request.WorkflowExecutionId); err != nil {
 		return shared.GetMissingArgumentError(shared.ExecutionID)
 	}
@@ -66,7 +66,7 @@ func ValidateNodeExecutionListRequest(request admin.NodeExecutionListRequest) er
 	return nil
 }
 
-func ValidateNodeExecutionForTaskListRequest(request admin.NodeExecutionForTaskListRequest) error {
+func ValidateNodeExecutionForTaskListRequest(request *admin.NodeExecutionForTaskListRequest) error {
 	if err := ValidateTaskExecutionIdentifier(request.TaskExecutionId); err != nil {
 		return err
 	}

--- a/flyteadmin/pkg/manager/impl/validation/node_execution_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/node_execution_validator_test.go
@@ -187,7 +187,7 @@ func TestValidateNodeExecutionEventRequest_Invalid(t *testing.T) {
 }
 
 func TestValidateNodeExecutionListRequest(t *testing.T) {
-	err := ValidateNodeExecutionListRequest(admin.NodeExecutionListRequest{
+	err := ValidateNodeExecutionListRequest(&admin.NodeExecutionListRequest{
 		WorkflowExecutionId: &testExecutionID,
 		Filters:             "foo",
 		Limit:               2,
@@ -196,19 +196,19 @@ func TestValidateNodeExecutionListRequest(t *testing.T) {
 }
 
 func TestValidateNodeExecutionListRequest_MissingFields(t *testing.T) {
-	err := ValidateNodeExecutionListRequest(admin.NodeExecutionListRequest{
+	err := ValidateNodeExecutionListRequest(&admin.NodeExecutionListRequest{
 		Limit: 2,
 	})
 	assert.EqualError(t, err, "missing execution_id")
 
-	err = ValidateNodeExecutionListRequest(admin.NodeExecutionListRequest{
+	err = ValidateNodeExecutionListRequest(&admin.NodeExecutionListRequest{
 		WorkflowExecutionId: &testExecutionID,
 	})
 	assert.EqualError(t, err, "invalid value for limit")
 }
 
 func TestValidateNodeExecutionForTaskListRequest(t *testing.T) {
-	err := ValidateNodeExecutionForTaskListRequest(admin.NodeExecutionForTaskListRequest{
+	err := ValidateNodeExecutionForTaskListRequest(&admin.NodeExecutionForTaskListRequest{
 		TaskExecutionId: &core.TaskExecutionIdentifier{
 			NodeExecutionId: &core.NodeExecutionIdentifier{
 				ExecutionId: &testExecutionID,
@@ -229,7 +229,7 @@ func TestValidateNodeExecutionForTaskListRequest(t *testing.T) {
 }
 
 func TestValidateNodeExecutionForTaskListRequest_MissingFields(t *testing.T) {
-	err := ValidateNodeExecutionForTaskListRequest(admin.NodeExecutionForTaskListRequest{
+	err := ValidateNodeExecutionForTaskListRequest(&admin.NodeExecutionForTaskListRequest{
 		TaskExecutionId: &core.TaskExecutionIdentifier{
 			NodeExecutionId: &core.NodeExecutionIdentifier{
 				ExecutionId: &testExecutionID,
@@ -246,7 +246,7 @@ func TestValidateNodeExecutionForTaskListRequest_MissingFields(t *testing.T) {
 	})
 	assert.EqualError(t, err, "invalid value for limit")
 
-	err = ValidateNodeExecutionForTaskListRequest(admin.NodeExecutionForTaskListRequest{
+	err = ValidateNodeExecutionForTaskListRequest(&admin.NodeExecutionForTaskListRequest{
 		TaskExecutionId: &core.TaskExecutionIdentifier{
 			NodeExecutionId: &core.NodeExecutionIdentifier{
 				ExecutionId: &testExecutionID,
@@ -263,7 +263,7 @@ func TestValidateNodeExecutionForTaskListRequest_MissingFields(t *testing.T) {
 	})
 	assert.EqualError(t, err, "missing node_id")
 
-	err = ValidateNodeExecutionForTaskListRequest(admin.NodeExecutionForTaskListRequest{
+	err = ValidateNodeExecutionForTaskListRequest(&admin.NodeExecutionForTaskListRequest{
 		TaskExecutionId: &core.TaskExecutionIdentifier{
 			NodeExecutionId: &core.NodeExecutionIdentifier{
 				ExecutionId: &testExecutionID,

--- a/flyteadmin/pkg/manager/impl/validation/project_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/project_validator.go
@@ -20,25 +20,25 @@ const maxNameLength = 64
 const maxDescriptionLength = 300
 const maxLabelArrayLength = 16
 
-func ValidateProjectRegisterRequest(request admin.ProjectRegisterRequest) error {
+func ValidateProjectRegisterRequest(request *admin.ProjectRegisterRequest) error {
 	if request.Project == nil {
 		return shared.GetMissingArgumentError(shared.Project)
 	}
-	project := *request.Project
+	project := request.Project
 	if err := ValidateEmptyStringField(project.Name, projectName); err != nil {
 		return err
 	}
 	return ValidateProject(project)
 }
 
-func ValidateProjectGetRequest(request admin.ProjectGetRequest) error {
+func ValidateProjectGetRequest(request *admin.ProjectGetRequest) error {
 	if err := ValidateEmptyStringField(request.Id, projectID); err != nil {
 		return err
 	}
 	return nil
 }
 
-func ValidateProject(project admin.Project) error {
+func ValidateProject(project *admin.Project) error {
 	if err := ValidateEmptyStringField(project.Id, projectID); err != nil {
 		return err
 	}

--- a/flyteadmin/pkg/manager/impl/validation/project_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/project_validator_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestValidateProjectRegisterRequest_ValidRequest(t *testing.T) {
-	assert.Nil(t, ValidateProjectRegisterRequest(admin.ProjectRegisterRequest{
+	assert.Nil(t, ValidateProjectRegisterRequest(&admin.ProjectRegisterRequest{
 		Project: &admin.Project{
 			Id:   "proj",
 			Name: "proj",
@@ -27,16 +27,16 @@ func TestValidateProjectRegisterRequest_ValidRequest(t *testing.T) {
 
 func TestValidateProjectRegisterRequest(t *testing.T) {
 	type testValue struct {
-		request       admin.ProjectRegisterRequest
+		request       *admin.ProjectRegisterRequest
 		expectedError string
 	}
 	testValues := []testValue{
 		{
-			request:       admin.ProjectRegisterRequest{},
+			request:       &admin.ProjectRegisterRequest{},
 			expectedError: "missing project",
 		},
 		{
-			request: admin.ProjectRegisterRequest{
+			request: &admin.ProjectRegisterRequest{
 				Project: &admin.Project{
 					Name: "proj",
 					Domains: []*admin.Domain{
@@ -50,7 +50,7 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 			expectedError: "missing project_id",
 		},
 		{
-			request: admin.ProjectRegisterRequest{
+			request: &admin.ProjectRegisterRequest{
 				Project: &admin.Project{
 					Id:   "%)(*&",
 					Name: "proj",
@@ -59,7 +59,7 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 			expectedError: "invalid project id [%)(*&]: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
 		},
 		{
-			request: admin.ProjectRegisterRequest{
+			request: &admin.ProjectRegisterRequest{
 				Project: &admin.Project{
 					Id: "proj",
 				},
@@ -67,7 +67,7 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 			expectedError: "missing project_name",
 		},
 		{
-			request: admin.ProjectRegisterRequest{
+			request: &admin.ProjectRegisterRequest{
 				Project: &admin.Project{
 					Id:   "proj",
 					Name: "longnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamel",
@@ -76,7 +76,7 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 			expectedError: "project_name cannot exceed 64 characters",
 		},
 		{
-			request: admin.ProjectRegisterRequest{
+			request: &admin.ProjectRegisterRequest{
 				Project: &admin.Project{
 					Id:   "proj",
 					Name: "proj",
@@ -94,7 +94,7 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 			expectedError: "Domains are currently only set system wide. Please retry without domains included in your request.",
 		},
 		{
-			request: admin.ProjectRegisterRequest{
+			request: &admin.ProjectRegisterRequest{
 				Project: &admin.Project{
 					Id:   "proj",
 					Name: "name",
@@ -105,7 +105,7 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 			expectedError: "project_description cannot exceed 300 characters",
 		},
 		{
-			request: admin.ProjectRegisterRequest{
+			request: &admin.ProjectRegisterRequest{
 				Project: &admin.Project{
 					Id:   "proj",
 					Name: "name",
@@ -120,7 +120,7 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 			expectedError: "invalid label key [#badkey]: [name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')]",
 		},
 		{
-			request: admin.ProjectRegisterRequest{
+			request: &admin.ProjectRegisterRequest{
 				Project: &admin.Project{
 					Id:   "proj",
 					Name: "name",
@@ -144,7 +144,7 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 }
 
 func TestValidateProject_ValidProject(t *testing.T) {
-	assert.Nil(t, ValidateProject(admin.Project{
+	assert.Nil(t, ValidateProject(&admin.Project{
 		Id:          "proj",
 		Description: "An amazing description for this project",
 		State:       admin.Project_ARCHIVED,
@@ -159,12 +159,12 @@ func TestValidateProject_ValidProject(t *testing.T) {
 
 func TestValidateProject(t *testing.T) {
 	type testValue struct {
-		project       admin.Project
+		project       *admin.Project
 		expectedError string
 	}
 	testValues := []testValue{
 		{
-			project: admin.Project{
+			project: &admin.Project{
 				Name: "proj",
 				Domains: []*admin.Domain{
 					{
@@ -176,21 +176,21 @@ func TestValidateProject(t *testing.T) {
 			expectedError: "missing project_id",
 		},
 		{
-			project: admin.Project{
+			project: &admin.Project{
 				Id:   "%)(*&",
 				Name: "proj",
 			},
 			expectedError: "invalid project id [%)(*&]: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
 		},
 		{
-			project: admin.Project{
+			project: &admin.Project{
 				Id:   "proj",
 				Name: "longnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamel",
 			},
 			expectedError: "project_name cannot exceed 64 characters",
 		},
 		{
-			project: admin.Project{
+			project: &admin.Project{
 				Id:   "proj",
 				Name: "proj",
 				Domains: []*admin.Domain{
@@ -206,7 +206,7 @@ func TestValidateProject(t *testing.T) {
 			expectedError: "Domains are currently only set system wide. Please retry without domains included in your request.",
 		},
 		{
-			project: admin.Project{
+			project: &admin.Project{
 				Id:   "proj",
 				Name: "name",
 				// 301 character string
@@ -215,7 +215,7 @@ func TestValidateProject(t *testing.T) {
 			expectedError: "project_description cannot exceed 300 characters",
 		},
 		{
-			project: admin.Project{
+			project: &admin.Project{
 				Id:   "proj",
 				Name: "name",
 				Labels: &admin.Labels{
@@ -225,7 +225,7 @@ func TestValidateProject(t *testing.T) {
 			expectedError: "labels map cannot exceed 16 entries",
 		},
 		{
-			project: admin.Project{
+			project: &admin.Project{
 				Id:   "proj",
 				Name: "name",
 				Labels: &admin.Labels{
@@ -367,12 +367,12 @@ func TestValidateProjectExistsDb(t *testing.T) {
 
 func TestValidateProjectGetRequest(t *testing.T) {
 	t.Run("base case", func(t *testing.T) {
-		assert.Nil(t, ValidateProjectGetRequest(admin.ProjectGetRequest{
+		assert.Nil(t, ValidateProjectGetRequest(&admin.ProjectGetRequest{
 			Id: "project-id",
 		}))
 	})
 
 	t.Run("missing project id", func(t *testing.T) {
-		assert.EqualError(t, ValidateProjectGetRequest(admin.ProjectGetRequest{}), "missing project_id")
+		assert.EqualError(t, ValidateProjectGetRequest(&admin.ProjectGetRequest{}), "missing project_id")
 	})
 }

--- a/flyteadmin/pkg/manager/impl/validation/signal_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/signal_validator.go
@@ -14,11 +14,11 @@ import (
 	propellervalidators "github.com/flyteorg/flyte/flytepropeller/pkg/compiler/validators"
 )
 
-func ValidateSignalGetOrCreateRequest(ctx context.Context, request admin.SignalGetOrCreateRequest) error {
+func ValidateSignalGetOrCreateRequest(ctx context.Context, request *admin.SignalGetOrCreateRequest) error {
 	if request.Id == nil {
 		return shared.GetMissingArgumentError("id")
 	}
-	if err := ValidateSignalIdentifier(*request.Id); err != nil {
+	if err := ValidateSignalIdentifier(request.Id); err != nil {
 		return err
 	}
 	if request.Type == nil {
@@ -28,7 +28,7 @@ func ValidateSignalGetOrCreateRequest(ctx context.Context, request admin.SignalG
 	return nil
 }
 
-func ValidateSignalIdentifier(identifier core.SignalIdentifier) error {
+func ValidateSignalIdentifier(identifier *core.SignalIdentifier) error {
 	if identifier.ExecutionId == nil {
 		return shared.GetMissingArgumentError(shared.ExecutionID)
 	}
@@ -39,7 +39,7 @@ func ValidateSignalIdentifier(identifier core.SignalIdentifier) error {
 	return ValidateWorkflowExecutionIdentifier(identifier.ExecutionId)
 }
 
-func ValidateSignalListRequest(ctx context.Context, request admin.SignalListRequest) error {
+func ValidateSignalListRequest(ctx context.Context, request *admin.SignalListRequest) error {
 	if err := ValidateWorkflowExecutionIdentifier(request.WorkflowExecutionId); err != nil {
 		return shared.GetMissingArgumentError(shared.ExecutionID)
 	}
@@ -49,11 +49,11 @@ func ValidateSignalListRequest(ctx context.Context, request admin.SignalListRequ
 	return nil
 }
 
-func ValidateSignalSetRequest(ctx context.Context, db repositoryInterfaces.Repository, request admin.SignalSetRequest) error {
+func ValidateSignalSetRequest(ctx context.Context, db repositoryInterfaces.Repository, request *admin.SignalSetRequest) error {
 	if request.Id == nil {
 		return shared.GetMissingArgumentError("id")
 	}
-	if err := ValidateSignalIdentifier(*request.Id); err != nil {
+	if err := ValidateSignalIdentifier(request.Id); err != nil {
 		return err
 	}
 	if request.Value == nil {

--- a/flyteadmin/pkg/manager/impl/validation/signal_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/signal_validator_test.go
@@ -20,7 +20,7 @@ func TestValidateSignalGetOrCreateRequest(t *testing.T) {
 	ctx := context.TODO()
 
 	t.Run("Happy", func(t *testing.T) {
-		request := admin.SignalGetOrCreateRequest{
+		request := &admin.SignalGetOrCreateRequest{
 			Id: &core.SignalIdentifier{
 				ExecutionId: &core.WorkflowExecutionIdentifier{
 					Project: "project",
@@ -39,7 +39,7 @@ func TestValidateSignalGetOrCreateRequest(t *testing.T) {
 	})
 
 	t.Run("MissingSignalIdentifier", func(t *testing.T) {
-		request := admin.SignalGetOrCreateRequest{
+		request := &admin.SignalGetOrCreateRequest{
 			Type: &core.LiteralType{
 				Type: &core.LiteralType_Simple{
 					Simple: core.SimpleType_BOOLEAN,
@@ -50,7 +50,7 @@ func TestValidateSignalGetOrCreateRequest(t *testing.T) {
 	})
 
 	t.Run("InvalidSignalIdentifier", func(t *testing.T) {
-		request := admin.SignalGetOrCreateRequest{
+		request := &admin.SignalGetOrCreateRequest{
 			Id: &core.SignalIdentifier{
 				ExecutionId: &core.WorkflowExecutionIdentifier{
 					Project: "project",
@@ -68,7 +68,7 @@ func TestValidateSignalGetOrCreateRequest(t *testing.T) {
 	})
 
 	t.Run("MissingExecutionIdentifier", func(t *testing.T) {
-		request := admin.SignalGetOrCreateRequest{
+		request := &admin.SignalGetOrCreateRequest{
 			Id: &core.SignalIdentifier{
 				SignalId: "signal",
 			},
@@ -82,7 +82,7 @@ func TestValidateSignalGetOrCreateRequest(t *testing.T) {
 	})
 
 	t.Run("InvalidExecutionIdentifier", func(t *testing.T) {
-		request := admin.SignalGetOrCreateRequest{
+		request := &admin.SignalGetOrCreateRequest{
 			Id: &core.SignalIdentifier{
 				ExecutionId: &core.WorkflowExecutionIdentifier{
 					Domain: "domain",
@@ -100,7 +100,7 @@ func TestValidateSignalGetOrCreateRequest(t *testing.T) {
 	})
 
 	t.Run("MissingType", func(t *testing.T) {
-		request := admin.SignalGetOrCreateRequest{
+		request := &admin.SignalGetOrCreateRequest{
 			Id: &core.SignalIdentifier{
 				ExecutionId: &core.WorkflowExecutionIdentifier{
 					Project: "project",
@@ -118,7 +118,7 @@ func TestValidateSignalListrequest(t *testing.T) {
 	ctx := context.TODO()
 
 	t.Run("Happy", func(t *testing.T) {
-		request := admin.SignalListRequest{
+		request := &admin.SignalListRequest{
 			WorkflowExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "project",
 				Domain:  "domain",
@@ -130,14 +130,14 @@ func TestValidateSignalListrequest(t *testing.T) {
 	})
 
 	t.Run("MissingWorkflowExecutionIdentifier", func(t *testing.T) {
-		request := admin.SignalListRequest{
+		request := &admin.SignalListRequest{
 			Limit: 20,
 		}
 		assert.EqualError(t, ValidateSignalListRequest(ctx, request), "missing execution_id")
 	})
 
 	t.Run("MissingLimit", func(t *testing.T) {
-		request := admin.SignalListRequest{
+		request := &admin.SignalListRequest{
 			WorkflowExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "project",
 				Domain:  "domain",
@@ -168,7 +168,7 @@ func TestValidateSignalUpdateRequest(t *testing.T) {
 	)
 
 	t.Run("Happy", func(t *testing.T) {
-		request := admin.SignalSetRequest{
+		request := &admin.SignalSetRequest{
 			Id: &core.SignalIdentifier{
 				ExecutionId: &core.WorkflowExecutionIdentifier{
 					Project: "project",
@@ -195,7 +195,7 @@ func TestValidateSignalUpdateRequest(t *testing.T) {
 	})
 
 	t.Run("MissingValue", func(t *testing.T) {
-		request := admin.SignalSetRequest{
+		request := &admin.SignalSetRequest{
 			Id: &core.SignalIdentifier{
 				ExecutionId: &core.WorkflowExecutionIdentifier{
 					Project: "project",
@@ -213,7 +213,7 @@ func TestValidateSignalUpdateRequest(t *testing.T) {
 		repo.SignalRepo().(*repositoryMocks.SignalRepoInterface).
 			OnGetMatch(mock.Anything, mock.Anything).Return(models.Signal{}, errors.New("foo"))
 
-		request := admin.SignalSetRequest{
+		request := &admin.SignalSetRequest{
 			Id: &core.SignalIdentifier{
 				ExecutionId: &core.WorkflowExecutionIdentifier{
 					Project: "project",
@@ -257,7 +257,7 @@ func TestValidateSignalUpdateRequest(t *testing.T) {
 			nil,
 		)
 
-		request := admin.SignalSetRequest{
+		request := &admin.SignalSetRequest{
 			Id: &core.SignalIdentifier{
 				ExecutionId: &core.WorkflowExecutionIdentifier{
 					Project: "project",

--- a/flyteadmin/pkg/manager/impl/validation/task_execution_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/task_execution_validator.go
@@ -7,7 +7,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
-func ValidateTaskExecutionRequest(request admin.TaskExecutionEventRequest, maxOutputSizeInBytes int64) error {
+func ValidateTaskExecutionRequest(request *admin.TaskExecutionEventRequest, maxOutputSizeInBytes int64) error {
 	if request.Event == nil {
 		return shared.GetMissingArgumentError(shared.Event)
 	}
@@ -48,7 +48,7 @@ func ValidateTaskExecutionIdentifier(identifier *core.TaskExecutionIdentifier) e
 	return nil
 }
 
-func ValidateTaskExecutionListRequest(request admin.TaskExecutionListRequest) error {
+func ValidateTaskExecutionListRequest(request *admin.TaskExecutionListRequest) error {
 	if err := ValidateNodeExecutionIdentifier(request.NodeExecutionId); err != nil {
 		return err
 	}

--- a/flyteadmin/pkg/manager/impl/validation/task_execution_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/task_execution_validator_test.go
@@ -17,7 +17,7 @@ var taskEventOccurredAtProto, _ = ptypes.TimestampProto(taskEventOccurredAt)
 var maxOutputSizeInBytes = int64(1000000)
 
 func TestValidateTaskExecutionRequest(t *testing.T) {
-	assert.Nil(t, ValidateTaskExecutionRequest(admin.TaskExecutionEventRequest{
+	assert.Nil(t, ValidateTaskExecutionRequest(&admin.TaskExecutionEventRequest{
 		Event: &event.TaskExecutionEvent{
 			OccurredAt: taskEventOccurredAtProto,
 			TaskId: &core.Identifier{
@@ -41,7 +41,7 @@ func TestValidateTaskExecutionRequest(t *testing.T) {
 }
 
 func TestValidateTaskExecutionRequest_MissingFields(t *testing.T) {
-	err := ValidateTaskExecutionRequest(admin.TaskExecutionEventRequest{
+	err := ValidateTaskExecutionRequest(&admin.TaskExecutionEventRequest{
 		Event: &event.TaskExecutionEvent{
 			TaskId: &core.Identifier{
 				ResourceType: core.ResourceType_TASK,
@@ -63,7 +63,7 @@ func TestValidateTaskExecutionRequest_MissingFields(t *testing.T) {
 	}, maxOutputSizeInBytes)
 	assert.EqualError(t, err, "missing occurred_at")
 
-	err = ValidateTaskExecutionRequest(admin.TaskExecutionEventRequest{
+	err = ValidateTaskExecutionRequest(&admin.TaskExecutionEventRequest{
 		Event: &event.TaskExecutionEvent{
 			OccurredAt: taskEventOccurredAtProto,
 			TaskId: &core.Identifier{
@@ -85,7 +85,7 @@ func TestValidateTaskExecutionRequest_MissingFields(t *testing.T) {
 	}, maxOutputSizeInBytes)
 	assert.EqualError(t, err, "missing version")
 
-	err = ValidateTaskExecutionRequest(admin.TaskExecutionEventRequest{
+	err = ValidateTaskExecutionRequest(&admin.TaskExecutionEventRequest{
 		Event: &event.TaskExecutionEvent{
 			OccurredAt: taskEventOccurredAtProto,
 			TaskId: &core.Identifier{
@@ -107,7 +107,7 @@ func TestValidateTaskExecutionRequest_MissingFields(t *testing.T) {
 	}, maxOutputSizeInBytes)
 	assert.EqualError(t, err, "missing node_id")
 
-	err = ValidateTaskExecutionRequest(admin.TaskExecutionEventRequest{}, maxOutputSizeInBytes)
+	err = ValidateTaskExecutionRequest(&admin.TaskExecutionEventRequest{}, maxOutputSizeInBytes)
 	assert.EqualError(t, err, "missing event")
 }
 
@@ -133,7 +133,7 @@ func TestValidateTaskExecutionIdentifier(t *testing.T) {
 }
 
 func TestValidateTaskExecutionListRequest(t *testing.T) {
-	assert.Nil(t, ValidateTaskExecutionListRequest(admin.TaskExecutionListRequest{
+	assert.Nil(t, ValidateTaskExecutionListRequest(&admin.TaskExecutionListRequest{
 		NodeExecutionId: &core.NodeExecutionIdentifier{
 			NodeId: "nodey",
 			ExecutionId: &core.WorkflowExecutionIdentifier{
@@ -147,7 +147,7 @@ func TestValidateTaskExecutionListRequest(t *testing.T) {
 }
 
 func TestValidateTaskExecutionListRequest_MissingFields(t *testing.T) {
-	err := ValidateTaskExecutionListRequest(admin.TaskExecutionListRequest{
+	err := ValidateTaskExecutionListRequest(&admin.TaskExecutionListRequest{
 		NodeExecutionId: &core.NodeExecutionIdentifier{
 			NodeId: "nodey",
 			ExecutionId: &core.WorkflowExecutionIdentifier{
@@ -159,7 +159,7 @@ func TestValidateTaskExecutionListRequest_MissingFields(t *testing.T) {
 	})
 	assert.EqualError(t, err, "missing domain")
 
-	err = ValidateTaskExecutionListRequest(admin.TaskExecutionListRequest{
+	err = ValidateTaskExecutionListRequest(&admin.TaskExecutionListRequest{
 		NodeExecutionId: &core.NodeExecutionIdentifier{
 			NodeId: "nodey",
 			ExecutionId: &core.WorkflowExecutionIdentifier{

--- a/flyteadmin/pkg/manager/impl/validation/task_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/task_validator.go
@@ -25,7 +25,7 @@ import (
 var whitelistedTaskErr = errors.NewFlyteAdminErrorf(codes.InvalidArgument, "task type must be whitelisted before use")
 
 // This is called for a task with a non-nil container.
-func validateContainer(task core.TaskTemplate, platformTaskResources workflowengineInterfaces.TaskResources) error {
+func validateContainer(task *core.TaskTemplate, platformTaskResources workflowengineInterfaces.TaskResources) error {
 	if err := ValidateEmptyStringField(task.GetContainer().Image, shared.Image); err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func validateContainer(task core.TaskTemplate, platformTaskResources workfloweng
 }
 
 // This is called for a task with a non-nil k8s pod.
-func validateK8sPod(task core.TaskTemplate, platformTaskResources workflowengineInterfaces.TaskResources) error {
+func validateK8sPod(task *core.TaskTemplate, platformTaskResources workflowengineInterfaces.TaskResources) error {
 	if task.GetK8SPod().PodSpec == nil {
 		return errors.NewFlyteAdminErrorf(codes.InvalidArgument,
 			"invalid TaskSpecification, pod tasks should specify their target as a K8sPod with a defined pod spec")
@@ -68,14 +68,14 @@ func validateK8sPod(task core.TaskTemplate, platformTaskResources workflowengine
 	return nil
 }
 
-func validateRuntimeMetadata(metadata core.RuntimeMetadata) error {
+func validateRuntimeMetadata(metadata *core.RuntimeMetadata) error {
 	if err := ValidateEmptyStringField(metadata.Version, shared.RuntimeVersion); err != nil {
 		return err
 	}
 	return nil
 }
 
-func validateTaskTemplate(taskID core.Identifier, task core.TaskTemplate,
+func validateTaskTemplate(taskID *core.Identifier, task *core.TaskTemplate,
 	platformTaskResources workflowengineInterfaces.TaskResources, whitelistConfig runtime.WhitelistConfiguration) error {
 
 	if err := ValidateEmptyStringField(task.Type, shared.Type); err != nil {
@@ -88,7 +88,7 @@ func validateTaskTemplate(taskID core.Identifier, task core.TaskTemplate,
 		return shared.GetMissingArgumentError(shared.Metadata)
 	}
 	if task.Metadata.Runtime != nil {
-		if err := validateRuntimeMetadata(*task.Metadata.Runtime); err != nil {
+		if err := validateRuntimeMetadata(task.Metadata.Runtime); err != nil {
 			return err
 		}
 	}
@@ -107,7 +107,7 @@ func validateTaskTemplate(taskID core.Identifier, task core.TaskTemplate,
 }
 
 func ValidateTask(
-	ctx context.Context, request admin.TaskCreateRequest, db repositoryInterfaces.Repository,
+	ctx context.Context, request *admin.TaskCreateRequest, db repositoryInterfaces.Repository,
 	platformTaskResources workflowengineInterfaces.TaskResources, whitelistConfig runtime.WhitelistConfiguration,
 	applicationConfig runtime.ApplicationConfiguration) error {
 	if err := ValidateIdentifier(request.Id, common.Task); err != nil {
@@ -119,7 +119,7 @@ func ValidateTask(
 	if request.Spec == nil || request.Spec.Template == nil {
 		return shared.GetMissingArgumentError(shared.Spec)
 	}
-	return validateTaskTemplate(*request.Id, *request.Spec.Template, platformTaskResources, whitelistConfig)
+	return validateTaskTemplate(request.Id, request.Spec.Template, platformTaskResources, whitelistConfig)
 }
 
 func taskResourceSetToMap(
@@ -282,7 +282,7 @@ func validateResource(identifier *core.Identifier, requestedResourceDefaults,
 	return nil
 }
 
-func validateTaskType(taskID core.Identifier, taskType string, whitelistConfig runtime.WhitelistConfiguration) error {
+func validateTaskType(taskID *core.Identifier, taskType string, whitelistConfig runtime.WhitelistConfiguration) error {
 	taskTypeWhitelist := whitelistConfig.GetTaskTypeWhitelist()
 	if taskTypeWhitelist == nil {
 		return nil

--- a/flyteadmin/pkg/manager/impl/validation/task_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/task_validator_test.go
@@ -185,41 +185,41 @@ func TestValidateTaskTypeWhitelist(t *testing.T) {
 			},
 		},
 	}
-	err := validateTaskType(core.Identifier{
+	err := validateTaskType(&core.Identifier{
 		Project: "proj_a",
 		Domain:  "domain_a",
 	}, "type_a", whitelistConfig)
 	assert.Nil(t, err)
 
-	err = validateTaskType(core.Identifier{
+	err = validateTaskType(&core.Identifier{
 		Project: "proj_b",
 		Domain:  "domain_a",
 	}, "type_b", whitelistConfig)
 	assert.NotNil(t, err)
 
-	err = validateTaskType(core.Identifier{
+	err = validateTaskType(&core.Identifier{
 		Project: "proj_b",
 		Domain:  "domain_b",
 	}, "type_a", whitelistConfig)
 	assert.NotNil(t, err)
 
-	err = validateTaskType(core.Identifier{
+	err = validateTaskType(&core.Identifier{
 		Project: "proj_b",
 		Domain:  "domain_b",
 	}, "type_b", whitelistConfig)
 	assert.Nil(t, err)
 
-	err = validateTaskType(core.Identifier{
+	err = validateTaskType(&core.Identifier{
 		Project: "proj_c",
 	}, "every_type", whitelistConfig)
 	assert.Nil(t, err)
 
-	err = validateTaskType(core.Identifier{
+	err = validateTaskType(&core.Identifier{
 		Project: "proj_c",
 	}, "type_b", whitelistConfig)
 	assert.Nil(t, err)
 
-	err = validateTaskType(core.Identifier{}, "some_generally_supported_type", whitelistConfig)
+	err = validateTaskType(&core.Identifier{}, "some_generally_supported_type", whitelistConfig)
 	assert.Nil(t, err)
 }
 

--- a/flyteadmin/pkg/manager/impl/validation/validation.go
+++ b/flyteadmin/pkg/manager/impl/validation/validation.go
@@ -144,7 +144,7 @@ func ValidateVersion(version string) error {
 	return nil
 }
 
-func ValidateResourceListRequest(request admin.ResourceListRequest) error {
+func ValidateResourceListRequest(request *admin.ResourceListRequest) error {
 	if request.Id == nil {
 		return shared.GetMissingArgumentError(shared.ID)
 	}
@@ -160,7 +160,7 @@ func ValidateResourceListRequest(request admin.ResourceListRequest) error {
 	return nil
 }
 
-func ValidateDescriptionEntityListRequest(request admin.DescriptionEntityListRequest) error {
+func ValidateDescriptionEntityListRequest(request *admin.DescriptionEntityListRequest) error {
 	if request.Id == nil {
 		return shared.GetMissingArgumentError(shared.ID)
 	}
@@ -179,7 +179,7 @@ func ValidateDescriptionEntityListRequest(request admin.DescriptionEntityListReq
 	return nil
 }
 
-func ValidateActiveLaunchPlanRequest(request admin.ActiveLaunchPlanRequest) error {
+func ValidateActiveLaunchPlanRequest(request *admin.ActiveLaunchPlanRequest) error {
 	if err := ValidateEmptyStringField(request.Id.Project, shared.Project); err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func ValidateActiveLaunchPlanRequest(request admin.ActiveLaunchPlanRequest) erro
 	return nil
 }
 
-func ValidateActiveLaunchPlanListRequest(request admin.ActiveLaunchPlanListRequest) error {
+func ValidateActiveLaunchPlanListRequest(request *admin.ActiveLaunchPlanListRequest) error {
 	if err := ValidateEmptyStringField(request.Project, shared.Project); err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func ValidateActiveLaunchPlanListRequest(request admin.ActiveLaunchPlanListReque
 	return nil
 }
 
-func ValidateNamedEntityIdentifierListRequest(request admin.NamedEntityIdentifierListRequest) error {
+func ValidateNamedEntityIdentifierListRequest(request *admin.NamedEntityIdentifierListRequest) error {
 	if err := ValidateEmptyStringField(request.Project, shared.Project); err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func ValidateNamedEntityIdentifierListRequest(request admin.NamedEntityIdentifie
 	return nil
 }
 
-func ValidateDescriptionEntityGetRequest(request admin.ObjectGetRequest) error {
+func ValidateDescriptionEntityGetRequest(request *admin.ObjectGetRequest) error {
 	if err := ValidateResourceType(request.Id.ResourceType); err != nil {
 		return err
 	}

--- a/flyteadmin/pkg/manager/impl/validation/validation_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/validation_test.go
@@ -73,30 +73,30 @@ func TestValidateIdentifier(t *testing.T) {
 }
 
 func TestValidateNamedEntityIdentifierListRequest(t *testing.T) {
-	assert.Nil(t, ValidateNamedEntityIdentifierListRequest(admin.NamedEntityIdentifierListRequest{
+	assert.Nil(t, ValidateNamedEntityIdentifierListRequest(&admin.NamedEntityIdentifierListRequest{
 		Project: "project",
 		Domain:  "domain",
 		Limit:   2,
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityIdentifierListRequest(admin.NamedEntityIdentifierListRequest{
+	assert.NotNil(t, ValidateNamedEntityIdentifierListRequest(&admin.NamedEntityIdentifierListRequest{
 		Domain: "domain",
 		Limit:  2,
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityIdentifierListRequest(admin.NamedEntityIdentifierListRequest{
+	assert.NotNil(t, ValidateNamedEntityIdentifierListRequest(&admin.NamedEntityIdentifierListRequest{
 		Project: "project",
 		Limit:   2,
 	}))
 
-	assert.NotNil(t, ValidateNamedEntityIdentifierListRequest(admin.NamedEntityIdentifierListRequest{
+	assert.NotNil(t, ValidateNamedEntityIdentifierListRequest(&admin.NamedEntityIdentifierListRequest{
 		Project: "project",
 		Domain:  "domain",
 	}))
 }
 
 func TestValidateDescriptionEntityIdentifierGetRequest(t *testing.T) {
-	assert.Nil(t, ValidateDescriptionEntityGetRequest(admin.ObjectGetRequest{
+	assert.Nil(t, ValidateDescriptionEntityGetRequest(&admin.ObjectGetRequest{
 		Id: &core.Identifier{
 			ResourceType: core.ResourceType_WORKFLOW,
 			Project:      "project",
@@ -106,13 +106,13 @@ func TestValidateDescriptionEntityIdentifierGetRequest(t *testing.T) {
 		},
 	}))
 
-	assert.NotNil(t, ValidateDescriptionEntityGetRequest(admin.ObjectGetRequest{
+	assert.NotNil(t, ValidateDescriptionEntityGetRequest(&admin.ObjectGetRequest{
 		Id: &core.Identifier{
 			Project: "project",
 		},
 	}))
 
-	assert.NotNil(t, ValidateDescriptionEntityGetRequest(admin.ObjectGetRequest{
+	assert.NotNil(t, ValidateDescriptionEntityGetRequest(&admin.ObjectGetRequest{
 		Id: &core.Identifier{
 			ResourceType: core.ResourceType_WORKFLOW,
 			Project:      "project",
@@ -121,7 +121,7 @@ func TestValidateDescriptionEntityIdentifierGetRequest(t *testing.T) {
 }
 
 func TestValidateDescriptionEntityListRequest(t *testing.T) {
-	assert.Nil(t, ValidateDescriptionEntityListRequest(admin.DescriptionEntityListRequest{
+	assert.Nil(t, ValidateDescriptionEntityListRequest(&admin.DescriptionEntityListRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -131,7 +131,7 @@ func TestValidateDescriptionEntityListRequest(t *testing.T) {
 		Limit: 1,
 	}))
 
-	assert.NotNil(t, ValidateDescriptionEntityListRequest(admin.DescriptionEntityListRequest{
+	assert.NotNil(t, ValidateDescriptionEntityListRequest(&admin.DescriptionEntityListRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -140,30 +140,30 @@ func TestValidateDescriptionEntityListRequest(t *testing.T) {
 		},
 	}))
 
-	assert.NotNil(t, ValidateDescriptionEntityListRequest(admin.DescriptionEntityListRequest{
+	assert.NotNil(t, ValidateDescriptionEntityListRequest(&admin.DescriptionEntityListRequest{
 		Id: nil,
 	}))
 
-	assert.NotNil(t, ValidateDescriptionEntityListRequest(admin.DescriptionEntityListRequest{
+	assert.NotNil(t, ValidateDescriptionEntityListRequest(&admin.DescriptionEntityListRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id:           nil,
 	}))
 
-	assert.NotNil(t, ValidateDescriptionEntityListRequest(admin.DescriptionEntityListRequest{
+	assert.NotNil(t, ValidateDescriptionEntityListRequest(&admin.DescriptionEntityListRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Domain: "domain",
 		},
 	}))
 
-	assert.NotNil(t, ValidateDescriptionEntityListRequest(admin.DescriptionEntityListRequest{
+	assert.NotNil(t, ValidateDescriptionEntityListRequest(&admin.DescriptionEntityListRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
 		},
 	}))
 
-	assert.NotNil(t, ValidateDescriptionEntityListRequest(admin.DescriptionEntityListRequest{
+	assert.NotNil(t, ValidateDescriptionEntityListRequest(&admin.DescriptionEntityListRequest{
 		ResourceType: core.ResourceType_WORKFLOW,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
@@ -186,7 +186,7 @@ func TestValidateVersion(t *testing.T) {
 }
 
 func TestValidateListTaskRequest(t *testing.T) {
-	request := admin.ResourceListRequest{
+	request := &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
 			Domain:  "domain",
@@ -198,7 +198,7 @@ func TestValidateListTaskRequest(t *testing.T) {
 }
 
 func TestValidateListTaskRequest_MissingProject(t *testing.T) {
-	request := admin.ResourceListRequest{
+	request := &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Domain: "domain",
 			Name:   "name",
@@ -209,7 +209,7 @@ func TestValidateListTaskRequest_MissingProject(t *testing.T) {
 }
 
 func TestValidateListTaskRequest_MissingDomain(t *testing.T) {
-	request := admin.ResourceListRequest{
+	request := &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
 			Name:    "name",
@@ -220,7 +220,7 @@ func TestValidateListTaskRequest_MissingDomain(t *testing.T) {
 }
 
 func TestValidateListTaskRequest_MissingName(t *testing.T) {
-	request := admin.ResourceListRequest{
+	request := &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
 			Domain:  "domain",
@@ -231,7 +231,7 @@ func TestValidateListTaskRequest_MissingName(t *testing.T) {
 }
 
 func TestValidateListTaskRequest_MissingLimit(t *testing.T) {
-	request := admin.ResourceListRequest{
+	request := &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
 			Domain:  "domain",
@@ -378,7 +378,7 @@ func TestValidateToken(t *testing.T) {
 
 func TestValidateActiveLaunchPlanRequest(t *testing.T) {
 	err := ValidateActiveLaunchPlanRequest(
-		admin.ActiveLaunchPlanRequest{
+		&admin.ActiveLaunchPlanRequest{
 			Id: &admin.NamedEntityIdentifier{
 				Project: "p",
 				Domain:  "d",
@@ -389,7 +389,7 @@ func TestValidateActiveLaunchPlanRequest(t *testing.T) {
 	assert.Nil(t, err)
 
 	err = ValidateActiveLaunchPlanRequest(
-		admin.ActiveLaunchPlanRequest{
+		&admin.ActiveLaunchPlanRequest{
 			Id: &admin.NamedEntityIdentifier{
 				Domain: "d",
 				Name:   "n",
@@ -399,7 +399,7 @@ func TestValidateActiveLaunchPlanRequest(t *testing.T) {
 	assert.Error(t, err)
 
 	err = ValidateActiveLaunchPlanRequest(
-		admin.ActiveLaunchPlanRequest{
+		&admin.ActiveLaunchPlanRequest{
 			Id: &admin.NamedEntityIdentifier{
 				Project: "p",
 				Name:    "n",
@@ -409,7 +409,7 @@ func TestValidateActiveLaunchPlanRequest(t *testing.T) {
 	assert.Error(t, err)
 
 	err = ValidateActiveLaunchPlanRequest(
-		admin.ActiveLaunchPlanRequest{
+		&admin.ActiveLaunchPlanRequest{
 			Id: &admin.NamedEntityIdentifier{
 				Project: "p",
 				Domain:  "d",
@@ -421,7 +421,7 @@ func TestValidateActiveLaunchPlanRequest(t *testing.T) {
 
 func TestValidateActiveLaunchPlanListRequest(t *testing.T) {
 	err := ValidateActiveLaunchPlanListRequest(
-		admin.ActiveLaunchPlanListRequest{
+		&admin.ActiveLaunchPlanListRequest{
 			Project: "p",
 			Domain:  "d",
 			Limit:   2,
@@ -430,21 +430,21 @@ func TestValidateActiveLaunchPlanListRequest(t *testing.T) {
 	assert.Nil(t, err)
 
 	err = ValidateActiveLaunchPlanListRequest(
-		admin.ActiveLaunchPlanListRequest{
+		&admin.ActiveLaunchPlanListRequest{
 			Domain: "d",
 		},
 	)
 	assert.Error(t, err)
 
 	err = ValidateActiveLaunchPlanListRequest(
-		admin.ActiveLaunchPlanListRequest{
+		&admin.ActiveLaunchPlanListRequest{
 			Project: "p",
 		},
 	)
 	assert.Error(t, err)
 
 	err = ValidateActiveLaunchPlanListRequest(
-		admin.ActiveLaunchPlanListRequest{
+		&admin.ActiveLaunchPlanListRequest{
 			Project: "p",
 			Domain:  "d",
 			Limit:   0,

--- a/flyteadmin/pkg/manager/impl/validation/workflow_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/workflow_validator.go
@@ -20,7 +20,7 @@ import (
 const numSystemNodes = 2 // A workflow graph always has a start and end node injected by the platform.
 
 func ValidateWorkflow(
-	ctx context.Context, request admin.WorkflowCreateRequest, db repositoryInterfaces.Repository,
+	ctx context.Context, request *admin.WorkflowCreateRequest, db repositoryInterfaces.Repository,
 	config runtime.ApplicationConfiguration) error {
 	if err := ValidateIdentifier(request.Id, common.Workflow); err != nil {
 		return err
@@ -34,10 +34,10 @@ func ValidateWorkflow(
 	return nil
 }
 
-func ValidateCompiledWorkflow(identifier core.Identifier, workflow admin.WorkflowClosure, config runtime.RegistrationValidationConfiguration) error {
+func ValidateCompiledWorkflow(identifier *core.Identifier, workflow *admin.WorkflowClosure, config runtime.RegistrationValidationConfiguration) error {
 	if len(config.GetWorkflowSizeLimit()) > 0 {
 		workflowSizeLimit := resource.MustParse(config.GetWorkflowSizeLimit())
-		workflowSizeValue := resource.NewQuantity(int64(proto.Size(&workflow)), resource.DecimalExponent)
+		workflowSizeValue := resource.NewQuantity(int64(proto.Size(workflow)), resource.DecimalExponent)
 		if workflowSizeLimit.Cmp(*workflowSizeValue) <= -1 {
 			return errors.NewFlyteAdminErrorf(codes.InvalidArgument,
 				"Workflow closure size exceeds max limit [%v]", config.GetWorkflowSizeLimit())

--- a/flyteadmin/pkg/manager/impl/validation/workflow_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/workflow_validator_test.go
@@ -48,7 +48,7 @@ func TestValidateCompiledWorkflow(t *testing.T) {
 	mockConfig := runtimeMocks.MockRegistrationValidationProvider{
 		WorkflowSizeLimit: "1",
 	}
-	workflowClosure := admin.WorkflowClosure{
+	workflowClosure := &admin.WorkflowClosure{
 		CompiledWorkflow: &core.CompiledWorkflowClosure{
 			Primary: &core.CompiledWorkflow{
 				Connections: &core.ConnectionSet{
@@ -75,7 +75,7 @@ func TestValidateCompiledWorkflow(t *testing.T) {
 			},
 		},
 	}
-	err := ValidateCompiledWorkflow(core.Identifier{}, workflowClosure, &mockConfig)
+	err := ValidateCompiledWorkflow(&core.Identifier{}, workflowClosure, &mockConfig)
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "Workflow closure size exceeds max limit [1]")
 }

--- a/flyteadmin/pkg/manager/impl/workflow_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/workflow_manager_test.go
@@ -35,7 +35,7 @@ import (
 const remoteClosureIdentifier = "s3://flyte/metadata/admin/remote closure id"
 const returnWorkflowOnGet = true
 
-var workflowIdentifier = core.Identifier{
+var workflowIdentifier = &core.Identifier{
 	ResourceType: core.ResourceType_WORKFLOW,
 	Project:      "project",
 	Domain:       "domain",
@@ -45,7 +45,7 @@ var workflowIdentifier = core.Identifier{
 
 var storagePrefix = []string{"metadata", "admin"}
 
-var workflowClosure = admin.WorkflowClosure{
+var workflowClosure = &admin.WorkflowClosure{
 	CompiledWorkflow: &core.CompiledWorkflowClosure{
 		Primary: &core.CompiledWorkflow{
 			Template: &core.WorkflowTemplate{
@@ -67,7 +67,7 @@ var workflowClosure = admin.WorkflowClosure{
 		},
 	},
 }
-var workflowClosureBytes, _ = proto.Marshal(&workflowClosure)
+var workflowClosureBytes, _ = proto.Marshal(workflowClosure)
 
 func getMockWorkflowConfigProvider() runtimeInterfaces.Configuration {
 	mockWorkflowConfigProvider := runtimeMocks.NewMockConfigurationProvider(
@@ -128,7 +128,7 @@ func TestSetWorkflowDefaults(t *testing.T) {
 	request := testutils.GetWorkflowRequest()
 	finalizedRequest, err := workflowManager.(*WorkflowManager).setDefaults(request)
 	assert.NoError(t, err)
-	assert.True(t, proto.Equal(&workflowIdentifier, finalizedRequest.Spec.Template.Id))
+	assert.True(t, proto.Equal(workflowIdentifier, finalizedRequest.Spec.Template.Id))
 }
 
 func TestCreateWorkflow(t *testing.T) {
@@ -305,8 +305,8 @@ func TestGetWorkflow(t *testing.T) {
 	workflowManager := NewWorkflowManager(
 		repository, getMockWorkflowConfigProvider(), getMockWorkflowCompiler(), mockStorageClient, storagePrefix,
 		mockScope.NewTestScope())
-	workflow, err := workflowManager.GetWorkflow(context.Background(), admin.ObjectGetRequest{
-		Id: &workflowIdentifier,
+	workflow, err := workflowManager.GetWorkflow(context.Background(), &admin.ObjectGetRequest{
+		Id: workflowIdentifier,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "project", workflow.Id.Project)
@@ -327,8 +327,8 @@ func TestGetWorkflow_DatabaseError(t *testing.T) {
 	workflowManager := NewWorkflowManager(
 		repository, getMockWorkflowConfigProvider(), getMockWorkflowCompiler(), commonMocks.GetMockStorageClient(),
 		storagePrefix, mockScope.NewTestScope())
-	workflow, err := workflowManager.GetWorkflow(context.Background(), admin.ObjectGetRequest{
-		Id: &workflowIdentifier,
+	workflow, err := workflowManager.GetWorkflow(context.Background(), &admin.ObjectGetRequest{
+		Id: workflowIdentifier,
 	})
 	assert.Nil(t, workflow)
 	assert.EqualError(t, err, expectedErr.Error())
@@ -363,8 +363,8 @@ func TestGetWorkflow_TransformerError(t *testing.T) {
 	workflowManager := NewWorkflowManager(
 		repository, getMockWorkflowConfigProvider(), getMockWorkflowCompiler(), mockStorageClient, storagePrefix,
 		mockScope.NewTestScope())
-	workflow, err := workflowManager.GetWorkflow(context.Background(), admin.ObjectGetRequest{
-		Id: &workflowIdentifier,
+	workflow, err := workflowManager.GetWorkflow(context.Background(), &admin.ObjectGetRequest{
+		Id: workflowIdentifier,
 	})
 	assert.Nil(t, workflow)
 	assert.Equal(t, codes.Internal, err.(adminErrors.FlyteAdminError).Code())
@@ -435,7 +435,7 @@ func TestListWorkflows(t *testing.T) {
 		repository, getMockWorkflowConfigProvider(), getMockWorkflowCompiler(), mockStorageClient, storagePrefix,
 		mockScope.NewTestScope())
 
-	workflowList, err := workflowManager.ListWorkflows(context.Background(), admin.ResourceListRequest{
+	workflowList, err := workflowManager.ListWorkflows(context.Background(), &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Project: projectValue,
 			Domain:  domainValue,
@@ -476,7 +476,7 @@ func TestListWorkflows_MissingParameters(t *testing.T) {
 		repositoryMocks.NewMockRepository(),
 		getMockWorkflowConfigProvider(), getMockWorkflowCompiler(), commonMocks.GetMockStorageClient(), storagePrefix,
 		mockScope.NewTestScope())
-	_, err := workflowManager.ListWorkflows(context.Background(), admin.ResourceListRequest{
+	_, err := workflowManager.ListWorkflows(context.Background(), &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Domain: domainValue,
 			Name:   nameValue,
@@ -486,7 +486,7 @@ func TestListWorkflows_MissingParameters(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, err.(adminErrors.FlyteAdminError).Code())
 
-	_, err = workflowManager.ListWorkflows(context.Background(), admin.ResourceListRequest{
+	_, err = workflowManager.ListWorkflows(context.Background(), &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Project: projectValue,
 			Name:    nameValue,
@@ -508,7 +508,7 @@ func TestListWorkflows_DatabaseError(t *testing.T) {
 	workflowManager := NewWorkflowManager(repository,
 		getMockWorkflowConfigProvider(), getMockWorkflowCompiler(), commonMocks.GetMockStorageClient(), storagePrefix,
 		mockScope.NewTestScope())
-	_, err := workflowManager.ListWorkflows(context.Background(), admin.ResourceListRequest{
+	_, err := workflowManager.ListWorkflows(context.Background(), &admin.ResourceListRequest{
 		Id: &admin.NamedEntityIdentifier{
 			Project: projectValue,
 			Domain:  domainValue,
@@ -573,7 +573,7 @@ func TestWorkflowManager_ListWorkflowIdentifiers(t *testing.T) {
 		mockScope.NewTestScope())
 
 	workflowList, err := workflowManager.ListWorkflowIdentifiers(context.Background(),
-		admin.NamedEntityIdentifierListRequest{
+		&admin.NamedEntityIdentifierListRequest{
 			Project: projectValue,
 			Domain:  domainValue,
 			Limit:   100,

--- a/flyteadmin/pkg/manager/interfaces/description_entity.go
+++ b/flyteadmin/pkg/manager/interfaces/description_entity.go
@@ -8,6 +8,6 @@ import (
 
 // DescriptionEntityInterface for managing DescriptionEntity
 type DescriptionEntityInterface interface {
-	GetDescriptionEntity(ctx context.Context, request admin.ObjectGetRequest) (*admin.DescriptionEntity, error)
-	ListDescriptionEntity(ctx context.Context, request admin.DescriptionEntityListRequest) (*admin.DescriptionEntityList, error)
+	GetDescriptionEntity(ctx context.Context, request *admin.ObjectGetRequest) (*admin.DescriptionEntity, error)
+	ListDescriptionEntity(ctx context.Context, request *admin.DescriptionEntityListRequest) (*admin.DescriptionEntityList, error)
 }

--- a/flyteadmin/pkg/manager/interfaces/execution.go
+++ b/flyteadmin/pkg/manager/interfaces/execution.go
@@ -9,23 +9,23 @@ import (
 
 // Interface for managing Flyte Workflow Executions
 type ExecutionInterface interface {
-	CreateExecution(ctx context.Context, request admin.ExecutionCreateRequest, requestedAt time.Time) (
+	CreateExecution(ctx context.Context, request *admin.ExecutionCreateRequest, requestedAt time.Time) (
 		*admin.ExecutionCreateResponse, error)
-	RelaunchExecution(ctx context.Context, request admin.ExecutionRelaunchRequest, requestedAt time.Time) (
+	RelaunchExecution(ctx context.Context, request *admin.ExecutionRelaunchRequest, requestedAt time.Time) (
 		*admin.ExecutionCreateResponse, error)
 	// Recreates a previously-run workflow execution that will point to the original execution so that propeller will
 	// only start executing from the last known failure point. Propeller can recover individual workflow execution nodes
 	// which previously succeeded based on the recovery (original) workflow execution id.
-	RecoverExecution(ctx context.Context, request admin.ExecutionRecoverRequest, requestedAt time.Time) (
+	RecoverExecution(ctx context.Context, request *admin.ExecutionRecoverRequest, requestedAt time.Time) (
 		*admin.ExecutionCreateResponse, error)
-	CreateWorkflowEvent(ctx context.Context, request admin.WorkflowExecutionEventRequest) (
+	CreateWorkflowEvent(ctx context.Context, request *admin.WorkflowExecutionEventRequest) (
 		*admin.WorkflowExecutionEventResponse, error)
-	GetExecution(ctx context.Context, request admin.WorkflowExecutionGetRequest) (*admin.Execution, error)
-	UpdateExecution(ctx context.Context, request admin.ExecutionUpdateRequest, requestedAt time.Time) (
+	GetExecution(ctx context.Context, request *admin.WorkflowExecutionGetRequest) (*admin.Execution, error)
+	UpdateExecution(ctx context.Context, request *admin.ExecutionUpdateRequest, requestedAt time.Time) (
 		*admin.ExecutionUpdateResponse, error)
-	GetExecutionData(ctx context.Context, request admin.WorkflowExecutionGetDataRequest) (
+	GetExecutionData(ctx context.Context, request *admin.WorkflowExecutionGetDataRequest) (
 		*admin.WorkflowExecutionGetDataResponse, error)
-	ListExecutions(ctx context.Context, request admin.ResourceListRequest) (*admin.ExecutionList, error)
+	ListExecutions(ctx context.Context, request *admin.ResourceListRequest) (*admin.ExecutionList, error)
 	TerminateExecution(
-		ctx context.Context, request admin.ExecutionTerminateRequest) (*admin.ExecutionTerminateResponse, error)
+		ctx context.Context, request *admin.ExecutionTerminateRequest) (*admin.ExecutionTerminateResponse, error)
 }

--- a/flyteadmin/pkg/manager/interfaces/launch_plan.go
+++ b/flyteadmin/pkg/manager/interfaces/launch_plan.go
@@ -9,18 +9,18 @@ import (
 // Interface for managing Flyte Launch Plans
 type LaunchPlanInterface interface {
 	// Interface to create Launch Plans based on the request.
-	CreateLaunchPlan(ctx context.Context, request admin.LaunchPlanCreateRequest) (
+	CreateLaunchPlan(ctx context.Context, request *admin.LaunchPlanCreateRequest) (
 		*admin.LaunchPlanCreateResponse, error)
-	UpdateLaunchPlan(ctx context.Context, request admin.LaunchPlanUpdateRequest) (
+	UpdateLaunchPlan(ctx context.Context, request *admin.LaunchPlanUpdateRequest) (
 		*admin.LaunchPlanUpdateResponse, error)
-	GetLaunchPlan(ctx context.Context, request admin.ObjectGetRequest) (
+	GetLaunchPlan(ctx context.Context, request *admin.ObjectGetRequest) (
 		*admin.LaunchPlan, error)
-	GetActiveLaunchPlan(ctx context.Context, request admin.ActiveLaunchPlanRequest) (
+	GetActiveLaunchPlan(ctx context.Context, request *admin.ActiveLaunchPlanRequest) (
 		*admin.LaunchPlan, error)
-	ListLaunchPlans(ctx context.Context, request admin.ResourceListRequest) (
+	ListLaunchPlans(ctx context.Context, request *admin.ResourceListRequest) (
 		*admin.LaunchPlanList, error)
-	ListActiveLaunchPlans(ctx context.Context, request admin.ActiveLaunchPlanListRequest) (
+	ListActiveLaunchPlans(ctx context.Context, request *admin.ActiveLaunchPlanListRequest) (
 		*admin.LaunchPlanList, error)
-	ListLaunchPlanIds(ctx context.Context, request admin.NamedEntityIdentifierListRequest) (
+	ListLaunchPlanIds(ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (
 		*admin.NamedEntityIdentifierList, error)
 }

--- a/flyteadmin/pkg/manager/interfaces/metrics.go
+++ b/flyteadmin/pkg/manager/interfaces/metrics.go
@@ -10,6 +10,6 @@ import (
 
 // Interface for managing Flyte execution metrics
 type MetricsInterface interface {
-	GetExecutionMetrics(ctx context.Context, request admin.WorkflowExecutionGetMetricsRequest) (
+	GetExecutionMetrics(ctx context.Context, request *admin.WorkflowExecutionGetMetricsRequest) (
 		*admin.WorkflowExecutionGetMetricsResponse, error)
 }

--- a/flyteadmin/pkg/manager/interfaces/named_entity.go
+++ b/flyteadmin/pkg/manager/interfaces/named_entity.go
@@ -8,7 +8,7 @@ import (
 
 // Interface for managing metadata associated with NamedEntityIdentifiers
 type NamedEntityInterface interface {
-	GetNamedEntity(ctx context.Context, request admin.NamedEntityGetRequest) (*admin.NamedEntity, error)
-	UpdateNamedEntity(ctx context.Context, request admin.NamedEntityUpdateRequest) (*admin.NamedEntityUpdateResponse, error)
-	ListNamedEntities(ctx context.Context, request admin.NamedEntityListRequest) (*admin.NamedEntityList, error)
+	GetNamedEntity(ctx context.Context, request *admin.NamedEntityGetRequest) (*admin.NamedEntity, error)
+	UpdateNamedEntity(ctx context.Context, request *admin.NamedEntityUpdateRequest) (*admin.NamedEntityUpdateResponse, error)
+	ListNamedEntities(ctx context.Context, request *admin.NamedEntityListRequest) (*admin.NamedEntityList, error)
 }

--- a/flyteadmin/pkg/manager/interfaces/node_execution.go
+++ b/flyteadmin/pkg/manager/interfaces/node_execution.go
@@ -8,12 +8,12 @@ import (
 
 // Interface for managing Flyte Workflow NodeExecutions
 type NodeExecutionInterface interface {
-	CreateNodeEvent(ctx context.Context, request admin.NodeExecutionEventRequest) (
+	CreateNodeEvent(ctx context.Context, request *admin.NodeExecutionEventRequest) (
 		*admin.NodeExecutionEventResponse, error)
-	GetNodeExecution(ctx context.Context, request admin.NodeExecutionGetRequest) (*admin.NodeExecution, error)
-	ListNodeExecutions(ctx context.Context, request admin.NodeExecutionListRequest) (*admin.NodeExecutionList, error)
-	ListNodeExecutionsForTask(ctx context.Context, request admin.NodeExecutionForTaskListRequest) (*admin.NodeExecutionList, error)
+	GetNodeExecution(ctx context.Context, request *admin.NodeExecutionGetRequest) (*admin.NodeExecution, error)
+	ListNodeExecutions(ctx context.Context, request *admin.NodeExecutionListRequest) (*admin.NodeExecutionList, error)
+	ListNodeExecutionsForTask(ctx context.Context, request *admin.NodeExecutionForTaskListRequest) (*admin.NodeExecutionList, error)
 	GetNodeExecutionData(
-		ctx context.Context, request admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error)
-	GetDynamicNodeWorkflow(ctx context.Context, request admin.GetDynamicNodeWorkflowRequest) (*admin.DynamicNodeWorkflowResponse, error)
+		ctx context.Context, request *admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error)
+	GetDynamicNodeWorkflow(ctx context.Context, request *admin.GetDynamicNodeWorkflowRequest) (*admin.DynamicNodeWorkflowResponse, error)
 }

--- a/flyteadmin/pkg/manager/interfaces/project.go
+++ b/flyteadmin/pkg/manager/interfaces/project.go
@@ -8,9 +8,9 @@ import (
 
 // Interface for managing projects (and domains).
 type ProjectInterface interface {
-	CreateProject(ctx context.Context, request admin.ProjectRegisterRequest) (*admin.ProjectRegisterResponse, error)
-	ListProjects(ctx context.Context, request admin.ProjectListRequest) (*admin.Projects, error)
-	UpdateProject(ctx context.Context, request admin.Project) (*admin.ProjectUpdateResponse, error)
-	GetProject(ctx context.Context, request admin.ProjectGetRequest) (*admin.Project, error)
-	GetDomains(ctx context.Context, request admin.GetDomainRequest) *admin.GetDomainsResponse
+	CreateProject(ctx context.Context, request *admin.ProjectRegisterRequest) (*admin.ProjectRegisterResponse, error)
+	ListProjects(ctx context.Context, request *admin.ProjectListRequest) (*admin.Projects, error)
+	UpdateProject(ctx context.Context, request *admin.Project) (*admin.ProjectUpdateResponse, error)
+	GetProject(ctx context.Context, request *admin.ProjectGetRequest) (*admin.Project, error)
+	GetDomains(ctx context.Context, request *admin.GetDomainRequest) *admin.GetDomainsResponse
 }

--- a/flyteadmin/pkg/manager/interfaces/resource.go
+++ b/flyteadmin/pkg/manager/interfaces/resource.go
@@ -8,29 +8,29 @@ import (
 
 // ResourceInterface manages project, domain and workflow -specific attributes.
 type ResourceInterface interface {
-	ListAll(ctx context.Context, request admin.ListMatchableAttributesRequest) (
+	ListAll(ctx context.Context, request *admin.ListMatchableAttributesRequest) (
 		*admin.ListMatchableAttributesResponse, error)
 	GetResource(ctx context.Context, request ResourceRequest) (*ResourceResponse, error)
 
-	UpdateProjectAttributes(ctx context.Context, request admin.ProjectAttributesUpdateRequest) (
+	UpdateProjectAttributes(ctx context.Context, request *admin.ProjectAttributesUpdateRequest) (
 		*admin.ProjectAttributesUpdateResponse, error)
-	GetProjectAttributes(ctx context.Context, request admin.ProjectAttributesGetRequest) (
+	GetProjectAttributes(ctx context.Context, request *admin.ProjectAttributesGetRequest) (
 		*admin.ProjectAttributesGetResponse, error)
-	DeleteProjectAttributes(ctx context.Context, request admin.ProjectAttributesDeleteRequest) (
+	DeleteProjectAttributes(ctx context.Context, request *admin.ProjectAttributesDeleteRequest) (
 		*admin.ProjectAttributesDeleteResponse, error)
 
-	UpdateProjectDomainAttributes(ctx context.Context, request admin.ProjectDomainAttributesUpdateRequest) (
+	UpdateProjectDomainAttributes(ctx context.Context, request *admin.ProjectDomainAttributesUpdateRequest) (
 		*admin.ProjectDomainAttributesUpdateResponse, error)
-	GetProjectDomainAttributes(ctx context.Context, request admin.ProjectDomainAttributesGetRequest) (
+	GetProjectDomainAttributes(ctx context.Context, request *admin.ProjectDomainAttributesGetRequest) (
 		*admin.ProjectDomainAttributesGetResponse, error)
-	DeleteProjectDomainAttributes(ctx context.Context, request admin.ProjectDomainAttributesDeleteRequest) (
+	DeleteProjectDomainAttributes(ctx context.Context, request *admin.ProjectDomainAttributesDeleteRequest) (
 		*admin.ProjectDomainAttributesDeleteResponse, error)
 
-	UpdateWorkflowAttributes(ctx context.Context, request admin.WorkflowAttributesUpdateRequest) (
+	UpdateWorkflowAttributes(ctx context.Context, request *admin.WorkflowAttributesUpdateRequest) (
 		*admin.WorkflowAttributesUpdateResponse, error)
-	GetWorkflowAttributes(ctx context.Context, request admin.WorkflowAttributesGetRequest) (
+	GetWorkflowAttributes(ctx context.Context, request *admin.WorkflowAttributesGetRequest) (
 		*admin.WorkflowAttributesGetResponse, error)
-	DeleteWorkflowAttributes(ctx context.Context, request admin.WorkflowAttributesDeleteRequest) (
+	DeleteWorkflowAttributes(ctx context.Context, request *admin.WorkflowAttributesDeleteRequest) (
 		*admin.WorkflowAttributesDeleteResponse, error)
 }
 

--- a/flyteadmin/pkg/manager/interfaces/signal.go
+++ b/flyteadmin/pkg/manager/interfaces/signal.go
@@ -10,7 +10,7 @@ import (
 
 // Interface for managing Flyte Signals
 type SignalInterface interface {
-	GetOrCreateSignal(ctx context.Context, request admin.SignalGetOrCreateRequest) (*admin.Signal, error)
-	ListSignals(ctx context.Context, request admin.SignalListRequest) (*admin.SignalList, error)
-	SetSignal(ctx context.Context, request admin.SignalSetRequest) (*admin.SignalSetResponse, error)
+	GetOrCreateSignal(ctx context.Context, request *admin.SignalGetOrCreateRequest) (*admin.Signal, error)
+	ListSignals(ctx context.Context, request *admin.SignalListRequest) (*admin.SignalList, error)
+	SetSignal(ctx context.Context, request *admin.SignalSetRequest) (*admin.SignalSetResponse, error)
 }

--- a/flyteadmin/pkg/manager/interfaces/task.go
+++ b/flyteadmin/pkg/manager/interfaces/task.go
@@ -8,9 +8,9 @@ import (
 
 // Interface for managing Flyte Tasks
 type TaskInterface interface {
-	CreateTask(ctx context.Context, request admin.TaskCreateRequest) (*admin.TaskCreateResponse, error)
-	GetTask(ctx context.Context, request admin.ObjectGetRequest) (*admin.Task, error)
-	ListTasks(ctx context.Context, request admin.ResourceListRequest) (*admin.TaskList, error)
-	ListUniqueTaskIdentifiers(ctx context.Context, request admin.NamedEntityIdentifierListRequest) (
+	CreateTask(ctx context.Context, request *admin.TaskCreateRequest) (*admin.TaskCreateResponse, error)
+	GetTask(ctx context.Context, request *admin.ObjectGetRequest) (*admin.Task, error)
+	ListTasks(ctx context.Context, request *admin.ResourceListRequest) (*admin.TaskList, error)
+	ListUniqueTaskIdentifiers(ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (
 		*admin.NamedEntityIdentifierList, error)
 }

--- a/flyteadmin/pkg/manager/interfaces/task_execution.go
+++ b/flyteadmin/pkg/manager/interfaces/task_execution.go
@@ -8,10 +8,10 @@ import (
 
 // Interface for managing Flyte Workflow TaskExecutions
 type TaskExecutionInterface interface {
-	CreateTaskExecutionEvent(ctx context.Context, request admin.TaskExecutionEventRequest) (
+	CreateTaskExecutionEvent(ctx context.Context, request *admin.TaskExecutionEventRequest) (
 		*admin.TaskExecutionEventResponse, error)
-	GetTaskExecution(ctx context.Context, request admin.TaskExecutionGetRequest) (*admin.TaskExecution, error)
-	ListTaskExecutions(ctx context.Context, request admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error)
+	GetTaskExecution(ctx context.Context, request *admin.TaskExecutionGetRequest) (*admin.TaskExecution, error)
+	ListTaskExecutions(ctx context.Context, request *admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error)
 	GetTaskExecutionData(
-		ctx context.Context, request admin.TaskExecutionGetDataRequest) (*admin.TaskExecutionGetDataResponse, error)
+		ctx context.Context, request *admin.TaskExecutionGetDataRequest) (*admin.TaskExecutionGetDataResponse, error)
 }

--- a/flyteadmin/pkg/manager/interfaces/workflow.go
+++ b/flyteadmin/pkg/manager/interfaces/workflow.go
@@ -8,9 +8,9 @@ import (
 
 // Interface for managing Flyte Workflows
 type WorkflowInterface interface {
-	CreateWorkflow(ctx context.Context, request admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error)
-	GetWorkflow(ctx context.Context, request admin.ObjectGetRequest) (*admin.Workflow, error)
-	ListWorkflows(ctx context.Context, request admin.ResourceListRequest) (*admin.WorkflowList, error)
-	ListWorkflowIdentifiers(ctx context.Context, request admin.NamedEntityIdentifierListRequest) (
+	CreateWorkflow(ctx context.Context, request *admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error)
+	GetWorkflow(ctx context.Context, request *admin.ObjectGetRequest) (*admin.Workflow, error)
+	ListWorkflows(ctx context.Context, request *admin.ResourceListRequest) (*admin.WorkflowList, error)
+	ListWorkflowIdentifiers(ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (
 		*admin.NamedEntityIdentifierList, error)
 }

--- a/flyteadmin/pkg/manager/mocks/execution.go
+++ b/flyteadmin/pkg/manager/mocks/execution.go
@@ -8,23 +8,23 @@ import (
 )
 
 type CreateExecutionFunc func(
-	ctx context.Context, request admin.ExecutionCreateRequest, requestedAt time.Time) (
+	ctx context.Context, request *admin.ExecutionCreateRequest, requestedAt time.Time) (
 	*admin.ExecutionCreateResponse, error)
 type RelaunchExecutionFunc func(
-	ctx context.Context, request admin.ExecutionRelaunchRequest, requestedAt time.Time) (
+	ctx context.Context, request *admin.ExecutionRelaunchRequest, requestedAt time.Time) (
 	*admin.ExecutionCreateResponse, error)
-type RecoverExecutionFunc func(ctx context.Context, request admin.ExecutionRecoverRequest, requestedAt time.Time) (
+type RecoverExecutionFunc func(ctx context.Context, request *admin.ExecutionRecoverRequest, requestedAt time.Time) (
 	*admin.ExecutionCreateResponse, error)
-type CreateExecutionEventFunc func(ctx context.Context, request admin.WorkflowExecutionEventRequest) (
+type CreateExecutionEventFunc func(ctx context.Context, request *admin.WorkflowExecutionEventRequest) (
 	*admin.WorkflowExecutionEventResponse, error)
-type GetExecutionFunc func(ctx context.Context, request admin.WorkflowExecutionGetRequest) (*admin.Execution, error)
-type UpdateExecutionFunc func(ctx context.Context, request admin.ExecutionUpdateRequest, requestedAt time.Time) (
+type GetExecutionFunc func(ctx context.Context, request *admin.WorkflowExecutionGetRequest) (*admin.Execution, error)
+type UpdateExecutionFunc func(ctx context.Context, request *admin.ExecutionUpdateRequest, requestedAt time.Time) (
 	*admin.ExecutionUpdateResponse, error)
-type GetExecutionDataFunc func(ctx context.Context, request admin.WorkflowExecutionGetDataRequest) (
+type GetExecutionDataFunc func(ctx context.Context, request *admin.WorkflowExecutionGetDataRequest) (
 	*admin.WorkflowExecutionGetDataResponse, error)
-type ListExecutionFunc func(ctx context.Context, request admin.ResourceListRequest) (*admin.ExecutionList, error)
+type ListExecutionFunc func(ctx context.Context, request *admin.ResourceListRequest) (*admin.ExecutionList, error)
 type TerminateExecutionFunc func(
-	ctx context.Context, request admin.ExecutionTerminateRequest) (*admin.ExecutionTerminateResponse, error)
+	ctx context.Context, request *admin.ExecutionTerminateRequest) (*admin.ExecutionTerminateResponse, error)
 
 type MockExecutionManager struct {
 	createExecutionFunc      CreateExecutionFunc
@@ -43,7 +43,7 @@ func (m *MockExecutionManager) SetCreateCallback(createFunction CreateExecutionF
 }
 
 func (m *MockExecutionManager) CreateExecution(
-	ctx context.Context, request admin.ExecutionCreateRequest, requestedAt time.Time) (
+	ctx context.Context, request *admin.ExecutionCreateRequest, requestedAt time.Time) (
 	*admin.ExecutionCreateResponse, error) {
 	if m.createExecutionFunc != nil {
 		return m.createExecutionFunc(ctx, request, requestedAt)
@@ -56,7 +56,7 @@ func (m *MockExecutionManager) SetRelaunchCallback(relaunchFunction RelaunchExec
 }
 
 func (m *MockExecutionManager) RelaunchExecution(
-	ctx context.Context, request admin.ExecutionRelaunchRequest, requestedAt time.Time) (
+	ctx context.Context, request *admin.ExecutionRelaunchRequest, requestedAt time.Time) (
 	*admin.ExecutionCreateResponse, error) {
 	if m.relaunchExecutionFunc != nil {
 		return m.relaunchExecutionFunc(ctx, request, requestedAt)
@@ -68,7 +68,7 @@ func (m *MockExecutionManager) SetCreateEventCallback(createEventFunc CreateExec
 	m.createExecutionEventFunc = createEventFunc
 }
 
-func (m *MockExecutionManager) RecoverExecution(ctx context.Context, request admin.ExecutionRecoverRequest, requestedAt time.Time) (
+func (m *MockExecutionManager) RecoverExecution(ctx context.Context, request *admin.ExecutionRecoverRequest, requestedAt time.Time) (
 	*admin.ExecutionCreateResponse, error) {
 	if m.RecoverExecutionFunc != nil {
 		return m.RecoverExecutionFunc(ctx, request, requestedAt)
@@ -78,7 +78,7 @@ func (m *MockExecutionManager) RecoverExecution(ctx context.Context, request adm
 
 func (m *MockExecutionManager) CreateWorkflowEvent(
 	ctx context.Context,
-	request admin.WorkflowExecutionEventRequest) (*admin.WorkflowExecutionEventResponse, error) {
+	request *admin.WorkflowExecutionEventRequest) (*admin.WorkflowExecutionEventResponse, error) {
 	if m.createExecutionEventFunc != nil {
 		return m.createExecutionEventFunc(ctx, request)
 	}
@@ -89,7 +89,7 @@ func (m *MockExecutionManager) SetUpdateExecutionCallback(updateExecutionFunc Up
 	m.updateExecutionFunc = updateExecutionFunc
 }
 
-func (m *MockExecutionManager) UpdateExecution(ctx context.Context, request admin.ExecutionUpdateRequest,
+func (m *MockExecutionManager) UpdateExecution(ctx context.Context, request *admin.ExecutionUpdateRequest,
 	requestedAt time.Time) (*admin.ExecutionUpdateResponse, error) {
 	if m.updateExecutionFunc != nil {
 		return m.updateExecutionFunc(ctx, request, requestedAt)
@@ -102,7 +102,7 @@ func (m *MockExecutionManager) SetGetCallback(getExecutionFunc GetExecutionFunc)
 }
 
 func (m *MockExecutionManager) GetExecution(
-	ctx context.Context, request admin.WorkflowExecutionGetRequest) (*admin.Execution, error) {
+	ctx context.Context, request *admin.WorkflowExecutionGetRequest) (*admin.Execution, error) {
 	if m.getExecutionFunc != nil {
 		return m.getExecutionFunc(ctx, request)
 	}
@@ -113,7 +113,7 @@ func (m *MockExecutionManager) SetGetDataCallback(getExecutionDataFunc GetExecut
 	m.getExecutionDataFunc = getExecutionDataFunc
 }
 
-func (m *MockExecutionManager) GetExecutionData(ctx context.Context, request admin.WorkflowExecutionGetDataRequest) (
+func (m *MockExecutionManager) GetExecutionData(ctx context.Context, request *admin.WorkflowExecutionGetDataRequest) (
 	*admin.WorkflowExecutionGetDataResponse, error) {
 	if m.getExecutionDataFunc != nil {
 		return m.getExecutionDataFunc(ctx, request)
@@ -126,7 +126,7 @@ func (m *MockExecutionManager) SetListCallback(listExecutionFunc ListExecutionFu
 }
 
 func (m *MockExecutionManager) ListExecutions(
-	ctx context.Context, request admin.ResourceListRequest) (*admin.ExecutionList, error) {
+	ctx context.Context, request *admin.ResourceListRequest) (*admin.ExecutionList, error) {
 	if m.listExecutionFunc != nil {
 		return m.listExecutionFunc(ctx, request)
 	}
@@ -138,7 +138,7 @@ func (m *MockExecutionManager) SetTerminateExecutionCallback(terminateExecutionF
 }
 
 func (m *MockExecutionManager) TerminateExecution(
-	ctx context.Context, request admin.ExecutionTerminateRequest) (*admin.ExecutionTerminateResponse, error) {
+	ctx context.Context, request *admin.ExecutionTerminateRequest) (*admin.ExecutionTerminateResponse, error) {
 	if m.terminateExecutionFunc != nil {
 		return m.terminateExecutionFunc(ctx, request)
 	}

--- a/flyteadmin/pkg/manager/mocks/launch_plan.go
+++ b/flyteadmin/pkg/manager/mocks/launch_plan.go
@@ -7,19 +7,19 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-type CreateLaunchPlanFunc func(ctx context.Context, request admin.LaunchPlanCreateRequest) (
+type CreateLaunchPlanFunc func(ctx context.Context, request *admin.LaunchPlanCreateRequest) (
 	*admin.LaunchPlanCreateResponse, error)
-type UpdateLaunchPlanFunc func(ctx context.Context, request admin.LaunchPlanUpdateRequest) (
+type UpdateLaunchPlanFunc func(ctx context.Context, request *admin.LaunchPlanUpdateRequest) (
 	*admin.LaunchPlanUpdateResponse, error)
-type GetLaunchPlanFunc func(ctx context.Context, request admin.ObjectGetRequest) (
+type GetLaunchPlanFunc func(ctx context.Context, request *admin.ObjectGetRequest) (
 	*admin.LaunchPlan, error)
-type GetActiveLaunchPlanFunc func(ctx context.Context, request admin.ActiveLaunchPlanRequest) (
+type GetActiveLaunchPlanFunc func(ctx context.Context, request *admin.ActiveLaunchPlanRequest) (
 	*admin.LaunchPlan, error)
-type ListLaunchPlansFunc func(ctx context.Context, request admin.ResourceListRequest) (
+type ListLaunchPlansFunc func(ctx context.Context, request *admin.ResourceListRequest) (
 	*admin.LaunchPlanList, error)
-type ListLaunchPlanIdsFunc func(ctx context.Context, request admin.NamedEntityIdentifierListRequest) (
+type ListLaunchPlanIdsFunc func(ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (
 	*admin.NamedEntityIdentifierList, error)
-type ListActiveLaunchPlansFunc func(ctx context.Context, request admin.ActiveLaunchPlanListRequest) (
+type ListActiveLaunchPlansFunc func(ctx context.Context, request *admin.ActiveLaunchPlanListRequest) (
 	*admin.LaunchPlanList, error)
 
 type MockLaunchPlanManager struct {
@@ -38,7 +38,7 @@ func (r *MockLaunchPlanManager) SetCreateCallback(createFunction CreateLaunchPla
 
 func (r *MockLaunchPlanManager) CreateLaunchPlan(
 	ctx context.Context,
-	request admin.LaunchPlanCreateRequest) (*admin.LaunchPlanCreateResponse, error) {
+	request *admin.LaunchPlanCreateRequest) (*admin.LaunchPlanCreateResponse, error) {
 	if r.createLaunchPlanFunc != nil {
 		return r.createLaunchPlanFunc(ctx, request)
 	}
@@ -49,7 +49,7 @@ func (r *MockLaunchPlanManager) SetUpdateLaunchPlan(updateFunction UpdateLaunchP
 	r.updateLaunchPlanFunc = updateFunction
 }
 
-func (r *MockLaunchPlanManager) UpdateLaunchPlan(ctx context.Context, request admin.LaunchPlanUpdateRequest) (
+func (r *MockLaunchPlanManager) UpdateLaunchPlan(ctx context.Context, request *admin.LaunchPlanUpdateRequest) (
 	*admin.LaunchPlanUpdateResponse, error) {
 	if r.updateLaunchPlanFunc != nil {
 		return r.updateLaunchPlanFunc(ctx, request)
@@ -57,7 +57,7 @@ func (r *MockLaunchPlanManager) UpdateLaunchPlan(ctx context.Context, request ad
 	return nil, nil
 }
 
-func (r *MockLaunchPlanManager) GetLaunchPlan(ctx context.Context, request admin.ObjectGetRequest) (
+func (r *MockLaunchPlanManager) GetLaunchPlan(ctx context.Context, request *admin.ObjectGetRequest) (
 	*admin.LaunchPlan, error) {
 	if r.getLaunchPlanFunc != nil {
 		return r.getLaunchPlanFunc(ctx, request)
@@ -69,7 +69,7 @@ func (r *MockLaunchPlanManager) SetGetActiveLaunchPlanCallback(plansFunc GetActi
 	r.getActiveLaunchPlanFunc = plansFunc
 }
 
-func (r *MockLaunchPlanManager) GetActiveLaunchPlan(ctx context.Context, request admin.ActiveLaunchPlanRequest) (
+func (r *MockLaunchPlanManager) GetActiveLaunchPlan(ctx context.Context, request *admin.ActiveLaunchPlanRequest) (
 	*admin.LaunchPlan, error) {
 	if r.getActiveLaunchPlanFunc != nil {
 		return r.getActiveLaunchPlanFunc(ctx, request)
@@ -81,7 +81,7 @@ func (r *MockLaunchPlanManager) SetListLaunchPlansCallback(listLaunchPlansFunc L
 	r.listLaunchPlansFunc = listLaunchPlansFunc
 }
 
-func (r *MockLaunchPlanManager) ListLaunchPlans(ctx context.Context, request admin.ResourceListRequest) (
+func (r *MockLaunchPlanManager) ListLaunchPlans(ctx context.Context, request *admin.ResourceListRequest) (
 	*admin.LaunchPlanList, error) {
 	if r.listLaunchPlansFunc != nil {
 		return r.listLaunchPlansFunc(ctx, request)
@@ -93,7 +93,7 @@ func (r *MockLaunchPlanManager) SetListActiveLaunchPlansCallback(plansFunc ListA
 	r.listActiveLaunchPlansFunc = plansFunc
 }
 
-func (r *MockLaunchPlanManager) ListActiveLaunchPlans(ctx context.Context, request admin.ActiveLaunchPlanListRequest) (
+func (r *MockLaunchPlanManager) ListActiveLaunchPlans(ctx context.Context, request *admin.ActiveLaunchPlanListRequest) (
 	*admin.LaunchPlanList, error) {
 	if r.listActiveLaunchPlansFunc != nil {
 		return r.listActiveLaunchPlansFunc(ctx, request)
@@ -101,7 +101,7 @@ func (r *MockLaunchPlanManager) ListActiveLaunchPlans(ctx context.Context, reque
 	return nil, nil
 }
 
-func (r *MockLaunchPlanManager) ListLaunchPlanIds(ctx context.Context, request admin.NamedEntityIdentifierListRequest) (
+func (r *MockLaunchPlanManager) ListLaunchPlanIds(ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (
 	*admin.NamedEntityIdentifierList, error) {
 	if r.listLaunchPlanIdsFunc != nil {
 		return r.ListLaunchPlanIds(ctx, request)

--- a/flyteadmin/pkg/manager/mocks/metrics_interface.go
+++ b/flyteadmin/pkg/manager/mocks/metrics_interface.go
@@ -23,7 +23,7 @@ func (_m MetricsInterface_GetExecutionMetrics) Return(_a0 *admin.WorkflowExecuti
 	return &MetricsInterface_GetExecutionMetrics{Call: _m.Call.Return(_a0, _a1)}
 }
 
-func (_m *MetricsInterface) OnGetExecutionMetrics(ctx context.Context, request admin.WorkflowExecutionGetMetricsRequest) *MetricsInterface_GetExecutionMetrics {
+func (_m *MetricsInterface) OnGetExecutionMetrics(ctx context.Context, request *admin.WorkflowExecutionGetMetricsRequest) *MetricsInterface_GetExecutionMetrics {
 	c_call := _m.On("GetExecutionMetrics", ctx, request)
 	return &MetricsInterface_GetExecutionMetrics{Call: c_call}
 }
@@ -34,11 +34,11 @@ func (_m *MetricsInterface) OnGetExecutionMetricsMatch(matchers ...interface{}) 
 }
 
 // GetExecutionMetrics provides a mock function with given fields: ctx, request
-func (_m *MetricsInterface) GetExecutionMetrics(ctx context.Context, request admin.WorkflowExecutionGetMetricsRequest) (*admin.WorkflowExecutionGetMetricsResponse, error) {
+func (_m *MetricsInterface) GetExecutionMetrics(ctx context.Context, request *admin.WorkflowExecutionGetMetricsRequest) (*admin.WorkflowExecutionGetMetricsResponse, error) {
 	ret := _m.Called(ctx, request)
 
 	var r0 *admin.WorkflowExecutionGetMetricsResponse
-	if rf, ok := ret.Get(0).(func(context.Context, admin.WorkflowExecutionGetMetricsRequest) *admin.WorkflowExecutionGetMetricsResponse); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *admin.WorkflowExecutionGetMetricsRequest) *admin.WorkflowExecutionGetMetricsResponse); ok {
 		r0 = rf(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
@@ -47,7 +47,7 @@ func (_m *MetricsInterface) GetExecutionMetrics(ctx context.Context, request adm
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, admin.WorkflowExecutionGetMetricsRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *admin.WorkflowExecutionGetMetricsRequest) error); ok {
 		r1 = rf(ctx, request)
 	} else {
 		r1 = ret.Error(1)

--- a/flyteadmin/pkg/manager/mocks/named_entity.go
+++ b/flyteadmin/pkg/manager/mocks/named_entity.go
@@ -6,9 +6,9 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-type GetNamedEntityFunc func(ctx context.Context, request admin.NamedEntityGetRequest) (*admin.NamedEntity, error)
-type UpdateNamedEntityFunc func(ctx context.Context, request admin.NamedEntityUpdateRequest) (*admin.NamedEntityUpdateResponse, error)
-type ListNamedEntitiesFunc func(ctx context.Context, request admin.NamedEntityListRequest) (*admin.NamedEntityList, error)
+type GetNamedEntityFunc func(ctx context.Context, request *admin.NamedEntityGetRequest) (*admin.NamedEntity, error)
+type UpdateNamedEntityFunc func(ctx context.Context, request *admin.NamedEntityUpdateRequest) (*admin.NamedEntityUpdateResponse, error)
+type ListNamedEntitiesFunc func(ctx context.Context, request *admin.NamedEntityListRequest) (*admin.NamedEntityList, error)
 
 type NamedEntityManager struct {
 	GetNamedEntityFunc    GetNamedEntityFunc
@@ -16,21 +16,21 @@ type NamedEntityManager struct {
 	ListNamedEntitiesFunc ListNamedEntitiesFunc
 }
 
-func (m *NamedEntityManager) GetNamedEntity(ctx context.Context, request admin.NamedEntityGetRequest) (*admin.NamedEntity, error) {
+func (m *NamedEntityManager) GetNamedEntity(ctx context.Context, request *admin.NamedEntityGetRequest) (*admin.NamedEntity, error) {
 	if m.GetNamedEntityFunc != nil {
 		return m.GetNamedEntityFunc(ctx, request)
 	}
 	return nil, nil
 }
 
-func (m *NamedEntityManager) UpdateNamedEntity(ctx context.Context, request admin.NamedEntityUpdateRequest) (*admin.NamedEntityUpdateResponse, error) {
+func (m *NamedEntityManager) UpdateNamedEntity(ctx context.Context, request *admin.NamedEntityUpdateRequest) (*admin.NamedEntityUpdateResponse, error) {
 	if m.UpdateNamedEntityFunc != nil {
 		return m.UpdateNamedEntityFunc(ctx, request)
 	}
 	return nil, nil
 }
 
-func (m *NamedEntityManager) ListNamedEntities(ctx context.Context, request admin.NamedEntityListRequest) (*admin.NamedEntityList, error) {
+func (m *NamedEntityManager) ListNamedEntities(ctx context.Context, request *admin.NamedEntityListRequest) (*admin.NamedEntityList, error) {
 	if m.ListNamedEntitiesFunc != nil {
 		return m.ListNamedEntitiesFunc(ctx, request)
 	}

--- a/flyteadmin/pkg/manager/mocks/node_execution.go
+++ b/flyteadmin/pkg/manager/mocks/node_execution.go
@@ -6,15 +6,15 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-type CreateNodeEventFunc func(ctx context.Context, request admin.NodeExecutionEventRequest) (
+type CreateNodeEventFunc func(ctx context.Context, request *admin.NodeExecutionEventRequest) (
 	*admin.NodeExecutionEventResponse, error)
-type GetNodeExecutionFunc func(ctx context.Context, request admin.NodeExecutionGetRequest) (*admin.NodeExecution, error)
+type GetNodeExecutionFunc func(ctx context.Context, request *admin.NodeExecutionGetRequest) (*admin.NodeExecution, error)
 type ListNodeExecutionsFunc func(
-	ctx context.Context, request admin.NodeExecutionListRequest) (*admin.NodeExecutionList, error)
-type ListNodeExecutionsForTaskFunc func(ctx context.Context, request admin.NodeExecutionForTaskListRequest) (
+	ctx context.Context, request *admin.NodeExecutionListRequest) (*admin.NodeExecutionList, error)
+type ListNodeExecutionsForTaskFunc func(ctx context.Context, request *admin.NodeExecutionForTaskListRequest) (
 	*admin.NodeExecutionList, error)
 type GetNodeExecutionDataFunc func(
-	ctx context.Context, request admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error)
+	ctx context.Context, request *admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error)
 
 type MockNodeExecutionManager struct {
 	createNodeEventFunc           CreateNodeEventFunc
@@ -30,7 +30,7 @@ func (m *MockNodeExecutionManager) SetCreateNodeEventCallback(createNodeEventFun
 
 func (m *MockNodeExecutionManager) CreateNodeEvent(
 	ctx context.Context,
-	request admin.NodeExecutionEventRequest) (*admin.NodeExecutionEventResponse, error) {
+	request *admin.NodeExecutionEventRequest) (*admin.NodeExecutionEventResponse, error) {
 	if m.createNodeEventFunc != nil {
 		return m.createNodeEventFunc(ctx, request)
 	}
@@ -42,7 +42,7 @@ func (m *MockNodeExecutionManager) SetGetNodeExecutionFunc(getNodeExecutionFunc 
 }
 
 func (m *MockNodeExecutionManager) GetNodeExecution(
-	ctx context.Context, request admin.NodeExecutionGetRequest) (*admin.NodeExecution, error) {
+	ctx context.Context, request *admin.NodeExecutionGetRequest) (*admin.NodeExecution, error) {
 	if m.getNodeExecutionFunc != nil {
 		return m.getNodeExecutionFunc(ctx, request)
 	}
@@ -54,7 +54,7 @@ func (m *MockNodeExecutionManager) SetListNodeExecutionsFunc(listNodeExecutionsF
 }
 
 func (m *MockNodeExecutionManager) ListNodeExecutions(
-	ctx context.Context, request admin.NodeExecutionListRequest) (*admin.NodeExecutionList, error) {
+	ctx context.Context, request *admin.NodeExecutionListRequest) (*admin.NodeExecutionList, error) {
 	if m.listNodeExecutionsFunc != nil {
 		return m.listNodeExecutionsFunc(ctx, request)
 	}
@@ -66,7 +66,7 @@ func (m *MockNodeExecutionManager) SetListNodeExecutionsForTaskFunc(listNodeExec
 }
 
 func (m *MockNodeExecutionManager) ListNodeExecutionsForTask(
-	ctx context.Context, request admin.NodeExecutionForTaskListRequest) (*admin.NodeExecutionList, error) {
+	ctx context.Context, request *admin.NodeExecutionForTaskListRequest) (*admin.NodeExecutionList, error) {
 	if m.listNodeExecutionsForTaskFunc != nil {
 		return m.listNodeExecutionsForTaskFunc(ctx, request)
 	}
@@ -78,13 +78,13 @@ func (m *MockNodeExecutionManager) SetGetNodeExecutionDataFunc(getNodeExecutionD
 }
 
 func (m *MockNodeExecutionManager) GetNodeExecutionData(
-	ctx context.Context, request admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error) {
+	ctx context.Context, request *admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error) {
 	if m.getNodeExecutionDataFunc != nil {
 		return m.getNodeExecutionDataFunc(ctx, request)
 	}
 	return nil, nil
 }
 
-func (m *MockNodeExecutionManager) GetDynamicNodeWorkflow(ctx context.Context, request admin.GetDynamicNodeWorkflowRequest) (*admin.DynamicNodeWorkflowResponse, error) {
+func (m *MockNodeExecutionManager) GetDynamicNodeWorkflow(ctx context.Context, request *admin.GetDynamicNodeWorkflowRequest) (*admin.DynamicNodeWorkflowResponse, error) {
 	return nil, nil
 }

--- a/flyteadmin/pkg/manager/mocks/project.go
+++ b/flyteadmin/pkg/manager/mocks/project.go
@@ -6,11 +6,11 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-type CreateProjectFunc func(ctx context.Context, request admin.ProjectRegisterRequest) (*admin.ProjectRegisterResponse, error)
-type ListProjectFunc func(ctx context.Context, request admin.ProjectListRequest) (*admin.Projects, error)
-type UpdateProjectFunc func(ctx context.Context, request admin.Project) (*admin.ProjectUpdateResponse, error)
-type GetProjectFunc func(ctx context.Context, request admin.ProjectGetRequest) (*admin.Project, error)
-type GetDomainsFunc func(ctx context.Context, request admin.GetDomainRequest) *admin.GetDomainsResponse
+type CreateProjectFunc func(ctx context.Context, request *admin.ProjectRegisterRequest) (*admin.ProjectRegisterResponse, error)
+type ListProjectFunc func(ctx context.Context, request *admin.ProjectListRequest) (*admin.Projects, error)
+type UpdateProjectFunc func(ctx context.Context, request *admin.Project) (*admin.ProjectUpdateResponse, error)
+type GetProjectFunc func(ctx context.Context, request *admin.ProjectGetRequest) (*admin.Project, error)
+type GetDomainsFunc func(ctx context.Context, request *admin.GetDomainRequest) *admin.GetDomainsResponse
 
 type MockProjectManager struct {
 	listProjectFunc   ListProjectFunc
@@ -24,14 +24,14 @@ func (m *MockProjectManager) SetCreateProject(createProjectFunc CreateProjectFun
 	m.createProjectFunc = createProjectFunc
 }
 
-func (m *MockProjectManager) CreateProject(ctx context.Context, request admin.ProjectRegisterRequest) (*admin.ProjectRegisterResponse, error) {
+func (m *MockProjectManager) CreateProject(ctx context.Context, request *admin.ProjectRegisterRequest) (*admin.ProjectRegisterResponse, error) {
 	if m.createProjectFunc != nil {
 		return m.createProjectFunc(ctx, request)
 	}
 	return nil, nil
 }
 
-func (m *MockProjectManager) UpdateProject(ctx context.Context, request admin.Project) (*admin.ProjectUpdateResponse, error) {
+func (m *MockProjectManager) UpdateProject(ctx context.Context, request *admin.Project) (*admin.ProjectUpdateResponse, error) {
 	if m.updateProjectFunc != nil {
 		return m.updateProjectFunc(ctx, request)
 	}
@@ -43,7 +43,7 @@ func (m *MockProjectManager) SetListCallback(listProjectFunc ListProjectFunc) {
 }
 
 func (m *MockProjectManager) ListProjects(
-	ctx context.Context, request admin.ProjectListRequest) (*admin.Projects, error) {
+	ctx context.Context, request *admin.ProjectListRequest) (*admin.Projects, error) {
 	if m.listProjectFunc != nil {
 		return m.listProjectFunc(ctx, request)
 	}
@@ -54,14 +54,14 @@ func (m *MockProjectManager) SetGetCallBack(getProjectFunc GetProjectFunc) {
 	m.getProjectFunc = getProjectFunc
 }
 
-func (m *MockProjectManager) GetProject(ctx context.Context, request admin.ProjectGetRequest) (*admin.Project, error) {
+func (m *MockProjectManager) GetProject(ctx context.Context, request *admin.ProjectGetRequest) (*admin.Project, error) {
 	if m.getProjectFunc != nil {
 		return m.getProjectFunc(ctx, request)
 	}
 	return nil, nil
 }
 
-func (m *MockProjectManager) GetDomains(ctx context.Context, request admin.GetDomainRequest) *admin.GetDomainsResponse {
+func (m *MockProjectManager) GetDomains(ctx context.Context, request *admin.GetDomainRequest) *admin.GetDomainsResponse {
 	if m.getDomainsFunc != nil {
 		return m.getDomainsFunc(ctx, request)
 	}

--- a/flyteadmin/pkg/manager/mocks/resource.go
+++ b/flyteadmin/pkg/manager/mocks/resource.go
@@ -7,20 +7,20 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-type UpdateProjectAttrsFunc func(ctx context.Context, request admin.ProjectAttributesUpdateRequest) (
+type UpdateProjectAttrsFunc func(ctx context.Context, request *admin.ProjectAttributesUpdateRequest) (
 	*admin.ProjectAttributesUpdateResponse, error)
-type GetProjectAttrFunc func(ctx context.Context, request admin.ProjectAttributesGetRequest) (
+type GetProjectAttrFunc func(ctx context.Context, request *admin.ProjectAttributesGetRequest) (
 	*admin.ProjectAttributesGetResponse, error)
-type DeleteProjectAttrFunc func(ctx context.Context, request admin.ProjectAttributesDeleteRequest) (
+type DeleteProjectAttrFunc func(ctx context.Context, request *admin.ProjectAttributesDeleteRequest) (
 	*admin.ProjectAttributesDeleteResponse, error)
 
-type UpdateProjectDomainFunc func(ctx context.Context, request admin.ProjectDomainAttributesUpdateRequest) (
+type UpdateProjectDomainFunc func(ctx context.Context, request *admin.ProjectDomainAttributesUpdateRequest) (
 	*admin.ProjectDomainAttributesUpdateResponse, error)
-type GetProjectDomainFunc func(ctx context.Context, request admin.ProjectDomainAttributesGetRequest) (
+type GetProjectDomainFunc func(ctx context.Context, request *admin.ProjectDomainAttributesGetRequest) (
 	*admin.ProjectDomainAttributesGetResponse, error)
-type DeleteProjectDomainFunc func(ctx context.Context, request admin.ProjectDomainAttributesDeleteRequest) (
+type DeleteProjectDomainFunc func(ctx context.Context, request *admin.ProjectDomainAttributesDeleteRequest) (
 	*admin.ProjectDomainAttributesDeleteResponse, error)
-type ListResourceFunc func(ctx context.Context, request admin.ListMatchableAttributesRequest) (
+type ListResourceFunc func(ctx context.Context, request *admin.ListMatchableAttributesRequest) (
 	*admin.ListMatchableAttributesResponse, error)
 type GetResourceFunc func(ctx context.Context, request interfaces.ResourceRequest) (*interfaces.ResourceResponse, error)
 
@@ -42,17 +42,17 @@ func (m *MockResourceManager) GetResource(ctx context.Context, request interface
 	return nil, nil
 }
 
-func (m *MockResourceManager) UpdateWorkflowAttributes(ctx context.Context, request admin.WorkflowAttributesUpdateRequest) (
+func (m *MockResourceManager) UpdateWorkflowAttributes(ctx context.Context, request *admin.WorkflowAttributesUpdateRequest) (
 	*admin.WorkflowAttributesUpdateResponse, error) {
 	panic("implement me")
 }
 
-func (m *MockResourceManager) GetWorkflowAttributes(ctx context.Context, request admin.WorkflowAttributesGetRequest) (
+func (m *MockResourceManager) GetWorkflowAttributes(ctx context.Context, request *admin.WorkflowAttributesGetRequest) (
 	*admin.WorkflowAttributesGetResponse, error) {
 	panic("implement me")
 }
 
-func (m *MockResourceManager) DeleteWorkflowAttributes(ctx context.Context, request admin.WorkflowAttributesDeleteRequest) (
+func (m *MockResourceManager) DeleteWorkflowAttributes(ctx context.Context, request *admin.WorkflowAttributesDeleteRequest) (
 	*admin.WorkflowAttributesDeleteResponse, error) {
 	panic("implement me")
 }
@@ -62,7 +62,7 @@ func (m *MockResourceManager) SetUpdateProjectDomainAttributes(updateProjectDoma
 }
 
 func (m *MockResourceManager) UpdateProjectDomainAttributes(
-	ctx context.Context, request admin.ProjectDomainAttributesUpdateRequest) (
+	ctx context.Context, request *admin.ProjectDomainAttributesUpdateRequest) (
 	*admin.ProjectDomainAttributesUpdateResponse, error) {
 	if m.updateProjectDomainFunc != nil {
 		return m.updateProjectDomainFunc(ctx, request)
@@ -71,7 +71,7 @@ func (m *MockResourceManager) UpdateProjectDomainAttributes(
 }
 
 func (m *MockResourceManager) GetProjectDomainAttributes(
-	ctx context.Context, request admin.ProjectDomainAttributesGetRequest) (
+	ctx context.Context, request *admin.ProjectDomainAttributesGetRequest) (
 	*admin.ProjectDomainAttributesGetResponse, error) {
 	if m.GetFunc != nil {
 		return m.GetFunc(ctx, request)
@@ -80,7 +80,7 @@ func (m *MockResourceManager) GetProjectDomainAttributes(
 }
 
 func (m *MockResourceManager) DeleteProjectDomainAttributes(
-	ctx context.Context, request admin.ProjectDomainAttributesDeleteRequest) (
+	ctx context.Context, request *admin.ProjectDomainAttributesDeleteRequest) (
 	*admin.ProjectDomainAttributesDeleteResponse, error) {
 	if m.DeleteFunc != nil {
 		return m.DeleteFunc(ctx, request)
@@ -92,7 +92,7 @@ func (m *MockResourceManager) SetUpdateProjectAttributes(updateProjectAttrsFunc 
 	m.updateProjectAttrsFunc = updateProjectAttrsFunc
 }
 
-func (m *MockResourceManager) UpdateProjectAttributes(ctx context.Context, request admin.ProjectAttributesUpdateRequest) (
+func (m *MockResourceManager) UpdateProjectAttributes(ctx context.Context, request *admin.ProjectAttributesUpdateRequest) (
 	*admin.ProjectAttributesUpdateResponse, error) {
 	if m.updateProjectAttrsFunc != nil {
 		return m.updateProjectAttrsFunc(ctx, request)
@@ -104,7 +104,7 @@ func (m *MockResourceManager) SetGetProjectAttributes(getProjectFunc GetProjectA
 	m.getProjectAttrFunc = getProjectFunc
 }
 
-func (m *MockResourceManager) GetProjectAttributes(ctx context.Context, request admin.ProjectAttributesGetRequest) (
+func (m *MockResourceManager) GetProjectAttributes(ctx context.Context, request *admin.ProjectAttributesGetRequest) (
 	*admin.ProjectAttributesGetResponse, error) {
 	if m.getProjectAttrFunc != nil {
 		return m.getProjectAttrFunc(ctx, request)
@@ -116,7 +116,7 @@ func (m *MockResourceManager) SetDeleteProjectAttributes(deleteProjectFunc Delet
 	m.deleteProjectAttrFunc = deleteProjectFunc
 }
 
-func (m *MockResourceManager) DeleteProjectAttributes(ctx context.Context, request admin.ProjectAttributesDeleteRequest) (
+func (m *MockResourceManager) DeleteProjectAttributes(ctx context.Context, request *admin.ProjectAttributesDeleteRequest) (
 	*admin.ProjectAttributesDeleteResponse, error) {
 	if m.deleteProjectAttrFunc != nil {
 		return m.deleteProjectAttrFunc(ctx, request)
@@ -124,7 +124,7 @@ func (m *MockResourceManager) DeleteProjectAttributes(ctx context.Context, reque
 	return nil, nil
 }
 
-func (m *MockResourceManager) ListAll(ctx context.Context, request admin.ListMatchableAttributesRequest) (
+func (m *MockResourceManager) ListAll(ctx context.Context, request *admin.ListMatchableAttributesRequest) (
 	*admin.ListMatchableAttributesResponse, error) {
 	if m.ListFunc != nil {
 		return m.ListFunc(ctx, request)

--- a/flyteadmin/pkg/manager/mocks/signal_interface.go
+++ b/flyteadmin/pkg/manager/mocks/signal_interface.go
@@ -24,7 +24,7 @@ func (_m *SignalInterface) EXPECT() *SignalInterface_Expecter {
 }
 
 // GetOrCreateSignal provides a mock function with given fields: ctx, request
-func (_m *SignalInterface) GetOrCreateSignal(ctx context.Context, request admin.SignalGetOrCreateRequest) (*admin.Signal, error) {
+func (_m *SignalInterface) GetOrCreateSignal(ctx context.Context, request *admin.SignalGetOrCreateRequest) (*admin.Signal, error) {
 	ret := _m.Called(ctx, request)
 
 	if len(ret) == 0 {
@@ -33,10 +33,10 @@ func (_m *SignalInterface) GetOrCreateSignal(ctx context.Context, request admin.
 
 	var r0 *admin.Signal
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, admin.SignalGetOrCreateRequest) (*admin.Signal, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *admin.SignalGetOrCreateRequest) (*admin.Signal, error)); ok {
 		return rf(ctx, request)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, admin.SignalGetOrCreateRequest) *admin.Signal); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *admin.SignalGetOrCreateRequest) *admin.Signal); ok {
 		r0 = rf(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
@@ -44,7 +44,7 @@ func (_m *SignalInterface) GetOrCreateSignal(ctx context.Context, request admin.
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, admin.SignalGetOrCreateRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *admin.SignalGetOrCreateRequest) error); ok {
 		r1 = rf(ctx, request)
 	} else {
 		r1 = ret.Error(1)
@@ -60,14 +60,14 @@ type SignalInterface_GetOrCreateSignal_Call struct {
 
 // GetOrCreateSignal is a helper method to define mock.On call
 //   - ctx context.Context
-//   - request admin.SignalGetOrCreateRequest
+//   - request *admin.SignalGetOrCreateRequest
 func (_e *SignalInterface_Expecter) GetOrCreateSignal(ctx interface{}, request interface{}) *SignalInterface_GetOrCreateSignal_Call {
 	return &SignalInterface_GetOrCreateSignal_Call{Call: _e.mock.On("GetOrCreateSignal", ctx, request)}
 }
 
-func (_c *SignalInterface_GetOrCreateSignal_Call) Run(run func(ctx context.Context, request admin.SignalGetOrCreateRequest)) *SignalInterface_GetOrCreateSignal_Call {
+func (_c *SignalInterface_GetOrCreateSignal_Call) Run(run func(ctx context.Context, request *admin.SignalGetOrCreateRequest)) *SignalInterface_GetOrCreateSignal_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(admin.SignalGetOrCreateRequest))
+		run(args[0].(context.Context), args[1].(*admin.SignalGetOrCreateRequest))
 	})
 	return _c
 }
@@ -77,13 +77,13 @@ func (_c *SignalInterface_GetOrCreateSignal_Call) Return(_a0 *admin.Signal, _a1 
 	return _c
 }
 
-func (_c *SignalInterface_GetOrCreateSignal_Call) RunAndReturn(run func(context.Context, admin.SignalGetOrCreateRequest) (*admin.Signal, error)) *SignalInterface_GetOrCreateSignal_Call {
+func (_c *SignalInterface_GetOrCreateSignal_Call) RunAndReturn(run func(context.Context, *admin.SignalGetOrCreateRequest) (*admin.Signal, error)) *SignalInterface_GetOrCreateSignal_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListSignals provides a mock function with given fields: ctx, request
-func (_m *SignalInterface) ListSignals(ctx context.Context, request admin.SignalListRequest) (*admin.SignalList, error) {
+func (_m *SignalInterface) ListSignals(ctx context.Context, request *admin.SignalListRequest) (*admin.SignalList, error) {
 	ret := _m.Called(ctx, request)
 
 	if len(ret) == 0 {
@@ -92,10 +92,10 @@ func (_m *SignalInterface) ListSignals(ctx context.Context, request admin.Signal
 
 	var r0 *admin.SignalList
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, admin.SignalListRequest) (*admin.SignalList, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *admin.SignalListRequest) (*admin.SignalList, error)); ok {
 		return rf(ctx, request)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, admin.SignalListRequest) *admin.SignalList); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *admin.SignalListRequest) *admin.SignalList); ok {
 		r0 = rf(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
@@ -103,7 +103,7 @@ func (_m *SignalInterface) ListSignals(ctx context.Context, request admin.Signal
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, admin.SignalListRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *admin.SignalListRequest) error); ok {
 		r1 = rf(ctx, request)
 	} else {
 		r1 = ret.Error(1)
@@ -119,14 +119,14 @@ type SignalInterface_ListSignals_Call struct {
 
 // ListSignals is a helper method to define mock.On call
 //   - ctx context.Context
-//   - request admin.SignalListRequest
+//   - request *admin.SignalListRequest
 func (_e *SignalInterface_Expecter) ListSignals(ctx interface{}, request interface{}) *SignalInterface_ListSignals_Call {
 	return &SignalInterface_ListSignals_Call{Call: _e.mock.On("ListSignals", ctx, request)}
 }
 
-func (_c *SignalInterface_ListSignals_Call) Run(run func(ctx context.Context, request admin.SignalListRequest)) *SignalInterface_ListSignals_Call {
+func (_c *SignalInterface_ListSignals_Call) Run(run func(ctx context.Context, request *admin.SignalListRequest)) *SignalInterface_ListSignals_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(admin.SignalListRequest))
+		run(args[0].(context.Context), args[1].(*admin.SignalListRequest))
 	})
 	return _c
 }
@@ -136,13 +136,13 @@ func (_c *SignalInterface_ListSignals_Call) Return(_a0 *admin.SignalList, _a1 er
 	return _c
 }
 
-func (_c *SignalInterface_ListSignals_Call) RunAndReturn(run func(context.Context, admin.SignalListRequest) (*admin.SignalList, error)) *SignalInterface_ListSignals_Call {
+func (_c *SignalInterface_ListSignals_Call) RunAndReturn(run func(context.Context, *admin.SignalListRequest) (*admin.SignalList, error)) *SignalInterface_ListSignals_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // SetSignal provides a mock function with given fields: ctx, request
-func (_m *SignalInterface) SetSignal(ctx context.Context, request admin.SignalSetRequest) (*admin.SignalSetResponse, error) {
+func (_m *SignalInterface) SetSignal(ctx context.Context, request *admin.SignalSetRequest) (*admin.SignalSetResponse, error) {
 	ret := _m.Called(ctx, request)
 
 	if len(ret) == 0 {
@@ -151,10 +151,10 @@ func (_m *SignalInterface) SetSignal(ctx context.Context, request admin.SignalSe
 
 	var r0 *admin.SignalSetResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, admin.SignalSetRequest) (*admin.SignalSetResponse, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *admin.SignalSetRequest) (*admin.SignalSetResponse, error)); ok {
 		return rf(ctx, request)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, admin.SignalSetRequest) *admin.SignalSetResponse); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *admin.SignalSetRequest) *admin.SignalSetResponse); ok {
 		r0 = rf(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
@@ -162,7 +162,7 @@ func (_m *SignalInterface) SetSignal(ctx context.Context, request admin.SignalSe
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, admin.SignalSetRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *admin.SignalSetRequest) error); ok {
 		r1 = rf(ctx, request)
 	} else {
 		r1 = ret.Error(1)
@@ -178,14 +178,14 @@ type SignalInterface_SetSignal_Call struct {
 
 // SetSignal is a helper method to define mock.On call
 //   - ctx context.Context
-//   - request admin.SignalSetRequest
+//   - request *admin.SignalSetRequest
 func (_e *SignalInterface_Expecter) SetSignal(ctx interface{}, request interface{}) *SignalInterface_SetSignal_Call {
 	return &SignalInterface_SetSignal_Call{Call: _e.mock.On("SetSignal", ctx, request)}
 }
 
-func (_c *SignalInterface_SetSignal_Call) Run(run func(ctx context.Context, request admin.SignalSetRequest)) *SignalInterface_SetSignal_Call {
+func (_c *SignalInterface_SetSignal_Call) Run(run func(ctx context.Context, request *admin.SignalSetRequest)) *SignalInterface_SetSignal_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(admin.SignalSetRequest))
+		run(args[0].(context.Context), args[1].(*admin.SignalSetRequest))
 	})
 	return _c
 }
@@ -195,7 +195,7 @@ func (_c *SignalInterface_SetSignal_Call) Return(_a0 *admin.SignalSetResponse, _
 	return _c
 }
 
-func (_c *SignalInterface_SetSignal_Call) RunAndReturn(run func(context.Context, admin.SignalSetRequest) (*admin.SignalSetResponse, error)) *SignalInterface_SetSignal_Call {
+func (_c *SignalInterface_SetSignal_Call) RunAndReturn(run func(context.Context, *admin.SignalSetRequest) (*admin.SignalSetResponse, error)) *SignalInterface_SetSignal_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/flyteadmin/pkg/manager/mocks/task.go
+++ b/flyteadmin/pkg/manager/mocks/task.go
@@ -6,8 +6,8 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-type CreateTaskFunc func(ctx context.Context, request admin.TaskCreateRequest) (*admin.TaskCreateResponse, error)
-type ListUniqueIdsFunc func(ctx context.Context, request admin.NamedEntityIdentifierListRequest) (*admin.NamedEntityIdentifierList, error)
+type CreateTaskFunc func(ctx context.Context, request *admin.TaskCreateRequest) (*admin.TaskCreateResponse, error)
+type ListUniqueIdsFunc func(ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (*admin.NamedEntityIdentifierList, error)
 
 type MockTaskManager struct {
 	createTaskFunc    CreateTaskFunc
@@ -20,18 +20,18 @@ func (r *MockTaskManager) SetCreateCallback(createFunction CreateTaskFunc) {
 
 func (r *MockTaskManager) CreateTask(
 	ctx context.Context,
-	request admin.TaskCreateRequest) (*admin.TaskCreateResponse, error) {
+	request *admin.TaskCreateRequest) (*admin.TaskCreateResponse, error) {
 	if r.createTaskFunc != nil {
 		return r.createTaskFunc(ctx, request)
 	}
 	return nil, nil
 }
 
-func (r *MockTaskManager) GetTask(ctx context.Context, request admin.ObjectGetRequest) (*admin.Task, error) {
+func (r *MockTaskManager) GetTask(ctx context.Context, request *admin.ObjectGetRequest) (*admin.Task, error) {
 	return nil, nil
 }
 
-func (r *MockTaskManager) ListTasks(ctx context.Context, request admin.ResourceListRequest) (*admin.TaskList, error) {
+func (r *MockTaskManager) ListTasks(ctx context.Context, request *admin.ResourceListRequest) (*admin.TaskList, error) {
 	return nil, nil
 }
 
@@ -39,7 +39,7 @@ func (r *MockTaskManager) SetListUniqueIdsFunc(fn ListUniqueIdsFunc) {
 	r.listUniqueIdsFunc = fn
 }
 
-func (r *MockTaskManager) ListUniqueTaskIdentifiers(ctx context.Context, request admin.NamedEntityIdentifierListRequest) (
+func (r *MockTaskManager) ListUniqueTaskIdentifiers(ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (
 	*admin.NamedEntityIdentifierList, error) {
 
 	if r.listUniqueIdsFunc != nil {

--- a/flyteadmin/pkg/manager/mocks/task_execution.go
+++ b/flyteadmin/pkg/manager/mocks/task_execution.go
@@ -6,13 +6,13 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-type CreateTaskExecutionEventFunc func(ctx context.Context, request admin.TaskExecutionEventRequest) (
+type CreateTaskExecutionEventFunc func(ctx context.Context, request *admin.TaskExecutionEventRequest) (
 	*admin.TaskExecutionEventResponse, error)
-type GetTaskExecutionFunc func(ctx context.Context, request admin.TaskExecutionGetRequest) (
+type GetTaskExecutionFunc func(ctx context.Context, request *admin.TaskExecutionGetRequest) (
 	*admin.TaskExecution, error)
-type ListTaskExecutionsFunc func(ctx context.Context, request admin.TaskExecutionListRequest) (
+type ListTaskExecutionsFunc func(ctx context.Context, request *admin.TaskExecutionListRequest) (
 	*admin.TaskExecutionList, error)
-type GetTaskExecutionDataFunc func(ctx context.Context, request admin.TaskExecutionGetDataRequest) (
+type GetTaskExecutionDataFunc func(ctx context.Context, request *admin.TaskExecutionGetDataRequest) (
 	*admin.TaskExecutionGetDataResponse, error)
 
 type MockTaskExecutionManager struct {
@@ -23,7 +23,7 @@ type MockTaskExecutionManager struct {
 }
 
 func (m *MockTaskExecutionManager) CreateTaskExecutionEvent(
-	ctx context.Context, request admin.TaskExecutionEventRequest) (*admin.TaskExecutionEventResponse, error) {
+	ctx context.Context, request *admin.TaskExecutionEventRequest) (*admin.TaskExecutionEventResponse, error) {
 	if m.createTaskExecutionEventFunc != nil {
 		return m.createTaskExecutionEventFunc(ctx, request)
 	}
@@ -36,7 +36,7 @@ func (m *MockTaskExecutionManager) SetCreateTaskEventCallback(
 }
 
 func (m *MockTaskExecutionManager) GetTaskExecution(
-	ctx context.Context, request admin.TaskExecutionGetRequest) (*admin.TaskExecution, error) {
+	ctx context.Context, request *admin.TaskExecutionGetRequest) (*admin.TaskExecution, error) {
 	if m.getTaskExecutionFunc != nil {
 		return m.getTaskExecutionFunc(ctx, request)
 	}
@@ -49,7 +49,7 @@ func (m *MockTaskExecutionManager) SetGetTaskExecutionCallback(
 }
 
 func (m *MockTaskExecutionManager) ListTaskExecutions(
-	ctx context.Context, request admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error) {
+	ctx context.Context, request *admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error) {
 	if m.listTaskExecutionsFunc != nil {
 		return m.listTaskExecutionsFunc(ctx, request)
 	}
@@ -62,7 +62,7 @@ func (m *MockTaskExecutionManager) SetListTaskExecutionsCallback(
 }
 
 func (m *MockTaskExecutionManager) GetTaskExecutionData(
-	ctx context.Context, request admin.TaskExecutionGetDataRequest) (*admin.TaskExecutionGetDataResponse, error) {
+	ctx context.Context, request *admin.TaskExecutionGetDataRequest) (*admin.TaskExecutionGetDataResponse, error) {
 	if m.getTaskExecutionDataFunc != nil {
 		return m.getTaskExecutionDataFunc(ctx, request)
 	}

--- a/flyteadmin/pkg/manager/mocks/workflow.go
+++ b/flyteadmin/pkg/manager/mocks/workflow.go
@@ -6,8 +6,8 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-type CreateWorkflowFunc func(ctx context.Context, request admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error)
-type GetWorkflowFunc func(ctx context.Context, request admin.ObjectGetRequest) (*admin.Workflow, error)
+type CreateWorkflowFunc func(ctx context.Context, request *admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error)
+type GetWorkflowFunc func(ctx context.Context, request *admin.ObjectGetRequest) (*admin.Workflow, error)
 
 type MockWorkflowManager struct {
 	createWorkflowFunc CreateWorkflowFunc
@@ -20,7 +20,7 @@ func (r *MockWorkflowManager) SetCreateCallback(createFunction CreateWorkflowFun
 
 func (r *MockWorkflowManager) CreateWorkflow(
 	ctx context.Context,
-	request admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error) {
+	request *admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error) {
 	if r.createWorkflowFunc != nil {
 		return r.createWorkflowFunc(ctx, request)
 	}
@@ -28,7 +28,7 @@ func (r *MockWorkflowManager) CreateWorkflow(
 }
 
 func (r *MockWorkflowManager) ListWorkflows(ctx context.Context,
-	request admin.ResourceListRequest) (*admin.WorkflowList, error) {
+	request *admin.ResourceListRequest) (*admin.WorkflowList, error) {
 	return nil, nil
 }
 
@@ -37,14 +37,14 @@ func (r *MockWorkflowManager) SetGetCallback(getFunction GetWorkflowFunc) {
 }
 
 func (r *MockWorkflowManager) GetWorkflow(
-	ctx context.Context, request admin.ObjectGetRequest) (*admin.Workflow, error) {
+	ctx context.Context, request *admin.ObjectGetRequest) (*admin.Workflow, error) {
 	if r.getWorkflowFunc != nil {
 		return r.getWorkflowFunc(ctx, request)
 	}
 	return nil, nil
 }
 
-func (r *MockWorkflowManager) ListWorkflowIdentifiers(ctx context.Context, request admin.NamedEntityIdentifierListRequest) (
+func (r *MockWorkflowManager) ListWorkflowIdentifiers(ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (
 	*admin.NamedEntityIdentifierList, error) {
 	return nil, nil
 }

--- a/flyteadmin/pkg/repositories/gormimpl/node_execution_repo_test.go
+++ b/flyteadmin/pkg/repositories/gormimpl/node_execution_repo_test.go
@@ -139,7 +139,7 @@ func TestGetNodeExecution(t *testing.T) {
 	GlobalMock.NewMock().WithQuery(
 		`SELECT * FROM "node_executions" WHERE "node_executions"."execution_project" = $1 AND "node_executions"."execution_domain" = $2 AND "node_executions"."execution_name" = $3 AND "node_executions"."node_id" = $4 LIMIT 1`).WithReply(nodeExecutions)
 	output, err := nodeExecutionRepo.Get(context.Background(), interfaces.NodeExecutionResource{
-		NodeExecutionIdentifier: core.NodeExecutionIdentifier{
+		NodeExecutionIdentifier: &core.NodeExecutionIdentifier{
 			NodeId: "1",
 			ExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "execution_project",
@@ -160,7 +160,7 @@ func TestGetNodeExecutionErr(t *testing.T) {
 		GlobalMock.NewMock().WithError(gorm.ErrRecordNotFound)
 
 		_, err := nodeExecutionRepo.Get(context.Background(), interfaces.NodeExecutionResource{
-			NodeExecutionIdentifier: core.NodeExecutionIdentifier{
+			NodeExecutionIdentifier: &core.NodeExecutionIdentifier{
 				NodeId: "1",
 				ExecutionId: &core.WorkflowExecutionIdentifier{
 					Project: "execution_project",
@@ -176,7 +176,7 @@ func TestGetNodeExecutionErr(t *testing.T) {
 		GlobalMock.NewMock().WithError(gorm.ErrInvalidData)
 
 		_, err := nodeExecutionRepo.Get(context.Background(), interfaces.NodeExecutionResource{
-			NodeExecutionIdentifier: core.NodeExecutionIdentifier{
+			NodeExecutionIdentifier: &core.NodeExecutionIdentifier{
 				NodeId: "1",
 				ExecutionId: &core.WorkflowExecutionIdentifier{
 					Project: "execution_project",
@@ -362,7 +362,7 @@ func TestNodeExecutionExists(t *testing.T) {
 	GlobalMock.NewMock().WithQuery(
 		`SELECT "id" FROM "node_executions" WHERE "node_executions"."execution_project" = $1 AND "node_executions"."execution_domain" = $2 AND "node_executions"."execution_name" = $3 AND "node_executions"."node_id" = $4 LIMIT 1`).WithReply(nodeExecutions)
 	exists, err := nodeExecutionRepo.Exists(context.Background(), interfaces.NodeExecutionResource{
-		NodeExecutionIdentifier: core.NodeExecutionIdentifier{
+		NodeExecutionIdentifier: &core.NodeExecutionIdentifier{
 			NodeId: "1",
 			ExecutionId: &core.WorkflowExecutionIdentifier{
 				Project: "execution_project",

--- a/flyteadmin/pkg/repositories/gormimpl/task_execution_repo_test.go
+++ b/flyteadmin/pkg/repositories/gormimpl/task_execution_repo_test.go
@@ -104,7 +104,7 @@ func TestGetTaskExecution(t *testing.T) {
 		WithReply(taskExecutions)
 
 	output, err := taskExecutionRepo.Get(context.Background(), interfaces.GetTaskExecutionInput{
-		TaskExecutionID: core.TaskExecutionIdentifier{
+		TaskExecutionID: &core.TaskExecutionIdentifier{
 			TaskId: &core.Identifier{
 				ResourceType: core.ResourceType_TASK,
 				Project:      "project",

--- a/flyteadmin/pkg/repositories/interfaces/node_execution_repo.go
+++ b/flyteadmin/pkg/repositories/interfaces/node_execution_repo.go
@@ -27,7 +27,7 @@ type NodeExecutionRepoInterface interface {
 }
 
 type NodeExecutionResource struct {
-	NodeExecutionIdentifier core.NodeExecutionIdentifier
+	NodeExecutionIdentifier *core.NodeExecutionIdentifier
 }
 
 // Response format for a query on node executions.

--- a/flyteadmin/pkg/repositories/interfaces/task_execution_repo.go
+++ b/flyteadmin/pkg/repositories/interfaces/task_execution_repo.go
@@ -22,7 +22,7 @@ type TaskExecutionRepoInterface interface {
 }
 
 type GetTaskExecutionInput struct {
-	TaskExecutionID core.TaskExecutionIdentifier
+	TaskExecutionID *core.TaskExecutionIdentifier
 }
 
 // Response format for a query on task executions.

--- a/flyteadmin/pkg/repositories/transformers/description_entity.go
+++ b/flyteadmin/pkg/repositories/transformers/description_entity.go
@@ -16,7 +16,7 @@ import (
 // CreateDescriptionEntityModel Transforms a TaskCreateRequest to a Description entity model
 func CreateDescriptionEntityModel(
 	descriptionEntity *admin.DescriptionEntity,
-	id core.Identifier) (*models.DescriptionEntity, error) {
+	id *core.Identifier) (*models.DescriptionEntity, error) {
 	ctx := context.Background()
 	if descriptionEntity == nil {
 		return nil, nil

--- a/flyteadmin/pkg/repositories/transformers/description_entity_test.go
+++ b/flyteadmin/pkg/repositories/transformers/description_entity_test.go
@@ -26,7 +26,7 @@ func TestToDescriptionEntityExecutionModel(t *testing.T) {
 		SourceCode:       sourceCode,
 	}
 
-	id := core.Identifier{
+	id := &core.Identifier{
 		ResourceType: core.ResourceType_TASK,
 		Project:      "project",
 		Domain:       "domain",

--- a/flyteadmin/pkg/repositories/transformers/execution.go
+++ b/flyteadmin/pkg/repositories/transformers/execution.go
@@ -29,7 +29,7 @@ var clusterReassignablePhases = sets.NewString(core.WorkflowExecution_UNDEFINED.
 
 // CreateExecutionModelInput encapsulates request parameters for calls to CreateExecutionModel.
 type CreateExecutionModelInput struct {
-	WorkflowExecutionID   core.WorkflowExecutionIdentifier
+	WorkflowExecutionID   *core.WorkflowExecutionIdentifier
 	RequestSpec           *admin.ExecutionSpec
 	LaunchPlanID          uint
 	WorkflowID            uint
@@ -207,7 +207,7 @@ func reassignCluster(ctx context.Context, cluster string, executionID *core.Work
 // Updates an existing model given a WorkflowExecution event.
 func UpdateExecutionModelState(
 	ctx context.Context,
-	execution *models.Execution, request admin.WorkflowExecutionEventRequest,
+	execution *models.Execution, request *admin.WorkflowExecutionEventRequest,
 	inlineEventDataPolicy interfaces.InlineEventDataPolicy, storageClient *storage.DataStore) error {
 	var executionClosure admin.ExecutionClosure
 	err := proto.Unmarshal(execution.Closure, &executionClosure)

--- a/flyteadmin/pkg/repositories/transformers/execution_event.go
+++ b/flyteadmin/pkg/repositories/transformers/execution_event.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Transforms a ExecutionEventCreateRequest to a ExecutionEvent model
-func CreateExecutionEventModel(request admin.WorkflowExecutionEventRequest) (*models.ExecutionEvent, error) {
+func CreateExecutionEventModel(request *admin.WorkflowExecutionEventRequest) (*models.ExecutionEvent, error) {
 	occurredAt, err := ptypes.Timestamp(request.Event.OccurredAt)
 	if err != nil {
 		return nil, errors.NewFlyteAdminErrorf(codes.Internal, "failed to marshal occurred at timestamp")

--- a/flyteadmin/pkg/repositories/transformers/execution_event_test.go
+++ b/flyteadmin/pkg/repositories/transformers/execution_event_test.go
@@ -20,7 +20,7 @@ func TestCreateExecutionEventModel(t *testing.T) {
 	timestamp := time.Now().UTC()
 	occurredAt, _ := ptypes.TimestampProto(timestamp)
 	executionEvent, err := CreateExecutionEventModel(
-		admin.WorkflowExecutionEventRequest{
+		&admin.WorkflowExecutionEventRequest{
 			RequestId: requestID,
 			Event: &event.WorkflowExecutionEvent{
 				ExecutionId: &core.WorkflowExecutionIdentifier{

--- a/flyteadmin/pkg/repositories/transformers/execution_test.go
+++ b/flyteadmin/pkg/repositories/transformers/execution_test.go
@@ -73,7 +73,7 @@ func TestCreateExecutionModel(t *testing.T) {
 	namespace := "ns"
 	t.Run("successful execution", func(t *testing.T) {
 		execution, err := CreateExecutionModel(CreateExecutionModelInput{
-			WorkflowExecutionID: core.WorkflowExecutionIdentifier{
+			WorkflowExecutionID: &core.WorkflowExecutionIdentifier{
 				Project: "project",
 				Domain:  "domain",
 				Name:    "name",
@@ -131,7 +131,7 @@ func TestCreateExecutionModel(t *testing.T) {
 	t.Run("failed with unknown error", func(t *testing.T) {
 		execErr := fmt.Errorf("bla-bla")
 		execution, err := CreateExecutionModel(CreateExecutionModelInput{
-			WorkflowExecutionID: core.WorkflowExecutionIdentifier{
+			WorkflowExecutionID: &core.WorkflowExecutionIdentifier{
 				Project: "project",
 				Domain:  "domain",
 				Name:    "name",
@@ -197,7 +197,7 @@ func TestCreateExecutionModel(t *testing.T) {
 	t.Run("failed with invalid argument error", func(t *testing.T) {
 		execErr := errors.NewFlyteAdminError(codes.InvalidArgument, "task validation failed")
 		execution, err := CreateExecutionModel(CreateExecutionModelInput{
-			WorkflowExecutionID: core.WorkflowExecutionIdentifier{
+			WorkflowExecutionID: &core.WorkflowExecutionIdentifier{
 				Project: "project",
 				Domain:  "domain",
 				Name:    "name",
@@ -263,7 +263,7 @@ func TestCreateExecutionModel(t *testing.T) {
 	t.Run("failed with internal error", func(t *testing.T) {
 		execErr := errors.NewFlyteAdminError(codes.Internal, "db failed")
 		execution, err := CreateExecutionModel(CreateExecutionModelInput{
-			WorkflowExecutionID: core.WorkflowExecutionIdentifier{
+			WorkflowExecutionID: &core.WorkflowExecutionIdentifier{
 				Project: "project",
 				Domain:  "domain",
 				Name:    "name",
@@ -349,7 +349,7 @@ func TestUpdateModelState_UnknownToRunning(t *testing.T) {
 
 	occurredAt := time.Date(2018, 10, 29, 16, 10, 0, 0, time.UTC)
 	occurredAtProto, _ := ptypes.TimestampProto(occurredAt)
-	err := UpdateExecutionModelState(context.TODO(), &executionModel, admin.WorkflowExecutionEventRequest{
+	err := UpdateExecutionModelState(context.TODO(), &executionModel, &admin.WorkflowExecutionEventRequest{
 		Event: &event.WorkflowExecutionEvent{
 			Phase:      core.WorkflowExecution_RUNNING,
 			OccurredAt: occurredAtProto,
@@ -413,7 +413,7 @@ func TestUpdateModelState_RunningToFailed(t *testing.T) {
 		Kind:    ek,
 		Message: "bar baz",
 	}
-	err := UpdateExecutionModelState(context.TODO(), &executionModel, admin.WorkflowExecutionEventRequest{
+	err := UpdateExecutionModelState(context.TODO(), &executionModel, &admin.WorkflowExecutionEventRequest{
 		Event: &event.WorkflowExecutionEvent{
 			Phase:      core.WorkflowExecution_ABORTED,
 			OccurredAt: occurredAtProto,
@@ -500,7 +500,7 @@ func TestUpdateModelState_RunningToSuccess(t *testing.T) {
 	}
 
 	t.Run("output URI set", func(t *testing.T) {
-		err := UpdateExecutionModelState(context.TODO(), &executionModel, admin.WorkflowExecutionEventRequest{
+		err := UpdateExecutionModelState(context.TODO(), &executionModel, &admin.WorkflowExecutionEventRequest{
 			Event: &event.WorkflowExecutionEvent{
 				Phase:      core.WorkflowExecution_SUCCEEDED,
 				OccurredAt: occurredAtProto,
@@ -551,7 +551,7 @@ func TestUpdateModelState_RunningToSuccess(t *testing.T) {
 				},
 			},
 		}
-		err := UpdateExecutionModelState(context.TODO(), &executionModel, admin.WorkflowExecutionEventRequest{
+		err := UpdateExecutionModelState(context.TODO(), &executionModel, &admin.WorkflowExecutionEventRequest{
 			Event: &event.WorkflowExecutionEvent{
 				Phase:      core.WorkflowExecution_SUCCEEDED,
 				OccurredAt: occurredAtProto,
@@ -603,7 +603,7 @@ func TestUpdateModelState_RunningToSuccess(t *testing.T) {
 			assert.Equal(t, reference.String(), "s3://bucket/metadata/project/domain/name/offloaded_outputs")
 			return nil
 		}
-		err := UpdateExecutionModelState(context.TODO(), &executionModel, admin.WorkflowExecutionEventRequest{
+		err := UpdateExecutionModelState(context.TODO(), &executionModel, &admin.WorkflowExecutionEventRequest{
 			Event: &event.WorkflowExecutionEvent{
 				ExecutionId: &core.WorkflowExecutionIdentifier{
 					Project: "project",
@@ -926,7 +926,7 @@ func TestUpdateModelState_WithClusterInformation(t *testing.T) {
 	occurredAtProto, _ := ptypes.TimestampProto(occurredAt)
 	t.Run("update", func(t *testing.T) {
 		executionModel.Cluster = altCluster
-		err := UpdateExecutionModelState(context.TODO(), &executionModel, admin.WorkflowExecutionEventRequest{
+		err := UpdateExecutionModelState(context.TODO(), &executionModel, &admin.WorkflowExecutionEventRequest{
 			Event: &event.WorkflowExecutionEvent{
 				Phase:      core.WorkflowExecution_QUEUED,
 				OccurredAt: occurredAtProto,
@@ -938,7 +938,7 @@ func TestUpdateModelState_WithClusterInformation(t *testing.T) {
 		executionModel.Cluster = testCluster
 	})
 	t.Run("do not update", func(t *testing.T) {
-		err := UpdateExecutionModelState(context.TODO(), &executionModel, admin.WorkflowExecutionEventRequest{
+		err := UpdateExecutionModelState(context.TODO(), &executionModel, &admin.WorkflowExecutionEventRequest{
 			Event: &event.WorkflowExecutionEvent{
 				Phase:      core.WorkflowExecution_RUNNING,
 				OccurredAt: occurredAtProto,
@@ -949,7 +949,7 @@ func TestUpdateModelState_WithClusterInformation(t *testing.T) {
 	})
 	t.Run("matches recorded", func(t *testing.T) {
 		executionModel.Cluster = testCluster
-		err := UpdateExecutionModelState(context.TODO(), &executionModel, admin.WorkflowExecutionEventRequest{
+		err := UpdateExecutionModelState(context.TODO(), &executionModel, &admin.WorkflowExecutionEventRequest{
 			Event: &event.WorkflowExecutionEvent{
 				Phase:      core.WorkflowExecution_RUNNING,
 				OccurredAt: occurredAtProto,
@@ -960,7 +960,7 @@ func TestUpdateModelState_WithClusterInformation(t *testing.T) {
 	})
 	t.Run("default cluster value", func(t *testing.T) {
 		executionModel.Cluster = testCluster
-		err := UpdateExecutionModelState(context.TODO(), &executionModel, admin.WorkflowExecutionEventRequest{
+		err := UpdateExecutionModelState(context.TODO(), &executionModel, &admin.WorkflowExecutionEventRequest{
 			Event: &event.WorkflowExecutionEvent{
 				Phase:      core.WorkflowExecution_RUNNING,
 				OccurredAt: occurredAtProto,
@@ -1068,8 +1068,8 @@ func TestUpdateExecutionModelStateChangeDetails(t *testing.T) {
 		assert.Nil(t, err)
 		stateInt := int32(admin.ExecutionState_EXECUTION_ARCHIVED)
 		assert.Equal(t, execModel.State, &stateInt)
-		var closure admin.ExecutionClosure
-		err = proto.Unmarshal(execModel.Closure, &closure)
+		closure := &admin.ExecutionClosure{}
+		err = proto.Unmarshal(execModel.Closure, closure)
 		assert.Nil(t, err)
 		assert.NotNil(t, closure)
 		assert.NotNil(t, closure.StateChangeDetails)

--- a/flyteadmin/pkg/repositories/transformers/launch_plan.go
+++ b/flyteadmin/pkg/repositories/transformers/launch_plan.go
@@ -12,10 +12,10 @@ import (
 )
 
 func CreateLaunchPlan(
-	request admin.LaunchPlanCreateRequest,
-	expectedOutputs *core.VariableMap) admin.LaunchPlan {
+	request *admin.LaunchPlanCreateRequest,
+	expectedOutputs *core.VariableMap) *admin.LaunchPlan {
 
-	return admin.LaunchPlan{
+	return &admin.LaunchPlan{
 		Id:   request.Id,
 		Spec: request.Spec,
 		Closure: &admin.LaunchPlanClosure{
@@ -27,7 +27,7 @@ func CreateLaunchPlan(
 
 // Transforms a admin.LaunchPlan object to a LaunchPlan model
 func CreateLaunchPlanModel(
-	launchPlan admin.LaunchPlan,
+	launchPlan *admin.LaunchPlan,
 	workflowRepoID uint,
 	digest []byte,
 	initState admin.LaunchPlanState) (models.LaunchPlan, error) {

--- a/flyteadmin/pkg/repositories/transformers/launch_plan_test.go
+++ b/flyteadmin/pkg/repositories/transformers/launch_plan_test.go
@@ -27,7 +27,7 @@ var expectedOutputs = &core.VariableMap{
 	},
 }
 
-func getRequest() admin.LaunchPlanCreateRequest {
+func getRequest() *admin.LaunchPlanCreateRequest {
 	request := testutils.GetLaunchPlanRequest()
 	request.Spec.DefaultInputs = expectedInputs
 	return request
@@ -45,7 +45,7 @@ func TestCreateLaunchPlan(t *testing.T) {
 				ExpectedInputs:  expectedInputs,
 				ExpectedOutputs: expectedOutputs,
 			},
-		}, &launchPlan))
+		}, launchPlan))
 }
 
 func TestToLaunchPlanModel(t *testing.T) {
@@ -53,7 +53,7 @@ func TestToLaunchPlanModel(t *testing.T) {
 	workflowID := uint(11)
 	launchPlanDigest := []byte("launch plan")
 
-	launchPlan := admin.LaunchPlan{
+	launchPlan := &admin.LaunchPlan{
 		Id:   lpRequest.Id,
 		Spec: lpRequest.Spec,
 		Closure: &admin.LaunchPlanClosure{
@@ -95,12 +95,12 @@ func TestToLaunchPlanModelWithCronSchedule(t *testing.T) {
 	})
 }
 
-func testLaunchPlanWithCronInternal(t *testing.T, lpRequest admin.LaunchPlanCreateRequest) {
+func testLaunchPlanWithCronInternal(t *testing.T, lpRequest *admin.LaunchPlanCreateRequest) {
 	lpRequest.Spec.DefaultInputs = expectedInputs
 	workflowID := uint(11)
 	launchPlanDigest := []byte("launch plan")
 
-	launchPlan := admin.LaunchPlan{
+	launchPlan := &admin.LaunchPlan{
 		Id:   lpRequest.Id,
 		Spec: lpRequest.Spec,
 		Closure: &admin.LaunchPlanClosure{
@@ -136,7 +136,7 @@ func TestToLaunchPlanModelWithFixedRateSchedule(t *testing.T) {
 	workflowID := uint(11)
 	launchPlanDigest := []byte("launch plan")
 
-	launchPlan := admin.LaunchPlan{
+	launchPlan := &admin.LaunchPlan{
 		Id:   lpRequest.Id,
 		Spec: lpRequest.Spec,
 		Closure: &admin.LaunchPlanClosure{

--- a/flyteadmin/pkg/repositories/transformers/node_execution_event.go
+++ b/flyteadmin/pkg/repositories/transformers/node_execution_event.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Transforms a NodeExecutionEventRequest to a NodeExecutionEvent model
-func CreateNodeExecutionEventModel(request admin.NodeExecutionEventRequest) (*models.NodeExecutionEvent, error) {
+func CreateNodeExecutionEventModel(request *admin.NodeExecutionEventRequest) (*models.NodeExecutionEvent, error) {
 	occurredAt, err := ptypes.Timestamp(request.Event.OccurredAt)
 	if err != nil {
 		return nil, errors.NewFlyteAdminErrorf(codes.Internal, "failed to marshal occurred at timestamp")

--- a/flyteadmin/pkg/repositories/transformers/node_execution_event_test.go
+++ b/flyteadmin/pkg/repositories/transformers/node_execution_event_test.go
@@ -16,7 +16,7 @@ import (
 func TestCreateNodeExecutionEventModel(t *testing.T) {
 	occurredAt := time.Now().UTC()
 	occurredAtProto, _ := ptypes.TimestampProto(occurredAt)
-	request := admin.NodeExecutionEventRequest{
+	request := &admin.NodeExecutionEventRequest{
 		RequestId: "request id",
 		Event: &event.NodeExecutionEvent{
 			Id: &core.NodeExecutionIdentifier{

--- a/flyteadmin/pkg/repositories/transformers/project.go
+++ b/flyteadmin/pkg/repositories/transformers/project.go
@@ -36,13 +36,13 @@ func CreateProjectModel(project *admin.Project) models.Project {
 	}
 }
 
-func FromProjectModel(projectModel models.Project, domains []*admin.Domain) admin.Project {
+func FromProjectModel(projectModel models.Project, domains []*admin.Domain) *admin.Project {
 	projectDeserialized := &admin.Project{}
 	err := proto.Unmarshal(projectModel.Labels, projectDeserialized)
 	if err != nil {
-		return admin.Project{}
+		return &admin.Project{}
 	}
-	project := admin.Project{
+	project := &admin.Project{
 		Id:          projectModel.Identifier,
 		Name:        projectModel.Name,
 		Description: projectModel.Description,
@@ -57,7 +57,7 @@ func FromProjectModels(projectModels []models.Project, domains []*admin.Domain) 
 	projects := make([]*admin.Project, len(projectModels))
 	for index, projectModel := range projectModels {
 		project := FromProjectModel(projectModel, domains)
-		projects[index] = &project
+		projects[index] = project
 	}
 	return projects
 }

--- a/flyteadmin/pkg/repositories/transformers/project_test.go
+++ b/flyteadmin/pkg/repositories/transformers/project_test.go
@@ -63,7 +63,7 @@ func TestFromProjectModel(t *testing.T) {
 		Description: "proj_description",
 		Domains:     domains,
 		State:       admin.Project_ACTIVE,
-	}, &project))
+	}, project))
 }
 
 func TestFromProjectModels(t *testing.T) {

--- a/flyteadmin/pkg/repositories/transformers/resource.go
+++ b/flyteadmin/pkg/repositories/transformers/resource.go
@@ -13,7 +13,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
-func WorkflowAttributesToResourceModel(attributes admin.WorkflowAttributes, resource admin.MatchableResource) (models.Resource, error) {
+func WorkflowAttributesToResourceModel(attributes *admin.WorkflowAttributes, resource admin.MatchableResource) (models.Resource, error) {
 	attributeBytes, err := proto.Marshal(attributes.MatchingAttributes)
 	if err != nil {
 		return models.Resource{}, err
@@ -28,7 +28,7 @@ func WorkflowAttributesToResourceModel(attributes admin.WorkflowAttributes, reso
 	}, nil
 }
 
-func mergeUpdatePluginOverrides(existingAttributes admin.MatchingAttributes,
+func mergeUpdatePluginOverrides(existingAttributes *admin.MatchingAttributes,
 	newMatchingAttributes *admin.MatchingAttributes) *admin.MatchingAttributes {
 	taskPluginOverrides := make(map[string]*admin.PluginOverride)
 	if existingAttributes.GetPluginOverrides() != nil && len(existingAttributes.GetPluginOverrides().Overrides) > 0 {
@@ -60,8 +60,8 @@ func MergeUpdateWorkflowAttributes(ctx context.Context, model models.Resource, r
 	resourceID *repoInterfaces.ResourceID, workflowAttributes *admin.WorkflowAttributes) (models.Resource, error) {
 	switch resource {
 	case admin.MatchableResource_PLUGIN_OVERRIDE:
-		var existingAttributes admin.MatchingAttributes
-		err := proto.Unmarshal(model.Attributes, &existingAttributes)
+		existingAttributes := &admin.MatchingAttributes{}
+		err := proto.Unmarshal(model.Attributes, existingAttributes)
 		if err != nil {
 			return models.Resource{}, errors.NewFlyteAdminErrorf(codes.Internal,
 				"Unable to unmarshal existing resource attributes for [%+v] with err: %v", resourceID, err)
@@ -98,7 +98,7 @@ func FromResourceModelToWorkflowAttributes(model models.Resource) (admin.Workflo
 	}, nil
 }
 
-func ProjectDomainAttributesToResourceModel(attributes admin.ProjectDomainAttributes, resource admin.MatchableResource) (models.Resource, error) {
+func ProjectDomainAttributesToResourceModel(attributes *admin.ProjectDomainAttributes, resource admin.MatchableResource) (models.Resource, error) {
 	attributeBytes, err := proto.Marshal(attributes.MatchingAttributes)
 	if err != nil {
 		return models.Resource{}, err
@@ -112,7 +112,7 @@ func ProjectDomainAttributesToResourceModel(attributes admin.ProjectDomainAttrib
 	}, nil
 }
 
-func ProjectAttributesToResourceModel(attributes admin.ProjectAttributes, resource admin.MatchableResource) (models.Resource, error) {
+func ProjectAttributesToResourceModel(attributes *admin.ProjectAttributes, resource admin.MatchableResource) (models.Resource, error) {
 	attributeBytes, err := proto.Marshal(attributes.MatchingAttributes)
 	if err != nil {
 		return models.Resource{}, err
@@ -131,8 +131,8 @@ func MergeUpdatePluginAttributes(ctx context.Context, model models.Resource, res
 	resourceID *repoInterfaces.ResourceID, matchingAttributes *admin.MatchingAttributes) (models.Resource, error) {
 	switch resource {
 	case admin.MatchableResource_PLUGIN_OVERRIDE:
-		var existingAttributes admin.MatchingAttributes
-		err := proto.Unmarshal(model.Attributes, &existingAttributes)
+		existingAttributes := &admin.MatchingAttributes{}
+		err := proto.Unmarshal(model.Attributes, existingAttributes)
 		if err != nil {
 			return models.Resource{}, errors.NewFlyteAdminErrorf(codes.Internal,
 				"Unable to unmarshal existing resource attributes for [%+v] with err: %v", resourceID, err)

--- a/flyteadmin/pkg/repositories/transformers/resource_test.go
+++ b/flyteadmin/pkg/repositories/transformers/resource_test.go
@@ -29,7 +29,7 @@ var matchingClusterResourceAttributes = &admin.MatchingAttributes{
 	},
 }
 
-var workflowAttributes = admin.WorkflowAttributes{
+var workflowAttributes = &admin.WorkflowAttributes{
 	Project:            resourceProject,
 	Domain:             resourceDomain,
 	Workflow:           resourceWorkflow,
@@ -48,7 +48,7 @@ var matchingExecutionQueueAttributes = &admin.MatchingAttributes{
 	},
 }
 
-var projectDomainAttributes = admin.ProjectDomainAttributes{
+var projectDomainAttributes = &admin.ProjectDomainAttributes{
 	Project:            resourceProject,
 	Domain:             resourceDomain,
 	MatchingAttributes: matchingExecutionQueueAttributes,
@@ -135,7 +135,7 @@ func TestFromProjectDomainAttributesModel(t *testing.T) {
 	}
 	unmarshalledAttributes, err := FromResourceModelToProjectDomainAttributes(model)
 	assert.Nil(t, err)
-	assert.True(t, proto.Equal(&projectDomainAttributes, &unmarshalledAttributes))
+	assert.True(t, proto.Equal(projectDomainAttributes, &unmarshalledAttributes))
 }
 
 func TestFromProjectDomainAttributesModel_InvalidResourceAttributes(t *testing.T) {
@@ -233,7 +233,7 @@ func TestFromWorkflowAttributesModel(t *testing.T) {
 	}
 	unmarshalledAttributes, err := FromResourceModelToWorkflowAttributes(model)
 	assert.Nil(t, err)
-	assert.True(t, proto.Equal(&workflowAttributes, &unmarshalledAttributes))
+	assert.True(t, proto.Equal(workflowAttributes, &unmarshalledAttributes))
 }
 
 func TestFromWorkflowAttributesModel_InvalidResourceAttributes(t *testing.T) {
@@ -250,7 +250,7 @@ func TestFromWorkflowAttributesModel_InvalidResourceAttributes(t *testing.T) {
 }
 
 func TestProjectAttributesToResourceModel(t *testing.T) {
-	pa := admin.ProjectAttributes{
+	pa := &admin.ProjectAttributes{
 		Project:            resourceProject,
 		MatchingAttributes: matchingClusterResourceAttributes,
 	}

--- a/flyteadmin/pkg/repositories/transformers/signal.go
+++ b/flyteadmin/pkg/repositories/transformers/signal.go
@@ -67,8 +67,8 @@ func initWorkflowExecutionIdentifier(id *core.WorkflowExecutionIdentifier) *core
 	return id
 }
 
-func FromSignalModel(signalModel models.Signal) (admin.Signal, error) {
-	signal := admin.Signal{}
+func FromSignalModel(signalModel models.Signal) (*admin.Signal, error) {
+	signal := &admin.Signal{}
 
 	var executionID *core.WorkflowExecutionIdentifier
 	if len(signalModel.SignalKey.ExecutionKey.Project) > 0 {
@@ -102,7 +102,7 @@ func FromSignalModel(signalModel models.Signal) (admin.Signal, error) {
 		var typeDeserialized core.LiteralType
 		err := proto.Unmarshal(signalModel.Type, &typeDeserialized)
 		if err != nil {
-			return admin.Signal{}, errors.NewFlyteAdminError(codes.Internal, "failed to unmarshal signal type")
+			return &admin.Signal{}, errors.NewFlyteAdminError(codes.Internal, "failed to unmarshal signal type")
 		}
 		signal.Type = &typeDeserialized
 	}
@@ -111,7 +111,7 @@ func FromSignalModel(signalModel models.Signal) (admin.Signal, error) {
 		var valueDeserialized core.Literal
 		err := proto.Unmarshal(signalModel.Value, &valueDeserialized)
 		if err != nil {
-			return admin.Signal{}, errors.NewFlyteAdminError(codes.Internal, "failed to unmarshal signal value")
+			return &admin.Signal{}, errors.NewFlyteAdminError(codes.Internal, "failed to unmarshal signal value")
 		}
 		signal.Value = &valueDeserialized
 	}
@@ -126,7 +126,7 @@ func FromSignalModels(signalModels []models.Signal) ([]*admin.Signal, error) {
 		if err != nil {
 			return nil, err
 		}
-		signals[idx] = &signal
+		signals[idx] = signal
 	}
 	return signals, nil
 }

--- a/flyteadmin/pkg/repositories/transformers/signal_test.go
+++ b/flyteadmin/pkg/repositories/transformers/signal_test.go
@@ -58,12 +58,12 @@ func TestCreateSignalModel(t *testing.T) {
 	tests := []struct {
 		name  string
 		model models.Signal
-		proto admin.Signal
+		proto *admin.Signal
 	}{
 		{
 			name:  "Empty",
 			model: models.Signal{},
-			proto: admin.Signal{},
+			proto: &admin.Signal{},
 		},
 		{
 			name: "Full",
@@ -72,7 +72,7 @@ func TestCreateSignalModel(t *testing.T) {
 				Type:      booleanTypeBytes,
 				Value:     booleanValueBytes,
 			},
-			proto: admin.Signal{
+			proto: &admin.Signal{
 				Id:    &signalID,
 				Type:  &booleanType,
 				Value: &booleanValue,
@@ -97,12 +97,12 @@ func TestFromSignalModel(t *testing.T) {
 	tests := []struct {
 		name  string
 		model models.Signal
-		proto admin.Signal
+		proto *admin.Signal
 	}{
 		{
 			name:  "Empty",
 			model: models.Signal{},
-			proto: admin.Signal{},
+			proto: &admin.Signal{},
 		},
 		{
 			name: "Full",
@@ -111,7 +111,7 @@ func TestFromSignalModel(t *testing.T) {
 				Type:      booleanTypeBytes,
 				Value:     booleanValueBytes,
 			},
-			proto: admin.Signal{
+			proto: &admin.Signal{
 				Id:    &signalID,
 				Type:  &booleanType,
 				Value: &booleanValue,
@@ -124,7 +124,7 @@ func TestFromSignalModel(t *testing.T) {
 			signal, err := FromSignalModel(test.model)
 			assert.NoError(t, err)
 
-			assert.True(t, proto.Equal(&test.proto, &signal))
+			assert.True(t, proto.Equal(test.proto, signal))
 		})
 	}
 }

--- a/flyteadmin/pkg/repositories/transformers/task.go
+++ b/flyteadmin/pkg/repositories/transformers/task.go
@@ -14,10 +14,10 @@ import (
 
 // Transforms a TaskCreateRequest to a task model
 func CreateTaskModel(
-	request admin.TaskCreateRequest,
-	taskClosure admin.TaskClosure,
+	request *admin.TaskCreateRequest,
+	taskClosure *admin.TaskClosure,
 	digest []byte) (models.Task, error) {
-	closureBytes, err := proto.Marshal(&taskClosure)
+	closureBytes, err := proto.Marshal(taskClosure)
 	if err != nil {
 		return models.Task{}, errors.NewFlyteAdminError(codes.Internal, "Failed to serialize task closure")
 	}

--- a/flyteadmin/pkg/repositories/transformers/task_test.go
+++ b/flyteadmin/pkg/repositories/transformers/task_test.go
@@ -18,7 +18,7 @@ var taskDigest = []byte("task digest")
 
 func TestCreateTask(t *testing.T) {
 	request := testutils.GetValidTaskRequest()
-	task, err := CreateTaskModel(request, *testutils.GetTaskClosure(), taskDigest)
+	task, err := CreateTaskModel(request, testutils.GetTaskClosure(), taskDigest)
 	assert.NoError(t, err)
 	assert.Equal(t, "project", task.Project)
 	assert.Equal(t, "domain", task.Domain)

--- a/flyteadmin/pkg/repositories/transformers/workflow.go
+++ b/flyteadmin/pkg/repositories/transformers/workflow.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Transforms a WorkflowCreateRequest to a workflow model
-func CreateWorkflowModel(request admin.WorkflowCreateRequest, remoteClosureIdentifier string,
+func CreateWorkflowModel(request *admin.WorkflowCreateRequest, remoteClosureIdentifier string,
 	digest []byte) (models.Workflow, error) {
 	var typedInterface []byte
 	if request.Spec != nil && request.Spec.Template != nil && request.Spec.Template.Interface != nil {

--- a/flyteadmin/pkg/rpc/adminservice/attributes.go
+++ b/flyteadmin/pkg/rpc/adminservice/attributes.go
@@ -3,22 +3,16 @@ package adminservice
 import (
 	"context"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/flyteorg/flyte/flyteadmin/pkg/rpc/adminservice/util"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
 func (m *AdminService) UpdateWorkflowAttributes(ctx context.Context, request *admin.WorkflowAttributesUpdateRequest) (
 	*admin.WorkflowAttributesUpdateResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.WorkflowAttributesUpdateResponse
 	var err error
 	m.Metrics.workflowAttributesEndpointMetrics.update.Time(func() {
-		response, err = m.ResourceManager.UpdateWorkflowAttributes(ctx, *request)
+		response, err = m.ResourceManager.UpdateWorkflowAttributes(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowAttributesEndpointMetrics.update)
@@ -29,13 +23,10 @@ func (m *AdminService) UpdateWorkflowAttributes(ctx context.Context, request *ad
 
 func (m *AdminService) GetWorkflowAttributes(ctx context.Context, request *admin.WorkflowAttributesGetRequest) (
 	*admin.WorkflowAttributesGetResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.WorkflowAttributesGetResponse
 	var err error
 	m.Metrics.workflowAttributesEndpointMetrics.get.Time(func() {
-		response, err = m.ResourceManager.GetWorkflowAttributes(ctx, *request)
+		response, err = m.ResourceManager.GetWorkflowAttributes(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowAttributesEndpointMetrics.get)
@@ -46,13 +37,10 @@ func (m *AdminService) GetWorkflowAttributes(ctx context.Context, request *admin
 
 func (m *AdminService) DeleteWorkflowAttributes(ctx context.Context, request *admin.WorkflowAttributesDeleteRequest) (
 	*admin.WorkflowAttributesDeleteResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.WorkflowAttributesDeleteResponse
 	var err error
 	m.Metrics.workflowAttributesEndpointMetrics.delete.Time(func() {
-		response, err = m.ResourceManager.DeleteWorkflowAttributes(ctx, *request)
+		response, err = m.ResourceManager.DeleteWorkflowAttributes(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowAttributesEndpointMetrics.delete)
@@ -63,13 +51,10 @@ func (m *AdminService) DeleteWorkflowAttributes(ctx context.Context, request *ad
 
 func (m *AdminService) UpdateProjectDomainAttributes(ctx context.Context, request *admin.ProjectDomainAttributesUpdateRequest) (
 	*admin.ProjectDomainAttributesUpdateResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ProjectDomainAttributesUpdateResponse
 	var err error
 	m.Metrics.projectDomainAttributesEndpointMetrics.update.Time(func() {
-		response, err = m.ResourceManager.UpdateProjectDomainAttributes(ctx, *request)
+		response, err = m.ResourceManager.UpdateProjectDomainAttributes(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.projectDomainAttributesEndpointMetrics.update)
@@ -80,13 +65,10 @@ func (m *AdminService) UpdateProjectDomainAttributes(ctx context.Context, reques
 
 func (m *AdminService) GetProjectDomainAttributes(ctx context.Context, request *admin.ProjectDomainAttributesGetRequest) (
 	*admin.ProjectDomainAttributesGetResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ProjectDomainAttributesGetResponse
 	var err error
 	m.Metrics.workflowAttributesEndpointMetrics.get.Time(func() {
-		response, err = m.ResourceManager.GetProjectDomainAttributes(ctx, *request)
+		response, err = m.ResourceManager.GetProjectDomainAttributes(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowAttributesEndpointMetrics.get)
@@ -97,13 +79,10 @@ func (m *AdminService) GetProjectDomainAttributes(ctx context.Context, request *
 
 func (m *AdminService) DeleteProjectDomainAttributes(ctx context.Context, request *admin.ProjectDomainAttributesDeleteRequest) (
 	*admin.ProjectDomainAttributesDeleteResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ProjectDomainAttributesDeleteResponse
 	var err error
 	m.Metrics.workflowAttributesEndpointMetrics.delete.Time(func() {
-		response, err = m.ResourceManager.DeleteProjectDomainAttributes(ctx, *request)
+		response, err = m.ResourceManager.DeleteProjectDomainAttributes(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowAttributesEndpointMetrics.delete)
@@ -114,14 +93,10 @@ func (m *AdminService) DeleteProjectDomainAttributes(ctx context.Context, reques
 
 func (m *AdminService) UpdateProjectAttributes(ctx context.Context, request *admin.ProjectAttributesUpdateRequest) (
 	*admin.ProjectAttributesUpdateResponse, error) {
-
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ProjectAttributesUpdateResponse
 	var err error
 	m.Metrics.projectAttributesEndpointMetrics.get.Time(func() {
-		response, err = m.ResourceManager.UpdateProjectAttributes(ctx, *request)
+		response, err = m.ResourceManager.UpdateProjectAttributes(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.projectAttributesEndpointMetrics.get)
@@ -132,14 +107,10 @@ func (m *AdminService) UpdateProjectAttributes(ctx context.Context, request *adm
 
 func (m *AdminService) GetProjectAttributes(ctx context.Context, request *admin.ProjectAttributesGetRequest) (
 	*admin.ProjectAttributesGetResponse, error) {
-
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ProjectAttributesGetResponse
 	var err error
 	m.Metrics.projectAttributesEndpointMetrics.get.Time(func() {
-		response, err = m.ResourceManager.GetProjectAttributes(ctx, *request)
+		response, err = m.ResourceManager.GetProjectAttributes(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.projectAttributesEndpointMetrics.get)
@@ -150,14 +121,10 @@ func (m *AdminService) GetProjectAttributes(ctx context.Context, request *admin.
 
 func (m *AdminService) DeleteProjectAttributes(ctx context.Context, request *admin.ProjectAttributesDeleteRequest) (
 	*admin.ProjectAttributesDeleteResponse, error) {
-
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ProjectAttributesDeleteResponse
 	var err error
 	m.Metrics.projectAttributesEndpointMetrics.delete.Time(func() {
-		response, err = m.ResourceManager.DeleteProjectAttributes(ctx, *request)
+		response, err = m.ResourceManager.DeleteProjectAttributes(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.projectAttributesEndpointMetrics.delete)
@@ -168,13 +135,10 @@ func (m *AdminService) DeleteProjectAttributes(ctx context.Context, request *adm
 
 func (m *AdminService) ListMatchableAttributes(ctx context.Context, request *admin.ListMatchableAttributesRequest) (
 	*admin.ListMatchableAttributesResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ListMatchableAttributesResponse
 	var err error
 	m.Metrics.matchableAttributesEndpointMetrics.list.Time(func() {
-		response, err = m.ResourceManager.ListAll(ctx, *request)
+		response, err = m.ResourceManager.ListAll(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.matchableAttributesEndpointMetrics.list)

--- a/flyteadmin/pkg/rpc/adminservice/description_entity.go
+++ b/flyteadmin/pkg/rpc/adminservice/description_entity.go
@@ -3,9 +3,6 @@ package adminservice
 import (
 	"context"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/flyteorg/flyte/flyteadmin/pkg/rpc/adminservice/util"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
@@ -13,9 +10,6 @@ import (
 )
 
 func (m *AdminService) GetDescriptionEntity(ctx context.Context, request *admin.ObjectGetRequest) (*admin.DescriptionEntity, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	// NOTE: When the Get HTTP endpoint is called the resource type is implicit (from the URL) so we must add it
 	// to the request.
 	if request.Id != nil && request.Id.ResourceType == core.ResourceType_UNSPECIFIED {
@@ -25,7 +19,7 @@ func (m *AdminService) GetDescriptionEntity(ctx context.Context, request *admin.
 	var response *admin.DescriptionEntity
 	var err error
 	m.Metrics.descriptionEntityMetrics.get.Time(func() {
-		response, err = m.DescriptionEntityManager.GetDescriptionEntity(ctx, *request)
+		response, err = m.DescriptionEntityManager.GetDescriptionEntity(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.descriptionEntityMetrics.get)
@@ -35,13 +29,10 @@ func (m *AdminService) GetDescriptionEntity(ctx context.Context, request *admin.
 }
 
 func (m *AdminService) ListDescriptionEntities(ctx context.Context, request *admin.DescriptionEntityListRequest) (*admin.DescriptionEntityList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.DescriptionEntityList
 	var err error
 	m.Metrics.descriptionEntityMetrics.list.Time(func() {
-		response, err = m.DescriptionEntityManager.ListDescriptionEntity(ctx, *request)
+		response, err = m.DescriptionEntityManager.ListDescriptionEntity(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.descriptionEntityMetrics.list)

--- a/flyteadmin/pkg/rpc/adminservice/execution.go
+++ b/flyteadmin/pkg/rpc/adminservice/execution.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"time"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/flyteorg/flyte/flyteadmin/pkg/rpc/adminservice/util"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
@@ -14,13 +11,10 @@ import (
 func (m *AdminService) CreateExecution(
 	ctx context.Context, request *admin.ExecutionCreateRequest) (*admin.ExecutionCreateResponse, error) {
 	requestedAt := time.Now()
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ExecutionCreateResponse
 	var err error
 	m.Metrics.executionEndpointMetrics.create.Time(func() {
-		response, err = m.ExecutionManager.CreateExecution(ctx, *request, requestedAt)
+		response, err = m.ExecutionManager.CreateExecution(ctx, request, requestedAt)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.executionEndpointMetrics.create)
@@ -32,13 +26,10 @@ func (m *AdminService) CreateExecution(
 func (m *AdminService) RelaunchExecution(
 	ctx context.Context, request *admin.ExecutionRelaunchRequest) (*admin.ExecutionCreateResponse, error) {
 	requestedAt := time.Now()
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ExecutionCreateResponse
 	var err error
 	m.Metrics.executionEndpointMetrics.relaunch.Time(func() {
-		response, err = m.ExecutionManager.RelaunchExecution(ctx, *request, requestedAt)
+		response, err = m.ExecutionManager.RelaunchExecution(ctx, request, requestedAt)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.executionEndpointMetrics.relaunch)
@@ -50,13 +41,10 @@ func (m *AdminService) RelaunchExecution(
 func (m *AdminService) RecoverExecution(
 	ctx context.Context, request *admin.ExecutionRecoverRequest) (*admin.ExecutionCreateResponse, error) {
 	requestedAt := time.Now()
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ExecutionCreateResponse
 	var err error
 	m.Metrics.executionEndpointMetrics.recover.Time(func() {
-		response, err = m.ExecutionManager.RecoverExecution(ctx, *request, requestedAt)
+		response, err = m.ExecutionManager.RecoverExecution(ctx, request, requestedAt)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.executionEndpointMetrics.relaunch)
@@ -67,13 +55,10 @@ func (m *AdminService) RecoverExecution(
 
 func (m *AdminService) CreateWorkflowEvent(
 	ctx context.Context, request *admin.WorkflowExecutionEventRequest) (*admin.WorkflowExecutionEventResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.WorkflowExecutionEventResponse
 	var err error
 	m.Metrics.executionEndpointMetrics.createEvent.Time(func() {
-		response, err = m.ExecutionManager.CreateWorkflowEvent(ctx, *request)
+		response, err = m.ExecutionManager.CreateWorkflowEvent(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.executionEndpointMetrics.createEvent)
@@ -85,13 +70,10 @@ func (m *AdminService) CreateWorkflowEvent(
 
 func (m *AdminService) GetExecution(
 	ctx context.Context, request *admin.WorkflowExecutionGetRequest) (*admin.Execution, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.Execution
 	var err error
 	m.Metrics.executionEndpointMetrics.get.Time(func() {
-		response, err = m.ExecutionManager.GetExecution(ctx, *request)
+		response, err = m.ExecutionManager.GetExecution(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.executionEndpointMetrics.get)
@@ -103,13 +85,10 @@ func (m *AdminService) GetExecution(
 func (m *AdminService) UpdateExecution(
 	ctx context.Context, request *admin.ExecutionUpdateRequest) (*admin.ExecutionUpdateResponse, error) {
 	requestedAt := time.Now()
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ExecutionUpdateResponse
 	var err error
 	m.Metrics.executionEndpointMetrics.update.Time(func() {
-		response, err = m.ExecutionManager.UpdateExecution(ctx, *request, requestedAt)
+		response, err = m.ExecutionManager.UpdateExecution(ctx, request, requestedAt)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.executionEndpointMetrics.update)
@@ -120,13 +99,10 @@ func (m *AdminService) UpdateExecution(
 
 func (m *AdminService) GetExecutionData(
 	ctx context.Context, request *admin.WorkflowExecutionGetDataRequest) (*admin.WorkflowExecutionGetDataResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.WorkflowExecutionGetDataResponse
 	var err error
 	m.Metrics.executionEndpointMetrics.getData.Time(func() {
-		response, err = m.ExecutionManager.GetExecutionData(ctx, *request)
+		response, err = m.ExecutionManager.GetExecutionData(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.executionEndpointMetrics.getData)
@@ -137,13 +113,10 @@ func (m *AdminService) GetExecutionData(
 
 func (m *AdminService) GetExecutionMetrics(
 	ctx context.Context, request *admin.WorkflowExecutionGetMetricsRequest) (*admin.WorkflowExecutionGetMetricsResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.WorkflowExecutionGetMetricsResponse
 	var err error
 	m.Metrics.executionEndpointMetrics.getMetrics.Time(func() {
-		response, err = m.MetricsManager.GetExecutionMetrics(ctx, *request)
+		response, err = m.MetricsManager.GetExecutionMetrics(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.executionEndpointMetrics.getMetrics)
@@ -154,13 +127,10 @@ func (m *AdminService) GetExecutionMetrics(
 
 func (m *AdminService) ListExecutions(
 	ctx context.Context, request *admin.ResourceListRequest) (*admin.ExecutionList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ExecutionList
 	var err error
 	m.Metrics.executionEndpointMetrics.list.Time(func() {
-		response, err = m.ExecutionManager.ListExecutions(ctx, *request)
+		response, err = m.ExecutionManager.ListExecutions(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.executionEndpointMetrics.list)
@@ -171,13 +141,10 @@ func (m *AdminService) ListExecutions(
 
 func (m *AdminService) TerminateExecution(
 	ctx context.Context, request *admin.ExecutionTerminateRequest) (*admin.ExecutionTerminateResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ExecutionTerminateResponse
 	var err error
 	m.Metrics.executionEndpointMetrics.terminate.Time(func() {
-		response, err = m.ExecutionManager.TerminateExecution(ctx, *request)
+		response, err = m.ExecutionManager.TerminateExecution(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.executionEndpointMetrics.terminate)

--- a/flyteadmin/pkg/rpc/adminservice/launch_plan.go
+++ b/flyteadmin/pkg/rpc/adminservice/launch_plan.go
@@ -3,9 +3,6 @@ package adminservice
 import (
 	"context"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/flyteorg/flyte/flyteadmin/pkg/rpc/adminservice/util"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
@@ -14,13 +11,10 @@ import (
 
 func (m *AdminService) CreateLaunchPlan(
 	ctx context.Context, request *admin.LaunchPlanCreateRequest) (*admin.LaunchPlanCreateResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.LaunchPlanCreateResponse
 	var err error
 	m.Metrics.launchPlanEndpointMetrics.create.Time(func() {
-		response, err = m.LaunchPlanManager.CreateLaunchPlan(ctx, *request)
+		response, err = m.LaunchPlanManager.CreateLaunchPlan(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.launchPlanEndpointMetrics.create)
@@ -30,9 +24,6 @@ func (m *AdminService) CreateLaunchPlan(
 }
 
 func (m *AdminService) GetLaunchPlan(ctx context.Context, request *admin.ObjectGetRequest) (*admin.LaunchPlan, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	// NOTE: When the Get HTTP endpoint is called the resource type is implicit (from the URL) so we must add it
 	// to the request.
 	if request.Id != nil && request.Id.ResourceType == core.ResourceType_UNSPECIFIED {
@@ -42,7 +33,7 @@ func (m *AdminService) GetLaunchPlan(ctx context.Context, request *admin.ObjectG
 	var response *admin.LaunchPlan
 	var err error
 	m.Metrics.launchPlanEndpointMetrics.get.Time(func() {
-		response, err = m.LaunchPlanManager.GetLaunchPlan(ctx, *request)
+		response, err = m.LaunchPlanManager.GetLaunchPlan(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.launchPlanEndpointMetrics.get)
@@ -53,13 +44,10 @@ func (m *AdminService) GetLaunchPlan(ctx context.Context, request *admin.ObjectG
 }
 
 func (m *AdminService) GetActiveLaunchPlan(ctx context.Context, request *admin.ActiveLaunchPlanRequest) (*admin.LaunchPlan, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.LaunchPlan
 	var err error
 	m.Metrics.launchPlanEndpointMetrics.getActive.Time(func() {
-		response, err = m.LaunchPlanManager.GetActiveLaunchPlan(ctx, *request)
+		response, err = m.LaunchPlanManager.GetActiveLaunchPlan(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.launchPlanEndpointMetrics.getActive)
@@ -70,9 +58,6 @@ func (m *AdminService) GetActiveLaunchPlan(ctx context.Context, request *admin.A
 
 func (m *AdminService) UpdateLaunchPlan(ctx context.Context, request *admin.LaunchPlanUpdateRequest) (
 	*admin.LaunchPlanUpdateResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	// NOTE: When the Get HTTP endpoint is called the resource type is implicit (from the URL) so we must add it
 	// to the request.
 	if request.Id != nil && request.Id.ResourceType == core.ResourceType_UNSPECIFIED {
@@ -82,7 +67,7 @@ func (m *AdminService) UpdateLaunchPlan(ctx context.Context, request *admin.Laun
 	var response *admin.LaunchPlanUpdateResponse
 	var err error
 	m.Metrics.launchPlanEndpointMetrics.update.Time(func() {
-		response, err = m.LaunchPlanManager.UpdateLaunchPlan(ctx, *request)
+		response, err = m.LaunchPlanManager.UpdateLaunchPlan(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.launchPlanEndpointMetrics.update)
@@ -93,13 +78,10 @@ func (m *AdminService) UpdateLaunchPlan(ctx context.Context, request *admin.Laun
 
 func (m *AdminService) ListLaunchPlans(ctx context.Context, request *admin.ResourceListRequest) (
 	*admin.LaunchPlanList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Empty request.  Please rephrase.")
-	}
 	var response *admin.LaunchPlanList
 	var err error
 	m.Metrics.launchPlanEndpointMetrics.list.Time(func() {
-		response, err = m.LaunchPlanManager.ListLaunchPlans(ctx, *request)
+		response, err = m.LaunchPlanManager.ListLaunchPlans(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.launchPlanEndpointMetrics.list)
@@ -111,13 +93,10 @@ func (m *AdminService) ListLaunchPlans(ctx context.Context, request *admin.Resou
 
 func (m *AdminService) ListActiveLaunchPlans(ctx context.Context, request *admin.ActiveLaunchPlanListRequest) (
 	*admin.LaunchPlanList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Empty request.  Please rephrase.")
-	}
 	var response *admin.LaunchPlanList
 	var err error
 	m.Metrics.launchPlanEndpointMetrics.listActive.Time(func() {
-		response, err = m.LaunchPlanManager.ListActiveLaunchPlans(ctx, *request)
+		response, err = m.LaunchPlanManager.ListActiveLaunchPlans(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.launchPlanEndpointMetrics.listActive)
@@ -129,14 +108,10 @@ func (m *AdminService) ListActiveLaunchPlans(ctx context.Context, request *admin
 
 func (m *AdminService) ListLaunchPlanIds(ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (
 	*admin.NamedEntityIdentifierList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Empty request.  Please rephrase.")
-	}
-
 	var response *admin.NamedEntityIdentifierList
 	var err error
 	m.Metrics.launchPlanEndpointMetrics.listIds.Time(func() {
-		response, err = m.LaunchPlanManager.ListLaunchPlanIds(ctx, *request)
+		response, err = m.LaunchPlanManager.ListLaunchPlanIds(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.launchPlanEndpointMetrics.listIds)

--- a/flyteadmin/pkg/rpc/adminservice/named_entity.go
+++ b/flyteadmin/pkg/rpc/adminservice/named_entity.go
@@ -3,22 +3,15 @@ package adminservice
 import (
 	"context"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/flyteorg/flyte/flyteadmin/pkg/rpc/adminservice/util"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
 func (m *AdminService) GetNamedEntity(ctx context.Context, request *admin.NamedEntityGetRequest) (*admin.NamedEntity, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
-
 	var response *admin.NamedEntity
 	var err error
 	m.Metrics.namedEntityEndpointMetrics.get.Time(func() {
-		response, err = m.NamedEntityManager.GetNamedEntity(ctx, *request)
+		response, err = m.NamedEntityManager.GetNamedEntity(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.namedEntityEndpointMetrics.get)
@@ -30,14 +23,10 @@ func (m *AdminService) GetNamedEntity(ctx context.Context, request *admin.NamedE
 
 func (m *AdminService) UpdateNamedEntity(ctx context.Context, request *admin.NamedEntityUpdateRequest) (
 	*admin.NamedEntityUpdateResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
-
 	var response *admin.NamedEntityUpdateResponse
 	var err error
 	m.Metrics.namedEntityEndpointMetrics.update.Time(func() {
-		response, err = m.NamedEntityManager.UpdateNamedEntity(ctx, *request)
+		response, err = m.NamedEntityManager.UpdateNamedEntity(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.namedEntityEndpointMetrics.update)
@@ -48,14 +37,10 @@ func (m *AdminService) UpdateNamedEntity(ctx context.Context, request *admin.Nam
 
 func (m *AdminService) ListNamedEntities(ctx context.Context, request *admin.NamedEntityListRequest) (
 	*admin.NamedEntityList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
-
 	var response *admin.NamedEntityList
 	var err error
 	m.Metrics.namedEntityEndpointMetrics.list.Time(func() {
-		response, err = m.NamedEntityManager.ListNamedEntities(ctx, *request)
+		response, err = m.NamedEntityManager.ListNamedEntities(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.namedEntityEndpointMetrics.list)

--- a/flyteadmin/pkg/rpc/adminservice/node_execution.go
+++ b/flyteadmin/pkg/rpc/adminservice/node_execution.go
@@ -3,9 +3,6 @@ package adminservice
 import (
 	"context"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/flyteorg/flyte/flyteadmin/pkg/rpc/adminservice/util"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
@@ -14,13 +11,10 @@ import (
 
 func (m *AdminService) CreateNodeEvent(
 	ctx context.Context, request *admin.NodeExecutionEventRequest) (*admin.NodeExecutionEventResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.NodeExecutionEventResponse
 	var err error
 	m.Metrics.nodeExecutionEndpointMetrics.createEvent.Time(func() {
-		response, err = m.NodeExecutionManager.CreateNodeEvent(ctx, *request)
+		response, err = m.NodeExecutionManager.CreateNodeEvent(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.nodeExecutionEndpointMetrics.createEvent)
@@ -31,13 +25,10 @@ func (m *AdminService) CreateNodeEvent(
 
 func (m *AdminService) GetNodeExecution(
 	ctx context.Context, request *admin.NodeExecutionGetRequest) (*admin.NodeExecution, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.NodeExecution
 	var err error
 	m.Metrics.nodeExecutionEndpointMetrics.get.Time(func() {
-		response, err = m.NodeExecutionManager.GetNodeExecution(ctx, *request)
+		response, err = m.NodeExecutionManager.GetNodeExecution(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.nodeExecutionEndpointMetrics.get)
@@ -47,14 +38,10 @@ func (m *AdminService) GetNodeExecution(
 }
 
 func (m *AdminService) GetDynamicNodeWorkflow(ctx context.Context, request *admin.GetDynamicNodeWorkflowRequest) (*admin.DynamicNodeWorkflowResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
-
 	var response *admin.DynamicNodeWorkflowResponse
 	var err error
 	m.Metrics.nodeExecutionEndpointMetrics.getDynamicNodeWorkflow.Time(func() {
-		response, err = m.NodeExecutionManager.GetDynamicNodeWorkflow(ctx, *request)
+		response, err = m.NodeExecutionManager.GetDynamicNodeWorkflow(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowEndpointMetrics.get)
@@ -65,13 +52,10 @@ func (m *AdminService) GetDynamicNodeWorkflow(ctx context.Context, request *admi
 
 func (m *AdminService) ListNodeExecutions(
 	ctx context.Context, request *admin.NodeExecutionListRequest) (*admin.NodeExecutionList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.NodeExecutionList
 	var err error
 	m.Metrics.nodeExecutionEndpointMetrics.list.Time(func() {
-		response, err = m.NodeExecutionManager.ListNodeExecutions(ctx, *request)
+		response, err = m.NodeExecutionManager.ListNodeExecutions(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.nodeExecutionEndpointMetrics.list)
@@ -82,9 +66,6 @@ func (m *AdminService) ListNodeExecutions(
 
 func (m *AdminService) ListNodeExecutionsForTask(
 	ctx context.Context, request *admin.NodeExecutionForTaskListRequest) (*admin.NodeExecutionList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	// NOTE: When the Get HTTP endpoint is called the resource type is implicit (from the URL) so we must add it
 	// to the request.
 	if request.TaskExecutionId != nil && request.TaskExecutionId.TaskId != nil &&
@@ -95,7 +76,7 @@ func (m *AdminService) ListNodeExecutionsForTask(
 	var response *admin.NodeExecutionList
 	var err error
 	m.Metrics.nodeExecutionEndpointMetrics.listChildren.Time(func() {
-		response, err = m.NodeExecutionManager.ListNodeExecutionsForTask(ctx, *request)
+		response, err = m.NodeExecutionManager.ListNodeExecutionsForTask(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.nodeExecutionEndpointMetrics.listChildren)
@@ -106,13 +87,10 @@ func (m *AdminService) ListNodeExecutionsForTask(
 
 func (m *AdminService) GetNodeExecutionData(
 	ctx context.Context, request *admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.NodeExecutionGetDataResponse
 	var err error
 	m.Metrics.nodeExecutionEndpointMetrics.getData.Time(func() {
-		response, err = m.NodeExecutionManager.GetNodeExecutionData(ctx, *request)
+		response, err = m.NodeExecutionManager.GetNodeExecutionData(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.nodeExecutionEndpointMetrics.getData)

--- a/flyteadmin/pkg/rpc/adminservice/project.go
+++ b/flyteadmin/pkg/rpc/adminservice/project.go
@@ -3,22 +3,16 @@ package adminservice
 import (
 	"context"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/flyteorg/flyte/flyteadmin/pkg/rpc/adminservice/util"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
 func (m *AdminService) RegisterProject(ctx context.Context, request *admin.ProjectRegisterRequest) (
 	*admin.ProjectRegisterResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ProjectRegisterResponse
 	var err error
 	m.Metrics.projectEndpointMetrics.register.Time(func() {
-		response, err = m.ProjectManager.CreateProject(ctx, *request)
+		response, err = m.ProjectManager.CreateProject(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.projectEndpointMetrics.register)
@@ -28,13 +22,10 @@ func (m *AdminService) RegisterProject(ctx context.Context, request *admin.Proje
 }
 
 func (m *AdminService) ListProjects(ctx context.Context, request *admin.ProjectListRequest) (*admin.Projects, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.Projects
 	var err error
 	m.Metrics.projectEndpointMetrics.list.Time(func() {
-		response, err = m.ProjectManager.ListProjects(ctx, *request)
+		response, err = m.ProjectManager.ListProjects(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.projectEndpointMetrics.list)
@@ -46,13 +37,10 @@ func (m *AdminService) ListProjects(ctx context.Context, request *admin.ProjectL
 
 func (m *AdminService) UpdateProject(ctx context.Context, request *admin.Project) (
 	*admin.ProjectUpdateResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.ProjectUpdateResponse
 	var err error
 	m.Metrics.projectEndpointMetrics.register.Time(func() {
-		response, err = m.ProjectManager.UpdateProject(ctx, *request)
+		response, err = m.ProjectManager.UpdateProject(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.projectEndpointMetrics.update)
@@ -62,13 +50,10 @@ func (m *AdminService) UpdateProject(ctx context.Context, request *admin.Project
 }
 
 func (m *AdminService) GetProject(ctx context.Context, request *admin.ProjectGetRequest) (*admin.Project, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.Project
 	var err error
 	m.Metrics.projectEndpointMetrics.get.Time(func() {
-		response, err = m.ProjectManager.GetProject(ctx, *request)
+		response, err = m.ProjectManager.GetProject(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.projectEndpointMetrics.get)
@@ -79,12 +64,9 @@ func (m *AdminService) GetProject(ctx context.Context, request *admin.ProjectGet
 }
 
 func (m *AdminService) GetDomains(ctx context.Context, request *admin.GetDomainRequest) (*admin.GetDomainsResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.GetDomainsResponse
 	m.Metrics.domainEndpointMetrics.get.Time(func() {
-		response = m.ProjectManager.GetDomains(ctx, *request)
+		response = m.ProjectManager.GetDomains(ctx, request)
 	})
 
 	m.Metrics.domainEndpointMetrics.get.Success()

--- a/flyteadmin/pkg/rpc/adminservice/task.go
+++ b/flyteadmin/pkg/rpc/adminservice/task.go
@@ -3,9 +3,6 @@ package adminservice
 import (
 	"context"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/flyteorg/flyte/flyteadmin/pkg/rpc/adminservice/util"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
@@ -15,13 +12,10 @@ import (
 func (m *AdminService) CreateTask(
 	ctx context.Context,
 	request *admin.TaskCreateRequest) (*admin.TaskCreateResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.TaskCreateResponse
 	var err error
 	m.Metrics.taskEndpointMetrics.create.Time(func() {
-		response, err = m.TaskManager.CreateTask(ctx, *request)
+		response, err = m.TaskManager.CreateTask(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.taskEndpointMetrics.create)
@@ -31,9 +25,6 @@ func (m *AdminService) CreateTask(
 }
 
 func (m *AdminService) GetTask(ctx context.Context, request *admin.ObjectGetRequest) (*admin.Task, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	// NOTE: When the Get HTTP endpoint is called the resource type is implicit (from the URL) so we must add it
 	// to the request.
 	if request.Id != nil && request.Id.ResourceType == core.ResourceType_UNSPECIFIED {
@@ -43,7 +34,7 @@ func (m *AdminService) GetTask(ctx context.Context, request *admin.ObjectGetRequ
 	var response *admin.Task
 	var err error
 	m.Metrics.taskEndpointMetrics.get.Time(func() {
-		response, err = m.TaskManager.GetTask(ctx, *request)
+		response, err = m.TaskManager.GetTask(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.taskEndpointMetrics.get)
@@ -54,13 +45,10 @@ func (m *AdminService) GetTask(ctx context.Context, request *admin.ObjectGetRequ
 
 func (m *AdminService) ListTaskIds(
 	ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (*admin.NamedEntityIdentifierList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.NamedEntityIdentifierList
 	var err error
 	m.Metrics.taskEndpointMetrics.listIds.Time(func() {
-		response, err = m.TaskManager.ListUniqueTaskIdentifiers(ctx, *request)
+		response, err = m.TaskManager.ListUniqueTaskIdentifiers(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.taskEndpointMetrics.listIds)
@@ -71,13 +59,10 @@ func (m *AdminService) ListTaskIds(
 }
 
 func (m *AdminService) ListTasks(ctx context.Context, request *admin.ResourceListRequest) (*admin.TaskList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.TaskList
 	var err error
 	m.Metrics.taskEndpointMetrics.list.Time(func() {
-		response, err = m.TaskManager.ListTasks(ctx, *request)
+		response, err = m.TaskManager.ListTasks(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.taskEndpointMetrics.list)

--- a/flyteadmin/pkg/rpc/adminservice/task_execution.go
+++ b/flyteadmin/pkg/rpc/adminservice/task_execution.go
@@ -3,9 +3,6 @@ package adminservice
 import (
 	"context"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/flyteorg/flyte/flyteadmin/pkg/manager/impl/validation"
 	"github.com/flyteorg/flyte/flyteadmin/pkg/rpc/adminservice/util"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
@@ -15,14 +12,10 @@ import (
 
 func (m *AdminService) CreateTaskEvent(
 	ctx context.Context, request *admin.TaskExecutionEventRequest) (*admin.TaskExecutionEventResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
-
 	var response *admin.TaskExecutionEventResponse
 	var err error
 	m.Metrics.taskExecutionEndpointMetrics.createEvent.Time(func() {
-		response, err = m.TaskExecutionManager.CreateTaskExecutionEvent(ctx, *request)
+		response, err = m.TaskExecutionManager.CreateTaskExecutionEvent(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.taskExecutionEndpointMetrics.createEvent)
@@ -33,9 +26,6 @@ func (m *AdminService) CreateTaskEvent(
 
 func (m *AdminService) GetTaskExecution(
 	ctx context.Context, request *admin.TaskExecutionGetRequest) (*admin.TaskExecution, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	// NOTE: When the Get HTTP endpoint is called the resource type is implicit (from the URL) so we must add it
 	// to the request.
 	if request.Id != nil && request.Id.TaskId != nil && request.Id.TaskId.ResourceType == core.ResourceType_UNSPECIFIED {
@@ -49,7 +39,7 @@ func (m *AdminService) GetTaskExecution(
 	var response *admin.TaskExecution
 	var err error
 	m.Metrics.taskExecutionEndpointMetrics.get.Time(func() {
-		response, err = m.TaskExecutionManager.GetTaskExecution(ctx, *request)
+		response, err = m.TaskExecutionManager.GetTaskExecution(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.taskExecutionEndpointMetrics.get)
@@ -60,17 +50,14 @@ func (m *AdminService) GetTaskExecution(
 
 func (m *AdminService) ListTaskExecutions(
 	ctx context.Context, request *admin.TaskExecutionListRequest) (*admin.TaskExecutionList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Nil request")
-	}
-	if err := validation.ValidateTaskExecutionListRequest(*request); err != nil {
+	if err := validation.ValidateTaskExecutionListRequest(request); err != nil {
 		return nil, err
 	}
 
 	var response *admin.TaskExecutionList
 	var err error
 	m.Metrics.taskExecutionEndpointMetrics.list.Time(func() {
-		response, err = m.TaskExecutionManager.ListTaskExecutions(ctx, *request)
+		response, err = m.TaskExecutionManager.ListTaskExecutions(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.taskExecutionEndpointMetrics.list)
@@ -81,9 +68,6 @@ func (m *AdminService) ListTaskExecutions(
 
 func (m *AdminService) GetTaskExecutionData(
 	ctx context.Context, request *admin.TaskExecutionGetDataRequest) (*admin.TaskExecutionGetDataResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	// NOTE: When the Get HTTP endpoint is called the resource type is implicit (from the URL) so we must add it
 	// to the request.
 	if request.Id != nil && request.Id.TaskId != nil && request.Id.TaskId.ResourceType == core.ResourceType_UNSPECIFIED {
@@ -93,7 +77,7 @@ func (m *AdminService) GetTaskExecutionData(
 	var response *admin.TaskExecutionGetDataResponse
 	var err error
 	m.Metrics.taskExecutionEndpointMetrics.getData.Time(func() {
-		response, err = m.TaskExecutionManager.GetTaskExecutionData(ctx, *request)
+		response, err = m.TaskExecutionManager.GetTaskExecutionData(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.taskExecutionEndpointMetrics.getData)

--- a/flyteadmin/pkg/rpc/adminservice/tests/execution_test.go
+++ b/flyteadmin/pkg/rpc/adminservice/tests/execution_test.go
@@ -33,7 +33,7 @@ func TestCreateExecutionHappyCase(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.SetCreateCallback(
 		func(ctx context.Context,
-			request admin.ExecutionCreateRequest, requestedAt time.Time) (*admin.ExecutionCreateResponse, error) {
+			request *admin.ExecutionCreateRequest, requestedAt time.Time) (*admin.ExecutionCreateResponse, error) {
 			return &admin.ExecutionCreateResponse{
 				Id: &core.WorkflowExecutionIdentifier{
 					Project: request.Project,
@@ -62,7 +62,7 @@ func TestCreateExecutionError(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.SetCreateCallback(
 		func(ctx context.Context,
-			request admin.ExecutionCreateRequest, requestedAt time.Time) (*admin.ExecutionCreateResponse, error) {
+			request *admin.ExecutionCreateRequest, requestedAt time.Time) (*admin.ExecutionCreateResponse, error) {
 			return nil, repoErrors.GetMissingEntityError("execution", &core.Identifier{
 				Project: request.Project,
 				Domain:  request.Domain,
@@ -90,7 +90,7 @@ func TestRelaunchExecutionHappyCase(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.SetRelaunchCallback(
 		func(ctx context.Context,
-			request admin.ExecutionRelaunchRequest, requestedAt time.Time) (*admin.ExecutionCreateResponse, error) {
+			request *admin.ExecutionRelaunchRequest, requestedAt time.Time) (*admin.ExecutionCreateResponse, error) {
 			return &admin.ExecutionCreateResponse{
 				Id: &core.WorkflowExecutionIdentifier{
 					Project: request.Id.Project,
@@ -123,7 +123,7 @@ func TestRelaunchExecutionError(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.SetRelaunchCallback(
 		func(ctx context.Context,
-			request admin.ExecutionRelaunchRequest, requestedAt time.Time) (*admin.ExecutionCreateResponse, error) {
+			request *admin.ExecutionRelaunchRequest, requestedAt time.Time) (*admin.ExecutionCreateResponse, error) {
 			return nil, repoErrors.GetMissingEntityError("execution", request.Id)
 		},
 	)
@@ -145,7 +145,7 @@ func TestRecoverExecutionHappyCase(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.RecoverExecutionFunc =
 		func(ctx context.Context,
-			request admin.ExecutionRecoverRequest, requestedAt time.Time) (*admin.ExecutionCreateResponse, error) {
+			request *admin.ExecutionRecoverRequest, requestedAt time.Time) (*admin.ExecutionCreateResponse, error) {
 			return &admin.ExecutionCreateResponse{
 				Id: &core.WorkflowExecutionIdentifier{
 					Project: request.Id.Project,
@@ -178,7 +178,7 @@ func TestRecoverExecutionError(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.RecoverExecutionFunc =
 		func(ctx context.Context,
-			request admin.ExecutionRecoverRequest, requestedAt time.Time) (*admin.ExecutionCreateResponse, error) {
+			request *admin.ExecutionRecoverRequest, requestedAt time.Time) (*admin.ExecutionCreateResponse, error) {
 			return nil, repoErrors.GetMissingEntityError("execution", request.Id)
 		}
 	mockServer := NewMockAdminServer(NewMockAdminServerInput{
@@ -193,20 +193,11 @@ func TestRecoverExecutionError(t *testing.T) {
 		"missing entity of type execution with identifier <nil>")
 }
 
-func TestRecoverExecution_InvalidRequest(t *testing.T) {
-	ctx := context.Background()
-	mockServer := NewMockAdminServer(NewMockAdminServerInput{})
-	resp, err := mockServer.RecoverExecution(ctx, nil)
-	assert.Nil(t, resp)
-	assert.EqualError(t, err,
-		"rpc error: code = InvalidArgument desc = Incorrect request, nil requests not allowed")
-}
-
 func TestCreateWorkflowEvent(t *testing.T) {
 	phase := core.WorkflowExecution_RUNNING
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.SetCreateEventCallback(
-		func(ctx context.Context, request admin.WorkflowExecutionEventRequest) (
+		func(ctx context.Context, request *admin.WorkflowExecutionEventRequest) (
 			*admin.WorkflowExecutionEventResponse, error) {
 			assert.Equal(t, requestID, request.RequestId)
 			assert.NotNil(t, request.Event)
@@ -230,7 +221,7 @@ func TestCreateWorkflowEvent(t *testing.T) {
 func TestCreateWorkflowEventErr(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.SetCreateEventCallback(
-		func(ctx context.Context, request admin.WorkflowExecutionEventRequest) (
+		func(ctx context.Context, request *admin.WorkflowExecutionEventRequest) (
 			*admin.WorkflowExecutionEventResponse, error) {
 			return nil, errors.New("expected error")
 		})
@@ -256,7 +247,7 @@ func TestGetExecution(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.SetGetCallback(
 		func(ctx context.Context,
-			request admin.WorkflowExecutionGetRequest) (*admin.Execution, error) {
+			request *admin.WorkflowExecutionGetRequest) (*admin.Execution, error) {
 			assert.True(t, proto.Equal(&workflowExecutionIdentifier, request.Id))
 			return response, nil
 		},
@@ -276,7 +267,7 @@ func TestGetExecutionError(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.SetGetCallback(
 		func(ctx context.Context,
-			request admin.WorkflowExecutionGetRequest) (*admin.Execution, error) {
+			request *admin.WorkflowExecutionGetRequest) (*admin.Execution, error) {
 			return nil, errors.New("expected error")
 		},
 	)
@@ -296,7 +287,7 @@ func TestUpdateExecution(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.SetUpdateExecutionCallback(
 		func(ctx context.Context,
-			request admin.ExecutionUpdateRequest, requestedAt time.Time) (*admin.ExecutionUpdateResponse, error) {
+			request *admin.ExecutionUpdateRequest, requestedAt time.Time) (*admin.ExecutionUpdateResponse, error) {
 			assert.True(t, proto.Equal(&workflowExecutionIdentifier, request.Id))
 			return response, nil
 		},
@@ -316,7 +307,7 @@ func TestUpdateExecutionError(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
 	mockExecutionManager.SetUpdateExecutionCallback(
 		func(ctx context.Context,
-			request admin.ExecutionUpdateRequest, requestedAt time.Time) (*admin.ExecutionUpdateResponse, error) {
+			request *admin.ExecutionUpdateRequest, requestedAt time.Time) (*admin.ExecutionUpdateResponse, error) {
 			return nil, errors.New("expected error")
 		},
 	)
@@ -333,7 +324,7 @@ func TestUpdateExecutionError(t *testing.T) {
 
 func TestListExecutions(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
-	mockExecutionManager.SetListCallback(func(ctx context.Context, request admin.ResourceListRequest) (
+	mockExecutionManager.SetListCallback(func(ctx context.Context, request *admin.ResourceListRequest) (
 		*admin.ExecutionList, error) {
 		assert.Equal(t, "project", request.Id.Project)
 		assert.Equal(t, "domain", request.Id.Domain)
@@ -364,7 +355,7 @@ func TestListExecutions(t *testing.T) {
 
 func TestListExecutionsError(t *testing.T) {
 	mockExecutionManager := mocks.MockExecutionManager{}
-	mockExecutionManager.SetListCallback(func(ctx context.Context, request admin.ResourceListRequest) (
+	mockExecutionManager.SetListCallback(func(ctx context.Context, request *admin.ResourceListRequest) (
 		*admin.ExecutionList, error) {
 		return nil, errors.New("expected error")
 	})
@@ -394,7 +385,7 @@ func TestTerminateExecution(t *testing.T) {
 	}
 	abortCause := "abort cause"
 	mockExecutionManager.SetTerminateExecutionCallback(func(
-		ctx context.Context, request admin.ExecutionTerminateRequest) (*admin.ExecutionTerminateResponse, error) {
+		ctx context.Context, request *admin.ExecutionTerminateRequest) (*admin.ExecutionTerminateResponse, error) {
 		assert.True(t, proto.Equal(&identifier, request.Id))
 		assert.Equal(t, abortCause, request.Cause)
 		return &admin.ExecutionTerminateResponse{}, nil
@@ -418,7 +409,7 @@ func TestTerminateExecution_Error(t *testing.T) {
 	}
 	abortCause := "abort cause"
 	mockExecutionManager.SetTerminateExecutionCallback(func(
-		ctx context.Context, request admin.ExecutionTerminateRequest) (*admin.ExecutionTerminateResponse, error) {
+		ctx context.Context, request *admin.ExecutionTerminateRequest) (*admin.ExecutionTerminateResponse, error) {
 		return nil, errors.New("expected error")
 	})
 	mockServer := NewMockAdminServer(NewMockAdminServerInput{

--- a/flyteadmin/pkg/rpc/adminservice/tests/launch_plan_test.go
+++ b/flyteadmin/pkg/rpc/adminservice/tests/launch_plan_test.go
@@ -19,7 +19,7 @@ func TestCreateLaunchPlanHappyCase(t *testing.T) {
 	mockLaunchPlanManager := mocks.MockLaunchPlanManager{}
 	mockLaunchPlanManager.SetCreateCallback(
 		func(ctx context.Context,
-			request admin.LaunchPlanCreateRequest) (*admin.LaunchPlanCreateResponse, error) {
+			request *admin.LaunchPlanCreateRequest) (*admin.LaunchPlanCreateResponse, error) {
 			return &admin.LaunchPlanCreateResponse{}, nil
 		},
 	)
@@ -46,7 +46,7 @@ func TestCreateLaunchPlanError(t *testing.T) {
 	mockLaunchPlanManager := mocks.MockLaunchPlanManager{}
 	mockLaunchPlanManager.SetCreateCallback(
 		func(ctx context.Context,
-			request admin.LaunchPlanCreateRequest) (*admin.LaunchPlanCreateResponse, error) {
+			request *admin.LaunchPlanCreateRequest) (*admin.LaunchPlanCreateResponse, error) {
 			return nil, errors.GetMissingEntityError(core.ResourceType_LAUNCH_PLAN.String(), request.Id)
 		},
 	)
@@ -74,7 +74,7 @@ func TestGetActiveLaunchPlan(t *testing.T) {
 	mockLaunchPlanManager := mocks.MockLaunchPlanManager{}
 	mockLaunchPlanManager.SetGetActiveLaunchPlanCallback(
 		func(ctx context.Context,
-			request admin.ActiveLaunchPlanRequest) (*admin.LaunchPlan, error) {
+			request *admin.ActiveLaunchPlanRequest) (*admin.LaunchPlan, error) {
 			return &admin.LaunchPlan{}, nil
 		},
 	)
@@ -99,7 +99,7 @@ func TestGetActiveLaunchPlan_Error(t *testing.T) {
 	mockLaunchPlanManager := mocks.MockLaunchPlanManager{}
 	mockLaunchPlanManager.SetGetActiveLaunchPlanCallback(
 		func(ctx context.Context,
-			request admin.ActiveLaunchPlanRequest) (*admin.LaunchPlan, error) {
+			request *admin.ActiveLaunchPlanRequest) (*admin.LaunchPlan, error) {
 			return nil, errors.GetInvalidInputError("invalid input")
 		},
 	)
@@ -124,7 +124,7 @@ func TestListActiveLaunchPlans(t *testing.T) {
 	mockLaunchPlanManager := mocks.MockLaunchPlanManager{}
 	mockLaunchPlanManager.SetListActiveLaunchPlansCallback(
 		func(ctx context.Context,
-			request admin.ActiveLaunchPlanListRequest) (*admin.LaunchPlanList, error) {
+			request *admin.ActiveLaunchPlanListRequest) (*admin.LaunchPlanList, error) {
 			return &admin.LaunchPlanList{}, nil
 		},
 	)
@@ -146,7 +146,7 @@ func TestListActiveLaunchPlans_Error(t *testing.T) {
 	mockLaunchPlanManager := mocks.MockLaunchPlanManager{}
 	mockLaunchPlanManager.SetListActiveLaunchPlansCallback(
 		func(ctx context.Context,
-			request admin.ActiveLaunchPlanListRequest) (*admin.LaunchPlanList, error) {
+			request *admin.ActiveLaunchPlanListRequest) (*admin.LaunchPlanList, error) {
 			return nil, errors.GetInvalidInputError("oops")
 		},
 	)

--- a/flyteadmin/pkg/rpc/adminservice/tests/node_execution_test.go
+++ b/flyteadmin/pkg/rpc/adminservice/tests/node_execution_test.go
@@ -30,7 +30,7 @@ func TestCreateNodeEvent(t *testing.T) {
 	phase := core.NodeExecution_RUNNING
 	mockNodeExecutionManager := mocks.MockNodeExecutionManager{}
 	mockNodeExecutionManager.SetCreateNodeEventCallback(
-		func(ctx context.Context, request admin.NodeExecutionEventRequest) (
+		func(ctx context.Context, request *admin.NodeExecutionEventRequest) (
 			*admin.NodeExecutionEventResponse, error) {
 			assert.Equal(t, requestID, request.RequestId)
 			assert.NotNil(t, request.Event)
@@ -55,7 +55,7 @@ func TestCreateNodeEvent(t *testing.T) {
 func TestCreateNodeEventErr(t *testing.T) {
 	mockNodeExecutionManager := mocks.MockNodeExecutionManager{}
 	mockNodeExecutionManager.SetCreateNodeEventCallback(
-		func(ctx context.Context, request admin.NodeExecutionEventRequest) (
+		func(ctx context.Context, request *admin.NodeExecutionEventRequest) (
 			*admin.NodeExecutionEventResponse, error) {
 			return nil, errors.New("expected error")
 		})
@@ -81,7 +81,7 @@ func TestGetNodeExecution(t *testing.T) {
 	mockNodeExecutionManager := mocks.MockNodeExecutionManager{}
 	mockNodeExecutionManager.SetGetNodeExecutionFunc(
 		func(ctx context.Context,
-			request admin.NodeExecutionGetRequest) (*admin.NodeExecution, error) {
+			request *admin.NodeExecutionGetRequest) (*admin.NodeExecution, error) {
 			assert.True(t, proto.Equal(&nodeExecutionID, request.Id))
 			return response, nil
 		},
@@ -101,7 +101,7 @@ func TestGetNodeExecutionError(t *testing.T) {
 	mockNodeExecutionManager := mocks.MockNodeExecutionManager{}
 	mockNodeExecutionManager.SetGetNodeExecutionFunc(
 		func(ctx context.Context,
-			request admin.NodeExecutionGetRequest) (*admin.NodeExecution, error) {
+			request *admin.NodeExecutionGetRequest) (*admin.NodeExecution, error) {
 			assert.True(t, proto.Equal(&nodeExecutionID, request.Id))
 			return nil, errors.New("expected error")
 		},
@@ -121,7 +121,7 @@ func TestGetNodeExecutionError(t *testing.T) {
 func TestListNodeExecutions(t *testing.T) {
 	mockNodeExecutionManager := mocks.MockNodeExecutionManager{}
 	filters := "encoded filters probably"
-	mockNodeExecutionManager.SetListNodeExecutionsFunc(func(ctx context.Context, request admin.NodeExecutionListRequest) (
+	mockNodeExecutionManager.SetListNodeExecutionsFunc(func(ctx context.Context, request *admin.NodeExecutionListRequest) (
 		*admin.NodeExecutionList, error) {
 		assert.Equal(t, filters, request.Filters)
 		assert.Equal(t, uint32(1), request.Limit)
@@ -150,7 +150,7 @@ func TestListNodeExecutions(t *testing.T) {
 
 func TestListNodeExecutionsError(t *testing.T) {
 	mockNodeExecutionManager := mocks.MockNodeExecutionManager{}
-	mockNodeExecutionManager.SetListNodeExecutionsFunc(func(ctx context.Context, request admin.NodeExecutionListRequest) (
+	mockNodeExecutionManager.SetListNodeExecutionsFunc(func(ctx context.Context, request *admin.NodeExecutionListRequest) (
 		*admin.NodeExecutionList, error) {
 		return nil, errors.New("expected error")
 	})
@@ -172,7 +172,7 @@ func TestListNodeExecutionsForTask(t *testing.T) {
 	mockNodeExecutionManager := mocks.MockNodeExecutionManager{}
 	filters := "encoded filters probably"
 	mockNodeExecutionManager.SetListNodeExecutionsForTaskFunc(
-		func(ctx context.Context, request admin.NodeExecutionForTaskListRequest) (
+		func(ctx context.Context, request *admin.NodeExecutionForTaskListRequest) (
 			*admin.NodeExecutionList, error) {
 			assert.Equal(t, filters, request.Filters)
 			assert.Equal(t, uint32(1), request.Limit)
@@ -202,7 +202,7 @@ func TestListNodeExecutionsForTask(t *testing.T) {
 func TestListNodeExecutionsForTaskError(t *testing.T) {
 	mockNodeExecutionManager := mocks.MockNodeExecutionManager{}
 	mockNodeExecutionManager.SetListNodeExecutionsForTaskFunc(
-		func(ctx context.Context, request admin.NodeExecutionForTaskListRequest) (
+		func(ctx context.Context, request *admin.NodeExecutionForTaskListRequest) (
 			*admin.NodeExecutionList, error) {
 			return nil, errors.New("expected error")
 		})
@@ -224,7 +224,7 @@ func TestGetNodeExecutionData(t *testing.T) {
 	mockNodeExecutionManager := mocks.MockNodeExecutionManager{}
 	mockNodeExecutionManager.SetGetNodeExecutionDataFunc(
 		func(ctx context.Context,
-			request admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error) {
+			request *admin.NodeExecutionGetDataRequest) (*admin.NodeExecutionGetDataResponse, error) {
 			assert.True(t, proto.Equal(&nodeExecutionID, request.Id))
 			return &admin.NodeExecutionGetDataResponse{
 				Inputs: &admin.UrlBlob{

--- a/flyteadmin/pkg/rpc/adminservice/tests/project_domain_test.go
+++ b/flyteadmin/pkg/rpc/adminservice/tests/project_domain_test.go
@@ -17,7 +17,7 @@ func TestUpdateProjectDomain(t *testing.T) {
 	var updateCalled bool
 	mockProjectDomainManager.SetUpdateProjectDomainAttributes(
 		func(ctx context.Context,
-			request admin.ProjectDomainAttributesUpdateRequest) (*admin.ProjectDomainAttributesUpdateResponse, error) {
+			request *admin.ProjectDomainAttributesUpdateRequest) (*admin.ProjectDomainAttributesUpdateResponse, error) {
 			updateCalled = true
 			return &admin.ProjectDomainAttributesUpdateResponse{}, nil
 		},
@@ -44,7 +44,7 @@ func TestUpdateProjectAttr(t *testing.T) {
 	var updateCalled bool
 	mockProjectDomainManager.SetUpdateProjectAttributes(
 		func(ctx context.Context,
-			request admin.ProjectAttributesUpdateRequest) (*admin.ProjectAttributesUpdateResponse, error) {
+			request *admin.ProjectAttributesUpdateRequest) (*admin.ProjectAttributesUpdateResponse, error) {
 			updateCalled = true
 			return &admin.ProjectAttributesUpdateResponse{}, nil
 		},
@@ -70,7 +70,7 @@ func TestDeleteProjectAttr(t *testing.T) {
 	var deleteCalled bool
 	mockProjectDomainManager.SetDeleteProjectAttributes(
 		func(ctx context.Context,
-			request admin.ProjectAttributesDeleteRequest) (*admin.ProjectAttributesDeleteResponse, error) {
+			request *admin.ProjectAttributesDeleteRequest) (*admin.ProjectAttributesDeleteResponse, error) {
 			deleteCalled = true
 			return &admin.ProjectAttributesDeleteResponse{}, nil
 		},
@@ -95,7 +95,7 @@ func TestGetProjectAttr(t *testing.T) {
 	var getCalled bool
 	mockProjectDomainManager.SetGetProjectAttributes(
 		func(ctx context.Context,
-			request admin.ProjectAttributesGetRequest) (*admin.ProjectAttributesGetResponse, error) {
+			request *admin.ProjectAttributesGetRequest) (*admin.ProjectAttributesGetResponse, error) {
 			getCalled = true
 			return &admin.ProjectAttributesGetResponse{}, nil
 		},

--- a/flyteadmin/pkg/rpc/adminservice/tests/project_test.go
+++ b/flyteadmin/pkg/rpc/adminservice/tests/project_test.go
@@ -17,7 +17,7 @@ func TestRegisterProject(t *testing.T) {
 	mockProjectManager := mocks.MockProjectManager{}
 	mockProjectManager.SetCreateProject(
 		func(ctx context.Context,
-			request admin.ProjectRegisterRequest) (*admin.ProjectRegisterResponse, error) {
+			request *admin.ProjectRegisterRequest) (*admin.ProjectRegisterResponse, error) {
 			return &admin.ProjectRegisterResponse{}, nil
 		},
 	)
@@ -50,11 +50,11 @@ func TestListProjects(t *testing.T) {
 			},
 		},
 	}
-	mockProjectManager.SetListCallback(func(ctx context.Context, request admin.ProjectListRequest) (*admin.Projects, error) {
+	mockProjectManager.SetListCallback(func(ctx context.Context, request *admin.ProjectListRequest) (*admin.Projects, error) {
 		assert.NotNil(t, request)
 		return projects, nil
 	})
-	resp, err := mockProjectManager.ListProjects(context.Background(), admin.ProjectListRequest{})
+	resp, err := mockProjectManager.ListProjects(context.Background(), &admin.ProjectListRequest{})
 	assert.Nil(t, err)
 	assert.True(t, proto.Equal(projects, resp))
 }
@@ -62,11 +62,11 @@ func TestListProjects(t *testing.T) {
 func TestGetProject(t *testing.T) {
 	mockProjectManager := mocks.MockProjectManager{}
 	project := &admin.Project{Id: "project id", Name: "project"}
-	mockProjectManager.SetGetCallBack(func(ctx context.Context, request admin.ProjectGetRequest) (*admin.Project, error) {
+	mockProjectManager.SetGetCallBack(func(ctx context.Context, request *admin.ProjectGetRequest) (*admin.Project, error) {
 		assert.NotNil(t, request)
 		return project, nil
 	})
-	resp, err := mockProjectManager.GetProject(context.Background(), admin.ProjectGetRequest{})
+	resp, err := mockProjectManager.GetProject(context.Background(), &admin.ProjectGetRequest{})
 	assert.Nil(t, err)
 	assert.True(t, proto.Equal(project, resp))
 }

--- a/flyteadmin/pkg/rpc/adminservice/tests/task_execution_test.go
+++ b/flyteadmin/pkg/rpc/adminservice/tests/task_execution_test.go
@@ -18,14 +18,14 @@ import (
 )
 
 func TestTaskExecution(t *testing.T) {
-	executionID := core.WorkflowExecutionIdentifier{
+	executionID := &core.WorkflowExecutionIdentifier{
 		Project: "project",
 		Domain:  "domain",
 		Name:    "name",
 	}
-	nodeExecutionID := core.NodeExecutionIdentifier{
+	nodeExecutionID := &core.NodeExecutionIdentifier{
 		NodeId:      "node id",
-		ExecutionId: &executionID,
+		ExecutionId: executionID,
 	}
 
 	taskID := &core.Identifier{
@@ -45,7 +45,7 @@ func TestTaskExecution(t *testing.T) {
 	t.Run("TestCreateTaskEvent", func(t *testing.T) {
 		mockTaskExecutionManager := mocks.MockTaskExecutionManager{}
 		mockTaskExecutionManager.SetCreateTaskEventCallback(
-			func(ctx context.Context, request admin.TaskExecutionEventRequest) (
+			func(ctx context.Context, request *admin.TaskExecutionEventRequest) (
 				*admin.TaskExecutionEventResponse, error) {
 				assert.Equal(t, requestID, request.RequestId)
 				assert.NotNil(t, request.Event)
@@ -61,7 +61,7 @@ func TestTaskExecution(t *testing.T) {
 			RequestId: requestID,
 			Event: &event.TaskExecutionEvent{
 				TaskId:                taskID,
-				ParentNodeExecutionId: &nodeExecutionID,
+				ParentNodeExecutionId: nodeExecutionID,
 				RetryAttempt:          retryAttempt,
 				Phase:                 phase,
 				OccurredAt:            occurredAt,
@@ -141,10 +141,10 @@ func TestTaskExecution(t *testing.T) {
 	t.Run("TestGetTaskExecution", func(t *testing.T) {
 		mockTaskExecutionManager := mocks.MockTaskExecutionManager{}
 		mockTaskExecutionManager.SetGetTaskExecutionCallback(
-			func(ctx context.Context, request admin.TaskExecutionGetRequest) (
+			func(ctx context.Context, request *admin.TaskExecutionGetRequest) (
 				*admin.TaskExecution, error) {
 				assert.Equal(t, taskID, request.Id.TaskId)
-				assert.Equal(t, nodeExecutionID, *request.Id.NodeExecutionId)
+				assert.Equal(t, nodeExecutionID, request.Id.NodeExecutionId)
 				assert.Equal(t, retryAttempt, request.Id.RetryAttempt)
 				return &admin.TaskExecution{}, nil
 			})
@@ -154,7 +154,7 @@ func TestTaskExecution(t *testing.T) {
 		resp, err := mockServer.GetTaskExecution(context.Background(), &admin.TaskExecutionGetRequest{
 			Id: &core.TaskExecutionIdentifier{
 				TaskId:          taskID,
-				NodeExecutionId: &nodeExecutionID,
+				NodeExecutionId: nodeExecutionID,
 				RetryAttempt:    retryAttempt,
 			},
 		})
@@ -165,7 +165,7 @@ func TestTaskExecution(t *testing.T) {
 	t.Run("TestGetTaskExecutionErr", func(t *testing.T) {
 		mockTaskExecutionManager := mocks.MockTaskExecutionManager{}
 		mockTaskExecutionManager.SetGetTaskExecutionCallback(
-			func(ctx context.Context, request admin.TaskExecutionGetRequest) (
+			func(ctx context.Context, request *admin.TaskExecutionGetRequest) (
 				*admin.TaskExecution, error) {
 				return nil, errors.New("expected error")
 			})
@@ -175,7 +175,7 @@ func TestTaskExecution(t *testing.T) {
 		resp, err := mockServer.GetTaskExecution(context.Background(), &admin.TaskExecutionGetRequest{
 			Id: &core.TaskExecutionIdentifier{
 				TaskId:          taskID,
-				NodeExecutionId: &nodeExecutionID,
+				NodeExecutionId: nodeExecutionID,
 				RetryAttempt:    retryAttempt,
 			},
 		})
@@ -187,7 +187,7 @@ func TestTaskExecution(t *testing.T) {
 	t.Run("TestGetTaskExecutionMissingId", func(t *testing.T) {
 		mockTaskExecutionManager := mocks.MockTaskExecutionManager{}
 		mockTaskExecutionManager.SetGetTaskExecutionCallback(
-			func(ctx context.Context, request admin.TaskExecutionGetRequest) (
+			func(ctx context.Context, request *admin.TaskExecutionGetRequest) (
 				*admin.TaskExecution, error) {
 				t.Fatal("Parameters should be checked before this call")
 				return nil, nil
@@ -197,7 +197,7 @@ func TestTaskExecution(t *testing.T) {
 		})
 		resp, err := mockServer.GetTaskExecution(context.Background(), &admin.TaskExecutionGetRequest{
 			Id: &core.TaskExecutionIdentifier{
-				NodeExecutionId: &nodeExecutionID,
+				NodeExecutionId: nodeExecutionID,
 				RetryAttempt:    1,
 			},
 		})
@@ -208,7 +208,7 @@ func TestTaskExecution(t *testing.T) {
 	t.Run("TestGetTaskExecutionMissingNodeExecutionId", func(t *testing.T) {
 		mockTaskExecutionManager := mocks.MockTaskExecutionManager{}
 		mockTaskExecutionManager.SetGetTaskExecutionCallback(
-			func(ctx context.Context, request admin.TaskExecutionGetRequest) (
+			func(ctx context.Context, request *admin.TaskExecutionGetRequest) (
 				*admin.TaskExecution, error) {
 				t.Fatal("Parameters should be checked before this call")
 				return nil, nil
@@ -230,7 +230,7 @@ func TestTaskExecution(t *testing.T) {
 	t.Run("TestListTaskExecutions", func(t *testing.T) {
 		mockTaskExecutionManager := mocks.MockTaskExecutionManager{}
 		mockTaskExecutionManager.SetListTaskExecutionsCallback(
-			func(ctx context.Context, request admin.TaskExecutionListRequest) (
+			func(ctx context.Context, request *admin.TaskExecutionListRequest) (
 				*admin.TaskExecutionList, error) {
 				assert.Equal(t, "1", request.Token)
 				assert.Equal(t, uint32(99), request.Limit)
@@ -266,7 +266,7 @@ func TestTaskExecution(t *testing.T) {
 	t.Run("TestListTaskExecutions_NoLimit", func(t *testing.T) {
 		mockTaskExecutionManager := mocks.MockTaskExecutionManager{}
 		mockTaskExecutionManager.SetListTaskExecutionsCallback(
-			func(ctx context.Context, request admin.TaskExecutionListRequest) (
+			func(ctx context.Context, request *admin.TaskExecutionListRequest) (
 				*admin.TaskExecutionList, error) {
 				return &admin.TaskExecutionList{}, nil
 			})
@@ -291,7 +291,7 @@ func TestTaskExecution(t *testing.T) {
 	t.Run("TestListTaskExecutions_NoFilters", func(t *testing.T) {
 		mockTaskExecutionManager := mocks.MockTaskExecutionManager{}
 		mockTaskExecutionManager.SetListTaskExecutionsCallback(
-			func(ctx context.Context, request admin.TaskExecutionListRequest) (
+			func(ctx context.Context, request *admin.TaskExecutionListRequest) (
 				*admin.TaskExecutionList, error) {
 				return &admin.TaskExecutionList{}, nil
 			})
@@ -310,7 +310,7 @@ func TestTaskExecution(t *testing.T) {
 func TestGetTaskExecutionData(t *testing.T) {
 	mockTaskExecutionManager := mocks.MockTaskExecutionManager{}
 	mockTaskExecutionManager.SetGetTaskExecutionDataCallback(
-		func(ctx context.Context, request admin.TaskExecutionGetDataRequest) (
+		func(ctx context.Context, request *admin.TaskExecutionGetDataRequest) (
 			*admin.TaskExecutionGetDataResponse, error) {
 			return &admin.TaskExecutionGetDataResponse{
 				Inputs: &admin.UrlBlob{

--- a/flyteadmin/pkg/rpc/adminservice/tests/task_test.go
+++ b/flyteadmin/pkg/rpc/adminservice/tests/task_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/utils"
 )
 
-var taskIdentifier = core.Identifier{
+var taskIdentifier = &core.Identifier{
 	ResourceType: core.ResourceType_TASK,
 	Name:         "Name",
 	Domain:       "Domain",
@@ -36,7 +36,7 @@ func TestTaskHappyCase(t *testing.T) {
 	})
 
 	resp, err := mockServer.CreateTask(ctx, &admin.TaskCreateRequest{
-		Id: &taskIdentifier,
+		Id: taskIdentifier,
 	})
 	assert.NotNil(t, resp)
 	assert.NoError(t, err)

--- a/flyteadmin/pkg/rpc/adminservice/tests/task_test.go
+++ b/flyteadmin/pkg/rpc/adminservice/tests/task_test.go
@@ -27,7 +27,7 @@ func TestTaskHappyCase(t *testing.T) {
 	mockTaskManager := mocks.MockTaskManager{}
 	mockTaskManager.SetCreateCallback(
 		func(ctx context.Context,
-			request admin.TaskCreateRequest) (*admin.TaskCreateResponse, error) {
+			request *admin.TaskCreateRequest) (*admin.TaskCreateResponse, error) {
 			return &admin.TaskCreateResponse{}, nil
 		},
 	)
@@ -48,7 +48,7 @@ func TestTaskError(t *testing.T) {
 	mockTaskManager := mocks.MockTaskManager{}
 	mockTaskManager.SetCreateCallback(
 		func(ctx context.Context,
-			request admin.TaskCreateRequest) (*admin.TaskCreateResponse, error) {
+			request *admin.TaskCreateRequest) (*admin.TaskCreateResponse, error) {
 			return nil, errors.GetMissingEntityError(core.ResourceType_TASK.String(), request.Id)
 		},
 	)
@@ -74,7 +74,7 @@ func TestListUniqueTaskIds(t *testing.T) {
 	ctx := context.Background()
 
 	mockTaskManager := mocks.MockTaskManager{}
-	mockTaskManager.SetListUniqueIdsFunc(func(ctx context.Context, request admin.NamedEntityIdentifierListRequest) (
+	mockTaskManager.SetListUniqueIdsFunc(func(ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (
 		*admin.NamedEntityIdentifierList, error) {
 
 		assert.Equal(t, "staging", request.Domain)

--- a/flyteadmin/pkg/rpc/adminservice/tests/workflow_test.go
+++ b/flyteadmin/pkg/rpc/adminservice/tests/workflow_test.go
@@ -27,7 +27,7 @@ func TestCreateWorkflowHappyCase(t *testing.T) {
 	mockWorkflowManager := mocks.MockWorkflowManager{}
 	mockWorkflowManager.SetCreateCallback(
 		func(ctx context.Context,
-			request admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error) {
+			request *admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error) {
 			return &admin.WorkflowCreateResponse{}, nil
 		},
 	)
@@ -48,7 +48,7 @@ func TestCreateWorkflowError(t *testing.T) {
 	mockWorkflowManager := mocks.MockWorkflowManager{}
 	mockWorkflowManager.SetCreateCallback(
 		func(ctx context.Context,
-			request admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error) {
+			request *admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error) {
 			return nil, errors.GetMissingEntityError(core.ResourceType_WORKFLOW.String(), request.Id)
 		},
 	)

--- a/flyteadmin/pkg/rpc/adminservice/workflow.go
+++ b/flyteadmin/pkg/rpc/adminservice/workflow.go
@@ -3,9 +3,6 @@ package adminservice
 import (
 	"context"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/flyteorg/flyte/flyteadmin/pkg/rpc/adminservice/util"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
@@ -15,13 +12,10 @@ import (
 func (m *AdminService) CreateWorkflow(
 	ctx context.Context,
 	request *admin.WorkflowCreateRequest) (*admin.WorkflowCreateResponse, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.WorkflowCreateResponse
 	var err error
 	m.Metrics.workflowEndpointMetrics.create.Time(func() {
-		response, err = m.WorkflowManager.CreateWorkflow(ctx, *request)
+		response, err = m.WorkflowManager.CreateWorkflow(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowEndpointMetrics.create)
@@ -31,9 +25,6 @@ func (m *AdminService) CreateWorkflow(
 }
 
 func (m *AdminService) GetWorkflow(ctx context.Context, request *admin.ObjectGetRequest) (*admin.Workflow, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	// NOTE: When the Get HTTP endpoint is called the resource type is implicit (from the URL) so we must add it
 	// to the request.
 	if request.Id != nil && request.Id.ResourceType == core.ResourceType_UNSPECIFIED {
@@ -43,7 +34,7 @@ func (m *AdminService) GetWorkflow(ctx context.Context, request *admin.ObjectGet
 	var response *admin.Workflow
 	var err error
 	m.Metrics.workflowEndpointMetrics.get.Time(func() {
-		response, err = m.WorkflowManager.GetWorkflow(ctx, *request)
+		response, err = m.WorkflowManager.GetWorkflow(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowEndpointMetrics.get)
@@ -54,14 +45,10 @@ func (m *AdminService) GetWorkflow(ctx context.Context, request *admin.ObjectGet
 
 func (m *AdminService) ListWorkflowIds(ctx context.Context, request *admin.NamedEntityIdentifierListRequest) (
 	*admin.NamedEntityIdentifierList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
-
 	var response *admin.NamedEntityIdentifierList
 	var err error
 	m.Metrics.workflowEndpointMetrics.listIds.Time(func() {
-		response, err = m.WorkflowManager.ListWorkflowIdentifiers(ctx, *request)
+		response, err = m.WorkflowManager.ListWorkflowIdentifiers(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowEndpointMetrics.listIds)
@@ -72,13 +59,10 @@ func (m *AdminService) ListWorkflowIds(ctx context.Context, request *admin.Named
 }
 
 func (m *AdminService) ListWorkflows(ctx context.Context, request *admin.ResourceListRequest) (*admin.WorkflowList, error) {
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.WorkflowList
 	var err error
 	m.Metrics.workflowEndpointMetrics.list.Time(func() {
-		response, err = m.WorkflowManager.ListWorkflows(ctx, *request)
+		response, err = m.WorkflowManager.ListWorkflows(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowEndpointMetrics.list)

--- a/flyteadmin/pkg/rpc/signal_service.go
+++ b/flyteadmin/pkg/rpc/signal_service.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	manager "github.com/flyteorg/flyte/flyteadmin/pkg/manager/impl"
 	"github.com/flyteorg/flyte/flyteadmin/pkg/manager/interfaces"
@@ -91,13 +89,10 @@ func (s *SignalService) interceptPanic(ctx context.Context, request proto.Messag
 func (s *SignalService) GetOrCreateSignal(
 	ctx context.Context, request *admin.SignalGetOrCreateRequest) (*admin.Signal, error) {
 	defer s.interceptPanic(ctx, request)
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.Signal
 	var err error
 	s.metrics.create.Time(func() {
-		response, err = s.signalManager.GetOrCreateSignal(ctx, *request)
+		response, err = s.signalManager.GetOrCreateSignal(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &s.metrics.create)
@@ -109,13 +104,10 @@ func (s *SignalService) GetOrCreateSignal(
 func (s *SignalService) ListSignals(
 	ctx context.Context, request *admin.SignalListRequest) (*admin.SignalList, error) {
 	defer s.interceptPanic(ctx, request)
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.SignalList
 	var err error
 	s.metrics.get.Time(func() {
-		response, err = s.signalManager.ListSignals(ctx, *request)
+		response, err = s.signalManager.ListSignals(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &s.metrics.get)
@@ -127,13 +119,10 @@ func (s *SignalService) ListSignals(
 func (s *SignalService) SetSignal(
 	ctx context.Context, request *admin.SignalSetRequest) (*admin.SignalSetResponse, error) {
 	defer s.interceptPanic(ctx, request)
-	if request == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
-	}
 	var response *admin.SignalSetResponse
 	var err error
 	s.metrics.get.Time(func() {
-		response, err = s.signalManager.SetSignal(ctx, *request)
+		response, err = s.signalManager.SetSignal(ctx, request)
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &s.metrics.get)

--- a/flyteadmin/pkg/rpc/signal_service_test.go
+++ b/flyteadmin/pkg/rpc/signal_service_test.go
@@ -30,18 +30,6 @@ func TestGetOrCreateSignal(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("NilRequestError", func(t *testing.T) {
-		signalManager := mocks.SignalInterface{}
-		testScope := mockScope.NewTestScope()
-		mockServer := &SignalService{
-			signalManager: &signalManager,
-			metrics:       NewSignalMetrics(testScope),
-		}
-
-		_, err := mockServer.GetOrCreateSignal(ctx, nil)
-		assert.Error(t, err)
-	})
-
 	t.Run("ManagerError", func(t *testing.T) {
 		signalManager := mocks.SignalInterface{}
 		signalManager.EXPECT().GetOrCreateSignal(mock.Anything, mock.Anything).Return(nil, errors.New("foo"))
@@ -74,18 +62,6 @@ func TestListSignals(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("NilRequestError", func(t *testing.T) {
-		signalManager := mocks.SignalInterface{}
-		testScope := mockScope.NewTestScope()
-		mockServer := &SignalService{
-			signalManager: &signalManager,
-			metrics:       NewSignalMetrics(testScope),
-		}
-
-		_, err := mockServer.ListSignals(ctx, nil)
-		assert.Error(t, err)
-	})
-
 	t.Run("ManagerError", func(t *testing.T) {
 		signalManager := mocks.SignalInterface{}
 		signalManager.EXPECT().ListSignals(mock.Anything, mock.Anything).Return(nil, errors.New("foo"))
@@ -116,18 +92,6 @@ func TestSetSignal(t *testing.T) {
 
 		_, err := mockServer.SetSignal(ctx, &admin.SignalSetRequest{})
 		assert.NoError(t, err)
-	})
-
-	t.Run("NilRequestError", func(t *testing.T) {
-		signalManager := mocks.SignalInterface{}
-		testScope := mockScope.NewTestScope()
-		mockServer := &SignalService{
-			signalManager: &signalManager,
-			metrics:       NewSignalMetrics(testScope),
-		}
-
-		_, err := mockServer.SetSignal(ctx, nil)
-		assert.Error(t, err)
 	})
 
 	t.Run("ManagerError", func(t *testing.T) {

--- a/flyteadmin/pkg/runtime/interfaces/application_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/application_configuration.go
@@ -196,10 +196,10 @@ func (a *ApplicationConfig) GetEnvs() *admin.Envs {
 }
 
 // GetAsWorkflowExecutionConfig returns the WorkflowExecutionConfig as extracted from this object
-func (a *ApplicationConfig) GetAsWorkflowExecutionConfig() admin.WorkflowExecutionConfig {
+func (a *ApplicationConfig) GetAsWorkflowExecutionConfig() *admin.WorkflowExecutionConfig {
 	// These values should always be set as their fallback values equals to their zero value or nil,
 	// providing a sensible default even if the actual value was not set.
-	wec := admin.WorkflowExecutionConfig{
+	wec := &admin.WorkflowExecutionConfig{
 		MaxParallelism: a.GetMaxParallelism(),
 		OverwriteCache: a.GetOverwriteCache(),
 		Interruptible:  a.GetInterruptible(),

--- a/flyteadmin/pkg/runtime/interfaces/mocks/quality_of_service_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/mocks/quality_of_service_configuration.go
@@ -51,7 +51,7 @@ type QualityOfServiceConfiguration_GetTierExecutionValues struct {
 	*mock.Call
 }
 
-func (_m QualityOfServiceConfiguration_GetTierExecutionValues) Return(_a0 map[core.QualityOfService_Tier]core.QualityOfServiceSpec) *QualityOfServiceConfiguration_GetTierExecutionValues {
+func (_m QualityOfServiceConfiguration_GetTierExecutionValues) Return(_a0 map[core.QualityOfService_Tier]*core.QualityOfServiceSpec) *QualityOfServiceConfiguration_GetTierExecutionValues {
 	return &QualityOfServiceConfiguration_GetTierExecutionValues{Call: _m.Call.Return(_a0)}
 }
 
@@ -66,15 +66,15 @@ func (_m *QualityOfServiceConfiguration) OnGetTierExecutionValuesMatch(matchers 
 }
 
 // GetTierExecutionValues provides a mock function with given fields:
-func (_m *QualityOfServiceConfiguration) GetTierExecutionValues() map[core.QualityOfService_Tier]core.QualityOfServiceSpec {
+func (_m *QualityOfServiceConfiguration) GetTierExecutionValues() map[core.QualityOfService_Tier]*core.QualityOfServiceSpec {
 	ret := _m.Called()
 
-	var r0 map[core.QualityOfService_Tier]core.QualityOfServiceSpec
-	if rf, ok := ret.Get(0).(func() map[core.QualityOfService_Tier]core.QualityOfServiceSpec); ok {
+	var r0 map[core.QualityOfService_Tier]*core.QualityOfServiceSpec
+	if rf, ok := ret.Get(0).(func() map[core.QualityOfService_Tier]*core.QualityOfServiceSpec); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[core.QualityOfService_Tier]core.QualityOfServiceSpec)
+			r0 = ret.Get(0).(map[core.QualityOfService_Tier]*core.QualityOfServiceSpec)
 		}
 	}
 

--- a/flyteadmin/pkg/runtime/interfaces/quality_of_service_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/quality_of_service_configuration.go
@@ -20,6 +20,6 @@ type QualityOfServiceConfig struct {
 }
 
 type QualityOfServiceConfiguration interface {
-	GetTierExecutionValues() map[core.QualityOfService_Tier]core.QualityOfServiceSpec
+	GetTierExecutionValues() map[core.QualityOfService_Tier]*core.QualityOfServiceSpec
 	GetDefaultTiers() map[DomainName]core.QualityOfService_Tier
 }

--- a/flyteadmin/pkg/runtime/mocks/mock_configuration_provider.go
+++ b/flyteadmin/pkg/runtime/mocks/mock_configuration_provider.go
@@ -89,7 +89,7 @@ func NewMockConfigurationProvider(
 
 	mockQualityOfServiceConfiguration := &ifaceMocks.QualityOfServiceConfiguration{}
 	mockQualityOfServiceConfiguration.OnGetDefaultTiers().Return(make(map[string]core.QualityOfService_Tier))
-	mockQualityOfServiceConfiguration.OnGetTierExecutionValues().Return(make(map[core.QualityOfService_Tier]core.QualityOfServiceSpec))
+	mockQualityOfServiceConfiguration.OnGetTierExecutionValues().Return(make(map[core.QualityOfService_Tier]*core.QualityOfServiceSpec))
 
 	mockClusterPoolAssignmentConfiguration := &ifaceMocks.ClusterPoolAssignmentConfiguration{}
 	mockClusterPoolAssignmentConfiguration.OnGetClusterPoolAssignments().Return(make(map[string]interfaces.ClusterPoolAssignment))

--- a/flyteadmin/pkg/runtime/quality_of_service_provider.go
+++ b/flyteadmin/pkg/runtime/quality_of_service_provider.go
@@ -21,12 +21,12 @@ var qualityOfServiceConfig = config.MustRegisterSection(qualityOfServiceKey, &in
 type QualityOfServiceConfigProvider struct {
 }
 
-func (p *QualityOfServiceConfigProvider) GetTierExecutionValues() map[core.QualityOfService_Tier]core.QualityOfServiceSpec {
-	tierExecutionValues := make(map[core.QualityOfService_Tier]core.QualityOfServiceSpec)
+func (p *QualityOfServiceConfigProvider) GetTierExecutionValues() map[core.QualityOfService_Tier]*core.QualityOfServiceSpec {
+	tierExecutionValues := make(map[core.QualityOfService_Tier]*core.QualityOfServiceSpec)
 	configValues := qualityOfServiceConfig.GetConfig().(*interfaces.QualityOfServiceConfig).TierExecutionValues
 	for tierName, spec := range configValues {
 		tierExecutionValues[core.QualityOfService_Tier(core.QualityOfService_Tier_value[tierName])] =
-			core.QualityOfServiceSpec{
+			&core.QualityOfServiceSpec{
 				QueueingBudget: ptypes.DurationProto(spec.QueueingBudget.Duration),
 			}
 	}

--- a/flyteadmin/pkg/workflowengine/impl/interface_provider.go
+++ b/flyteadmin/pkg/workflowengine/impl/interface_provider.go
@@ -18,8 +18,8 @@ import (
 type InterfaceProvider = common.InterfaceProvider
 
 type LaunchPlanInterfaceProvider struct {
-	expectedInputs  core.ParameterMap
-	expectedOutputs core.VariableMap
+	expectedInputs  *core.ParameterMap
+	expectedOutputs *core.VariableMap
 	identifier      *core.Identifier
 }
 
@@ -27,23 +27,23 @@ func (p *LaunchPlanInterfaceProvider) GetID() *core.Identifier {
 	return p.identifier
 }
 func (p *LaunchPlanInterfaceProvider) GetExpectedInputs() *core.ParameterMap {
-	return &p.expectedInputs
+	return p.expectedInputs
 
 }
 func (p *LaunchPlanInterfaceProvider) GetExpectedOutputs() *core.VariableMap {
-	return &p.expectedOutputs
+	return p.expectedOutputs
 }
 
-func NewLaunchPlanInterfaceProvider(launchPlan models.LaunchPlan, identifier core.Identifier) (common.InterfaceProvider, error) {
-	var closure admin.LaunchPlanClosure
-	err := proto.Unmarshal(launchPlan.Closure, &closure)
+func NewLaunchPlanInterfaceProvider(launchPlan models.LaunchPlan, identifier *core.Identifier) (common.InterfaceProvider, error) {
+	closure := &admin.LaunchPlanClosure{}
+	err := proto.Unmarshal(launchPlan.Closure, closure)
 	if err != nil {
 		logger.Errorf(context.TODO(), "Failed to transform launch plan: %v", err)
 		return &LaunchPlanInterfaceProvider{}, err
 	}
 	return &LaunchPlanInterfaceProvider{
-		expectedInputs:  *closure.ExpectedInputs,
-		expectedOutputs: *closure.ExpectedOutputs,
-		identifier:      &identifier,
+		expectedInputs:  closure.ExpectedInputs,
+		expectedOutputs: closure.ExpectedOutputs,
+		identifier:      identifier,
 	}, nil
 }

--- a/flyteadmin/pkg/workflowengine/impl/interface_provider_test.go
+++ b/flyteadmin/pkg/workflowengine/impl/interface_provider_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
 )
 
-var launchPlanIdentifier = core.Identifier{
+var launchPlanIdentifier = &core.Identifier{
 	ResourceType: core.ResourceType_LAUNCH_PLAN,
 	Project:      "project",
 	Domain:       "domain",
@@ -42,11 +42,11 @@ var outputs = core.VariableMap{
 }
 
 func getProviderForTest(t *testing.T) common.InterfaceProvider {
-	launchPlanStatus := admin.LaunchPlanClosure{
+	launchPlanStatus := &admin.LaunchPlanClosure{
 		ExpectedInputs:  &inputs,
 		ExpectedOutputs: &outputs,
 	}
-	bytes, _ := proto.Marshal(&launchPlanStatus)
+	bytes, _ := proto.Marshal(launchPlanStatus)
 	provider, err := NewLaunchPlanInterfaceProvider(
 		models.LaunchPlan{
 			Closure: bytes,

--- a/flyteadmin/pkg/workflowengine/impl/prepare_execution.go
+++ b/flyteadmin/pkg/workflowengine/impl/prepare_execution.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/codes"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -28,7 +29,9 @@ func addPermissions(securityCtx *core.SecurityContext, roleNameKey string, flyte
 	if securityCtx == nil || securityCtx.RunAs == nil {
 		return
 	}
-	flyteWf.SecurityContext = *securityCtx
+
+	securityCtxCopy, _ := proto.Clone(securityCtx).(*core.SecurityContext)
+	flyteWf.SecurityContext = *securityCtxCopy
 	if len(securityCtx.RunAs.IamRole) > 0 {
 		if flyteWf.Annotations == nil {
 			flyteWf.Annotations = map[string]string{}

--- a/flyteadmin/scheduler/dbapi/event_scheduler_impl.go
+++ b/flyteadmin/scheduler/dbapi/event_scheduler_impl.go
@@ -20,11 +20,11 @@ type eventScheduler struct {
 }
 
 func (s *eventScheduler) CreateScheduleInput(ctx context.Context, appConfig *runtimeInterfaces.SchedulerConfig,
-	identifier core.Identifier, schedule *admin.Schedule) (interfaces.AddScheduleInput, error) {
+	identifier *core.Identifier, schedule *admin.Schedule) (interfaces.AddScheduleInput, error) {
 
 	addScheduleInput := scheduleInterfaces.AddScheduleInput{
 		Identifier:         identifier,
-		ScheduleExpression: *schedule,
+		ScheduleExpression: schedule,
 	}
 	return addScheduleInput, nil
 }

--- a/flyteadmin/scheduler/dbapi/event_scheduler_impl_test.go
+++ b/flyteadmin/scheduler/dbapi/event_scheduler_impl_test.go
@@ -34,7 +34,7 @@ func TestCreateScheduleInput(t *testing.T) {
 		},
 		KickoffTimeInputArg: "kickoff_time",
 	}
-	addScheduleInput, err := eventScheduler.CreateScheduleInput(context.Background(), nil, core.Identifier{
+	addScheduleInput, err := eventScheduler.CreateScheduleInput(context.Background(), nil, &core.Identifier{
 		Project: "project",
 		Domain:  "domain",
 		Name:    "scheduled_wroflow",
@@ -51,7 +51,7 @@ func TestRemoveSchedule(t *testing.T) {
 	scheduleEntitiesRepo.OnDeactivateMatch(mock.Anything, mock.Anything).Return(nil)
 
 	err := eventScheduler.RemoveSchedule(context.Background(), interfaces.RemoveScheduleInput{
-		Identifier: core.Identifier{
+		Identifier: &core.Identifier{
 			Project: "project",
 			Domain:  "domain",
 			Name:    "scheduled_wroflow",
@@ -64,7 +64,7 @@ func TestRemoveSchedule(t *testing.T) {
 func TestAddSchedule(t *testing.T) {
 	t.Run("schedule_rate", func(t *testing.T) {
 		eventScheduler := setupEventScheduler()
-		schedule := admin.Schedule{
+		schedule := &admin.Schedule{
 			ScheduleExpression: &admin.Schedule_Rate{
 				Rate: &admin.FixedRate{
 					Value: 1,
@@ -78,7 +78,7 @@ func TestAddSchedule(t *testing.T) {
 		scheduleEntitiesRepo.OnActivateMatch(mock.Anything, mock.Anything).Return(nil)
 
 		err := eventScheduler.AddSchedule(context.Background(), interfaces.AddScheduleInput{
-			Identifier: core.Identifier{
+			Identifier: &core.Identifier{
 				Project: "project",
 				Domain:  "domain",
 				Name:    "scheduled_wroflow",
@@ -91,7 +91,7 @@ func TestAddSchedule(t *testing.T) {
 
 	t.Run("cron_schedule", func(t *testing.T) {
 		eventScheduler := setupEventScheduler()
-		schedule := admin.Schedule{
+		schedule := &admin.Schedule{
 			ScheduleExpression: &admin.Schedule_CronSchedule{
 				CronSchedule: &admin.CronSchedule{
 					Schedule: "*/1 * * * *",
@@ -104,7 +104,7 @@ func TestAddSchedule(t *testing.T) {
 		scheduleEntitiesRepo.OnActivateMatch(mock.Anything, mock.Anything).Return(nil)
 
 		err := eventScheduler.AddSchedule(context.Background(), interfaces.AddScheduleInput{
-			Identifier: core.Identifier{
+			Identifier: &core.Identifier{
 				Project: "project",
 				Domain:  "domain",
 				Name:    "scheduled_wroflow",
@@ -117,7 +117,7 @@ func TestAddSchedule(t *testing.T) {
 
 	t.Run("cron_expression_unsupported", func(t *testing.T) {
 		eventScheduler := setupEventScheduler()
-		schedule := admin.Schedule{
+		schedule := &admin.Schedule{
 			ScheduleExpression: &admin.Schedule_CronExpression{
 				CronExpression: "* */1 * * * *",
 			},
@@ -128,7 +128,7 @@ func TestAddSchedule(t *testing.T) {
 		scheduleEntitiesRepo.OnActivateMatch(mock.Anything, mock.Anything).Return(nil)
 
 		err := eventScheduler.AddSchedule(context.Background(), interfaces.AddScheduleInput{
-			Identifier: core.Identifier{
+			Identifier: &core.Identifier{
 				Project: "project",
 				Domain:  "domain",
 				Name:    "scheduled_wroflow",

--- a/flyteadmin/scheduler/identifier/identifier.go
+++ b/flyteadmin/scheduler/identifier/identifier.go
@@ -24,7 +24,7 @@ const (
 
 // GetScheduleName generate the schedule name to be used as unique identification string within the scheduler
 func GetScheduleName(ctx context.Context, s models.SchedulableEntity) string {
-	return strconv.FormatUint(hashIdentifier(ctx, core.Identifier{
+	return strconv.FormatUint(hashIdentifier(ctx, &core.Identifier{
 		Project: s.Project,
 		Domain:  s.Domain,
 		Name:    s.Name,
@@ -33,7 +33,7 @@ func GetScheduleName(ctx context.Context, s models.SchedulableEntity) string {
 }
 
 // GetExecutionIdentifier returns UUID using the hashed value of the schedule identifier and the scheduledTime
-func GetExecutionIdentifier(ctx context.Context, identifier core.Identifier, scheduledTime time.Time) (uuid.UUID, error) {
+func GetExecutionIdentifier(ctx context.Context, identifier *core.Identifier, scheduledTime time.Time) (uuid.UUID, error) {
 	hashValue := hashScheduledTimeStamp(ctx, identifier, scheduledTime)
 	b := make([]byte, 16)
 	binary.LittleEndian.PutUint64(b, hashValue)
@@ -41,7 +41,7 @@ func GetExecutionIdentifier(ctx context.Context, identifier core.Identifier, sch
 }
 
 // hashIdentifier returns the hash of the identifier
-func hashIdentifier(ctx context.Context, identifier core.Identifier) uint64 {
+func hashIdentifier(ctx context.Context, identifier *core.Identifier) uint64 {
 	h := fnv.New64()
 	_, err := h.Write([]byte(fmt.Sprintf(scheduleNameInputsFormat,
 		identifier.Project, identifier.Domain, identifier.Name, identifier.Version)))
@@ -56,7 +56,7 @@ func hashIdentifier(ctx context.Context, identifier core.Identifier) uint64 {
 }
 
 // hashScheduledTimeStamp return the hash of the identifier and the scheduledTime
-func hashScheduledTimeStamp(ctx context.Context, identifier core.Identifier, scheduledTime time.Time) uint64 {
+func hashScheduledTimeStamp(ctx context.Context, identifier *core.Identifier, scheduledTime time.Time) uint64 {
 	h := fnv.New64()
 	_, err := h.Write([]byte(fmt.Sprintf(executionIDInputsFormat,
 		identifier.Project, identifier.Domain, identifier.Name, identifier.Version, scheduledTime.Unix())))

--- a/flyteadmin/tests/task_test.go
+++ b/flyteadmin/tests/task_test.go
@@ -70,7 +70,7 @@ func TestCreateTaskWithoutContainer(t *testing.T) {
 	req.Id.Version = "TestCreateTaskWithoutContainer"
 	req.Spec.Template.Target = nil
 
-	_, err := client.CreateTask(ctx, &req)
+	_, err := client.CreateTask(ctx, req)
 	assert.Nil(t, err)
 }
 

--- a/flyteadmin/tests/task_test.go
+++ b/flyteadmin/tests/task_test.go
@@ -45,7 +45,7 @@ func TestCreateBasic(t *testing.T) {
 
 	// Test that task creation and retrieval works
 	valid := testutils.GetValidTaskRequest()
-	response, err := client.CreateTask(ctx, &valid)
+	response, err := client.CreateTask(ctx, valid)
 	assert.NoError(t, err)
 	task, err := client.GetTask(ctx, &admin.ObjectGetRequest{
 		Id: valid.Id,
@@ -56,7 +56,7 @@ func TestCreateBasic(t *testing.T) {
 	// Currently the returned object does not have the URN
 
 	// Test creating twice in a row fails on uniqueness
-	response, err = client.CreateTask(ctx, &valid)
+	response, err = client.CreateTask(ctx, valid)
 	assert.Nil(t, response)
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "already exists"))
@@ -353,20 +353,20 @@ func TestListTaskIdsWithMultipleTaskVersions(t *testing.T) {
 
 	// Create two versions of one task and one version of another task, and one unrelated task
 	valid := testutils.GetValidTaskRequestWithOverrides("project", "domain", "name", "v1")
-	_, err := client.CreateTask(ctx, &valid)
+	_, err := client.CreateTask(ctx, valid)
 	assert.NoError(t, err)
 
 	valid = testutils.GetValidTaskRequestWithOverrides("project", "domain", "name", "v2")
-	_, err = client.CreateTask(ctx, &valid)
+	_, err = client.CreateTask(ctx, valid)
 	assert.NoError(t, err)
 
 	valid = testutils.GetValidTaskRequestWithOverrides("project", "domain", "secondtask", "v1")
-	_, err = client.CreateTask(ctx, &valid)
+	_, err = client.CreateTask(ctx, valid)
 	assert.NoError(t, err)
 
 	// This last one should not show up.
 	valid = testutils.GetValidTaskRequestWithOverrides("project", "development", "hidden", "v1")
-	_, err = client.CreateTask(ctx, &valid)
+	_, err = client.CreateTask(ctx, valid)
 	assert.NoError(t, err)
 
 	// We should only get back two entities
@@ -423,20 +423,20 @@ func TestListTaskIdsWithPagination(t *testing.T) {
 
 	// Create two versions of one task and one version of another task, and one unrelated task
 	valid := testutils.GetValidTaskRequestWithOverrides("project", "domain", "name", "v1")
-	_, err := client.CreateTask(ctx, &valid)
+	_, err := client.CreateTask(ctx, valid)
 	assert.NoError(t, err)
 
 	valid = testutils.GetValidTaskRequestWithOverrides("project", "domain", "name", "v2")
-	_, err = client.CreateTask(ctx, &valid)
+	_, err = client.CreateTask(ctx, valid)
 	assert.NoError(t, err)
 
 	valid = testutils.GetValidTaskRequestWithOverrides("project", "domain", "secondtask", "v1")
-	_, err = client.CreateTask(ctx, &valid)
+	_, err = client.CreateTask(ctx, valid)
 	assert.NoError(t, err)
 
 	// This last one should not show up.
 	valid = testutils.GetValidTaskRequestWithOverrides("project", "development", "hidden", "v1")
-	_, err = client.CreateTask(ctx, &valid)
+	_, err = client.CreateTask(ctx, valid)
 	assert.NoError(t, err)
 
 	// We should only get back one entity
@@ -502,7 +502,7 @@ func TestCreateInvalidTaskType(t *testing.T) {
 	// Test that task creation fails based on task type
 	valid := testutils.GetValidTaskRequest()
 	valid.Spec.Template.Type = "sparkonk8s"
-	_, err := client.CreateTask(ctx, &valid)
+	_, err := client.CreateTask(ctx, valid)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "task type must be whitelisted before use")
 }

--- a/flyteadmin/tests/workflow_test.go
+++ b/flyteadmin/tests/workflow_test.go
@@ -28,7 +28,7 @@ func TestCreateWorkflow(t *testing.T) {
 	taskCreateReq.Id.Project = "admintests"
 	taskCreateReq.Id.Domain = "development"
 	taskCreateReq.Id.Name = "simple task"
-	_, err := client.CreateTask(ctx, &taskCreateReq)
+	_, err := client.CreateTask(ctx, taskCreateReq)
 	assert.NoError(t, err)
 
 	identifier := core.Identifier{

--- a/flytectl/cmd/compile/compile.go
+++ b/flytectl/cmd/compile/compile.go
@@ -112,7 +112,7 @@ func handleWorkflow(
 
 	// Check if all the subworkflows referenced by launchplan are compiled
 	for i := range reqs.GetRequiredLaunchPlanIds() {
-		lpID := &reqs.GetRequiredLaunchPlanIds()[i]
+		lpID := reqs.GetRequiredLaunchPlanIds()[i]
 		lpWfName := plans[lpID.Name].Spec.WorkflowId.Name
 		missingWorkflow := workflows[lpWfName]
 		if compiledWorkflows[lpWfName] == nil {
@@ -152,7 +152,7 @@ func handleWorkflow(
 			plan.Closure.ExpectedInputs = &core.ParameterMap{
 				Parameters: newMap,
 			}
-			compiledLaunchPlanProviders = append(compiledLaunchPlanProviders, compiler.NewLaunchPlanInterfaceProvider(*plan))
+			compiledLaunchPlanProviders = append(compiledLaunchPlanProviders, compiler.NewLaunchPlanInterfaceProvider(plan))
 		}
 	}
 

--- a/flytepropeller/pkg/compiler/admin.go
+++ b/flytepropeller/pkg/compiler/admin.go
@@ -11,8 +11,8 @@ import (
 // but that implementation relies on the internal Admin Gorm model. We should consider deprecating that one in favor
 // of this one as Admin already has a dependency on the Propeller compiler.
 type LaunchPlanInterfaceProvider struct {
-	expectedInputs  core.ParameterMap
-	expectedOutputs core.VariableMap
+	expectedInputs  *core.ParameterMap
+	expectedOutputs *core.VariableMap
 	identifier      *core.Identifier
 }
 
@@ -20,17 +20,17 @@ func (p *LaunchPlanInterfaceProvider) GetID() *core.Identifier {
 	return p.identifier
 }
 func (p *LaunchPlanInterfaceProvider) GetExpectedInputs() *core.ParameterMap {
-	return &p.expectedInputs
+	return p.expectedInputs
 
 }
 func (p *LaunchPlanInterfaceProvider) GetExpectedOutputs() *core.VariableMap {
-	return &p.expectedOutputs
+	return p.expectedOutputs
 }
 
-func NewLaunchPlanInterfaceProvider(launchPlan admin.LaunchPlan) *LaunchPlanInterfaceProvider {
+func NewLaunchPlanInterfaceProvider(launchPlan *admin.LaunchPlan) *LaunchPlanInterfaceProvider {
 	return &LaunchPlanInterfaceProvider{
-		expectedInputs:  *launchPlan.Closure.ExpectedInputs,
-		expectedOutputs: *launchPlan.Closure.ExpectedOutputs,
+		expectedInputs:  launchPlan.Closure.ExpectedInputs,
+		expectedOutputs: launchPlan.Closure.ExpectedOutputs,
 		identifier:      launchPlan.Id,
 	}
 }

--- a/flytepropeller/pkg/compiler/admin_test.go
+++ b/flytepropeller/pkg/compiler/admin_test.go
@@ -38,12 +38,12 @@ var outputs = core.VariableMap{
 	},
 }
 
-func getDummyLaunchPlan() admin.LaunchPlan {
+func getDummyLaunchPlan() *admin.LaunchPlan {
 	launchPlanClosure := admin.LaunchPlanClosure{
 		ExpectedInputs:  &inputs,
 		ExpectedOutputs: &outputs,
 	}
-	return admin.LaunchPlan{
+	return &admin.LaunchPlan{
 		Id:      &launchPlanIdentifier,
 		Spec:    nil,
 		Closure: &launchPlanClosure,

--- a/flytepropeller/pkg/compiler/builders.go
+++ b/flytepropeller/pkg/compiler/builders.go
@@ -153,8 +153,8 @@ func (t taskBuilder) GetCoreTask() *core.TaskTemplate {
 
 func (t taskBuilder) GetID() c.Identifier {
 	if t.flyteTask.Id != nil {
-		return *t.flyteTask.Id
+		return t.flyteTask.Id
 	}
 
-	return c.Identifier{}
+	return &core.Identifier{}
 }

--- a/flytepropeller/pkg/compiler/common/id_set.go
+++ b/flytepropeller/pkg/compiler/common/id_set.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Empty struct{}
-type Identifier = core.Identifier
+type Identifier = *core.Identifier
 type IdentifierSet map[string]Identifier
 
 // NewString creates a String from a list of values.

--- a/flytepropeller/pkg/compiler/common/index.go
+++ b/flytepropeller/pkg/compiler/common/index.go
@@ -35,7 +35,7 @@ func NewTaskIndex(tasks ...Task) TaskIndex {
 	res := make(TaskIndex, len(tasks))
 	for _, task := range tasks {
 		id := task.GetID()
-		res[(&id).String()] = task
+		res[(id).String()] = task
 	}
 
 	return res

--- a/flytepropeller/pkg/compiler/common/mocks/task.go
+++ b/flytepropeller/pkg/compiler/common/mocks/task.go
@@ -50,7 +50,7 @@ type Task_GetID struct {
 	*mock.Call
 }
 
-func (_m Task_GetID) Return(_a0 core.Identifier) *Task_GetID {
+func (_m Task_GetID) Return(_a0 *core.Identifier) *Task_GetID {
 	return &Task_GetID{Call: _m.Call.Return(_a0)}
 }
 
@@ -65,14 +65,16 @@ func (_m *Task) OnGetIDMatch(matchers ...interface{}) *Task_GetID {
 }
 
 // GetID provides a mock function with given fields:
-func (_m *Task) GetID() core.Identifier {
+func (_m *Task) GetID() *core.Identifier {
 	ret := _m.Called()
 
-	var r0 core.Identifier
-	if rf, ok := ret.Get(0).(func() core.Identifier); ok {
+	var r0 *core.Identifier
+	if rf, ok := ret.Get(0).(func() *core.Identifier); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(core.Identifier)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.Identifier)
+		}
 	}
 
 	return r0

--- a/flytepropeller/pkg/compiler/common/mocks/workflow.go
+++ b/flytepropeller/pkg/compiler/common/mocks/workflow.go
@@ -22,7 +22,7 @@ func (_m Workflow_GetCompiledSubWorkflow) Return(wf *core.CompiledWorkflow, foun
 	return &Workflow_GetCompiledSubWorkflow{Call: _m.Call.Return(wf, found)}
 }
 
-func (_m *Workflow) OnGetCompiledSubWorkflow(id core.Identifier) *Workflow_GetCompiledSubWorkflow {
+func (_m *Workflow) OnGetCompiledSubWorkflow(id *core.Identifier) *Workflow_GetCompiledSubWorkflow {
 	c_call := _m.On("GetCompiledSubWorkflow", id)
 	return &Workflow_GetCompiledSubWorkflow{Call: c_call}
 }
@@ -33,11 +33,11 @@ func (_m *Workflow) OnGetCompiledSubWorkflowMatch(matchers ...interface{}) *Work
 }
 
 // GetCompiledSubWorkflow provides a mock function with given fields: id
-func (_m *Workflow) GetCompiledSubWorkflow(id core.Identifier) (*core.CompiledWorkflow, bool) {
+func (_m *Workflow) GetCompiledSubWorkflow(id *core.Identifier) (*core.CompiledWorkflow, bool) {
 	ret := _m.Called(id)
 
 	var r0 *core.CompiledWorkflow
-	if rf, ok := ret.Get(0).(func(core.Identifier) *core.CompiledWorkflow); ok {
+	if rf, ok := ret.Get(0).(func(*core.Identifier) *core.CompiledWorkflow); ok {
 		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
@@ -46,7 +46,7 @@ func (_m *Workflow) GetCompiledSubWorkflow(id core.Identifier) (*core.CompiledWo
 	}
 
 	var r1 bool
-	if rf, ok := ret.Get(1).(func(core.Identifier) bool); ok {
+	if rf, ok := ret.Get(1).(func(*core.Identifier) bool); ok {
 		r1 = rf(id)
 	} else {
 		r1 = ret.Get(1).(bool)
@@ -165,7 +165,7 @@ func (_m Workflow_GetLaunchPlan) Return(wf common.InterfaceProvider, found bool)
 	return &Workflow_GetLaunchPlan{Call: _m.Call.Return(wf, found)}
 }
 
-func (_m *Workflow) OnGetLaunchPlan(id core.Identifier) *Workflow_GetLaunchPlan {
+func (_m *Workflow) OnGetLaunchPlan(id *core.Identifier) *Workflow_GetLaunchPlan {
 	c_call := _m.On("GetLaunchPlan", id)
 	return &Workflow_GetLaunchPlan{Call: c_call}
 }
@@ -176,11 +176,11 @@ func (_m *Workflow) OnGetLaunchPlanMatch(matchers ...interface{}) *Workflow_GetL
 }
 
 // GetLaunchPlan provides a mock function with given fields: id
-func (_m *Workflow) GetLaunchPlan(id core.Identifier) (common.InterfaceProvider, bool) {
+func (_m *Workflow) GetLaunchPlan(id *core.Identifier) (common.InterfaceProvider, bool) {
 	ret := _m.Called(id)
 
 	var r0 common.InterfaceProvider
-	if rf, ok := ret.Get(0).(func(core.Identifier) common.InterfaceProvider); ok {
+	if rf, ok := ret.Get(0).(func(*core.Identifier) common.InterfaceProvider); ok {
 		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
@@ -189,7 +189,7 @@ func (_m *Workflow) GetLaunchPlan(id core.Identifier) (common.InterfaceProvider,
 	}
 
 	var r1 bool
-	if rf, ok := ret.Get(1).(func(core.Identifier) bool); ok {
+	if rf, ok := ret.Get(1).(func(*core.Identifier) bool); ok {
 		r1 = rf(id)
 	} else {
 		r1 = ret.Get(1).(bool)
@@ -281,7 +281,7 @@ func (_m Workflow_GetSubWorkflow) Return(wf *core.CompiledWorkflow, found bool) 
 	return &Workflow_GetSubWorkflow{Call: _m.Call.Return(wf, found)}
 }
 
-func (_m *Workflow) OnGetSubWorkflow(id core.Identifier) *Workflow_GetSubWorkflow {
+func (_m *Workflow) OnGetSubWorkflow(id *core.Identifier) *Workflow_GetSubWorkflow {
 	c_call := _m.On("GetSubWorkflow", id)
 	return &Workflow_GetSubWorkflow{Call: c_call}
 }
@@ -292,11 +292,11 @@ func (_m *Workflow) OnGetSubWorkflowMatch(matchers ...interface{}) *Workflow_Get
 }
 
 // GetSubWorkflow provides a mock function with given fields: id
-func (_m *Workflow) GetSubWorkflow(id core.Identifier) (*core.CompiledWorkflow, bool) {
+func (_m *Workflow) GetSubWorkflow(id *core.Identifier) (*core.CompiledWorkflow, bool) {
 	ret := _m.Called(id)
 
 	var r0 *core.CompiledWorkflow
-	if rf, ok := ret.Get(0).(func(core.Identifier) *core.CompiledWorkflow); ok {
+	if rf, ok := ret.Get(0).(func(*core.Identifier) *core.CompiledWorkflow); ok {
 		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
@@ -305,7 +305,7 @@ func (_m *Workflow) GetSubWorkflow(id core.Identifier) (*core.CompiledWorkflow, 
 	}
 
 	var r1 bool
-	if rf, ok := ret.Get(1).(func(core.Identifier) bool); ok {
+	if rf, ok := ret.Get(1).(func(*core.Identifier) bool); ok {
 		r1 = rf(id)
 	} else {
 		r1 = ret.Get(1).(bool)
@@ -322,7 +322,7 @@ func (_m Workflow_GetTask) Return(task common.Task, found bool) *Workflow_GetTas
 	return &Workflow_GetTask{Call: _m.Call.Return(task, found)}
 }
 
-func (_m *Workflow) OnGetTask(id core.Identifier) *Workflow_GetTask {
+func (_m *Workflow) OnGetTask(id *core.Identifier) *Workflow_GetTask {
 	c_call := _m.On("GetTask", id)
 	return &Workflow_GetTask{Call: c_call}
 }
@@ -333,11 +333,11 @@ func (_m *Workflow) OnGetTaskMatch(matchers ...interface{}) *Workflow_GetTask {
 }
 
 // GetTask provides a mock function with given fields: id
-func (_m *Workflow) GetTask(id core.Identifier) (common.Task, bool) {
+func (_m *Workflow) GetTask(id *core.Identifier) (common.Task, bool) {
 	ret := _m.Called(id)
 
 	var r0 common.Task
-	if rf, ok := ret.Get(0).(func(core.Identifier) common.Task); ok {
+	if rf, ok := ret.Get(0).(func(*core.Identifier) common.Task); ok {
 		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
@@ -346,7 +346,7 @@ func (_m *Workflow) GetTask(id core.Identifier) (common.Task, bool) {
 	}
 
 	var r1 bool
-	if rf, ok := ret.Get(1).(func(core.Identifier) bool); ok {
+	if rf, ok := ret.Get(1).(func(*core.Identifier) bool); ok {
 		r1 = rf(id)
 	} else {
 		r1 = ret.Get(1).(bool)

--- a/flytepropeller/pkg/compiler/common/mocks/workflow_builder.go
+++ b/flytepropeller/pkg/compiler/common/mocks/workflow_builder.go
@@ -112,7 +112,7 @@ func (_m WorkflowBuilder_GetCompiledSubWorkflow) Return(wf *core.CompiledWorkflo
 	return &WorkflowBuilder_GetCompiledSubWorkflow{Call: _m.Call.Return(wf, found)}
 }
 
-func (_m *WorkflowBuilder) OnGetCompiledSubWorkflow(id core.Identifier) *WorkflowBuilder_GetCompiledSubWorkflow {
+func (_m *WorkflowBuilder) OnGetCompiledSubWorkflow(id *core.Identifier) *WorkflowBuilder_GetCompiledSubWorkflow {
 	c_call := _m.On("GetCompiledSubWorkflow", id)
 	return &WorkflowBuilder_GetCompiledSubWorkflow{Call: c_call}
 }
@@ -123,11 +123,11 @@ func (_m *WorkflowBuilder) OnGetCompiledSubWorkflowMatch(matchers ...interface{}
 }
 
 // GetCompiledSubWorkflow provides a mock function with given fields: id
-func (_m *WorkflowBuilder) GetCompiledSubWorkflow(id core.Identifier) (*core.CompiledWorkflow, bool) {
+func (_m *WorkflowBuilder) GetCompiledSubWorkflow(id *core.Identifier) (*core.CompiledWorkflow, bool) {
 	ret := _m.Called(id)
 
 	var r0 *core.CompiledWorkflow
-	if rf, ok := ret.Get(0).(func(core.Identifier) *core.CompiledWorkflow); ok {
+	if rf, ok := ret.Get(0).(func(*core.Identifier) *core.CompiledWorkflow); ok {
 		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
@@ -136,7 +136,7 @@ func (_m *WorkflowBuilder) GetCompiledSubWorkflow(id core.Identifier) (*core.Com
 	}
 
 	var r1 bool
-	if rf, ok := ret.Get(1).(func(core.Identifier) bool); ok {
+	if rf, ok := ret.Get(1).(func(*core.Identifier) bool); ok {
 		r1 = rf(id)
 	} else {
 		r1 = ret.Get(1).(bool)
@@ -255,7 +255,7 @@ func (_m WorkflowBuilder_GetLaunchPlan) Return(wf common.InterfaceProvider, foun
 	return &WorkflowBuilder_GetLaunchPlan{Call: _m.Call.Return(wf, found)}
 }
 
-func (_m *WorkflowBuilder) OnGetLaunchPlan(id core.Identifier) *WorkflowBuilder_GetLaunchPlan {
+func (_m *WorkflowBuilder) OnGetLaunchPlan(id *core.Identifier) *WorkflowBuilder_GetLaunchPlan {
 	c_call := _m.On("GetLaunchPlan", id)
 	return &WorkflowBuilder_GetLaunchPlan{Call: c_call}
 }
@@ -266,11 +266,11 @@ func (_m *WorkflowBuilder) OnGetLaunchPlanMatch(matchers ...interface{}) *Workfl
 }
 
 // GetLaunchPlan provides a mock function with given fields: id
-func (_m *WorkflowBuilder) GetLaunchPlan(id core.Identifier) (common.InterfaceProvider, bool) {
+func (_m *WorkflowBuilder) GetLaunchPlan(id *core.Identifier) (common.InterfaceProvider, bool) {
 	ret := _m.Called(id)
 
 	var r0 common.InterfaceProvider
-	if rf, ok := ret.Get(0).(func(core.Identifier) common.InterfaceProvider); ok {
+	if rf, ok := ret.Get(0).(func(*core.Identifier) common.InterfaceProvider); ok {
 		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
@@ -279,7 +279,7 @@ func (_m *WorkflowBuilder) GetLaunchPlan(id core.Identifier) (common.InterfacePr
 	}
 
 	var r1 bool
-	if rf, ok := ret.Get(1).(func(core.Identifier) bool); ok {
+	if rf, ok := ret.Get(1).(func(*core.Identifier) bool); ok {
 		r1 = rf(id)
 	} else {
 		r1 = ret.Get(1).(bool)
@@ -405,7 +405,7 @@ func (_m WorkflowBuilder_GetSubWorkflow) Return(wf *core.CompiledWorkflow, found
 	return &WorkflowBuilder_GetSubWorkflow{Call: _m.Call.Return(wf, found)}
 }
 
-func (_m *WorkflowBuilder) OnGetSubWorkflow(id core.Identifier) *WorkflowBuilder_GetSubWorkflow {
+func (_m *WorkflowBuilder) OnGetSubWorkflow(id *core.Identifier) *WorkflowBuilder_GetSubWorkflow {
 	c_call := _m.On("GetSubWorkflow", id)
 	return &WorkflowBuilder_GetSubWorkflow{Call: c_call}
 }
@@ -416,11 +416,11 @@ func (_m *WorkflowBuilder) OnGetSubWorkflowMatch(matchers ...interface{}) *Workf
 }
 
 // GetSubWorkflow provides a mock function with given fields: id
-func (_m *WorkflowBuilder) GetSubWorkflow(id core.Identifier) (*core.CompiledWorkflow, bool) {
+func (_m *WorkflowBuilder) GetSubWorkflow(id *core.Identifier) (*core.CompiledWorkflow, bool) {
 	ret := _m.Called(id)
 
 	var r0 *core.CompiledWorkflow
-	if rf, ok := ret.Get(0).(func(core.Identifier) *core.CompiledWorkflow); ok {
+	if rf, ok := ret.Get(0).(func(*core.Identifier) *core.CompiledWorkflow); ok {
 		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
@@ -429,7 +429,7 @@ func (_m *WorkflowBuilder) GetSubWorkflow(id core.Identifier) (*core.CompiledWor
 	}
 
 	var r1 bool
-	if rf, ok := ret.Get(1).(func(core.Identifier) bool); ok {
+	if rf, ok := ret.Get(1).(func(*core.Identifier) bool); ok {
 		r1 = rf(id)
 	} else {
 		r1 = ret.Get(1).(bool)
@@ -446,7 +446,7 @@ func (_m WorkflowBuilder_GetTask) Return(task common.Task, found bool) *Workflow
 	return &WorkflowBuilder_GetTask{Call: _m.Call.Return(task, found)}
 }
 
-func (_m *WorkflowBuilder) OnGetTask(id core.Identifier) *WorkflowBuilder_GetTask {
+func (_m *WorkflowBuilder) OnGetTask(id *core.Identifier) *WorkflowBuilder_GetTask {
 	c_call := _m.On("GetTask", id)
 	return &WorkflowBuilder_GetTask{Call: c_call}
 }
@@ -457,11 +457,11 @@ func (_m *WorkflowBuilder) OnGetTaskMatch(matchers ...interface{}) *WorkflowBuil
 }
 
 // GetTask provides a mock function with given fields: id
-func (_m *WorkflowBuilder) GetTask(id core.Identifier) (common.Task, bool) {
+func (_m *WorkflowBuilder) GetTask(id *core.Identifier) (common.Task, bool) {
 	ret := _m.Called(id)
 
 	var r0 common.Task
-	if rf, ok := ret.Get(0).(func(core.Identifier) common.Task); ok {
+	if rf, ok := ret.Get(0).(func(*core.Identifier) common.Task); ok {
 		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
@@ -470,7 +470,7 @@ func (_m *WorkflowBuilder) GetTask(id core.Identifier) (common.Task, bool) {
 	}
 
 	var r1 bool
-	if rf, ok := ret.Get(1).(func(core.Identifier) bool); ok {
+	if rf, ok := ret.Get(1).(func(*core.Identifier) bool); ok {
 		r1 = rf(id)
 	} else {
 		r1 = ret.Get(1).(bool)
@@ -548,7 +548,7 @@ func (_m *WorkflowBuilder) GetUpstreamNodes() common.StringAdjacencyList {
 }
 
 // StoreCompiledSubWorkflow provides a mock function with given fields: id, compiledWorkflow
-func (_m *WorkflowBuilder) StoreCompiledSubWorkflow(id core.Identifier, compiledWorkflow *core.CompiledWorkflow) {
+func (_m *WorkflowBuilder) StoreCompiledSubWorkflow(id *core.Identifier, compiledWorkflow *core.CompiledWorkflow) {
 	_m.Called(id, compiledWorkflow)
 }
 

--- a/flytepropeller/pkg/compiler/requirements.go
+++ b/flytepropeller/pkg/compiler/requirements.go
@@ -69,10 +69,10 @@ func updateNodeRequirements(node *flyteNode, subWfs common.WorkflowIndex, taskId
 	followSubworkflows bool, errs errors.CompileErrors) {
 
 	if taskN := node.GetTaskNode(); taskN != nil && taskN.GetReferenceId() != nil {
-		taskIds.Insert(*taskN.GetReferenceId())
+		taskIds.Insert(taskN.GetReferenceId())
 	} else if workflowNode := node.GetWorkflowNode(); workflowNode != nil {
 		if workflowNode.GetLaunchplanRef() != nil {
-			workflowIds.Insert(*workflowNode.GetLaunchplanRef())
+			workflowIds.Insert(workflowNode.GetLaunchplanRef())
 		} else if workflowNode.GetSubWorkflowRef() != nil && followSubworkflows {
 			if subWf, found := subWfs[workflowNode.GetSubWorkflowRef().String()]; !found {
 				errs.Collect(errors.NewWorkflowReferenceNotFoundErr(node.Id, workflowNode.GetSubWorkflowRef().String()))

--- a/flytepropeller/pkg/compiler/validators/bindings_test.go
+++ b/flytepropeller/pkg/compiler/validators/bindings_test.go
@@ -777,8 +777,8 @@ func TestValidateBindings(t *testing.T) {
 		assert.False(t, ok)
 		assert.Equal(t, "MismatchingTypes", string(compileErrors.Errors().List()[0].Code()))
 		assert.Equal(t, "Code: MismatchingTypes, Node Id: node1, Description: Variable [x]"+
-			" (type [union_type:{variants:{simple:INTEGER  structure:{tag:\"int\"}}}]) doesn't match expected type"+
-			" [union_type:{variants:{simple:INTEGER  structure:{tag:\"int_other\"}}}].", compileErrors.Errors().List()[0].Error())
+			" (type [union_type:{variants:{simple:INTEGER structure:{tag:\"int\"}}}]) doesn't match expected type"+
+			" [union_type:{variants:{simple:INTEGER structure:{tag:\"int_other\"}}}].", compileErrors.Errors().List()[0].Error())
 	})
 
 	t.Run("List of Int to List of Unions Binding", func(t *testing.T) {
@@ -1212,8 +1212,8 @@ func TestValidateBindings(t *testing.T) {
 		assert.Equal(t, "MismatchingTypes", string(compileErrors.Errors().List()[0].Code()))
 		assert.Equal(t, "Code: MismatchingTypes, Node Id: node1, Description: The output variable 'n2.n2_out'"+
 			" has type [simple:INTEGER], but it's assigned to the input variable 'n.x' which has type"+
-			" type [union_type:{variants:{simple:STRING  structure:{tag:\"str\"}}  variants:{simple:INTEGER  structure:{tag:\"int1\"}}"+
-			"  variants:{simple:INTEGER  structure:{tag:\"int2\"}}}].", compileErrors.Errors().List()[0].Error())
+			" type [union_type:{variants:{simple:STRING structure:{tag:\"str\"}} variants:{simple:INTEGER structure:{tag:\"int1\"}}"+
+			" variants:{simple:INTEGER structure:{tag:\"int2\"}}}].", compileErrors.Errors().List()[0].Error())
 	})
 
 	t.Run("Union Promise Union Literal", func(t *testing.T) {

--- a/flytepropeller/pkg/compiler/validators/interface.go
+++ b/flytepropeller/pkg/compiler/validators/interface.go
@@ -42,7 +42,7 @@ func ValidateUnderlyingInterface(w c.WorkflowBuilder, node c.NodeBuilder, errs e
 	case *core.Node_TaskNode:
 		if node.GetTaskNode().GetReferenceId() == nil {
 			errs.Collect(errors.NewValueRequiredErr(node.GetId(), "TaskNode.ReferenceId"))
-		} else if task, taskOk := w.GetTask(*node.GetTaskNode().GetReferenceId()); taskOk {
+		} else if task, taskOk := w.GetTask(node.GetTaskNode().GetReferenceId()); taskOk {
 			iface = task.GetInterface()
 			if iface == nil {
 				// Default value for no interface is nil, initialize an empty interface
@@ -61,7 +61,7 @@ func ValidateUnderlyingInterface(w c.WorkflowBuilder, node c.NodeBuilder, errs e
 				errs.Collect(errors.NewValueRequiredErr(node.GetId(), "WorkflowNode.Interface"))
 			}
 		} else if node.GetWorkflowNode().GetLaunchplanRef() != nil {
-			if launchPlan, launchPlanOk := w.GetLaunchPlan(*node.GetWorkflowNode().GetLaunchplanRef()); launchPlanOk {
+			if launchPlan, launchPlanOk := w.GetLaunchPlan(node.GetWorkflowNode().GetLaunchplanRef()); launchPlanOk {
 				inputs := launchPlan.GetExpectedInputs()
 				if inputs == nil {
 					errs.Collect(errors.NewValueRequiredErr(node.GetId(), "WorkflowNode.ExpectedInputs"))
@@ -97,7 +97,7 @@ func ValidateUnderlyingInterface(w c.WorkflowBuilder, node c.NodeBuilder, errs e
 					fmt.Sprintf("%v", node.GetWorkflowNode().GetLaunchplanRef())))
 			}
 		} else if node.GetWorkflowNode().GetSubWorkflowRef() != nil {
-			if wf, wfOk := w.GetSubWorkflow(*node.GetWorkflowNode().GetSubWorkflowRef()); wfOk {
+			if wf, wfOk := w.GetSubWorkflow(node.GetWorkflowNode().GetSubWorkflowRef()); wfOk {
 				if wf.Template == nil {
 					errs.Collect(errors.NewValueRequiredErr(node.GetId(), "WorkflowNode.Template"))
 				} else {

--- a/flytepropeller/pkg/compiler/validators/interface_test.go
+++ b/flytepropeller/pkg/compiler/validators/interface_test.go
@@ -91,7 +91,7 @@ func TestValidateUnderlyingInterface(t *testing.T) {
 		task.On("GetInterface").Return(nil)
 
 		wfBuilder := mocks.WorkflowBuilder{}
-		wfBuilder.On("GetTask", mock.MatchedBy(func(id core.Identifier) bool {
+		wfBuilder.On("GetTask", mock.MatchedBy(func(id *core.Identifier) bool {
 			return id.String() == (&core.Identifier{
 				Name: "Task_1",
 			}).String()
@@ -228,7 +228,7 @@ func TestValidateUnderlyingInterface(t *testing.T) {
 				},
 			})
 
-			wfBuilder.On("GetLaunchPlan", matchIdentifier(core.Identifier{Name: "Ref_1"})).Return(&lp, true)
+			wfBuilder.On("GetLaunchPlan", matchIdentifier(&core.Identifier{Name: "Ref_1"})).Return(&lp, true)
 
 			errs = errors.NewCompileErrors()
 			iface, ifaceOk := ValidateUnderlyingInterface(&wfBuilder, &nodeBuilder, errs.NewScope())
@@ -269,7 +269,7 @@ func TestValidateUnderlyingInterface(t *testing.T) {
 				},
 			})
 
-			wfBuilder.On("GetSubWorkflow", matchIdentifier(core.Identifier{Name: "Ref_1"})).Return(&subWf, true)
+			wfBuilder.On("GetSubWorkflow", matchIdentifier(&core.Identifier{Name: "Ref_1"})).Return(&subWf, true)
 
 			workflowNode.Reference = &core.WorkflowNode_SubWorkflowRef{
 				SubWorkflowRef: &core.Identifier{Name: "Ref_1"},
@@ -425,7 +425,7 @@ func TestValidateUnderlyingInterface(t *testing.T) {
 		taskNodeBuilder.On("SetInterface", mock.AnythingOfType("*core.TypedInterface")).Return(nil)
 
 		wfBuilder := mocks.WorkflowBuilder{}
-		wfBuilder.On("GetTask", mock.MatchedBy(func(id core.Identifier) bool {
+		wfBuilder.On("GetTask", mock.MatchedBy(func(id *core.Identifier) bool {
 			return id.String() == (&core.Identifier{
 				Name: "Task_1",
 			}).String()
@@ -459,8 +459,8 @@ func TestValidateUnderlyingInterface(t *testing.T) {
 	})
 }
 
-func matchIdentifier(id core.Identifier) interface{} {
-	return mock.MatchedBy(func(arg core.Identifier) bool {
+func matchIdentifier(id *core.Identifier) interface{} {
+	return mock.MatchedBy(func(arg *core.Identifier) bool {
 		return arg.String() == id.String()
 	})
 }

--- a/flytepropeller/pkg/compiler/validators/node.go
+++ b/flytepropeller/pkg/compiler/validators/node.go
@@ -136,7 +136,7 @@ func ValidateNode(w c.WorkflowBuilder, n c.NodeBuilder, validateConditionTypes b
 			}
 		}
 	} else if workflowN := n.GetWorkflowNode(); workflowN != nil && workflowN.GetSubWorkflowRef() != nil {
-		workflowID := *workflowN.GetSubWorkflowRef()
+		workflowID := workflowN.GetSubWorkflowRef()
 		// Only compile the subworkflow if it has not been error-free compiled before.
 		if _, wfOk := w.GetCompiledSubWorkflow(workflowID); !wfOk {
 			if wf, wfOk := w.GetSubWorkflow(workflowID); wfOk {
@@ -153,7 +153,7 @@ func ValidateNode(w c.WorkflowBuilder, n c.NodeBuilder, validateConditionTypes b
 			}
 		}
 	} else if taskN := n.GetTaskNode(); taskN != nil && taskN.GetReferenceId() != nil {
-		if task, found := w.GetTask(*taskN.GetReferenceId()); found {
+		if task, found := w.GetTask(taskN.GetReferenceId()); found {
 			n.SetTask(task)
 		} else if taskN.GetReferenceId() == nil {
 			errs.Collect(errors.NewValueRequiredErr(n.GetId(), "TaskNode.ReferenceId"))

--- a/flytepropeller/pkg/compiler/workflow_compiler_test.go
+++ b/flytepropeller/pkg/compiler/workflow_compiler_test.go
@@ -150,8 +150,8 @@ func TestCompileWorkflowWithFailureNode(t *testing.T) {
 	subWorkflows := make([]*core.WorkflowTemplate, 0)
 	reqs, err := GetRequirements(inputWorkflow, subWorkflows)
 	assert.Nil(t, err)
-	assert.True(t, proto.Equal(&reqs.taskIds[0], &[]common.Identifier{{Name: "cleanup"}, {Name: "task_123"}}[0]))
-	assert.True(t, proto.Equal(&reqs.taskIds[1], &[]common.Identifier{{Name: "cleanup"}, {Name: "task_123"}}[1]))
+	assert.True(t, proto.Equal(reqs.taskIds[0], []common.Identifier{{Name: "cleanup"}, {Name: "task_123"}}[0]))
+	assert.True(t, proto.Equal(reqs.taskIds[1], []common.Identifier{{Name: "cleanup"}, {Name: "task_123"}}[1]))
 
 	// Replace with logic to satisfy the requirements
 	workflows := make([]common.InterfaceProvider, 0)

--- a/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go
@@ -343,8 +343,7 @@ func (d dynamicNodeTaskNodeHandler) getLaunchPlanInterfaces(ctx context.Context,
 
 	var launchPlanInterfaces = make([]common.InterfaceProvider, len(launchPlanIDs))
 	for idx, id := range launchPlanIDs {
-		idVal := id
-		lp, err := d.lpReader.GetLaunchPlan(ctx, &idVal)
+		lp, err := d.lpReader.GetLaunchPlan(ctx, id)
 		if err != nil {
 			logger.Debugf(ctx, "Error fetching launch plan definition from admin")
 			if launchplan.IsNotFound(err) || launchplan.IsUserError(err) {
@@ -354,7 +353,7 @@ func (d dynamicNodeTaskNodeHandler) getLaunchPlanInterfaces(ctx context.Context,
 			return nil, errors.Wrapf(utils.ErrorCodeSystem, err, "unable to retrieve launchplan information %s:%s:%s:%s",
 				id.Project, id.Domain, id.Name, id.Version)
 		}
-		launchPlanInterfaces[idx] = compiler.NewLaunchPlanInterfaceProvider(*lp)
+		launchPlanInterfaces[idx] = compiler.NewLaunchPlanInterfaceProvider(lp)
 	}
 
 	return launchPlanInterfaces, nil


### PR DESCRIPTION
## Why are the changes needed?

Go structs generated by `protoc-gen-go` contain a [DoNotCopy](https://github.com/protocolbuffers/protobuf-go/blob/v1.34.2/internal/pragma/pragma.go#L29) mutex so that `go vet` will complain and discourage people from copying these go structs.

The `flyteadmin` code doesn't respect these intentions and has many of these warnings. 1,135 to be exact. The orange warnings are a bit noisy in the IDE and I noticed the `golangci` config ignores them.

As someone who comes from a Java background I'm guessing that the intent of passing around copies of these go structs is to prevent nil pointer errors and employ defensive programming. I think in most circumstances this makes sense, but in this case gRPC and `protoc-gen-go` are very intentional about using pointers. The structs are never nil in the gRPC API handlers, they are just passed with pointers so that the structs are used safely. 

Having said that, this pull request attempts to refactor `flyteadmin` to use pointers for protobuf structs throughout the codebase to eliminate these warnings. It updates the `golangci` config to ignore the singular unavoidable and safe copy that is made. 

see: https://stackoverflow.com/questions/64183794/why-do-the-go-generated-protobuf-files-contain-mutex-locks
 
## How was this patch tested?
Unit tests and integration test have been updated. 

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
