### PR TITLE
[flyteagent] Enable `agent-service` in every configuration 

### DIFF
--- a/charts/flyte-binary/gke-starter.yaml
+++ b/charts/flyte-binary/gke-starter.yaml
@@ -99,6 +99,7 @@ configuration:
           - container
           - sidecar
           - K8S-ARRAY #used for MapTasks
+          - agent-service
           - echo
         default-for-task-types:
           - container: container

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -429,6 +429,8 @@ data:
           - container
           - sidecar
           - k8s-array
+          - agent-service
+          - echo
         default-for-task-types:
           container: container
           sidecar: sidecar

--- a/docker/sandbox-bundled/manifests/complete-agent.yaml
+++ b/docker/sandbox-bundled/manifests/complete-agent.yaml
@@ -816,7 +816,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: WVl4Y1pFNm1JTkxOMjJpZQ==
+  haSharedSecret: bTM0eldMZ3IxWE1jZXZ3cg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1413,7 +1413,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: f0211dde23276e14b7254edd85e3afd32044562e409b56d79b27202e23dc224c
+        checksum/secret: f6b8f4ae413528aa882ed401dca20e11f8947e1ca829df6bedbf16698de03cdf
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -798,7 +798,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: Q3BDekMwb0JHM1pxaXAycg==
+  haSharedSecret: Wkl6V2diWk50S1Ftd1R3Nw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1362,7 +1362,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 65e52b61d9d5af16c4217a1ea9f625d8d18e3251ede28f012cc14ef665412685
+        checksum/secret: ab69c0935db6eb0dd11b9df6716336d8f993cb949d112fd0417d1133a88000cc
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: RU9mMGpZWGNCcnp4cEJ3bg==
+  haSharedSecret: Z1BQdzNCck9SbGF2bFBNcg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 90ba33230f60ed1ee81e3088a4c88b0c9408c36ad5d40270cf05f503149f25a8
+        checksum/secret: 42de0a9877ccf019375a303e7a813c44ec6dc92758e3af6c0f10aeb4c3a1071c
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/flyte-single-binary-local.yaml
+++ b/flyte-single-binary-local.yaml
@@ -41,6 +41,7 @@ tasks:
       - container
       - sidecar
       - K8S-ARRAY
+      - agent-service
       - echo
     default-for-task-types:
       - container: container

--- a/flytepropeller/propeller-config.yaml
+++ b/flytepropeller/propeller-config.yaml
@@ -34,6 +34,7 @@ tasks:
       - sidecar
       - K8S-ARRAY
       - echo
+      - agent-service
     # Uncomment to enable sagemaker plugin
     #      - sagemaker_training
     #      - sagemaker_hyperparameter_tuning


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936


## Why are the changes needed?
I found that [gke-starter.yaml](https://github.com/flyteorg/flyte/pull/5730/files#diff-0e473e4042fb88a97366ad70c9698cd5e1f65db3c02ce9d8d3fdddd64581ed25) doesn't enable `agent-service` in it's helm chart, since `agent watcher` is merged and well-tested, we can enable `agent-service` whether agent is deployed or not.

## What changes were proposed in this pull request?
add `agent-service` in every config that has `enabled-plugins` section.

## How was this patch tested?
```zsh
cd docker/sandbox-bundled
make build
flytectl demo start --force --disable-agent --image flyte-sandbox:latest
```

<img width="1159" alt="image" src="https://github.com/user-attachments/assets/f9a3c615-9c75-47bf-8b60-519fe20b4789">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
I will update the documentation in the follow-up PR.
