### PR TITLE
Add SYS_PTRACE setting to Co-pilot container config.

### DIFF
--- a/docs/deployment/configuration/generated/flyteadmin_config.rst
+++ b/docs/deployment/configuration/generated/flyteadmin_config.rst
@@ -2720,7 +2720,7 @@ k8s (`config.K8sPluginConfig`_)
     output-vol-name: flyte-outputs
     start-timeout: 1m40s
     storage: ""
-    add-sys-ptrace-capability: false
+    add-sys-ptrace-capability: true
   create-container-config-error-grace-period: 0s
   create-container-error-grace-period: 3m0s
   default-annotations:
@@ -3041,7 +3041,7 @@ Co-Pilot Configuration
   output-vol-name: flyte-outputs
   start-timeout: 1m40s
   storage: ""
-  add-sys-ptrace-capability: false
+  add-sys-ptrace-capability: true
   
 
 delete-resource-on-finalize (bool)
@@ -3386,7 +3386,7 @@ Used to enable SYS_PTRACE for co-pilot containers
 
 .. code-block:: yaml
 
-  "false"
+  "true"
   
 
 resource.Quantity

--- a/docs/deployment/configuration/generated/flyteadmin_config.rst
+++ b/docs/deployment/configuration/generated/flyteadmin_config.rst
@@ -2720,6 +2720,7 @@ k8s (`config.K8sPluginConfig`_)
     output-vol-name: flyte-outputs
     start-timeout: 1m40s
     storage: ""
+    add-sys-ptrace-capability: false
   create-container-config-error-grace-period: 0s
   create-container-error-grace-period: 3m0s
   default-annotations:
@@ -3040,6 +3041,7 @@ Co-Pilot Configuration
   output-vol-name: flyte-outputs
   start-timeout: 1m40s
   storage: ""
+  add-sys-ptrace-capability: false
   
 
 delete-resource-on-finalize (bool)
@@ -3373,6 +3375,18 @@ Default storage limit for individual inputs / outputs
 .. code-block:: yaml
 
   ""
+
+
+add-sys-ptrace-capability (bool)
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Used to enable SYS_PTRACE for co-pilot containers
+
+**Default Value**:
+
+.. code-block:: yaml
+
+  "false"
   
 
 resource.Quantity

--- a/docs/deployment/configuration/generated/flyteadmin_config.rst
+++ b/docs/deployment/configuration/generated/flyteadmin_config.rst
@@ -2720,7 +2720,7 @@ k8s (`config.K8sPluginConfig`_)
     output-vol-name: flyte-outputs
     start-timeout: 1m40s
     storage: ""
-    add-sys-ptrace-capability: true
+    add-ptrace: true
   create-container-config-error-grace-period: 0s
   create-container-error-grace-period: 3m0s
   default-annotations:
@@ -3041,7 +3041,7 @@ Co-Pilot Configuration
   output-vol-name: flyte-outputs
   start-timeout: 1m40s
   storage: ""
-  add-sys-ptrace-capability: true
+  add-ptrace: true
   
 
 delete-resource-on-finalize (bool)
@@ -3377,7 +3377,7 @@ Default storage limit for individual inputs / outputs
   ""
 
 
-add-sys-ptrace-capability (bool)
+add-ptrace (bool)
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Used to enable SYS_PTRACE for co-pilot containers

--- a/docs/deployment/configuration/generated/flytepropeller_config.rst
+++ b/docs/deployment/configuration/generated/flytepropeller_config.rst
@@ -1172,7 +1172,7 @@ k8s (`config.K8sPluginConfig`_)
     output-vol-name: flyte-outputs
     start-timeout: 1m40s
     storage: ""
-    add-sys-ptrace-capability: false
+    add-sys-ptrace-capability: true
   create-container-config-error-grace-period: 0s
   create-container-error-grace-period: 3m0s
   default-annotations:
@@ -2522,7 +2522,7 @@ Co-Pilot Configuration
   output-vol-name: flyte-outputs
   start-timeout: 1m40s
   storage: ""
