### PR TITLE
Run CI in release branches

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - master
+      - 'release-v**'
 env:
   GO_VERSION: "1.22"
   PRIORITIES: "P0"

--- a/.github/workflows/flytectl-install.yml
+++ b/.github/workflows/flytectl-install.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - flytectl/**
+      - 'release-v**'
   push:
     branches:
       - master

--- a/.github/workflows/flyteidl-buf-publish.yml
+++ b/.github/workflows/flyteidl-buf-publish.yml
@@ -6,6 +6,7 @@ on:
       - artifacts-shell-2
       - artifacts
       - master
+      - 'release-v**'
     paths:
       - 'flyteidl/**'
 jobs:

--- a/.github/workflows/flyteidl-checks.yml
+++ b/.github/workflows/flyteidl-checks.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - master
+      - 'release-v**'
 env:
   GO_VERSION: "1.22"
 jobs:

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - rc/*
+      - 'release-v**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/single-binary.yml
+++ b/.github/workflows/single-binary.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - rc/*
+      - 'release-v**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - master
+      - 'release-v**'
   pull_request:
 jobs:
   compile:

--- a/.github/workflows/validate-helm-charts.yaml
+++ b/.github/workflows/validate-helm-charts.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'release-v**'
     paths:
       - "charts/**"
       - "deployment/**"


### PR DESCRIPTION
Similar to https://github.com/flyteorg/flytekit/pull/2827, this PR ensures that CI checks run as part of the merges to release branches.