### PR TITLE
[Docs][flyteagent] Remove `agent-service` config in flyte agent documentation

### DIFF
--- a/docs/flyte_agents/developing_agents.md
+++ b/docs/flyte_agents/developing_agents.md
@@ -159,29 +159,15 @@ For flytekit versions `>v1.10.2`, use `pyflyte serve agent`.
 
 ### 4. Deploy Your Flyte agent
 
-1. Update the FlyteAgent deployment's [image](https://github.com/flyteorg/flyte/blob/master/charts/flyteagent/templates/agent/deployment.yaml#L35)
+Update the FlyteAgent deployment's [image](https://github.com/flyteorg/flyte/blob/master/charts/flyteagent/templates/agent/deployment.yaml#L35)
 
 ```bash
 kubectl set image deployment/flyteagent flyteagent=ghcr.io/flyteorg/flyteagent:latest
 ```
 
-2. Update the FlytePropeller configmap:
-
-```YAML
- tasks:
-   task-plugins:
-     enabled-plugins:
-       - agent-service
-     default-for-task-types:
-       - bigquery_query_job_task: agent-service
-       - custom_task: agent-service
-```
-
-3. Restart FlytePropeller:
-
-```
-kubectl rollout restart deployment flytepropeller -n flyte
-```
+:::{note}
+Please make sure your propeller's image is >= 1.13.0 so that the propeller can automatically fetch the supported task types from your agent deployment.
+:::
 
 ### 5. Canary deployment
 

--- a/docs/flyte_agents/developing_agents.md
+++ b/docs/flyte_agents/developing_agents.md
@@ -166,7 +166,7 @@ kubectl set image deployment/flyteagent flyteagent=ghcr.io/flyteorg/flyteagent:l
 ```
 
 :::{note}
-Please make sure your propeller's image is >= 1.13.0 so that the propeller can automatically fetch the supported task types from your agent deployment.
+Please make sure your propeller's image version is >= 1.13.0 so that the propeller can automatically fetch the supported task types from your agent deployment.
 :::
 
 ### 5. Canary deployment

--- a/docs/flyte_agents/testing_agents_in_a_local_development_cluster.md
+++ b/docs/flyte_agents/testing_agents_in_a_local_development_cluster.md
@@ -41,25 +41,10 @@ flytectl demo start --dev
 pyflyte serve agent
 ```
 
-3. Update the config for the task handled by the agent in the single binary yaml file.
+3. (Optional) Update the timeout configuration for each request to the agent deployment in the single binary YAML file:
 ```bash
 cd flyte
 vim ./flyte-single-binary-local.yaml
-```
-
-```yaml
-:emphasize-lines: 9
-tasks:
-  task-plugins:
-    enabled-plugins:
-      - agent-service
-      - container
-      - sidecar
-      - K8S-ARRAY
-    default-for-task-types:
-      - sensor: agent-service
-      - container: container
-      - container_array: K8S-ARRAY
 ```
 ```yaml
 plugins:


### PR DESCRIPTION
## Docs link
https://flyte--5731.org.readthedocs.build/en/5731/flyte_agents/developing_agents.html#deploy-your-flyte-agent
https://flyte--5731.org.readthedocs.build/en/5731/flyte_agents/testing_agents_in_a_local_development_cluster.html#configuring-the-agent-service-in-development-mode

## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
Since Agent Watcher is merged and released,  we don't need to configure by ourselves.

## What changes were proposed in this pull request?
Remove configuration about `agent-service`.


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

