### PR TITLE
[Docs] Recover the expected behaviors of example workflows

### DIFF
--- a/docs/user_guide/advanced_composition/conditionals.md
+++ b/docs/user_guide/advanced_composition/conditionals.md
@@ -18,9 +18,9 @@ To clone and run the example code on this page, see the [Flytesnacks repo][flyte
 
 To begin, import the necessary libraries.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
-:lines: 1-3
+:lines: 1-4
 ```
 
 ## Simple branch
@@ -29,9 +29,9 @@ In this example, we introduce two tasks, `calculate_circle_circumference` and
 `calculate_circle_area`. The workflow dynamically chooses between these tasks based on whether the input
 falls within the fraction range (0-1) or not.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
-:lines: 11-37
+:lines: 12-38
 ```
 
 ## Multiple branches
@@ -40,7 +40,7 @@ We establish an `if` condition with multiple branches, which will result in a fa
 It's important to note that any `conditional` statement in Flyte is expected to be complete,
 meaning that all possible branches must be accounted for.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :pyobject: shape_properties_with_multiple_branches
 ```
@@ -55,9 +55,9 @@ a convention also observed in other libraries.
 ## Consuming the output of a conditional
 Here, we write a task that consumes the output returned by a `conditional`.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
-:lines: 66-81
+:lines: 67-85
 ```
 
 ## Using the output of a previous task in a conditional
@@ -66,9 +66,9 @@ You can check if a boolean returned from the previous task is `True`,
 but unary operations are not supported directly. Instead, use the `is_true`,
 `is_false` and `is_none` methods on the result.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
-:lines: 89-119
+:lines: 93-123
 ```
 
 :::{note}
@@ -79,7 +79,7 @@ Inputs and outputs are automatically encapsulated in a special object known as {
 ## Using boolean workflow inputs in a conditional
 You can directly pass a boolean to a workflow.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :pyobject: boolean_input_wf
 ```
@@ -92,9 +92,9 @@ This special object enables it to exhibit additional behavior.
 
 You can run the workflows locally as follows:
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
-:lines: 129-135
+:lines: 133-139
 ```
 
 ## Nested conditionals
@@ -102,9 +102,9 @@ You can run the workflows locally as follows:
 You can nest conditional sections arbitrarily inside other conditional sections.
 However, these nested sections can only be in the `then` part of a `conditional` block.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
-:lines: 142-164
+:lines: 146-168
 ```
 
 ## Using the output of a task in a conditional
@@ -112,16 +112,16 @@ However, these nested sections can only be in the `then` part of a `conditional`
 Let's write a fun workflow that triggers the `calculate_circle_circumference` task in the event of a "heads" outcome,
 and alternatively, runs the `calculate_circle_area` task in the event of a "tail" outcome.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :pyobject: consume_task_output
 ```
 
 You can run the workflow locally as follows:
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
-:lines: 181-188
+:lines: 216-225
 ```
 
 ## Running a noop task in a conditional
@@ -138,9 +138,9 @@ task-plugins:
 ```
 :::
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/89bf7bc7788802097904c5f9ffb75ba70ef980a6/examples/advanced_composition/advanced_composition/conditional.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
-:lines: 197-209
+:lines: 200-212
 ```
 
 ## Run the example on the Flyte cluster
@@ -149,49 +149,49 @@ To run the provided workflows on the Flyte cluster, use the following commands:
 
 ```
 pyflyte run --remote \
-  https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py \
+  https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py \
   shape_properties --radius 3.0
 ```
 
 ```
 pyflyte run --remote \
-  https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py \
+  https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py \
   shape_properties_with_multiple_branches --radius 11.0
 ```
 
 ```
 pyflyte run --remote \
-  https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py \
+  https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py \
   shape_properties_accept_conditional_output --radius 0.5
 ```
 
 ```
 pyflyte run --remote \
-  https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py \
+  https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py \
   boolean_wf
 ```
 
 ```
 pyflyte run --remote \
-  https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py \
+  https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py \
   boolean_input_wf --boolean_input
 ```
 
 ```
 pyflyte run --remote \
-  https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py \
+  https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py \
   nested_conditions --radius 0.7
 ```
 
 ```
 pyflyte run --remote \
-  https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/conditional.py \
+  https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py \
   consume_task_output --radius 0.4 --seed 7
 ```
 
 ```
 pyflyte run --remote \
-  https://raw.githubusercontent.com/flyteorg/flytesnacks/89bf7bc7788802097904c5f9ffb75ba70ef980a6/examples/advanced_composition/advanced_composition/conditional.py \
+  https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py \
   noop_in_conditional --radius 0.4 --seed 5
 ```
 


### PR DESCRIPTION
## Why are the changes needed?
1. The import statement of `Echo` is missing.
2. The demonstration of the workflow `shape_properties_accept_conditional_output` is ignored in the main function right below it.
3. The descriptions of expected outputs of the workflow `consume_task_output` are inverted. 

## What changes were proposed in this pull request?
Reassign the example code url with the new gitsha and align code lines.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All commits are signed-off.

## Related PRs
The modified version of the example code in Flytesnacks can be found in [this PR](https://github.com/flyteorg/flytesnacks/pull/1760)

## Docs link
https://flyte--5880.org.readthedocs.build/en/5880/user_guide/advanced_composition/conditionals.html