-  add-sys-ptrace-capability: false
+  add-sys-ptrace-capability: true
   
 
 delete-resource-on-finalize (bool)
@@ -2867,7 +2867,7 @@ Used to enable SYS_PTRACE for co-pilot containers
 
 .. code-block:: yaml
 
-  "false"
+  "true"
 
 
 resource.Quantity

--- a/docs/deployment/configuration/generated/flytepropeller_config.rst
+++ b/docs/deployment/configuration/generated/flytepropeller_config.rst
@@ -1172,7 +1172,7 @@ k8s (`config.K8sPluginConfig`_)
     output-vol-name: flyte-outputs
     start-timeout: 1m40s
     storage: ""
-    add-sys-ptrace-capability: true
+    add-ptrace: true
   create-container-config-error-grace-period: 0s
   create-container-error-grace-period: 3m0s
   default-annotations:
@@ -2522,7 +2522,7 @@ Co-Pilot Configuration
   output-vol-name: flyte-outputs
   start-timeout: 1m40s
   storage: ""
-  add-sys-ptrace-capability: true
+  add-ptrace: true
   
 
 delete-resource-on-finalize (bool)
@@ -2858,7 +2858,7 @@ Default storage limit for individual inputs / outputs
   ""
   
 
-add-sys-ptrace-capability (bool)
+add-ptrace (bool)
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Used to enable SYS_PTRACE for co-pilot containers

--- a/docs/deployment/configuration/generated/flytepropeller_config.rst
+++ b/docs/deployment/configuration/generated/flytepropeller_config.rst
@@ -1172,6 +1172,7 @@ k8s (`config.K8sPluginConfig`_)
     output-vol-name: flyte-outputs
     start-timeout: 1m40s
     storage: ""
+    add-sys-ptrace-capability: false
   create-container-config-error-grace-period: 0s
   create-container-error-grace-period: 3m0s
   default-annotations:
@@ -2521,6 +2522,7 @@ Co-Pilot Configuration
   output-vol-name: flyte-outputs
   start-timeout: 1m40s
   storage: ""
+  add-sys-ptrace-capability: false
   
 
 delete-resource-on-finalize (bool)
@@ -2855,6 +2857,18 @@ Default storage limit for individual inputs / outputs
 
   ""
   
+
+add-sys-ptrace-capability (bool)
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Used to enable SYS_PTRACE for co-pilot containers
+
+**Default Value**:
+
+.. code-block:: yaml
+
+  "false"
+
 
 resource.Quantity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/deployment/configuration/generated/scheduler_config.rst
+++ b/docs/deployment/configuration/generated/scheduler_config.rst
@@ -2720,6 +2720,7 @@ k8s (`config.K8sPluginConfig`_)
     output-vol-name: flyte-outputs
     start-timeout: 1m40s
     storage: ""
+    add-sys-ptrace-capability: false
   create-container-config-error-grace-period: 0s
   create-container-error-grace-period: 3m0s
   default-annotations:
@@ -3040,6 +3041,7 @@ Co-Pilot Configuration
   output-vol-name: flyte-outputs
   start-timeout: 1m40s
   storage: ""
+  add-sys-ptrace-capability: false
   
 
 delete-resource-on-finalize (bool)
@@ -3374,6 +3376,18 @@ Default storage limit for individual inputs / outputs
 
   ""
   
+
+add-sys-ptrace-capability (bool)
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Used to enable SYS_PTRACE for co-pilot containers
+
+**Default Value**:
+
+.. code-block:: yaml
+
+  "false"
+
 
 resource.Quantity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/deployment/configuration/generated/scheduler_config.rst
+++ b/docs/deployment/configuration/generated/scheduler_config.rst
@@ -2720,7 +2720,7 @@ k8s (`config.K8sPluginConfig`_)
     output-vol-name: flyte-outputs
     start-timeout: 1m40s
     storage: ""
-    add-sys-ptrace-capability: true
+    add-ptrace: true
   create-container-config-error-grace-period: 0s
   create-container-error-grace-period: 3m0s
   default-annotations:
