### PR TITLE
fixed [Docs] Spot/interruptible docs imply retries come from the user… Closes #3956

### DIFF
--- a/docs/user_guide/concepts/main_concepts/tasks.rst
+++ b/docs/user_guide/concepts/main_concepts/tasks.rst
@@ -133,26 +133,26 @@ Tasks can define a retry strategy to handle different types of failures:
    - Network issues
    - Service unavailability
    - Hardware failures
-   
-   *Important*: When running on spot/interruptible instances, preemptions count against the system retry budget, not the user retry budget. The last retry attempt automatically runs on a non-preemptible instance to ensure task completion.
 
-2. **User Retries**: Specified in the `@task` decorator (via `retries` parameter), used for:
+*Important*: When running on spot/interruptible instances, preemptions count against the system retry budget, not the user retry budget. The last retry attempt automatically runs on a non-preemptible instance to ensure task completion.
+
+2. **User Retries**: Specified in the ``@task`` decorator (via ``retries`` parameter), used for:
    - Application-level errors
    - Invalid input handling
    - Business logic failures
 
-```python
-@task(retries=3)  # Sets user retry budget to 3
-def my_task() -> None:
-    ...
-```
+.. code-block:: python
+
+   @task(retries=3)  # Sets user retry budget to 3
+   def my_task() -> None:
+       ...
 
 ### Alternative Retry Behavior
 
-Starting with  from 1.10.0, Flyte offers a simplified retry behavior where both system and user retries count towards a single retry budget defined in the task decorator. To enable this:
+Starting from 1.10.0, Flyte offers a simplified retry behavior where both system and user retries count towards a single retry budget defined in the task decorator. To enable this:
 
-1. Set `configmap.core.propeller.node-config.ignore-retry-cause` to `true` in helm values
+1. Set ``configmap.core.propeller.node-config.ignore-retry-cause`` to ``true`` in helm values
 2. Define retries in the task decorator to set the total retry budget
 3. The last retries will automatically run on non-spot instances
 
-This provides a simpler, more predictable retry behavior while maintaining reliability. 
+This provides a simpler, more predictable retry behavior while maintaining reliability.

--- a/docs/user_guide/concepts/main_concepts/tasks.rst
+++ b/docs/user_guide/concepts/main_concepts/tasks.rst
@@ -149,7 +149,7 @@ def my_task() -> None:
 
 ### Alternative Retry Behavior
 
-Starting with RFC 3902, Flyte offers a simplified retry behavior where both system and user retries count towards a single retry budget defined in the task decorator. To enable this:
+Starting with  from 1.10.0, Flyte offers a simplified retry behavior where both system and user retries count towards a single retry budget defined in the task decorator. To enable this:
 
 1. Set `configmap.core.propeller.node-config.ignore-retry-cause` to `true` in helm values
 2. Define retries in the task decorator to set the total retry budget


### PR DESCRIPTION
… retry budget #3956



## What changes were proposed in this pull request?

This PR clarifies the documentation regarding retry behavior for interruptible tasks in Flyte. It updates sections to emphasize that retries for spot/interruptible instances utilize the system retry budget rather than the user-specified retry budget. Changes are made in the user guide and related documentation files to ensure accurate guidance for users managing task retries on preemptible compute resources.


