### PR TITLE
Fix: avoid log spam for log links generated during the pod's pending phase

### DIFF
--- a/flyteplugins/go/tasks/logs/logging_utils.go
+++ b/flyteplugins/go/tasks/logs/logging_utils.go
@@ -31,7 +31,14 @@ func GetLogsForContainerInPod(ctx context.Context, logPlugin tasklog.Plugin, tas
 
 	containerID := v1.ContainerStatus{}.ContainerID
 	if uint32(len(pod.Status.ContainerStatuses)) <= index {
-		logger.Errorf(ctx, "containerStatus IndexOutOfBound, requested [%d], but total containerStatuses [%d] in pod phase [%v]", index, len(pod.Status.ContainerStatuses), pod.Status.Phase)
+		msg := fmt.Sprintf("containerStatus IndexOutOfBound, requested [%d], but total containerStatuses [%d] in pod phase [%v]", index, len(pod.Status.ContainerStatuses), pod.Status.Phase)
+		if pod.Status.Phase == v1.PodPending {
+			// If the pod is pending, the container status may not be available yet. Log as debug.
+			logger.Debugf(ctx, msg)
+		} else {
+			// In other phases, this is unexpected. Log as error.
+			logger.Errorf(ctx, msg)
+		}
 	} else {
 		containerID = pod.Status.ContainerStatuses[index].ContainerID
 	}


### PR DESCRIPTION
## Why are the changes needed?

In https://github.com/flyteorg/flyte/pull/4726 I introduced the option to configure the lifecycle of log links as is documented [here](https://docs.flyte.org/en/latest/user_guide/productionizing/configuring_logging_links_in_the_ui.html#configure-lifetime-of-logging-links). In particular, log links can be configured to be already shown before a task starts running or be configured to disappear after a task stops.

@Tom-Newton [noted](https://github.com/flyteorg/flyte/pull/4726/files#r1819110678) that their flytepropeller logs are spammed with error messages because the log link generation logic for pod tasks checks whether container statuses exist and if not logs this as an error. Prior to https://github.com/flyteorg/flyte/pull/4726 it made sense to always log this as an error because log links were only generated in the "Running" phase of the task when the pod should have container statuses. Now that we optionally generate log links already in the pending phase, it is not unexpected that the container statuses are empty.

## What changes were proposed in this pull request?
Log the respective message with debug log level if the pod is in the pending phase. Keep logging with error log level in other pod phases.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