@@ -3041,7 +3041,7 @@ Co-Pilot Configuration
   output-vol-name: flyte-outputs
   start-timeout: 1m40s
   storage: ""
-  add-sys-ptrace-capability: true
+  add-ptrace: true
   
 
 delete-resource-on-finalize (bool)
@@ -3377,7 +3377,7 @@ Default storage limit for individual inputs / outputs
   ""
   
 
-add-sys-ptrace-capability (bool)
+add-ptrace (bool)
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Used to enable SYS_PTRACE for co-pilot containers

--- a/docs/deployment/configuration/generated/scheduler_config.rst
+++ b/docs/deployment/configuration/generated/scheduler_config.rst
@@ -2720,7 +2720,7 @@ k8s (`config.K8sPluginConfig`_)
     output-vol-name: flyte-outputs
     start-timeout: 1m40s
     storage: ""
-    add-sys-ptrace-capability: false
+    add-sys-ptrace-capability: true
   create-container-config-error-grace-period: 0s
   create-container-error-grace-period: 3m0s
   default-annotations:
@@ -3041,7 +3041,7 @@ Co-Pilot Configuration
   output-vol-name: flyte-outputs
   start-timeout: 1m40s
   storage: ""
-  add-sys-ptrace-capability: false
+  add-sys-ptrace-capability: true
   
 
 delete-resource-on-finalize (bool)
@@ -3386,7 +3386,7 @@ Used to enable SYS_PTRACE for co-pilot containers
 
 .. code-block:: yaml
 
