### PR TITLE
[Docs] Align Note with the Output Naming Convention

### DIFF
--- a/docs/user_guide/basics/tasks.md
+++ b/docs/user_guide/basics/tasks.md
@@ -51,9 +51,9 @@ We create a task that computes the slope of a regression line:
 ```
 
 :::{note}
-Flytekit will assign a default name to the output variable like `out0`.
+Flytekit will assign a default name to the output variable like `o0`.
 In case of multiple outputs, each output will be numbered in the order
-starting with 0, e.g., -> `out0, out1, out2, ...`.
+starting with 0, e.g., `o0`, `o1`, `o2`, etc.
 :::
 
 You can execute a Flyte task just like any regular Python function:


### PR DESCRIPTION
## Why are the changes needed?
To better align the note in the [tasks page](https://docs.flyte.org/en/latest/user_guide/basics/tasks.html) with the actual naming convention of output variables.

## What changes were proposed in this pull request?
Change the default name of output variables from `outx` to `ox`, where `x` is an ordinal number starting from `0`.

![Screenshot 2024-10-26 at 12 18 35 PM](https://github.com/user-attachments/assets/4571b6ab-8d32-4612-9cb4-33fe2aa37f08)

### Related Doc Section
https://docs.flyte.org/en/latest/user_guide/basics/named_outputs.html

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All commits are signed-off.

## Docs link
https://flyte--5919.org.readthedocs.build/en/5919/user_guide/basics/tasks.html