### PR TITLE
[flyteadmin][API] get control plane version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ define PIP_COMPILE
 pip-compile $(1) --upgrade --verbose --resolver=backtracking --annotation-style=line
 endef
 
-GIT_VERSION := $(shell git describe --always --tags)
+GIT_VERSION := $(shell git describe --tags --long --match "v*" --first-parent)
 GIT_HASH := $(shell git rev-parse --short HEAD)
 TIMESTAMP := $(shell date '+%Y-%m-%d')
-PACKAGE ?=github.com/flyteorg/flytestdlib
+PACKAGE ?=github.com/flyteorg/flyte/flytestdlib
 LD_FLAGS="-s -w -X $(PACKAGE)/version.Version=$(GIT_VERSION) -X $(PACKAGE)/version.Build=$(GIT_HASH) -X $(PACKAGE)/version.BuildTime=$(TIMESTAMP)"
 TMP_BUILD_DIR := .tmp_build
 

--- a/flyteadmin/Makefile
+++ b/flyteadmin/Makefile
@@ -5,11 +5,11 @@ include ../boilerplate/flyte/docker_build/Makefile
 include ../boilerplate/flyte/golang_test_targets/Makefile
 include ../boilerplate/flyte/end2end/Makefile
 
-GIT_VERSION := $(shell git describe --always --tags)
+GIT_VERSION := $(shell git describe --tags --long --match "v*" --first-parent)
 GIT_HASH := $(shell git rev-parse --short HEAD)
 TIMESTAMP := $(shell date '+%Y-%m-%d')
 # TODO(monorepo): Do we need to change this? This is used in the service that provides a version.
-PACKAGE ?=github.com/flyteorg/flytestdlib
+PACKAGE ?=github.com/flyteorg/flyte/flytestdlib
 
 LD_FLAGS="-s -w -X $(PACKAGE)/version.Version=$(GIT_VERSION) -X $(PACKAGE)/version.Build=$(GIT_HASH) -X $(PACKAGE)/version.BuildTime=$(TIMESTAMP)"
 

--- a/flytestdlib/version/version.go
+++ b/flytestdlib/version/version.go
@@ -16,7 +16,7 @@ var (
 	// Specifies the GIT sha of the build
 	Build = "unknown"
 	// Version for the build, should follow a semver
-	Version = "unknown"
+	Version = "v1.14"
 	// Build timestamp
 	BuildTime = time.Now().String()
 	// Git branch that was used to build the binary

--- a/flytestdlib/version/version.go
+++ b/flytestdlib/version/version.go
@@ -16,7 +16,7 @@ var (
 	// Specifies the GIT sha of the build
 	Build = "unknown"
 	// Version for the build, should follow a semver
-	Version = "v1.14"
+	Version = "unknown"
 	// Build timestamp
 	BuildTime = time.Now().String()
 	// Git branch that was used to build the binary


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5318

## Why are the changes needed?
provide version api for users.

## What changes were proposed in this pull request?
add a method `get_control_plane_version` in `class SynchronousFlyteClient(_RawSynchronousFlyteClient)`.

## How was this patch tested?
local and integration test.

### Setup process
```python
from flytekit.configuration import PlatformConfig
from flytekit.clients.friendly import SynchronousFlyteClient as _SynchronousFlyteClient
config = PlatformConfig(endpoint="localhost:30080", insecure=True)
client = _SynchronousFlyteClient(config)
print("Control Plane Version:", client.get_control_plane_version())
```

### Screenshots
Unknown version
<img width="449" alt="image" src="https://github.com/user-attachments/assets/2c059dc5-07eb-488e-8e4e-4f7b8a506809">

Know Version
<img width="439" alt="image" src="https://github.com/user-attachments/assets/9c72c92d-cd2c-449e-a637-22cc78d2d6c0">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

## Docs link

