### PR TITLE
Auto refresh cache tweaks

### DIFF
--- a/flytepropeller/pkg/controller/nodes/subworkflow/handler.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/handler.go
@@ -33,7 +33,7 @@ func newMetrics(scope promutils.Scope) metrics {
 }
 
 func (w *workflowNodeHandler) FinalizeRequired() bool {
-	return false
+	return true
 }
 
 func (w *workflowNodeHandler) Setup(_ context.Context, _ interfaces.SetupContext) error {
@@ -120,8 +120,12 @@ func (w *workflowNodeHandler) Abort(ctx context.Context, nCtx interfaces.NodeExe
 	return nil
 }
 
-func (w *workflowNodeHandler) Finalize(ctx context.Context, _ interfaces.NodeExecutionContext) error {
-	logger.Warnf(ctx, "Subworkflow finalize invoked. Nothing to be done")
+func (w *workflowNodeHandler) Finalize(ctx context.Context, nCtx interfaces.NodeExecutionContext) error {
+	logger.Warnf(ctx, "Subworkflow finalize invoked. Clearing up the cache")
+	wfNode := nCtx.Node().GetWorkflowNode()
+	if wfNode.GetLaunchPlanRefID() != nil {
+		return w.lpHandler.Finalize(ctx, nCtx)
+	}
 	return nil
 }
 

--- a/flytepropeller/pkg/controller/nodes/subworkflow/handler.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/handler.go
@@ -124,7 +124,7 @@ func (w *workflowNodeHandler) Finalize(ctx context.Context, nCtx interfaces.Node
 	logger.Warnf(ctx, "Subworkflow finalize invoked. Clearing up the cache")
 	wfNode := nCtx.Node().GetWorkflowNode()
 	if wfNode.GetLaunchPlanRefID() != nil {
-		return w.lpHandler.Finalize(ctx, nCtx)
+		return w.lpHandler.HandleFinalize(ctx, nCtx)
 	}
 	return nil
 }

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan.go
@@ -230,7 +230,7 @@ func (l *launchPlanHandler) HandleAbort(ctx context.Context, nCtx interfaces.Nod
 	return l.launchPlan.Kill(ctx, childID, fmt.Sprintf("cascading abort as parent execution id [%s] aborted, reason [%s]", nCtx.ExecutionContext().GetName(), reason))
 }
 
-func (l *launchPlanHandler) Finalize(ctx context.Context, nCtx interfaces.NodeExecutionContext) error {
+func (l *launchPlanHandler) HandleFinalize(ctx context.Context, nCtx interfaces.NodeExecutionContext) error {
 	parentNodeExecutionID, err := getParentNodeExecutionID(nCtx)
 	if err != nil {
 		return err
@@ -244,5 +244,5 @@ func (l *launchPlanHandler) Finalize(ctx context.Context, nCtx interfaces.NodeEx
 		return err
 	}
 
-	return l.launchPlan.Finalize(ctx, childID)
+	return l.launchPlan.ClearCache(ctx, childID)
 }

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan.go
@@ -229,3 +229,20 @@ func (l *launchPlanHandler) HandleAbort(ctx context.Context, nCtx interfaces.Nod
 	}
 	return l.launchPlan.Kill(ctx, childID, fmt.Sprintf("cascading abort as parent execution id [%s] aborted, reason [%s]", nCtx.ExecutionContext().GetName(), reason))
 }
+
+func (l *launchPlanHandler) Finalize(ctx context.Context, nCtx interfaces.NodeExecutionContext) error {
+	parentNodeExecutionID, err := getParentNodeExecutionID(nCtx)
+	if err != nil {
+		return err
+	}
+	childID, err := GetChildWorkflowExecutionIDForExecution(
+		parentNodeExecutionID,
+		nCtx,
+	)
+	if err != nil {
+		// THIS SHOULD NEVER HAPPEN
+		return err
+	}
+
+	return l.launchPlan.Finalize(ctx, childID)
+}

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/admin.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/admin.go
@@ -224,6 +224,10 @@ func (a *adminLaunchPlanExecutor) Initialize(ctx context.Context) error {
 	return a.cache.Start(ctx)
 }
 
+func (a *adminLaunchPlanExecutor) Finalize(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) error {
+	return a.cache.DeleteDelayed(executionID.String())
+}
+
 func (a *adminLaunchPlanExecutor) syncItem(ctx context.Context, batch cache.Batch) (
 	resp []cache.ItemSyncResponse, err error) {
 	resp = make([]cache.ItemSyncResponse, 0, len(batch))

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/admin.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/admin.go
@@ -224,7 +224,7 @@ func (a *adminLaunchPlanExecutor) Initialize(ctx context.Context) error {
 	return a.cache.Start(ctx)
 }
 
-func (a *adminLaunchPlanExecutor) Finalize(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) error {
+func (a *adminLaunchPlanExecutor) ClearCache(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) error {
 	return a.cache.DeleteDelayed(executionID.String())
 }
 

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/launchplan.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/launchplan.go
@@ -47,8 +47,8 @@ type Executor interface {
 	// Initialize initializes Executor.
 	Initialize(ctx context.Context) error
 
-	// Finalize clears the cache of the LaunchPlan execution
-	Finalize(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) error
+	// ClearCache clears the cache of the LaunchPlan execution
+	ClearCache(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) error
 }
 
 type Reader interface {

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/launchplan.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/launchplan.go
@@ -46,6 +46,9 @@ type Executor interface {
 
 	// Initialize initializes Executor.
 	Initialize(ctx context.Context) error
+
+	// Finalize clears the cache of the LaunchPlan execution
+	Finalize(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) error
 }
 
 type Reader interface {

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks/executor.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks/executor.go
@@ -19,26 +19,26 @@ type Executor struct {
 	mock.Mock
 }
 
-type Executor_Finalize struct {
+type Executor_ClearCache struct {
 	*mock.Call
 }
 
-func (_m Executor_Finalize) Return(_a0 error) *Executor_Finalize {
-	return &Executor_Finalize{Call: _m.Call.Return(_a0)}
+func (_m Executor_ClearCache) Return(_a0 error) *Executor_ClearCache {
+	return &Executor_ClearCache{Call: _m.Call.Return(_a0)}
 }
 
-func (_m *Executor) OnFinalize(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) *Executor_Finalize {
-	c_call := _m.On("Finalize", ctx, executionID)
-	return &Executor_Finalize{Call: c_call}
+func (_m *Executor) OnClearCache(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) *Executor_ClearCache {
+	c_call := _m.On("ClearCache", ctx, executionID)
+	return &Executor_ClearCache{Call: c_call}
 }
 
-func (_m *Executor) OnFinalizeMatch(matchers ...interface{}) *Executor_Finalize {
-	c_call := _m.On("Finalize", matchers...)
-	return &Executor_Finalize{Call: c_call}
+func (_m *Executor) OnClearCacheMatch(matchers ...interface{}) *Executor_ClearCache {
+	c_call := _m.On("ClearCache", matchers...)
+	return &Executor_ClearCache{Call: c_call}
 }
 
-// Finalize provides a mock function with given fields: ctx, executionID
-func (_m *Executor) Finalize(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) error {
+// ClearCache provides a mock function with given fields: ctx, executionID
+func (_m *Executor) ClearCache(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) error {
 	ret := _m.Called(ctx, executionID)
 
 	var r0 error

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks/executor.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks/executor.go
@@ -19,6 +19,38 @@ type Executor struct {
 	mock.Mock
 }
 
+type Executor_Finalize struct {
+	*mock.Call
+}
+
+func (_m Executor_Finalize) Return(_a0 error) *Executor_Finalize {
+	return &Executor_Finalize{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *Executor) OnFinalize(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) *Executor_Finalize {
+	c_call := _m.On("Finalize", ctx, executionID)
+	return &Executor_Finalize{Call: c_call}
+}
+
+func (_m *Executor) OnFinalizeMatch(matchers ...interface{}) *Executor_Finalize {
+	c_call := _m.On("Finalize", matchers...)
+	return &Executor_Finalize{Call: c_call}
+}
+
+// Finalize provides a mock function with given fields: ctx, executionID
+func (_m *Executor) Finalize(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) error {
+	ret := _m.Called(ctx, executionID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *core.WorkflowExecutionIdentifier) error); ok {
+		r0 = rf(ctx, executionID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type Executor_GetStatus struct {
 	*mock.Call
 }

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks/flyte_admin.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks/flyte_admin.go
@@ -19,26 +19,26 @@ type FlyteAdmin struct {
 	mock.Mock
 }
 
-type FlyteAdmin_Finalize struct {
+type FlyteAdmin_ClearCache struct {
 	*mock.Call
 }
 
-func (_m FlyteAdmin_Finalize) Return(_a0 error) *FlyteAdmin_Finalize {
-	return &FlyteAdmin_Finalize{Call: _m.Call.Return(_a0)}
+func (_m FlyteAdmin_ClearCache) Return(_a0 error) *FlyteAdmin_ClearCache {
+	return &FlyteAdmin_ClearCache{Call: _m.Call.Return(_a0)}
 }
 
-func (_m *FlyteAdmin) OnFinalize(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) *FlyteAdmin_Finalize {
-	c_call := _m.On("Finalize", ctx, executionID)
-	return &FlyteAdmin_Finalize{Call: c_call}
+func (_m *FlyteAdmin) OnClearCache(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) *FlyteAdmin_ClearCache {
+	c_call := _m.On("ClearCache", ctx, executionID)
+	return &FlyteAdmin_ClearCache{Call: c_call}
 }
 
-func (_m *FlyteAdmin) OnFinalizeMatch(matchers ...interface{}) *FlyteAdmin_Finalize {
-	c_call := _m.On("Finalize", matchers...)
-	return &FlyteAdmin_Finalize{Call: c_call}
+func (_m *FlyteAdmin) OnClearCacheMatch(matchers ...interface{}) *FlyteAdmin_ClearCache {
+	c_call := _m.On("ClearCache", matchers...)
+	return &FlyteAdmin_ClearCache{Call: c_call}
 }
 
-// Finalize provides a mock function with given fields: ctx, executionID
-func (_m *FlyteAdmin) Finalize(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) error {
+// ClearCache provides a mock function with given fields: ctx, executionID
+func (_m *FlyteAdmin) ClearCache(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) error {
 	ret := _m.Called(ctx, executionID)
 
 	var r0 error

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks/flyte_admin.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks/flyte_admin.go
@@ -19,6 +19,38 @@ type FlyteAdmin struct {
 	mock.Mock
 }
 
+type FlyteAdmin_Finalize struct {
+	*mock.Call
+}
+
+func (_m FlyteAdmin_Finalize) Return(_a0 error) *FlyteAdmin_Finalize {
+	return &FlyteAdmin_Finalize{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *FlyteAdmin) OnFinalize(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) *FlyteAdmin_Finalize {
+	c_call := _m.On("Finalize", ctx, executionID)
+	return &FlyteAdmin_Finalize{Call: c_call}
+}
+
+func (_m *FlyteAdmin) OnFinalizeMatch(matchers ...interface{}) *FlyteAdmin_Finalize {
+	c_call := _m.On("Finalize", matchers...)
+	return &FlyteAdmin_Finalize{Call: c_call}
+}
+
+// Finalize provides a mock function with given fields: ctx, executionID
+func (_m *FlyteAdmin) Finalize(ctx context.Context, executionID *core.WorkflowExecutionIdentifier) error {
+	ret := _m.Called(ctx, executionID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *core.WorkflowExecutionIdentifier) error); ok {
+		r0 = rf(ctx, executionID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type FlyteAdmin_GetLaunchPlan struct {
 	*mock.Call
 }

--- a/flytestdlib/cache/auto_refresh.go
+++ b/flytestdlib/cache/auto_refresh.go
@@ -198,9 +198,6 @@ func (w *autoRefresh) Delete(key interface{}) {
 func (w *autoRefresh) Get(id ItemID) (Item, error) {
 	if val, ok := w.lruMap.Get(id); ok {
 		w.metrics.CacheHit.Inc()
-		if fetchedItem, ok := val.(Item); ok && fetchedItem.IsTerminal() {
-			w.Delete(id)
-		}
 		return val.(Item), nil
 	}
 
@@ -213,9 +210,6 @@ func (w *autoRefresh) Get(id ItemID) (Item, error) {
 func (w *autoRefresh) GetOrCreate(id ItemID, item Item) (Item, error) {
 	if val, ok := w.lruMap.Get(id); ok {
 		w.metrics.CacheHit.Inc()
-		if fetchedItem, ok := val.(Item); ok && fetchedItem.IsTerminal() {
-			w.Delete(id)
-		}
 		return val.(Item), nil
 	}
 

--- a/flytestdlib/cache/auto_refresh.go
+++ b/flytestdlib/cache/auto_refresh.go
@@ -198,6 +198,9 @@ func (w *autoRefresh) Delete(key interface{}) {
 func (w *autoRefresh) Get(id ItemID) (Item, error) {
 	if val, ok := w.lruMap.Get(id); ok {
 		w.metrics.CacheHit.Inc()
+		if fetchedItem, ok := val.(Item); ok && fetchedItem.IsTerminal() {
+			w.Delete(id)
+		}
 		return val.(Item), nil
 	}
 
@@ -210,6 +213,9 @@ func (w *autoRefresh) Get(id ItemID) (Item, error) {
 func (w *autoRefresh) GetOrCreate(id ItemID, item Item) (Item, error) {
 	if val, ok := w.lruMap.Get(id); ok {
 		w.metrics.CacheHit.Inc()
+		if fetchedItem, ok := val.(Item); ok && fetchedItem.IsTerminal() {
+			w.Delete(id)
+		}
 		return val.(Item), nil
 	}
 


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?
Items remain in the LP admin cache in a terminal state until they are evicted based on LRU policy. This causes for more cache evictions than necessary.

## What changes were proposed in this pull request?
- Update subworkflow nodes to set cached lp status items to be deleted in auto refresh cache during Finalize

## How was this patch tested?
- tested in sandbox
- TODO: add unit test...

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
