### PR TITLE
[Docs][flyteagent] Update Databricks Agent Setup to V2

### DIFF
--- a/docs/deployment/agents/databricks.rst
+++ b/docs/deployment/agents/databricks.rst
@@ -147,7 +147,7 @@ Specify agent configuration
                 container: container
                 container_array: k8s-array
                 sidecar: sidecar
-                spark: agent-service
+                databricks: agent-service
               enabled-plugins:
                 - container
                 - sidecar
@@ -171,7 +171,7 @@ Specify agent configuration
               default-for-task-types:
                 - container: container
                 - container_array: k8s-array
-                - spark: agent-service
+                - databricks: agent-service
 
   .. group-tab:: Flyte core
 
@@ -192,7 +192,7 @@ Specify agent configuration
                 container: container
                 sidecar: sidecar
                 container_array: k8s-array
-                spark: agent-service
+                databricks: agent-service
 
 Add the Databricks access token
 -------------------------------


### PR DESCRIPTION
## Docs link
- databricks agent: https://flyte--5766.org.readthedocs.build/en/5766/deployment/agents/databricks.html

## Related PRs
- flytekit change
https://github.com/flyteorg/flytekit/pull/2574

- flytesnacks change
https://github.com/flyteorg/flytesnacks/pull/1733

## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
We want to let users run k8s spark and databricks agent together in the same workflow.

## What changes were proposed in this pull request?
update `default-for-task-types` for `databricks`.

## How was this patch tested?
In this PR by Kevin.
https://github.com/flyteorg/flytekit/pull/2574

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

