### PR TITLE
[WIP] [Flyteadmin] Improve flyteadmin secret handling

### DIFF
--- a/flyteadmin/auth/auth_context.go
+++ b/flyteadmin/auth/auth_context.go
@@ -205,7 +205,9 @@ func GetOAuth2ClientConfig(ctx context.Context, options config.OpenIDOptions, pr
 		}
 	}
 
-	secret = strings.TrimSuffix(secret, "\n")
+	if strings.HasSuffix(secret, "\n") {
+		logger.Warn(ctx, "Client secret file contains a trailing newline. This may cause unexpected behavior.")
+	}
 
 	return oauth2.Config{
 		RedirectURL:  callbackRelativeURL.String(),


### PR DESCRIPTION
## Tracking issue
Fix #2559 

## Why are the changes needed?
While handling user-provided secrets in FlyteAdmin, we trimmed trailing newlines, which introduced inconsistencies in how other parts of the system handle secrets. Therefore, instead of removing the newlines, we now warn users about potential unexpected behavior due to the presence of trailing newlines.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
1. We removed the `strings.TrimSuffix(secret, "\n")` and replaced it with a `logger.warn` statement when `strings.HasSuffix(secret, "\n")` evaluates to true.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
3. If there is design documentation, please add the link.
-->

## How was this patch tested?
1. Still working on tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
```
flytectl demo start --dev
git clone https://github.com/flyteorg/flytekit.git
gh pr checkout 5775
make compile
POD_NAMESPACE=flyte ./flyte start --config flyte-single-binary-local.yaml
```
### Screenshots
TODO
## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
None
<!-- Add related pull requests for reviewers to check -->

## Docs link
TODO
<!-- Add documentation link built by CI jobs here, and specify the changed place -->
