### PR TITLE
Set HttpOnly and Secure flags in session cookies

### DIFF
--- a/flyteadmin/auth/cookie.go
+++ b/flyteadmin/auth/cookie.go
@@ -70,7 +70,7 @@ func NewSecureCookie(cookieName, value string, hashKey, blockKey []byte, domain 
 		Domain:   domain,
 		SameSite: sameSiteMode,
 		HttpOnly: true,
-		Secure:   config.GetConfig().Security.Secure,
+		Secure:   !config.GetConfig().Security.InsecureCookieHeader,
 	}, nil
 }
 
@@ -129,7 +129,7 @@ func NewCsrfCookie() http.Cookie {
 		Value:    csrfStateToken,
 		SameSite: http.SameSiteLaxMode,
 		HttpOnly: true,
-		Secure:   config.GetConfig().Security.Secure,
+		Secure:   !config.GetConfig().Security.InsecureCookieHeader,
 	}
 }
 
@@ -168,6 +168,7 @@ func NewRedirectCookie(ctx context.Context, redirectURL string) *http.Cookie {
 		Value:    urlObj.String(),
 		SameSite: http.SameSiteLaxMode,
 		HttpOnly: true,
+		Secure:   !config.GetConfig().Security.InsecureCookieHeader,
 	}
 }
 

--- a/flyteadmin/auth/cookie.go
+++ b/flyteadmin/auth/cookie.go
@@ -68,6 +68,8 @@ func NewSecureCookie(cookieName, value string, hashKey, blockKey []byte, domain 
 		Value:    encoded,
 		Domain:   domain,
 		SameSite: sameSiteMode,
+		HttpOnly: true,
+		Secure:   true,
 	}, nil
 }
 

--- a/flyteadmin/auth/cookie.go
+++ b/flyteadmin/auth/cookie.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/securecookie"
 
 	"github.com/flyteorg/flyte/flyteadmin/auth/interfaces"
+	"github.com/flyteorg/flyte/flyteadmin/pkg/config"
 	"github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
@@ -69,7 +70,7 @@ func NewSecureCookie(cookieName, value string, hashKey, blockKey []byte, domain 
 		Domain:   domain,
 		SameSite: sameSiteMode,
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   config.GetConfig().Security.Secure,
 	}, nil
 }
 
@@ -128,7 +129,7 @@ func NewCsrfCookie() http.Cookie {
 		Value:    csrfStateToken,
 		SameSite: http.SameSiteLaxMode,
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   config.GetConfig().Security.Secure,
 	}
 }
 

--- a/flyteadmin/auth/cookie.go
+++ b/flyteadmin/auth/cookie.go
@@ -128,6 +128,7 @@ func NewCsrfCookie() http.Cookie {
 		Value:    csrfStateToken,
 		SameSite: http.SameSiteLaxMode,
 		HttpOnly: true,
+		Secure:   true,
 	}
 }
 

--- a/flyteadmin/auth/cookie_manager.go
+++ b/flyteadmin/auth/cookie_manager.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/flyteorg/flyte/flyteadmin/auth/config"
+	serverConfig "github.com/flyteorg/flyte/flyteadmin/pkg/config"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 	"github.com/flyteorg/flyte/flytestdlib/errors"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
@@ -218,7 +219,7 @@ func (c *CookieManager) getLogoutCookie(name string) *http.Cookie {
 		Domain:   c.domain,
 		MaxAge:   0,
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   serverConfig.GetConfig().Security.Secure,
 		Expires:  time.Now().Add(-1 * time.Hour),
 	}
 }

--- a/flyteadmin/auth/cookie_manager.go
+++ b/flyteadmin/auth/cookie_manager.go
@@ -218,6 +218,7 @@ func (c *CookieManager) getLogoutCookie(name string) *http.Cookie {
 		Domain:   c.domain,
 		MaxAge:   0,
 		HttpOnly: true,
+		Secure: true,
 		Expires:  time.Now().Add(-1 * time.Hour),
 	}
 }

--- a/flyteadmin/auth/cookie_manager.go
+++ b/flyteadmin/auth/cookie_manager.go
@@ -219,7 +219,7 @@ func (c *CookieManager) getLogoutCookie(name string) *http.Cookie {
 		Domain:   c.domain,
 		MaxAge:   0,
 		HttpOnly: true,
-		Secure:   serverConfig.GetConfig().Security.Secure,
+		Secure:   !serverConfig.GetConfig().Security.InsecureCookieHeader,
 		Expires:  time.Now().Add(-1 * time.Hour),
 	}
 }

