### PR TITLE
Reference task to fetch latest version by default

### DIFF
--- a/flyteadmin/pkg/manager/impl/validation/task_execution_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/task_execution_validator_test.go
@@ -71,28 +71,6 @@ func TestValidateTaskExecutionRequest_MissingFields(t *testing.T) {
 				Project:      "project",
 				Domain:       "domain",
 				Name:         "name",
-			},
-			ParentNodeExecutionId: &core.NodeExecutionIdentifier{
-				NodeId: "nodey",
-				ExecutionId: &core.WorkflowExecutionIdentifier{
-					Project: "project",
-					Domain:  "domain",
-					Name:    "name",
-				},
-			},
-			RetryAttempt: 0,
-		},
-	}, maxOutputSizeInBytes)
-	assert.EqualError(t, err, "missing version")
-
-	err = ValidateTaskExecutionRequest(&admin.TaskExecutionEventRequest{
-		Event: &event.TaskExecutionEvent{
-			OccurredAt: taskEventOccurredAtProto,
-			TaskId: &core.Identifier{
-				ResourceType: core.ResourceType_TASK,
-				Project:      "project",
-				Domain:       "domain",
-				Name:         "name",
 				Version:      "version",
 			},
 			ParentNodeExecutionId: &core.NodeExecutionIdentifier{

--- a/flyteadmin/pkg/manager/impl/validation/task_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/task_validator_test.go
@@ -110,14 +110,6 @@ func TestValidateTaskEmptyName(t *testing.T) {
 	assert.EqualError(t, err, "missing name")
 }
 
-func TestValidateTaskEmptyVersion(t *testing.T) {
-	request := testutils.GetValidTaskRequest()
-	request.Id.Version = ""
-	err := ValidateTask(context.Background(), request, testutils.GetRepoWithDefaultProject(),
-		getMockTaskResources(), mockWhitelistConfigProvider, taskApplicationConfigProvider)
-	assert.EqualError(t, err, "missing version")
-}
-
 func TestValidateTaskEmptyType(t *testing.T) {
 	request := testutils.GetValidTaskRequest()
 	request.Spec.Template.Type = ""

--- a/flyteadmin/pkg/manager/impl/validation/validation.go
+++ b/flyteadmin/pkg/manager/impl/validation/validation.go
@@ -95,6 +95,23 @@ func ValidateIdentifierFieldsSet(id *core.Identifier) error {
 	return nil
 }
 
+// ValidateTaskIdentifierFieldsSet Validates that all required fields, except version, for a task identifier are present.
+func ValidateTaskIdentifierFieldsSet(id *core.Identifier) error {
+	if id == nil {
+		return shared.GetMissingArgumentError(shared.ID)
+	}
+	if err := ValidateEmptyStringField(id.Project, shared.Project); err != nil {
+		return err
+	}
+	if err := ValidateEmptyStringField(id.Domain, shared.Domain); err != nil {
+		return err
+	}
+	if err := ValidateEmptyStringField(id.Name, shared.Name); err != nil {
+		return err
+	}
+	return nil
+}
+
 // ValidateIdentifier Validates that all required fields for an identifier are present.
 func ValidateIdentifier(id *core.Identifier, expectedType common.Entity) error {
 	if id == nil {
@@ -104,6 +121,9 @@ func ValidateIdentifier(id *core.Identifier, expectedType common.Entity) error {
 		return errors.NewFlyteAdminErrorf(codes.InvalidArgument,
 			"unexpected resource type %s for identifier [%+v], expected %s instead",
 			strings.ToLower(id.ResourceType.String()), id, strings.ToLower(entityToResourceType[expectedType].String()))
+	}
+	if id.ResourceType == core.ResourceType_TASK {
+		return ValidateTaskIdentifierFieldsSet(id)
 	}
 	return ValidateIdentifierFieldsSet(id)
 }

--- a/flyteadmin/pkg/repositories/gormimpl/task_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/task_repo.go
@@ -51,8 +51,8 @@ func (r *TaskRepo) Get(ctx context.Context, input interfaces.Identifier) (models
 	timer := r.metrics.GetDuration.Start()
 	var tx *gorm.DB
 	if input.Version == "" {
-		tx := r.db.WithContext(ctx).Where("project = ? AND domain = ? AND name = ?", input.Project, input.Domain, input.Name).Limit(1)
-		tx = tx.Order("version DESC")
+		tx = r.db.WithContext(ctx).Where(`"tasks"."project" = ? AND "tasks"."domain" = ? AND "tasks"."name" = ?`, input.Project, input.Domain, input.Name).Limit(1)
+		tx = tx.Order(`"tasks"."version" DESC`)
 		tx.Find(&task)
 	} else {
 		tx = r.db.WithContext(ctx).Where(&models.Task{

--- a/flyteadmin/pkg/repositories/gormimpl/task_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/task_repo.go
@@ -51,8 +51,8 @@ func (r *TaskRepo) Get(ctx context.Context, input interfaces.Identifier) (models
 	timer := r.metrics.GetDuration.Start()
 	var tx *gorm.DB
 	if input.Version == "" {
-		tx := r.db.WithContext(ctx).Limit(1)
-		tx = tx.Order("DESC")
+		tx := r.db.WithContext(ctx).Where("project = ? AND domain = ? AND name = ?", input.Project, input.Domain, input.Name).Limit(1)
+		tx = tx.Order("version DESC")
 		tx.Find(&task)
 	} else {
 		tx = r.db.WithContext(ctx).Where(&models.Task{

--- a/flyteadmin/pkg/repositories/gormimpl/task_repo_test.go
+++ b/flyteadmin/pkg/repositories/gormimpl/task_repo_test.go
@@ -79,6 +79,28 @@ func TestGetTask(t *testing.T) {
 	assert.Equal(t, version, output.Version)
 	assert.Equal(t, []byte{1, 2}, output.Closure)
 	assert.Equal(t, pythonTestTaskType, output.Type)
+
+	//When version is empty, return the latest task
+	GlobalMock = mocket.Catcher.Reset()
+	GlobalMock.Logging = true
+
+	GlobalMock.NewMock().WithQuery(
+		`SELECT * FROM "tasks" WHERE project = $1 AND domain = $2 AND name = $3 ORDER BY version DESC LIMIT 1`).
+		WithReply(tasks)
+	output, err = taskRepo.Get(context.Background(), interfaces.Identifier{
+		Project: project,
+		Domain:  domain,
+		Name:    name,
+		Version: "",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, project, output.Project)
+	assert.Equal(t, domain, output.Domain)
+	assert.Equal(t, name, output.Name)
+	assert.Equal(t, "v2", output.Version)
+	assert.Equal(t, []byte{3, 4}, output.Closure)
+	assert.Equal(t, pythonTestTaskType, output.Type)
 }
 
 func TestListTasks(t *testing.T) {

--- a/flyteadmin/pkg/repositories/gormimpl/task_repo_test.go
+++ b/flyteadmin/pkg/repositories/gormimpl/task_repo_test.go
@@ -85,7 +85,7 @@ func TestGetTask(t *testing.T) {
 	GlobalMock.Logging = true
 
 	GlobalMock.NewMock().WithQuery(
-		`SELECT * FROM "tasks" WHERE project = $1 AND domain = $2 AND name = $3 ORDER BY version DESC LIMIT 1`).
+		`SELECT * FROM "tasks" WHERE "tasks"."project" = $1 AND "tasks"."domain" = $2 AND "tasks"."name" = $3 ORDER BY "tasks"."version" DESC LIMIT 1`).
 		WithReply(tasks)
 	output, err = taskRepo.Get(context.Background(), interfaces.Identifier{
 		Project: project,
@@ -98,8 +98,8 @@ func TestGetTask(t *testing.T) {
 	assert.Equal(t, project, output.Project)
 	assert.Equal(t, domain, output.Domain)
 	assert.Equal(t, name, output.Name)
-	assert.Equal(t, "v2", output.Version)
-	assert.Equal(t, []byte{3, 4}, output.Closure)
+	assert.Equal(t, version, output.Version)
+	assert.Equal(t, []byte{1, 2}, output.Closure)
 	assert.Equal(t, pythonTestTaskType, output.Type)
 }
 

--- a/flyteadmin/tests/task_execution_test.go
+++ b/flyteadmin/tests/task_execution_test.go
@@ -45,6 +45,37 @@ var taskExecutionIdentifier = &core.TaskExecutionIdentifier{
 	RetryAttempt:    1,
 }
 
+func TestGetTaskExecutions(t *testing.T) {
+	truncateAllTablesForTestingOnly()
+	populateWorkflowExecutionsForTestingOnly()
+
+	ctx := context.Background()
+	client, conn := GetTestAdminServiceClient()
+	defer conn.Close()
+
+	_, err := client.CreateTask(ctx, &admin.TaskCreateRequest{
+		Id:   taskIdentifier,
+		Spec: testutils.GetValidTaskRequest().Spec,
+	})
+	require.NoError(t, err)
+
+	resp, err := client.GetTask(ctx, &admin.ObjectGetRequest{
+		Id: &core.Identifier{
+			ResourceType: core.ResourceType_TASK,
+			Project:      project,
+			Domain:       "development",
+			Name:         "task name",
+		},
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, resp.Id.Project, project)
+	assert.Equal(t, resp.Id.Domain, "development")
+	assert.Equal(t, resp.Id.Name, "task name")
+	assert.Equal(t, resp.Id.Version, "task version")
+
+}
+
 func createTaskAndNodeExecution(
 	ctx context.Context, t *testing.T, client service.AdminServiceClient, conn *grpc.ClientConn,
 	occurredAtProto *timestamp.Timestamp) {


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

Related to #5825 
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

When task version is not specified (i.e. ""), we should return the latest one when `getTask` is called
## What changes were proposed in this pull request?
When the version is "", we fetch DB directly to get the latest task.
Also remove the UT that check whether version is empty, since this situation is allowed now.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
By unit test (testGetTask)

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
