### PR TITLE
[Docs] Update configuring_logging_links_in_the_ui.md

### DIFF
--- a/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
+++ b/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
@@ -62,9 +62,7 @@ task_logs:
           cloudwatch-enabled: true
           cloudwatch-template-uri: "https://console.aws.amazon.com/cloudwatch/home?region=<MY_AWS_REGION>#logsV2:log-groups/log-group/$252Faws$252Fcontainerinsights$252F<MY_EKS_CLUSTER_NAME>$252Fapplication$3FlogStreamNameFilter$3Dvar.log.containers.{{`{{.podName}}`}}_{{`{{.namespace}}`}}_{{`{{.containerName}}`}}" 
             - "https://console.aws.amazon.com/cloudwatch/home?region={{.region}}#logEventViewer:group={{.logGroup}};stream=var.log.containers.{{.podName}}_{{.namespace}}_{{.containerName}}-{{.containerId}}.log"
-          prerequisites:
-            - EKS Cluster enabled with CloudWatch Observability Add-on
-            - Ensure the pod emits logs to CloudWatch log streams
+          
         - displayName: GCP Stackdriver Logs
           templateUris:
             - "https://console.cloud.google.com/logs/viewer?project={{.gcpProject}}&resource=k8s_container&advancedFilter=resource.labels.pod_name={{.podName}}&resource.labels.container_name={{.containerName}}&resource.labels.namespace_id={{.namespace}}"
@@ -74,6 +72,11 @@ task_logs:
       messageFormat: 0  # Optional: 0 = "unknown", 1 = "csv", 2 = "json"
 
 ```
+
+:::{Notes}
+prerequisites:
+            - EKS Cluster enabled with CloudWatch Observability Add-on
+            - Ensure the pod emits logs to CloudWatch log streams
 
 :::{tip}
 Since helm chart uses the same templating syntax for args (like `{{ }}`), compiling the chart results in helm replacing Flyte log link templates as well. To avoid this, you can use escaped templating for Flyte logs in the helm chart.

--- a/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
+++ b/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
@@ -58,7 +58,8 @@ task_logs:
   plugins:
     logs:
       cloudwatch-enabled: true
-      cloudwatch-template-uri: "https://console.aws.amazon.com/cloudwatch/home?region=<MY_AWS_REGION>#logsV2:log-groups/log-group/$252Faws$252Fcontainerinsights$252F<MY_EKS_CLUSTER_NAME>$252Fapplication$3FlogStreamNameFilter$3Dvar.log.containers.{{`{{.podName}}`}}_{{`{{.namespace}}`}}_{{`{{.containerName}}`}}" 
+      cloudwatch-template-uri:
+            -"https://console.aws.amazon.com/cloudwatch/home?region=<MY_AWS_REGION>#logsV2:log-groups/log-group/$252Faws$252Fcontainerinsights$252F<MY_EKS_CLUSTER_NAME>$252Fapplication$3FlogStreamNameFilter$3Dvar.log.containers.{{`{{.podName}}`}}_{{`{{.namespace}}`}}_{{`{{.containerName}}`}}" 
             - "https://console.aws.amazon.com/cloudwatch/home?region={{.region}}#logEventViewer:group={{.logGroup}};stream=var.log.containers.{{.podName}}_{{.namespace}}_{{.containerName}}-{{.containerId}}.log"
       messageFormat: 0  # Optional: 0 = "unknown", 1 = "csv", 2 = "json"
 

--- a/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
+++ b/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
@@ -59,7 +59,8 @@ task_logs:
     logs:
       templates:
         - displayName: AWS CloudWatch Logs
-          templateUris:
+          cloudwatch-enabled: true
+          cloudwatch-template-uri: "https://console.aws.amazon.com/cloudwatch/home?region=<MY_AWS_REGION>#logsV2:log-groups/log-group/$252Faws$252Fcontainerinsights$252F<MY_EKS_CLUSTER_NAME>$252Fapplication$3FlogStreamNameFilter$3Dvar.log.containers.{{`{{.podName}}`}}_{{`{{.namespace}}`}}_{{`{{.containerName}}`}}" 
             - "https://console.aws.amazon.com/cloudwatch/home?region={{.region}}#logEventViewer:group={{.logGroup}};stream=var.log.containers.{{.podName}}_{{.namespace}}_{{.containerName}}-{{.containerId}}.log"
           prerequisites:
             - EKS Cluster enabled with CloudWatch Observability Add-on

--- a/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
+++ b/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
@@ -58,11 +58,20 @@ task_logs:
   plugins:
     logs:
       templates:
-        - displayName: <name-to-show>
+        - displayName: AWS CloudWatch Logs
           templateUris:
-            - "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/flyte-production/kubernetes;stream=var.log.containers.{{.podName}}_{{.namespace}}_{{.containerName}}-{{.containerId}}.log"
-            - "https://some-other-source/home?region=us-east-1#logEventViewer:group=/flyte-production/kubernetes;stream=var.log.containers.{{.podName}}_{{.namespace}}_{{.containerName}}-{{.containerId}}.log"
-          messageFormat: 0 # this parameter is optional, but use 0 for "unknown", 1 for "csv", or 2 for "json"
+            - "https://console.aws.amazon.com/cloudwatch/home?region={{.region}}#logEventViewer:group={{.logGroup}};stream=var.log.containers.{{.podName}}_{{.namespace}}_{{.containerName}}-{{.containerId}}.log"
+          prerequisites:
+            - EKS Cluster enabled with CloudWatch Observability Add-on
+            - Ensure the pod emits logs to CloudWatch log streams
+        - displayName: GCP Stackdriver Logs
+          templateUris:
+            - "https://console.cloud.google.com/logs/viewer?project={{.gcpProject}}&resource=k8s_container&advancedFilter=resource.labels.pod_name={{.podName}}&resource.labels.container_name={{.containerName}}&resource.labels.namespace_id={{.namespace}}"
+        - displayName: Kubernetes Dashboard Logs
+          templateUris:
+            - "{{.kubernetesUrl}}/namespace/{{.namespace}}/pods/{{.podName}}/logs/{{.containerName}}"
+      messageFormat: 0  # Optional: 0 = "unknown", 1 = "csv", 2 = "json"
+
 ```
 
 :::{tip}

