### PR TITLE
Introducing Flyte Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
     <img src="https://img.shields.io/badge/X-000000.svg?style=for-the-badge&logo=X&logoColor=white" height=30px/></a>
   <a href="https://slack.flyte.org" alt="Twitter, formerly X logo label">
     <img src="https://img.shields.io/badge/Slack-Chat-pink?style=for-the-badge&logo=slack" alt="Flyte Slack label" /></a>
+  <a href="https://gurubase.io/g/flyte" alt="Flyte Guru on Gurubase.io">
+    <img src="https://img.shields.io/badge/Gurubase-Ask%20Flyte%20Guru-006BFF?style=for-the-badge" alt="Flyte Guru label" /></a>
 </p>
 
 Flyte is an open-source orchestrator that facilitates building production-grade data and ML pipelines. It is built for scalability and reproducibility, leveraging Kubernetes as its underlying platform. With Flyte, user teams can construct pipelines using the Python SDK, and seamlessly deploy them on both cloud and on-premises environments, enabling distributed processing and efficient resource utilization.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Flyte Guru](https://gurubase.io/g/flyte) to Gurubase. Flyte Guru uses the data from this repo and data from the [docs](https://docs.flyte.org/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Flyte Guru", which highlights that Flyte now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Flyte Guru in Gurubase, just let me know that's totally fine.