### PR TITLE
Remove explict go toolchain versions

### DIFF
--- a/datacatalog/go.mod
+++ b/datacatalog/go.mod
@@ -2,8 +2,6 @@ module github.com/flyteorg/flyte/datacatalog
 
 go 1.22
 
-toolchain go1.22.1
-
 require (
 	github.com/Selvatico/go-mocket v1.0.7
 	github.com/flyteorg/flyte/flyteidl v0.0.0-00010101000000-000000000000

--- a/flytectl/go.mod
+++ b/flytectl/go.mod
@@ -2,8 +2,6 @@ module github.com/flyteorg/flyte/flytectl
 
 go 1.22
 
-toolchain go1.22.0
-
 require (
 	github.com/apoorvam/goterminal v0.0.0-20180523175556-614d345c47e5
 	github.com/avast/retry-go v3.0.0+incompatible


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?

 - https://github.com/flyteorg/flyte/pull/5032 updated builds to use Go 1.22 -- but in practice it looks like flytectl is being built with an outdated toolchain based on Go 1.22.0 instead of Go 1.22.5 or 1.22.6 (i.e. latest)

   For instance, flytectl v0.9.0 reports being built with Go 1.22.0

>   ❯ go version -m -v 
>   flytectl flytectl: go1.22.0

   Ensure the proper Go environment for security reasons

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
