### PR TITLE
fix: align the default config output

### DIFF
--- a/flytectl/pkg/configutil/configutil.go
+++ b/flytectl/pkg/configutil/configutil.go
@@ -16,17 +16,6 @@ const (
 console:
   endpoint: {{.Console}}
 {{- end}}
-{{- if .DataConfig}}
-# This is not a needed configuration, only useful if you want to explore the data in sandbox. For non sandbox, please
-# do not use this configuration, instead prefer to use aws, gcs, azure sessions. Flytekit, should use fsspec to
-# auto select the right backend to pull data as long as the sessions are configured. For Sandbox, this is special, as
-# minio is s3 compatible and we ship with minio in sandbox.
-storage:
-  connection:
-    endpoint: {{.DataConfig.Endpoint}}
-    access-key: {{.DataConfig.AccessKey}}
-    secret-key: {{.DataConfig.SecretKey}}
-{{- end}}
 `
 )
 

--- a/flytectl/pkg/configutil/configutil_test.go
+++ b/flytectl/pkg/configutil/configutil_test.go
@@ -1,6 +1,7 @@
 package configutil
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -20,7 +21,7 @@ func TestSetupConfig(t *testing.T) {
 	}
 	err = SetupConfig(file.Name(), AdminConfigTemplate, templateValue)
 	assert.NoError(t, err)
-	configBytes, err := ioutil.ReadAll(file)
+	configBytes, err := io.ReadAll(file)
 	assert.NoError(t, err)
 	expected := `admin:
   # For GRPC endpoints you might want to use dns:///flyte.myexample.com
@@ -62,7 +63,7 @@ console:
 	}
 	err = SetupConfig(file.Name(), AdminConfigTemplate, templateValue)
 	assert.NoError(t, err)
-	configBytes, err = ioutil.ReadAll(file)
+	configBytes, err = io.ReadAll(file)
 	assert.NoError(t, err)
 	expected = `admin:
   # For GRPC endpoints you might want to use dns:///flyte.myexample.com
@@ -82,8 +83,8 @@ func TestConfigCleanup(t *testing.T) {
 	if os.IsNotExist(err) {
 		_ = os.MkdirAll(f.FilePathJoin(f.UserHomeDir(), ".flyte"), 0755)
 	}
-	_ = ioutil.WriteFile(FlytectlConfig, []byte("string"), 0600)
-	_ = ioutil.WriteFile(Kubeconfig, []byte("string"), 0600)
+	_ = os.WriteFile(FlytectlConfig, []byte("string"), 0600)
+	_ = os.WriteFile(Kubeconfig, []byte("string"), 0600)
 
 	err = ConfigCleanup()
 	assert.Nil(t, err)

--- a/flytectl/pkg/configutil/configutil_test.go
+++ b/flytectl/pkg/configutil/configutil_test.go
@@ -68,15 +68,6 @@ console:
   # For GRPC endpoints you might want to use dns:///flyte.myexample.com
   endpoint: dns:///admin.example.com
   insecure: true
-# This is not a needed configuration, only useful if you want to explore the data in sandbox. For non sandbox, please
-# do not use this configuration, instead prefer to use aws, gcs, azure sessions. Flytekit, should use fsspec to
-# auto select the right backend to pull data as long as the sessions are configured. For Sandbox, this is special, as
-# minio is s3 compatible and we ship with minio in sandbox.
-storage:
-  connection:
-    endpoint: http://localhost:9000
-    access-key: my-access-key
-    secret-key: my-secret-key
 `
 	assert.Equal(t, expected, string(configBytes))
 

--- a/flytectl/pkg/sandbox/start.go
+++ b/flytectl/pkg/sandbox/start.go
@@ -175,13 +175,8 @@ func startSandbox(ctx context.Context, cli docker.Docker, g github.GHRepoService
 	}
 
 	templateValues := configutil.ConfigTemplateSpec{
-		Host:     "localhost:30080",
+		Host:     "dns:///localhost:30080",
 		Insecure: true,
-		DataConfig: &configutil.DataConfig{
-			Endpoint:  "http://localhost:30002",
-			AccessKey: "minio",
-			SecretKey: "miniostorage",
-		},
 	}
 	if err := configutil.SetupConfig(configutil.FlytectlConfig, configutil.GetTemplate(), templateValues); err != nil {
 		return nil, err


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

Closes https://github.com/flyteorg/flyte/issues/3186

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
1. Removing Unused Fields: Remove `storage.connection`. This reduces clutter, making the config cleaner and easier to understand.
2. Aligning Configurations: Ensures `flytectl config init` and `flytectl demo start` produce consistent configs, simplifying setup and usage. Align the `admin.endpoint: dns:///localhost:30080`.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

unit test

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
