### PR TITLE
Improve Documentation for Registering Workflows to avoid confusion 

### DIFF
--- a/docs/user_guide/flyte_fundamentals/registering_workflows.md
+++ b/docs/user_guide/flyte_fundamentals/registering_workflows.md
@@ -295,7 +295,7 @@ entities compiled as protobuf files that you can register with multiple Flyte
 clusters.
 
 ````{note}
-Like `pyflyte register`, can also specify multiple workflow directories, like:
+You can specify multiple workflow directories using the following command:
 
 ```{prompt} bash $
 pyflyte --pkgs <dir1> --pkgs <dir2> package ...


### PR DESCRIPTION
### Tracking issue : #5435

### Why are the changes needed?

These changes are necessary to enhance the clarity for first-time users, ensuring they understand how to register workflows without confusion.

### What changes were proposed in this pull request?
Updated note section to remove "Like `pyflyte register`" in registering_workflows.md file. 

#### Screenshots
![Screenshot 2024-10-30 115429](https://github.com/user-attachments/assets/7cd0caff-a1ed-497b-a5bb-8298b906f2a7)


### Check all the applicable boxes 

- [x] All commits are signed-off.

### Related PRs