--- a/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
+++ b/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
@@ -57,18 +57,9 @@ The parameterization engine uses Golangs native templating format and hence uses
 task_logs:
   plugins:
     logs:
-      templates:
-        - displayName: AWS CloudWatch Logs
-          cloudwatch-enabled: true
-          cloudwatch-template-uri: "https://console.aws.amazon.com/cloudwatch/home?region=<MY_AWS_REGION>#logsV2:log-groups/log-group/$252Faws$252Fcontainerinsights$252F<MY_EKS_CLUSTER_NAME>$252Fapplication$3FlogStreamNameFilter$3Dvar.log.containers.{{`{{.podName}}`}}_{{`{{.namespace}}`}}_{{`{{.containerName}}`}}" 
+      cloudwatch-enabled: true
+      cloudwatch-template-uri: "https://console.aws.amazon.com/cloudwatch/home?region=<MY_AWS_REGION>#logsV2:log-groups/log-group/$252Faws$252Fcontainerinsights$252F<MY_EKS_CLUSTER_NAME>$252Fapplication$3FlogStreamNameFilter$3Dvar.log.containers.{{`{{.podName}}`}}_{{`{{.namespace}}`}}_{{`{{.containerName}}`}}" 
             - "https://console.aws.amazon.com/cloudwatch/home?region={{.region}}#logEventViewer:group={{.logGroup}};stream=var.log.containers.{{.podName}}_{{.namespace}}_{{.containerName}}-{{.containerId}}.log"
-          
-        - displayName: GCP Stackdriver Logs
-          templateUris:
-            - "https://console.cloud.google.com/logs/viewer?project={{.gcpProject}}&resource=k8s_container&advancedFilter=resource.labels.pod_name={{.podName}}&resource.labels.container_name={{.containerName}}&resource.labels.namespace_id={{.namespace}}"
-        - displayName: Kubernetes Dashboard Logs
-          templateUris:
-            - "{{.kubernetesUrl}}/namespace/{{.namespace}}/pods/{{.podName}}/logs/{{.containerName}}"
       messageFormat: 0  # Optional: 0 = "unknown", 1 = "csv", 2 = "json"
 
 ```

--- a/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
+++ b/docs/user_guide/productionizing/configuring_logging_links_in_the_ui.md
@@ -65,7 +65,7 @@ task_logs:
 
 ```
 
-:::{Notes}
+.. note::
 prerequisites:
             - EKS Cluster enabled with CloudWatch Observability Add-on
             - Ensure the pod emits logs to CloudWatch log streams


### PR DESCRIPTION
Added log templates for AWS CloudWatch, GCP Stackdriver, and Kubernetes logs with their templateUris in new example.

Also included prerequisites for CloudWatch Observability on EKS.

## Tracking issue
Closes #5760 

## Why are the changes needed?
The current example is generic and uses outdated configuration:

## What changes were proposed in this pull request?

I am just changing the example to be more flexible, up to date and with more specific templateUris.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Docs link
https://docs.flyte.org/en/latest/user_guide/productionizing/configuring_logging_links_in_the_ui.html#configure-logging