--- a/flyteadmin/auth/cookie_manager.go
+++ b/flyteadmin/auth/cookie_manager.go
@@ -218,7 +218,7 @@ func (c *CookieManager) getLogoutCookie(name string) *http.Cookie {
 		Domain:   c.domain,
 		MaxAge:   0,
 		HttpOnly: true,
-		Secure: true,
+		Secure:   true,
 		Expires:  time.Now().Add(-1 * time.Hour),
 	}
 }

--- a/flyteadmin/pkg/config/config.go
+++ b/flyteadmin/pkg/config/config.go
@@ -66,10 +66,13 @@ type KubeClientConfig struct {
 }
 
 type ServerSecurityOptions struct {
-	Secure      bool       `json:"secure"`
-	Ssl         SslOptions `json:"ssl"`
-	UseAuth     bool       `json:"useAuth"`
-	AuditAccess bool       `json:"auditAccess"`
+	Secure  bool       `json:"secure"`
+	Ssl     SslOptions `json:"ssl"`
+	UseAuth bool       `json:"useAuth"`
+	// InsecureCookieHeader should only be set in the case where we want to serve cookies with the header "Secure" set to false.
+	// This is useful for local development and *never* in production.
+	InsecureCookieHeader bool `json:"insecureCookieHeader"`
+	AuditAccess          bool `json:"auditAccess"`
 
 	// These options are here to allow deployments where the Flyte UI (Console) is served from a different domain/port.
 	// Note that CORS only applies to Admin's API endpoints. The health check endpoint for instance is unaffected.

--- a/flyteadmin/pkg/config/serverconfig_flags.go
+++ b/flyteadmin/pkg/config/serverconfig_flags.go
@@ -59,6 +59,7 @@ func (cfg ServerConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "security.ssl.certificateFile"), defaultServerConfig.Security.Ssl.CertificateFile, "")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "security.ssl.keyFile"), defaultServerConfig.Security.Ssl.KeyFile, "")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "security.useAuth"), defaultServerConfig.Security.UseAuth, "")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "security.insecureCookieHeader"), defaultServerConfig.Security.InsecureCookieHeader, "")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "security.auditAccess"), defaultServerConfig.Security.AuditAccess, "")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "security.allowCors"), defaultServerConfig.Security.AllowCors, "")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "security.allowedOrigins"), defaultServerConfig.Security.AllowedOrigins, "")

--- a/flyteadmin/pkg/config/serverconfig_flags_test.go
+++ b/flyteadmin/pkg/config/serverconfig_flags_test.go
@@ -225,6 +225,20 @@ func TestServerConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_security.insecureCookieHeader", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("security.insecureCookieHeader", testValue)
+			if vBool, err := cmdFlags.GetBool("security.insecureCookieHeader"); err == nil {
+				testDecodeJson_ServerConfig(t, fmt.Sprintf("%v", vBool), &actual.Security.InsecureCookieHeader)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_security.auditAccess", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {


### PR DESCRIPTION
## Why are the changes needed?
Setting these 2 fields is standard practice. All modern browsers implement them. 

## What changes were proposed in this pull request?
We set `HttpOnly` and `Secure` flags in all cookies produced by Flyte. Notice that those are generated only if auth is enabled.

More information about those flags:
- https://owasp.org/www-community/HttpOnly: The HttpOnly option prevents JavaScript code from accessing the cookie. This can provide some protection from cookie theft if an attacker successfully exploits a Cross-Site Scripting (XSS) vulnerability.
- https://cwe.mitre.org/data/definitions/614.html: The Secure cookie flag is an option that can be used to prevent the browser from sending the cookie over a plaintext connection. This can prevent an attacker from attempting session hijacking through Man-in-the-Middle (MitM) attacks.

~Currently we [allow the use of auth without TLS](https://github.com/flyteorg/flyte/blob/master/flyteadmin/pkg/server/service.go#L343-L375), but I'm wondering if we should remove that case (or disallow it explicitly).~
edit: This is a common setup. We now have a separate config to control whether cookies have the `Secure` header set. This is supposed to be used only for testing as it potentially exposes users who serve flyteconsole with TLS disabled and auth enabled to aforementioned attacks.


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
