### PR TITLE
Use child context in watchAgents

### DIFF
--- a/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
@@ -336,8 +336,10 @@ func (p *Plugin) getAsyncAgentClient(ctx context.Context, agent *Deployment) (se
 
 func (p *Plugin) watchAgents(ctx context.Context, agentService *core.AgentService) {
 	go wait.Until(func() {
-		clientSet := getAgentClientSets(ctx)
-		agentRegistry := getAgentRegistry(ctx, clientSet)
+		childCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		clientSet := getAgentClientSets(childCtx)
+		agentRegistry := getAgentRegistry(childCtx, clientSet)
 		p.setRegistry(agentRegistry)
 		agentService.SetSupportedTaskType(maps.Keys(agentRegistry))
 	}, p.cfg.PollInterval.Duration, ctx.Done())


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Rebuilding gRPC connections in Agents leaks goroutines
As part of the investigation for [this issue](https://linear.app/unionai/issue/PE-1326/flytepropeller-oomkilled-for-high-workload-customers) we discovered [Agents is periodically rebuilding gRPC connections](https://github.com/unionai/flyte/blob/master/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go#L386-L391) and [not closing them because the context used](https://github.com/unionai/flyte/blob/master/flyteplugins/go/tasks/plugins/webapi/agent/client.go#L67-L72) is that of the overall flyte binary. This results in very long-lived, unused gRPC connections and a goroutine leak that steadily increases memory utilization until crash.


## What changes were proposed in this pull request?
Use child context in the watcher and cancel the child context every time. Canceling this context will also remove the grpc connection [here](https://github.com/unionai/flyte/blob/a23f2fac4ec4df7cc32fd57c6c4f4088d84faee6/flyteplugins/go/tasks/plugins/webapi/agent/client.go#L69).


## How was this patch tested?
```
flyte start --config flyte-local-test.yaml
wget -O goroutine.out  http://localhost:10254/debug/pprof/goroutine\?debug\=1 && cat goroutine.out | grep "goroutine profile:"
```

Validated by starting single-binary with agents enabled and querying golang pprof with wget -O goroutine.out  http://localhost:10254/debug/pprof/goroutine?debug=1 to view the number of goroutines blocking on the gRPC CallbackSerializer. (the total number of goroutines should not increase)

### Setup process

### Screenshots
![Screenshot 2024-10-22 at 12 44 46 PM](https://github.com/user-attachments/assets/11475561-d28f-4317-9885-0deead80010f)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
