### PR TITLE
[FlyteCopilot] Binary IDL Attribute Access Primitive Input

### DIFF
--- a/flyteadmin/go.mod
+++ b/flyteadmin/go.mod
@@ -166,6 +166,7 @@ require (
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
 	github.com/sendgrid/rest v2.6.9+incompatible // indirect
+	github.com/shamaton/msgpack/v2 v2.2.2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.4.1 // indirect

--- a/flyteplugins/go.mod
+++ b/flyteplugins/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/ray-project/kuberay/ray-operator v1.1.0-rc.1
+	github.com/shamaton/msgpack/v2 v2.2.2
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8

--- a/flyteplugins/go.sum
+++ b/flyteplugins/go.sum
@@ -342,6 +342,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shamaton/msgpack/v2 v2.2.2 h1:GOIg0c9LV04VwzOOqZSrmsv/JzjNOOMxnS/HvOHGdgs=
+github.com/shamaton/msgpack/v2 v2.2.2/go.mod h1:6khjYnkx73f7VQU7wjcFS9DFjs+59naVWJv1TB7qdOI=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5318

## Why are the changes needed?
We need to support attribute access for `dataclass` when it is a msgpack binary IDL object to a raw container task.

Example:

```python
@workflow
def wf(dc: DC) -> Tuple[int, bool, float, str]:
    return python_return_same_values(a=dc.a, b=dc.b, c=dc.c, d=dc.d)

python_return_same_values = ContainerTask(
    name="python_return_same_values",
    inputs=kwtypes(a=int, b=bool, c=float, d=str),
    outputs=kwtypes(a=int, b=bool, c=float, d=str),
    image="futureoutlier/rawcontainer:0320",
    command=[
        "python", "return_same_value.py",
        "{{.inputs.a}}", "{{.inputs.b}}", "{{.inputs.c}}", "{{.inputs.d}}",
        "/var/outputs",
    ],
)
```

## What does this PR change?
It adds logic to deserialize the msgpack binary IDL object and convert it into a string for the container task input, similar to how we handle primitive types.

Related Code: [template.go#L175-L192](https://github.com/flyteorg/flyte/blob/master/flyteplugins/go/tasks/pluginmachinery/core/template/template.go#L175-L192)

## How was this tested?
- Unit tests
- Remote execution

### Example:

```python
import logging
from dataclasses import dataclass
from typing import Tuple
from flytekit import ContainerTask, kwtypes, workflow
logger = logging.getLogger(__file__)

@dataclass
class DC:
    a: int = 1
    b: bool = True
    c: float = 1.1
    d: str = "string"

@workflow
def wf(dc: DC) -> Tuple[int, bool, float, str]:
    return python_return_same_values(a=dc.a, b=dc.b, c=dc.c, d=dc.d)

python_return_same_values = ContainerTask(
    name="python_return_same_values",
    input_data_dir="/var/inputs",
    output_data_dir="/var/outputs",
    inputs=kwtypes(a=int, b=bool, c=float, d=str),
    outputs=kwtypes(a=int, b=bool, c=float, d=str),
    image="futureoutlier/rawcontainer:0320",
    command=[
        "python",
        "return_same_value.py",
        "{{.inputs.a}}",
        "{{.inputs.b}}",
        "{{.inputs.c}}",
        "{{.inputs.d}}",
        "/var/outputs",
    ],
)

if __name__ == "__main__":
    from flytekit.clis.sdk_in_container import pyflyte
    from click.testing import CliRunner
    import os

    runner = CliRunner()
    path = os.path.realpath(__file__)
    input_val = '{"a": 1, "b": true, "c": 1.0, "d": "string"}'

    result = runner.invoke(pyflyte.main,
                           ["run", path, "wf", "--dc", input_val])
    print("Local Execution: ", result.output)

    result = runner.invoke(pyflyte.main,
                           ["run", "--remote", path, "wf", "--dc", input_val])
    print("Remote Execution: ", result.output)
```

### Setup for remote execution:
1. Build the sandbox image:
   ```zsh
   cd docker/sandbox-bundled
   make build
   flytectl demo start --image flyte-sandbox:latest --force
   ```
2. Run the workflow example

Note: See related PR for image `futureoutlier/rawcontainer:0320`: https://github.com/flyteorg/flytekit/pull/2258

## Checklist
- [ ] Documentation updated
- [x] All tests passed
- [x] Commits signed-off

### Screenshots

<table>
  <tr>
    <td><img width="580" alt="image" src="https://github.com/user-attachments/assets/ed82edbd-44b4-4559-9b07-85885a831a2c"></td>
    <td><img width="308" alt="image" src="https://github.com/user-attachments/assets/ac27bcad-91e3-4623-8925-22577194d8d5"></td>
  </tr>
</table>


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
