### PR TITLE
DOC-619 Add pydata version switcher

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,8 +1,17 @@
 [
     {
+        "name": "dev",
+        "version": "dev",
+        "url": "https://docs.flyte.org/en/latest/"
+    },
+    {
         "name": "latest",
         "version": "latest",
         "url": "https://docs.flyte.org/en/latest/"
+    },
+    {
+        "version": "v1.13.2",
+        "url": "https://docs.flyte.org/en/v1.13.2"
     },
     {
         "version": "v1.13.1",

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,0 +1,31 @@
+[
+    {
+        "name": "latest",
+        "version": "latest",
+        "url": "https://docs.flyte.org/en/latest/"
+    },
+    {
+        "version": "v1.13.1",
+        "url": "https://docs.flyte.org/en/v1.13.1"
+    },
+    {
+        "version": "v1.13.0",
+        "url": "https://docs.flyte.org/en/v1.13.0"
+    },
+    {
+        "version": "v1.12.0",
+        "url": "https://docs.flyte.org/en/v1.12.0"
+    },
+    {
+        "version": "v1.11.0",
+        "url": "https://docs.flyte.org/en/v1.11.0"
+    },
+    {
+        "version": "v1.10.7",
+        "url": "https://docs.flyte.org/en/v1.10.7"
+    },
+    {
+        "version": "v1.10.6",
+        "url": "https://docs.flyte.org/en/v1.10.6"
+    }
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -385,6 +385,9 @@ html_context = {
     "doc_path": "docs",
 }
 
+json_url = "_static/switcher.json"
+version_match = "latest"
+
 html_theme_options = {
     # custom flyteorg pydata theme options
     # "github_url": "https://github.com/flyteorg/flyte",
@@ -415,8 +418,9 @@ html_theme_options = {
         }
     ],
     "use_edit_page_button": True,
-    "navbar_start": ["navbar-logo"],
+    "navbar_start": ["navbar-logo", "version-switcher"],
     "secondary_sidebar_items": ["page-toc", "edit-this-page"],
+    "switcher": {"json_url": json_url, "version_match": version_match}
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -386,7 +386,10 @@ html_context = {
 }
 
 json_url = "_static/switcher.json"
-version_match = "latest"
+version_match = os.environ.get("READTHEDOCS_VERSION")
+
+if not version_match:
+    version_match = "dev"
 
 html_theme_options = {
     # custom flyteorg pydata theme options

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -385,10 +385,11 @@ html_context = {
     "doc_path": "docs",
 }
 
-json_url = "_static/switcher.json"
+json_url = "https://flyte--5846.org.readthedocs.build/en/5846/_static/switcher.json"
 version_match = os.environ.get("READTHEDOCS_VERSION")
 
 if not version_match:
+    json_url = "_static/switcher.json"
     version_match = "dev"
 
 html_theme_options = {


### PR DESCRIPTION
## Why are the changes needed?

Allow readers to choose the docs version that corresponds to the version of Flyte they are using.

## What changes were proposed in this pull request?

Adds switcher.json and configuration changes in conf.py

## How was this patch tested?

Tested locally.

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Docs link

https://flyte--5846.org.readthedocs.build/en/5846/
