### PR TITLE
Add semver check for dev and beta version

### DIFF
--- a/flytepropeller/pkg/controller/config/config_test.go
+++ b/flytepropeller/pkg/controller/config/config_test.go
@@ -51,4 +51,21 @@ func TestIsSupportedSDKVersion(t *testing.T) {
 		}
 		assert.False(t, config.IsSupportedSDKVersion("flytekit", "0.16.0"))
 	})
+
+	t.Run("supported dev version", func(t *testing.T) {
+		config := LiteralOffloadingConfig{
+			SupportedSDKVersions: map[string]string{
+				"flytekit": "1.13.4",
+			},
+		}
+		assert.True(t, config.IsSupportedSDKVersion("flytekit", "1.13.4.dev12+g990b450ea.d20240917"))
+	})
+	t.Run("supported beta version", func(t *testing.T) {
+		config := LiteralOffloadingConfig{
+			SupportedSDKVersions: map[string]string{
+				"flytekit": "1.13.4",
+			},
+		}
+		assert.True(t, config.IsSupportedSDKVersion("flytekit", "v1.13.6b0"))
+	})
 }


### PR DESCRIPTION
## Why are the changes needed?

Supporting dev and beta versions of the flytekit sdk during semver version checks for literal offloading feature.
Follow up to https://github.com/flyteorg/flyte/pull/5705


## What changes were proposed in this pull request?
Do a regex match for the version string passed against a valid semver and use that for comparision with the supported one.

## How was this patch tested?

Unit test added to test dev and beta versions

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
