### PR TITLE
Add David as codeowner of deployment docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Automatically request docs team for docs PR review
-/docs/          @neverett @ppiegaze
-
+/docs/              @neverett @ppiegaze
+/docs/deployment/   @davidmirror-ops


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds @davidmirror-ops as codeowner of deployment guide docs so he is added as a reviewer on PRs for them.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
