### PR TITLE
Document clarifying notes about the data lifecycle

### DIFF
--- a/docs/user_guide/concepts/main_concepts/data_management.rst
+++ b/docs/user_guide/concepts/main_concepts/data_management.rst
@@ -186,20 +186,19 @@ The first task reads a file from the object store, shuffles the data, saves to l
 
 .. code-block:: python
 
-    @task()
-    def task_remove_column(input_file: FlyteFile, column_name: str) -> FlyteFile:
+    @task(container_image=basic_image, cache=True, cache_version="1.0")
+    def task_read_and_shuffle_file(input_file: FlyteFile) -> FlyteFile:
         """
-        Reads the input file as a DataFrame, removes a specified column, and outputs it as a new file.
+        Reads the input file as a DataFrame, shuffles the rows, and writes the shuffled DataFrame to a new file.
         """
         input_file.download()
         df = pd.read_csv(input_file.path)
 
-        # remove column
-        if column_name in df.columns:
-            df = df.drop(columns=[column_name])
+        # Shuffle the DataFrame rows
+        shuffled_df = df.sample(frac=1).reset_index(drop=True)
 
-        output_file_path = "data_finished.csv"
-        df.to_csv(output_file_path, index=False)
+        output_file_path = "data_shuffle.csv"
+        shuffled_df.to_csv(output_file_path, index=False)
 
         return FlyteFile(output_file_path)
        ...

--- a/docs/user_guide/concepts/main_concepts/data_management.rst
+++ b/docs/user_guide/concepts/main_concepts/data_management.rst
@@ -170,6 +170,13 @@ But for Metadata, the data should be accessible to Flyte control plane.
 
 Data persistence is also pluggable. By default, it supports all major blob stores and uses an interface defined in Flytestdlib.
 
+Deleting Raw Data in Your Own Datastores
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Flyte does not offer a direct function to delete raw data stored in external datastores like ``S3`` or ``GCS``. However, you can manage deletion by configuring a lifecycle policy within your datastore service.
+
+If caching is enabled in your Flyte ``task``, ensure that the ``max-cache-age`` is set to be shorter than the lifecycle policy in your datastore to prevent potential data inconsistency issues.
+
 Practical Example
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/user_guide/concepts/main_concepts/data_management.rst
+++ b/docs/user_guide/concepts/main_concepts/data_management.rst
@@ -186,7 +186,7 @@ The first task reads a file from the object store, shuffles the data, saves to l
 
 .. code-block:: python
 
-    @task(container_image=basic_image, cache=True, cache_version="1.0")
+    @task()
     def task_read_and_shuffle_file(input_file: FlyteFile) -> FlyteFile:
         """
         Reads the input file as a DataFrame, shuffles the rows, and writes the shuffled DataFrame to a new file.


### PR DESCRIPTION
## Tracking issue

Closes #4683 
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?
1. The [Understand How Flyte Handles Data doc](https://docs.flyte.org/en/latest/user_guide/concepts/main_concepts/data_management.html#understand-how-flyte-handles-data) is lacking information about deleting raw data in storage service such as s3 and gcs.
2. Some [example code](https://docs.flyte.org/en/latest/user_guide/concepts/main_concepts/data_management.html#practical-example) in the doc is incorrect. The workflow called a function 'task_read_and_shuffle_file', but the function is not defined in example code.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
3. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
1. Add information about  raw data deletion in the doc.
2. Fix example code. 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
3. If there is design documentation, please add the link.
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [X] All commits are signed-off.

## Docs link
[https://flyte--5921.org.readthedocs.build/en/5921/user_guide/concepts/main_concepts/data_management.html](https://flyte--5921.org.readthedocs.build/en/5921/user_guide/concepts/main_concepts/data_management.html)

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
