### PR TITLE
[flyteagent] Add Logging for Agent Supported Task Types

### DIFF
--- a/flyteplugins/go/tasks/plugins/webapi/agent/client.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/client.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"crypto/x509"
+	"strings"
 
 	"golang.org/x/exp/maps"
 	"google.golang.org/grpc"
@@ -127,8 +128,10 @@ func getAgentRegistry(ctx context.Context, cs *ClientSet) Registry {
 			continue
 		}
 
+		var agentSupportedTaskCategories []string
 		for _, agent := range res.GetAgents() {
 			deprecatedSupportedTaskTypes := agent.SupportedTaskTypes
+			agentSupportedTaskCategories = append(agentSupportedTaskCategories, deprecatedSupportedTaskTypes...)
 			for _, supportedTaskType := range deprecatedSupportedTaskTypes {
 				agent := &Agent{AgentDeployment: agentDeployment, IsSync: agent.IsSync}
 				newAgentRegistry[supportedTaskType] = map[int32]*Agent{defaultTaskTypeVersion: agent}
@@ -137,9 +140,13 @@ func getAgentRegistry(ctx context.Context, cs *ClientSet) Registry {
 			supportedTaskCategories := agent.SupportedTaskCategories
 			for _, supportedCategory := range supportedTaskCategories {
 				agent := &Agent{AgentDeployment: agentDeployment, IsSync: agent.IsSync}
-				newAgentRegistry[supportedCategory.GetName()] = map[int32]*Agent{supportedCategory.GetVersion(): agent}
+				supportedCategoryName := supportedCategory.GetName()
+				newAgentRegistry[supportedCategoryName] = map[int32]*Agent{supportedCategory.GetVersion(): agent}
+				agentSupportedTaskCategories = append(agentSupportedTaskCategories, supportedCategoryName)
 			}
+
 		}
+		logger.Infof(ctx, "AgentDeployment [%v] supports the following task types: [%v]", agentDeployment.Endpoint, strings.Join(agentSupportedTaskCategories, ", "))
 	}
 
 	// If the agent doesn't implement the metadata service, we construct the registry based on the configuration
@@ -160,6 +167,7 @@ func getAgentRegistry(ctx context.Context, cs *ClientSet) Registry {
 		}
 	}
 
+	logger.Infof(ctx, "AgentDeployments support the following task types: [%v]", strings.Join(maps.Keys(newAgentRegistry), ", "))
 	return newAgentRegistry
 }
 


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
We want to know whether the propeller received the expected `Supported Task Types` from each `Agent Deployment` and all `Supported Task Types`.

https://flyte-org.slack.com/archives/C06SYN9QJ5N/p1724970466413009

## What changes were proposed in this pull request?
### Summary
Add logs to track the `Supported Task Types` for each deployment and across all deployments.
### Details
Use `map[string]struct{}` to store supported task types because current flytekit will return `SupportedTaskTypes` and `supportedTaskCategories` with same metadata, which will make us get duplicate data

<img width="544" alt="image" src="https://github.com/user-attachments/assets/e54533ca-9071-468c-a951-4d0bffed7cee">

<img width="793" alt="image" src="https://github.com/user-attachments/assets/7f95627c-74f2-4c62-978a-dca9e678984b">


## How was this patch tested?
- single binary
- setup 2 endpoints, localhost:8000 and localhost:8001.

<img width="367" alt="image" src="https://github.com/user-attachments/assets/a3c84ec6-5efe-4980-8d1c-ef9677b16bc8">

<img width="444" alt="image" src="https://github.com/user-attachments/assets/9012302e-6a00-4c85-a145-a13a52cebe61">


```yaml
  agent-service:
    defaultAgent:
      endpoint: "localhost:8000"    
      insecure: true
      timeouts:
        CreateTask: 100s
        GetTask: 100s
      defaultTimeout: 100s
    agents:
      custom_agent:
        endpoint: "localhost:8001"
        insecure: true
        timeouts:
          ExecuteTaskSync: 300s
          GetTask: 100s
        defaultTimeout: 300s
```

```go
{"json":{"src":"client.go:149"},"level":"info","msg":"AgentDeployment [localhost:8000] supports the following task types: [snowflake, sensor]","ts":"2024-09-03T11:42:36+08:00"}
{"json":{"src":"client.go:149"},"level":"info","msg":"AgentDeployment [localhost:8001] supports the following task types: [sensor, snowflake, openai-batch, chatgpt]","ts":"2024-09-03T11:42:36+08:00"}
{"json":{"src":"client.go:171"},"level":"info","msg":"AgentDeployments support the following task types: [sensor, snowflake, openai-batch, chatgpt, task_type_1, task_type_2]","ts":"2024-09-03T11:42:36+08:00"}
```

### Screenshots

<img width="982" alt="image" src="https://github.com/user-attachments/assets/4da2ee12-f06e-494a-8cf3-960fbe7c55e5">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