-  "false"
+  "true"
 
 
 resource.Quantity

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/config.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/config.go
@@ -40,7 +40,7 @@ var (
 			OutputVolumeName:       "flyte-outputs",
 			CPU:                    "500m",
 			Memory:                 "128Mi",
-			AddSysPTraceCapability: false,
+			AddSysPTraceCapability: true,
 			StartTimeout: config2.Duration{
 				Duration: time.Second * 100,
 			},

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/config.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/config.go
@@ -32,14 +32,15 @@ var (
 			"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 		},
 		CoPilot: FlyteCoPilotConfig{
-			NamePrefix:           "flyte-copilot-",
-			Image:                "cr.flyte.org/flyteorg/flytecopilot:v0.0.15",
-			DefaultInputDataPath: "/var/flyte/inputs",
-			InputVolumeName:      "flyte-inputs",
-			DefaultOutputPath:    "/var/flyte/outputs",
-			OutputVolumeName:     "flyte-outputs",
-			CPU:                  "500m",
-			Memory:               "128Mi",
+			NamePrefix:             "flyte-copilot-",
+			Image:                  "cr.flyte.org/flyteorg/flytecopilot:v0.0.15",
+			DefaultInputDataPath:   "/var/flyte/inputs",
+			InputVolumeName:        "flyte-inputs",
+			DefaultOutputPath:      "/var/flyte/outputs",
+			OutputVolumeName:       "flyte-outputs",
+			CPU:                    "500m",
+			Memory:                 "128Mi",
+			AddSysPTraceCapability: false,
 			StartTimeout: config2.Duration{
 				Duration: time.Second * 100,
 			},
@@ -238,6 +239,8 @@ type FlyteCoPilotConfig struct {
 	CPU     string `json:"cpu" pflag:",Used to set cpu for co-pilot containers"`
 	Memory  string `json:"memory" pflag:",Used to set memory for co-pilot containers"`
 	Storage string `json:"storage" pflag:",Default storage limit for individual inputs / outputs"`
+	// Co-Pilot Security Context Capabilities
+	AddSysPTraceCapability bool `json:"add-sys-ptrace-capability" pflag:",Used to enable SYS_PTRACE for co-pilot containers"`
 }
 
 // GetK8sPluginConfig retrieves the current k8s plugin config or default.

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/config.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/config.go
@@ -32,15 +32,15 @@ var (
 			"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 		},
 		CoPilot: FlyteCoPilotConfig{
-			NamePrefix:             "flyte-copilot-",
-			Image:                  "cr.flyte.org/flyteorg/flytecopilot:v0.0.15",
-			DefaultInputDataPath:   "/var/flyte/inputs",
-			InputVolumeName:        "flyte-inputs",
-			DefaultOutputPath:      "/var/flyte/outputs",
-			OutputVolumeName:       "flyte-outputs",
-			CPU:                    "500m",
-			Memory:                 "128Mi",
-			AddSysPTraceCapability: true,
+			NamePrefix:           "flyte-copilot-",
+			Image:                "cr.flyte.org/flyteorg/flytecopilot:v0.0.15",
+			DefaultInputDataPath: "/var/flyte/inputs",
+			InputVolumeName:      "flyte-inputs",
+			DefaultOutputPath:    "/var/flyte/outputs",
+			OutputVolumeName:     "flyte-outputs",
+			CPU:                  "500m",
+			Memory:               "128Mi",
+			AddPTrace:            true,
 			StartTimeout: config2.Duration{
 				Duration: time.Second * 100,
 			},
@@ -240,7 +240,7 @@ type FlyteCoPilotConfig struct {
 	Memory  string `json:"memory" pflag:",Used to set memory for co-pilot containers"`
 	Storage string `json:"storage" pflag:",Default storage limit for individual inputs / outputs"`
 	// Co-Pilot Security Context Capabilities
-	AddSysPTraceCapability bool `json:"add-sys-ptrace-capability" pflag:",Used to enable SYS_PTRACE for co-pilot containers"`
+	AddPTrace bool `json:"add-ptrace" pflag:",Used to enable SYS_PTRACE for co-pilot containers"`
 }
 
 // GetK8sPluginConfig retrieves the current k8s plugin config or default.

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/k8spluginconfig_flags.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/k8spluginconfig_flags.go
@@ -63,6 +63,7 @@ func (cfg K8sPluginConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "co-pilot.cpu"), defaultK8sConfig.CoPilot.CPU, "Used to set cpu for co-pilot containers")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "co-pilot.memory"), defaultK8sConfig.CoPilot.Memory, "Used to set memory for co-pilot containers")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "co-pilot.storage"), defaultK8sConfig.CoPilot.Storage, "Default storage limit for individual inputs / outputs")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "co-pilot.add-sys-ptrace-capability"), defaultK8sConfig.CoPilot.AddSysPTraceCapability, "Used to enable SYS_PTRACE for co-pilot containers")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "delete-resource-on-finalize"), defaultK8sConfig.DeleteResourceOnFinalize, "Instructs the system to delete the resource upon successful execution of a k8s pod rather than have the k8s garbage collector clean it up. This ensures that no resources are kept around (potentially consuming cluster resources). This,  however,  will cause k8s log links to expire as soon as the resource is finalized.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "default-pod-template-name"), defaultK8sConfig.DefaultPodTemplateName, "Name of the PodTemplate to use as the base for all k8s pods created by FlytePropeller.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "default-pod-template-resync"), defaultK8sConfig.DefaultPodTemplateResync.String(), "Frequency of resyncing default pod templates")

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/k8spluginconfig_flags.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/k8spluginconfig_flags.go
@@ -63,7 +63,7 @@ func (cfg K8sPluginConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "co-pilot.cpu"), defaultK8sConfig.CoPilot.CPU, "Used to set cpu for co-pilot containers")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "co-pilot.memory"), defaultK8sConfig.CoPilot.Memory, "Used to set memory for co-pilot containers")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "co-pilot.storage"), defaultK8sConfig.CoPilot.Storage, "Default storage limit for individual inputs / outputs")
-	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "co-pilot.add-sys-ptrace-capability"), defaultK8sConfig.CoPilot.AddSysPTraceCapability, "Used to enable SYS_PTRACE for co-pilot containers")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "co-pilot.add-ptrace"), defaultK8sConfig.CoPilot.AddPTrace, "Used to enable SYS_PTRACE for co-pilot containers")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "delete-resource-on-finalize"), defaultK8sConfig.DeleteResourceOnFinalize, "Instructs the system to delete the resource upon successful execution of a k8s pod rather than have the k8s garbage collector clean it up. This ensures that no resources are kept around (potentially consuming cluster resources). This,  however,  will cause k8s log links to expire as soon as the resource is finalized.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "default-pod-template-name"), defaultK8sConfig.DefaultPodTemplateName, "Name of the PodTemplate to use as the base for all k8s pods created by FlytePropeller.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "default-pod-template-resync"), defaultK8sConfig.DefaultPodTemplateResync.String(), "Frequency of resyncing default pod templates")

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -172,7 +172,9 @@ func AddCoPilotToContainer(ctx context.Context, cfg config.FlyteCoPilotConfig, c
 	if c.SecurityContext.Capabilities == nil {
 		c.SecurityContext.Capabilities = &v1.Capabilities{}
 	}
-	c.SecurityContext.Capabilities.Add = append(c.SecurityContext.Capabilities.Add, pTraceCapability)
+	if cfg.AddSysPTraceCapability {
+		c.SecurityContext.Capabilities.Add = append(c.SecurityContext.Capabilities.Add, pTraceCapability)
+	}
 
 	if iFace != nil {
 		if iFace.Inputs != nil && len(iFace.Inputs.Variables) > 0 {

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -172,7 +172,7 @@ func AddCoPilotToContainer(ctx context.Context, cfg config.FlyteCoPilotConfig, c
 	if c.SecurityContext.Capabilities == nil {
 		c.SecurityContext.Capabilities = &v1.Capabilities{}
 	}
-	if cfg.AddSysPTraceCapability {
+	if cfg.AddPTrace {
 		c.SecurityContext.Capabilities.Add = append(c.SecurityContext.Capabilities.Add, pTraceCapability)
 	}
 

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
@@ -42,7 +42,7 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 		},
 		CPU:                    "1024m",
 		Memory:                 "1024Mi",
-		AddSysPTraceCapability: false,
+		AddSysPTraceCapability: true,
 	}
 
 	t.Run("happy", func(t *testing.T) {
@@ -56,7 +56,7 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 		assert.Equal(t, "/", c.WorkingDir)
 		assert.Equal(t, 2, len(c.Resources.Limits))
 		assert.Equal(t, 2, len(c.Resources.Requests))
-		assert.NotContains(t, c.SecurityContext.Capabilities.Add, pTraceCapability)
+		assert.Contains(t, c.SecurityContext.Capabilities.Add, pTraceCapability)
 	})
 
 	t.Run("happy stow backend", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 		assert.Equal(t, "/", c.WorkingDir)
 		assert.Equal(t, 2, len(c.Resources.Limits))
 		assert.Equal(t, 2, len(c.Resources.Requests))
-		assert.NotContains(t, c.SecurityContext.Capabilities.Add, pTraceCapability)
+		assert.Contains(t, c.SecurityContext.Capabilities.Add, pTraceCapability)
 	})
 
 	t.Run("happy-vols", func(t *testing.T) {
@@ -111,12 +111,12 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 		cfg.Memory = old
 	})
 
-	t.Run("sys-ptrace-add", func(t *testing.T) {
+	t.Run("no-sys-ptrace-add", func(t *testing.T) {
 		old := cfg.AddSysPTraceCapability
-		cfg.AddSysPTraceCapability = true
+		cfg.AddSysPTraceCapability = false
 		c, err := FlyteCoPilotContainer("x", cfg, []string{"hello"})
 		assert.NoError(t, err)
-		assert.Contains(t, c.SecurityContext.Capabilities.Add, pTraceCapability)
+		assert.NotContains(t, c.SecurityContext.Capabilities.Add, pTraceCapability)
 		cfg.AddSysPTraceCapability = old
 	})
 }


### PR DESCRIPTION
## Tracking issue

Related to #5462

## Why are the changes needed?

The issue https://github.com/flyteorg/flyte/issues/5462 describes the problem in detail.

## What changes were proposed in this pull request?

I made `SYS_PTRACE` an optional setting for co-pilot containers.

## How was this patch tested?

I added the default setting to the "happy" and "happy stow backend" Co-pilot Container tests. I also added a test to ensure the SYS_PTRACE capability is present when the setting is enabled.

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

See #5556.