### PR TITLE
[Docs][flyteagent] Improve Agent Secret Setup

### DIFF
--- a/docs/deployment/agents/chatgpt.rst
+++ b/docs/deployment/agents/chatgpt.rst
@@ -78,45 +78,25 @@ Specify agent configuration
 Add the OpenAI API token
 -------------------------------
 
-1. Install flyteagent pod using helm:
+1. Install the flyteagent pod using helm:
 
-.. code-block::
+.. code-block:: bash
 
   helm repo add flyteorg https://flyteorg.github.io/flyte
   helm install flyteagent flyteorg/flyteagent --namespace flyte
 
-2. Get the base64 value of your OpenAI API token:
+2. Set Your OpenAI API Token as a Secret (Base64 Encoded):
 
-.. code-block::
+.. code-block:: bash
 
-  echo -n "<OPENAI_API_TOKEN>" | base64
+  SECRET_VALUE=$(echo -n "<OPENAI_API_TOKEN>" | base64) && \
+  kubectl patch secret flyteagent -n flyte --patch "{\"data\":{\"flyte_openai_api_key\":\"$SECRET_VALUE\"}}"
 
-3. Edit the flyteagent secret:
+3. Restart development:
 
-      .. code-block:: bash
+.. code-block:: bash
 
-        kubectl edit secret flyteagent -n flyte
-
-      .. code-block:: yaml
-        :emphasize-lines: 3
-
-        apiVersion: v1
-        data:
-          flyte_openai_api_key: <BASE64_ENCODED_OPENAI_API_TOKEN>
-        kind: Secret
-        metadata:
-          annotations:
-            meta.helm.sh/release-name: flyteagent
-            meta.helm.sh/release-namespace: flyte
-          creationTimestamp: "2023-10-04T04:09:03Z"
-          labels:
-            app.kubernetes.io/managed-by: Helm
-          name: flyteagent
-          namespace: flyte
-          resourceVersion: "753"
-          uid: 5ac1e1b6-2a4c-4e26-9001-d4ba72c39e54
-        type: Opaque
-
+  kubectl rollout restart deployment flyteagent -n flyte
 
 Upgrade the Flyte Helm release
 ------------------------------

--- a/docs/deployment/agents/databricks.rst
+++ b/docs/deployment/agents/databricks.rst
@@ -199,45 +199,25 @@ Add the Databricks access token
 
 You have to set the Databricks token to the Flyte configuration.
 
-1. Install flyteagent pod using helm
+1. Install the flyteagent pod using helm
   
 .. code-block::
   
   helm repo add flyteorg https://flyteorg.github.io/flyte
   helm install flyteagent flyteorg/flyteagent --namespace flyte
 
-2. Get the base64 value of your Databricks token.
+2. Set Your Databricks Token as a Secret (Base64 Encoded):
 
-.. code-block::
+.. code-block:: bash
 
-  echo -n "<DATABRICKS_TOKEN>" | base64
+  SECRET_VALUE=$(echo -n "<DATABRICKS_TOKEN>" | base64) && \
+  kubectl patch secret flyteagent -n flyte --patch "{\"data\":{\"flyte_databricks_access_token\":\"$SECRET_VALUE\"}}"
 
-3. Edit the flyteagent secret
-  
-      .. code-block:: bash
-    
-        kubectl edit secret flyteagent -n flyte
-    
-      .. code-block:: yaml
-        :emphasize-lines: 3
+3. Restart development:
 
-        apiVersion: v1
-        data:
-          flyte_databricks_access_token: <BASE64_ENCODED_DATABRICKS_TOKEN>
-        kind: Secret
-        metadata:
-          annotations:
-            meta.helm.sh/release-name: flyteagent
-            meta.helm.sh/release-namespace: flyte
-          creationTimestamp: "2023-10-04T04:09:03Z"
-          labels:
-            app.kubernetes.io/managed-by: Helm
-          name: flyteagent
-          namespace: flyte
-          resourceVersion: "753"
-          uid: 5ac1e1b6-2a4c-4e26-9001-d4ba72c39e54
-        type: Opaque
+.. code-block:: bash
 
+  kubectl rollout restart deployment flyteagent -n flyte
 
 Upgrade the deployment
 ----------------------

--- a/docs/deployment/agents/openai_batch.rst
+++ b/docs/deployment/agents/openai_batch.rst
@@ -65,38 +65,18 @@ Add the OpenAI API token
   helm repo add flyteorg https://flyteorg.github.io/flyte
   helm install flyteagent flyteorg/flyteagent --namespace flyte
 
-2. Get the base64 value of your OpenAI API token:
+2. Set Your OpenAI API Token as a Secret (Base64 Encoded):
 
-.. code-block::
+.. code-block:: bash
 
-  echo -n "<OPENAI_API_TOKEN>" | base64
+  SECRET_VALUE=$(echo -n "<OPENAI_API_TOKEN>" | base64) && \
+  kubectl patch secret flyteagent -n flyte --patch "{\"data\":{\"flyte_openai_api_key\":\"$SECRET_VALUE\"}}"
 
-3. Edit the flyteagent secret:
+3. Restart development:
 
-    .. code-block:: bash
+.. code-block:: bash
 
