### PR TITLE
Sync client should call CloseSend when done sending

### DIFF
--- a/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
@@ -176,6 +176,12 @@ func (p *Plugin) ExecuteTaskSync(
 		return nil, nil, fmt.Errorf("failed to send inputsProto with error: %w", err)
 	}
 
+	// Client is done with sending
+	if err := stream.CloseSend(); err != nil {
+		logger.Errorf(ctx, "Failed to close stream with err %s", err.Error())
+		return nil, nil, err
+	}
+
 	in, err := stream.Recv()
 	if err != nil {
 		logger.Errorf(ctx, "Failed to write output with err %s", err.Error())
@@ -187,11 +193,6 @@ func (p *Plugin) ExecuteTaskSync(
 	// TODO: Read the streaming output from the agent, and merge it into the final output.
 	// For now, Propeller assumes that the output is always in the header.
 	resource := in.GetHeader().GetResource()
-
-	if err := stream.CloseSend(); err != nil {
-		logger.Errorf(ctx, "Failed to close stream with err %s", err.Error())
-		return nil, nil, err
-	}
 
 	return nil, ResourceWrapper{
 		Phase:      resource.Phase,

--- a/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
@@ -184,7 +184,7 @@ func (p *Plugin) ExecuteTaskSync(
 
 	in, err := stream.Recv()
 	if err != nil {
-		logger.Errorf(ctx, "Failed to write output with err %s", err.Error())
+		logger.Errorf(ctx, "failed to write output with err %s", err.Error())
 		return nil, nil, err
 	}
 	if in.GetHeader() == nil {
@@ -273,7 +273,7 @@ func (p *Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phas
 	case flyteIdl.TaskExecution_SUCCEEDED:
 		err = writeOutput(ctx, taskCtx, resource.Outputs)
 		if err != nil {
-			logger.Errorf(ctx, "Failed to write output with err %s", err.Error())
+			logger.Errorf(ctx, "failed to write output with err %s", err.Error())
 			return core.PhaseInfoUndefined, err
 		}
 		return core.PhaseInfoSuccess(taskInfo), nil
@@ -301,7 +301,7 @@ func (p *Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phas
 	case admin.State_SUCCEEDED:
 		err = writeOutput(ctx, taskCtx, resource.Outputs)
 		if err != nil {
-			logger.Errorf(ctx, "Failed to write output with err %s", err.Error())
+			logger.Errorf(ctx, "failed to write output with err %s", err.Error())
 			return core.PhaseInfoUndefined, err
 		}
 		return core.PhaseInfoSuccess(taskInfo), nil

--- a/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
@@ -178,7 +178,7 @@ func (p *Plugin) ExecuteTaskSync(
 
 	// Client is done with sending
 	if err := stream.CloseSend(); err != nil {
-		logger.Errorf(ctx, "Failed to close stream with err %s", err.Error())
+		logger.Errorf(ctx, "failed to close stream with err %s", err.Error())
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
## Tracking issue
Closes #5885

## Why are the changes needed?

The Grpc client never closes send so the server is unable to move forward in the grpc streaming onComplete method. This change will inform the server that is done sending so it can properly move to the next step.

## What changes were proposed in this pull request?

Move the `closeSend` after sending all the necessary things.


## How was this patch tested?

Unit test

### Setup process

### Screenshots
![Screenshot 2024-10-22 at 11 29 33](https://github.com/user-attachments/assets/89aa22b2-a28f-44fe-9411-37d1b2cae700)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
