### PR TITLE
Fix: Make appProtocols optional in flyteadmin and flyteconsole services in helm chart

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -191,7 +191,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flyteadmin deployment |
 | flyteadmin.secrets | object | `{}` |  |
 | flyteadmin.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for flyteadmin pod(s). |
-| flyteadmin.service | object | `{"additionalPorts":[],"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"loadBalancerSourceRanges":[],"type":"ClusterIP"}` | Service settings for Flyteadmin |
+| flyteadmin.service | object | `{"additionalPorts":[],"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"appProtocols":{"enabled":false},"loadBalancerSourceRanges":[],"type":"ClusterIP"}` | Service settings for Flyteadmin |
 | flyteadmin.service.additionalPorts | list | `[]` | Appends additional ports to the service spec. |
 | flyteadmin.serviceAccount | object | `{"alwaysCreate":false,"annotations":{},"clusterRole":{"apiGroups":["","flyte.lyft.com","rbac.authorization.k8s.io"],"resources":["configmaps","flyteworkflows","namespaces","pods","resourcequotas","roles","rolebindings","secrets","services","serviceaccounts","spark-role","limitranges"],"verbs":["*"]},"create":true,"createClusterRole":true,"imagePullSecrets":[]}` | Configuration for service accounts for FlyteAdmin |
 | flyteadmin.serviceAccount.alwaysCreate | bool | `false` | Should a service account always be created for flyteadmin even without an actual flyteadmin deployment running (e.g. for multi-cluster setups) |