-      kubectl edit secret flyteagent -n flyte
-
-    .. code-block:: yaml
-      :emphasize-lines: 3
-
-      apiVersion: v1
-      data:
-        FLYTE_OPENAI_API_KEY: <BASE64_ENCODED_OPENAI_API_TOKEN>
-      kind: Secret
-      metadata:
-        annotations:
-          meta.helm.sh/release-name: flyteagent
-          meta.helm.sh/release-namespace: flyte
-        creationTimestamp: "2023-10-04T04:09:03Z"
-        labels:
-          app.kubernetes.io/managed-by: Helm
-        name: flyteagent
-        namespace: flyte
-        resourceVersion: "753"
-        uid: 5ac1e1b6-2a4c-4e26-9001-d4ba72c39e54
-      type: Opaque
-
+  kubectl rollout restart deployment flyteagent -n flyte
 
 Upgrade the Flyte Helm release
 ------------------------------

--- a/docs/flyte_agents/deploying_agents_to_the_flyte_sandbox.md
+++ b/docs/flyte_agents/deploying_agents_to_the_flyte_sandbox.md
@@ -52,30 +52,8 @@ image: localhost:30000/flyteagent:example
 3. Set up your secrets:
 Let's take Databricks agent as an example:
 ```bash
-kubectl edit secret flyteagent -n flyte
-```
-Get your `BASE64_ENCODED_DATABRICKS_TOKEN`:
-```bash
-echo -n "<DATABRICKS_TOKEN>" | base64
-```
-Add your token to the `data` field:
-```yaml
-apiVersion: v1
-data:
-  flyte_databricks_access_token: <BASE64_ENCODED_DATABRICKS_TOKEN>
-kind: Secret
-metadata:
-  annotations:
-    meta.helm.sh/release-name: flyteagent
-    meta.helm.sh/release-namespace: flyte
-  creationTimestamp: "2023-10-04T04:09:03Z"
-  labels:
-    app.kubernetes.io/managed-by: Helm
-  name: flyteagent
-  namespace: flyte
-  resourceVersion: "753"
-  uid: 5ac1e1b6-2a4c-4e26-9001-d4ba72c39e54
-type: Opaque
+SECRET_VALUE=$(echo -n "<DATABRICKS_TOKEN>" | base64) && \
+kubectl patch secret flyteagent -n flyte --patch "{\"data\":{\"flyte_databricks_access_token\":\"$SECRET_VALUE\"}}"
 ```
 :::{note}
 Please ensure two things:
@@ -85,7 +63,7 @@ Please ensure two things:
 
 4. Restart development:
 ```bash
-kubectl rollout restart deployment flyte-sandbox -n flyte
+kubectl rollout restart deployment flyteagent -n flyte
 ```
 
 5. Test your agent remotely in the Flyte sandbox:


### PR DESCRIPTION
## Docs link
- chatgpt agent: https://flyte--5765.org.readthedocs.build/en/5765/deployment/agents/chatgpt.html

- databricks agent: https://flyte--5765.org.readthedocs.build/en/5765/deployment/agents/databricks.html


 
- openai batch agent: https://flyte--5765.org.readthedocs.build/en/5765/deployment/agents/openai_batch.html

- deploy to the flyte sandbox: https://flyte--5765.org.readthedocs.build/en/5765/flyte_agents/deploying_agents_to_the_flyte_sandbox.html



## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## What changes were proposed in this pull request?
1. use `kubectl patch secret` to set the secret value in the agent deployment.
2. add `kubectl rollout restart deployment flyteagent -n flyte` after the secret is set

## How was this patch tested?
ChatGPT Agent.
```python
from flytekit import workflow
from flytekitplugins.openai import ChatGPTTask

chatgpt_small_job = ChatGPTTask(
    name="3.5-turbo",
    chatgpt_config={
        "model": "gpt-3.5-turbo",
        "temperature": 0.7,
    },
)

chatgpt_big_job = ChatGPTTask(
    name="gpt-4",
    chatgpt_config={
        "model": "gpt-4",
        "temperature": 0.7,
    },
)


@workflow
def my_chatgpt_job(message: str) -> str:
    message = chatgpt_small_job(message=message)
    message = chatgpt_big_job(message=message)
    return message
```
### Setup process
0. start flyte sandbox
```bash
flytectl demo start --force
```
1. set your secret
```bash
SECRET_VALUE=$(echo -n "<OPENAI_API_TOKEN>" | base64) && \
  kubectl patch secret flyteagent -n flyte --patch "{\"data\":{\"flyte_openai_api_key\":\"$SECRET_VALUE\"}}"
```
2. restart your agent deployment
```
kubectl rollout restart deployment flyteagent -n flyte
```
3. run the agent workflow
```python
pyflyte run --remote  build/PR/agent/openai_chatgpt.py my_chatgpt_job --message hi
```

### Screenshots

<img width="1083" alt="image" src="https://github.com/user-attachments/assets/5a202d30-a880-48e5-999b-9a2b0e6db402">

<img width="1159" alt="image" src="https://github.com/user-attachments/assets/780e85d1-c27a-42f6-8214-b8f70ecfacbc">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