@@ -234,7 +234,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteconsole.replicaCount | int | `1` | Replicas count for Flyteconsole deployment |
 | flyteconsole.resources | object | `{"limits":{"cpu":"500m","memory":"250Mi"},"requests":{"cpu":"10m","memory":"50Mi"}}` | Default resources requests and limits for Flyteconsole deployment |
 | flyteconsole.securityContext | object | `{"fsGroupChangePolicy":"OnRootMismatch","runAsNonRoot":true,"runAsUser":1000,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for flyteconsole pod(s). |
-| flyteconsole.service | object | `{"annotations":{},"type":"ClusterIP"}` | Service settings for Flyteconsole |
+| flyteconsole.service | object | `{"annotations":{},"appProtocols":{"enabled":false},"type":"ClusterIP"}` | Service settings for Flyteconsole |
 | flyteconsole.serviceMonitor | object | `{"enabled":false,"interval":"60s","labels":{},"scrapeTimeout":"30s"}` | Settings for flyteconsole service monitor |
 | flyteconsole.serviceMonitor.enabled | bool | `false` | If enabled create the flyteconsole service monitor |
 | flyteconsole.serviceMonitor.interval | string | `"60s"` | Sets the interval at which metrics will be scraped by prometheus |

--- a/charts/flyte-core/templates/admin/service.yaml
+++ b/charts/flyte-core/templates/admin/service.yaml
@@ -20,22 +20,30 @@ spec:
     - name: http
       port: 80
       protocol: TCP
+      {{- if .Values.flyteadmin.service.appProtocols.enabled }}
       appProtocol: TCP
+      {{- end }}
       targetPort: 8088
     - name: grpc
       port: 81
       protocol: TCP
       # intentionally set to TCP instead of grpc
+      {{- if .Values.flyteadmin.service.appProtocols.enabled }}
       appProtocol: TCP
+      {{- end }}
       targetPort: 8089
     - name: redoc
       protocol: TCP
+      {{- if .Values.flyteadmin.service.appProtocols.enabled }}
       appProtocol: TCP
+      {{- end }}
       port: 87
       targetPort: 8087
     - name: http-metrics
       protocol: TCP
+      {{- if .Values.flyteadmin.service.appProtocols.enabled }}
       appProtocol: TCP
+      {{- end }}
       port: 10254
     {{- with .Values.flyteadmin.service.additionalPorts -}}
     {{ tpl (toYaml .) $ | nindent 4 }}

--- a/charts/flyte-core/templates/console/service.yaml
+++ b/charts/flyte-core/templates/console/service.yaml
@@ -16,7 +16,9 @@ spec:
   - name: http
     port: 80
     protocol: TCP
+    {{- if .Values.flyteconsole.service.appProtocols.enabled }}
     appProtocol: TCP
+    {{- end }}
     targetPort: 8080
     {{- if .Values.flyteconsole.serviceMonitor.enabled  }}
   - name: http-metrics

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -50,6 +50,8 @@ flyteadmin:
     - flyteexamples
   # -- Service settings for Flyteadmin
   service:
+    appProtocols:
+      enabled: false
     annotations:
       projectcontour.io/upstream-protocol.h2c: grpc
     type: ClusterIP
@@ -407,6 +409,8 @@ flyteconsole:
       memory: 50Mi
   # -- Service settings for Flyteconsole
   service:
+    appProtocols:
+      enabled: false
     annotations: {}
     type: ClusterIP
   # -- Annotations for Flyteconsole pods

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -751,22 +751,18 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      appProtocol: TCP
       targetPort: 8088
     - name: grpc
       port: 81
       protocol: TCP
       # intentionally set to TCP instead of grpc
-      appProtocol: TCP
       targetPort: 8089
     - name: redoc
       protocol: TCP
-      appProtocol: TCP
       port: 87
       targetPort: 8087
     - name: http-metrics
       protocol: TCP
-      appProtocol: TCP
       port: 10254
   selector: 
     app.kubernetes.io/name: flyteadmin
@@ -789,7 +785,6 @@ spec:
   - name: http
     port: 80
     protocol: TCP
-    appProtocol: TCP
     targetPort: 8080
   selector: 
     app.kubernetes.io/name: flyteconsole

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -474,22 +474,18 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      appProtocol: TCP
       targetPort: 8088
     - name: grpc
       port: 81
       protocol: TCP
       # intentionally set to TCP instead of grpc
-      appProtocol: TCP
       targetPort: 8089
     - name: redoc
       protocol: TCP
-      appProtocol: TCP
       port: 87
       targetPort: 8087
     - name: http-metrics
       protocol: TCP
-      appProtocol: TCP
       port: 10254
   selector: 
     app.kubernetes.io/name: flyteadmin
@@ -512,7 +508,6 @@ spec:
   - name: http
     port: 80
     protocol: TCP
-    appProtocol: TCP
     targetPort: 8080
   selector: 
     app.kubernetes.io/name: flyteconsole

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -782,22 +782,18 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      appProtocol: TCP
       targetPort: 8088
     - name: grpc
       port: 81
       protocol: TCP
       # intentionally set to TCP instead of grpc
-      appProtocol: TCP
       targetPort: 8089
     - name: redoc
       protocol: TCP
-      appProtocol: TCP
       port: 87
       targetPort: 8087
     - name: http-metrics
       protocol: TCP
-      appProtocol: TCP
       port: 10254
   selector: 
     app.kubernetes.io/name: flyteadmin
@@ -820,7 +816,6 @@ spec:
   - name: http
     port: 80
     protocol: TCP
-    appProtocol: TCP
     targetPort: 8080
   selector: 
     app.kubernetes.io/name: flyteconsole

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -488,22 +488,18 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      appProtocol: TCP
       targetPort: 8088
     - name: grpc
       port: 81
       protocol: TCP
       # intentionally set to TCP instead of grpc
-      appProtocol: TCP
       targetPort: 8089
     - name: redoc
       protocol: TCP
-      appProtocol: TCP
       port: 87
       targetPort: 8087
     - name: http-metrics
       protocol: TCP
-      appProtocol: TCP
       port: 10254
   selector: 
     app.kubernetes.io/name: flyteadmin
@@ -526,7 +522,6 @@ spec:
   - name: http
     port: 80
     protocol: TCP
-    appProtocol: TCP
     targetPort: 8080
   selector: 
     app.kubernetes.io/name: flyteconsole

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -804,22 +804,18 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      appProtocol: TCP
       targetPort: 8088
     - name: grpc
       port: 81
       protocol: TCP
       # intentionally set to TCP instead of grpc
-      appProtocol: TCP
       targetPort: 8089
     - name: redoc
       protocol: TCP
-      appProtocol: TCP
       port: 87
       targetPort: 8087
     - name: http-metrics
       protocol: TCP
-      appProtocol: TCP
       port: 10254
   selector: 
     app.kubernetes.io/name: flyteadmin
@@ -842,7 +838,6 @@ spec:
   - name: http
     port: 80
     protocol: TCP
-    appProtocol: TCP
     targetPort: 8080
   selector: 
     app.kubernetes.io/name: flyteconsole

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -6145,22 +6145,18 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      appProtocol: TCP
       targetPort: 8088
     - name: grpc
       port: 81
       protocol: TCP
       # intentionally set to TCP instead of grpc
-      appProtocol: TCP
       targetPort: 8089
     - name: redoc
       protocol: TCP
-      appProtocol: TCP
       port: 87
       targetPort: 8087
     - name: http-metrics
       protocol: TCP
-      appProtocol: TCP
       port: 10254
   selector: 
     app.kubernetes.io/name: flyteadmin
@@ -6183,7 +6179,6 @@ spec:
   - name: http
     port: 80
     protocol: TCP
-    appProtocol: TCP
     targetPort: 8080
   selector: 
     app.kubernetes.io/name: flyteconsole

--- a/docker/sandbox-bundled/manifests/complete-agent.yaml
+++ b/docker/sandbox-bundled/manifests/complete-agent.yaml
@@ -819,7 +819,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: c2Z6ZUdxTjJ1bEc1QlVaeQ==
+  haSharedSecret: MzdjVFBHVmlTTUJLV2FLRA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1416,7 +1416,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: ad072a5177dfbeacda100d536f1c7d611808b1c7f79dc6d02d9dbf24b8294e3b
+        checksum/secret: 51eef38b8d9341f4897669e28bab62b0ef7f2a690e6c78756e25dff548f68c57
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -801,7 +801,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: TUpUek9Ib3BpWTlEbFRvSw==
+  haSharedSecret: QzdpNFV1b01KaVpCZ3NrbQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1365,7 +1365,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 09204971564694f6090d55069cf0853843456945f781aa7842f33021d09f4f25
+        checksum/secret: 14a953a34adb01e2532145c9fc3eec829b95c5515b181f8877e9837c8ff5ed10
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: d2VkcjRnRHkyTmZrOU52cw==
+  haSharedSecret: SmFESFBwbUNNYWxHYWlzYQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 3b1376c2c63f4fff6745ad085844b7a1d7c8ad2cce13cae4e1e9c3ea495cebaa
+        checksum/secret: cdfbf45c37e81185184e6abf451cbe04ab03e455ccfd425e83f2e6fddb0b4339
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## Why are the changes needed?

https://github.com/flyteorg/flyte/pull/5240, among other things, set `appProtocol` values of `TCP` for the ports of the flyteadmin and flyteconsole services in the flyte-core helm chart.

[This](https://github.com/flyteorg/flyte/pull/5240#issuecomment-2400342871) comment by @ddl-ebrown explains why this was necessary in their deployment which uses an ingress in combination with the istio service mesh:

> [...] the ingress may be configured in a way that
it sends TLS traffic to internal Flyte services. Istio will use port
names to determine traffic - and may therefore assume the appProtocol
of http, even though traffic from ingress -> flyteadmin is actually
https. This misconfiguration prevents any traffic from flowing
through the ingress to the service.
Flyteadmin http and grcp ports are accessible using http and
grpc values for appProtocol respectively within the cluster (i.e.
from a user workspace), but as soon as traffic travels between the
ingress and the service those settings will not work. The most
"compatible" setting is tcp which works for any network stream.

---

In my deployment (which also uses istio but not with an nginx ingress but instead with a GCE ingress and an istio ingress gateway, see [here](https://github.com/flyteorg/flytekit/tree/master/plugins/flytekit-identity-aware-proxy#configuring-your-flyte-deployment-to-use-iap) for deplyoment guide), this particular change is problematic:

```yaml
# flyteadmin service
    - name: grpc
      port: 81
      protocol: TCP
      # intentionally set to TCP instead of grpc
      appProtocol: TCP
      targetPort: 8089
```

https://github.com/flyteorg/flyte/pull/5240 intentionally sets the `appProtocol` for the `grpc` port to `TCP` over `grpc`. In my deployment this prevents traffic flowing from the istio ingress gateway to the flyteadmin pod.

This worked before the `appProtocol` was set (assumably because the protocol was derived from the name of the port) and it does also work if I change the protocol to `grpc`.


## What changes were proposed in this pull request?
I currently cannot upgrade my deployment without manually patching the service after deployment. Because of this I'd like to make the `appProtocol` values in the helm chart optional.

Because the app protocols used to not be set since they are not required for the default nginx ingress/no service mesh deployment the helm chart provides, I propose to disable the app protocol fields by default.

This would mean that you, @ddl-ebrown, need to set the flags to true when upgrading to a helm chart version that contains this change.

If somebody has the opinion that the default should be true, I'm absolutely happy to discuss this.


## How was this patch tested?
The app protocol values used to not be set and are not needed for the default nginx ingress deployment offered by the helm chart.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

