### PR TITLE
Hide generated launch plans starting with .flytegen in the UI

### DIFF
--- a/flyteadmin/pkg/common/filters.go
+++ b/flyteadmin/pkg/common/filters.go
@@ -22,6 +22,7 @@ type GormQueryExpr struct {
 // Complete set of filters available for database queries.
 const (
 	Contains FilterExpression = iota
+	NotContains
 	GreaterThan
 	GreaterThanOrEqual
 	LessThan
@@ -37,6 +38,8 @@ const (
 	joinArgsFormat          = "%s.%s"
 	containsQuery           = "%s LIKE ?"
 	containsArgs            = "%%%s%%"
+	notContainsQuery        = "%s NOT LIKE ?"
+	notContainsArgs         = "%%%s%%"
 	greaterThanQuery        = "%s > ?"
 	greaterThanOrEqualQuery = "%s >= ?"
 	lessThanQuery           = "%s < ?"
@@ -50,6 +53,7 @@ const (
 // Set of available filters which exclusively accept a single argument value.
 var singleValueFilters = map[FilterExpression]bool{
 	Contains:           true,
+	NotContains:        true,
 	GreaterThan:        true,
 	GreaterThanOrEqual: true,
 	LessThan:           true,
@@ -68,6 +72,7 @@ const EqualExpression = "eq"
 
 var filterNameMappings = map[string]FilterExpression{
 	"contains":      Contains,
+	"not_contains":  NotContains,
 	"gt":            GreaterThan,
 	"gte":           GreaterThanOrEqual,
 	"lt":            LessThan,
@@ -80,6 +85,7 @@ var filterNameMappings = map[string]FilterExpression{
 
 var filterQueryMappings = map[FilterExpression]string{
 	Contains:           containsQuery,
+	NotContains:        notContainsQuery,
 	GreaterThan:        greaterThanQuery,
 	GreaterThanOrEqual: greaterThanOrEqualQuery,
 	LessThan:           lessThanQuery,
@@ -110,6 +116,8 @@ func getFilterExpressionName(expression FilterExpression) string {
 	switch expression {
 	case Contains:
 		return "contains"
+	case NotContains:
+		return "not contains"
 	case GreaterThan:
 		return "greater than"
 	case GreaterThanOrEqual:
@@ -200,6 +208,13 @@ func (f *inlineFilterImpl) getGormQueryExpr(formattedField string) (GormQueryExp
 			Query: fmt.Sprintf(containsQuery, formattedField),
 			// args renders to something like: "%value%"
 			Args: fmt.Sprintf(containsArgs, f.value),
+		}, nil
+	case NotContains:
+		return GormQueryExpr{
+			// WHERE field LIKE %value%
+			Query: fmt.Sprintf(notContainsQuery, formattedField),
+			// args renders to something like: "%value%"
+			Args: fmt.Sprintf(notContainsArgs, f.value),
 		}, nil
 	case GreaterThan:
 		return GormQueryExpr{

--- a/flyteadmin/pkg/common/filters.go
+++ b/flyteadmin/pkg/common/filters.go
@@ -22,7 +22,7 @@ type GormQueryExpr struct {
 // Complete set of filters available for database queries.
 const (
 	Contains FilterExpression = iota
-	NotContains
+	NotLike
 	GreaterThan
 	GreaterThanOrEqual
 	LessThan
@@ -38,8 +38,7 @@ const (
 	joinArgsFormat          = "%s.%s"
 	containsQuery           = "%s LIKE ?"
 	containsArgs            = "%%%s%%"
-	notContainsQuery        = "%s NOT LIKE ?"
-	notContainsArgs         = "%%%s%%"
+	notLikeQuery            = "%s NOT LIKE ?"
 	greaterThanQuery        = "%s > ?"
 	greaterThanOrEqualQuery = "%s >= ?"
 	lessThanQuery           = "%s < ?"
@@ -53,7 +52,7 @@ const (
 // Set of available filters which exclusively accept a single argument value.
 var singleValueFilters = map[FilterExpression]bool{
 	Contains:           true,
-	NotContains:        true,
+	NotLike:            true,
 	GreaterThan:        true,
 	GreaterThanOrEqual: true,
 	LessThan:           true,
@@ -72,7 +71,7 @@ const EqualExpression = "eq"
 
 var filterNameMappings = map[string]FilterExpression{
 	"contains":      Contains,
-	"not_contains":  NotContains,
+	"not_like":      NotLike,
 	"gt":            GreaterThan,
 	"gte":           GreaterThanOrEqual,
 	"lt":            LessThan,
@@ -85,7 +84,7 @@ var filterNameMappings = map[string]FilterExpression{
 
 var filterQueryMappings = map[FilterExpression]string{
 	Contains:           containsQuery,
-	NotContains:        notContainsQuery,
+	NotLike:            notLikeQuery,
 	GreaterThan:        greaterThanQuery,
 	GreaterThanOrEqual: greaterThanOrEqualQuery,
 	LessThan:           lessThanQuery,
@@ -116,8 +115,8 @@ func getFilterExpressionName(expression FilterExpression) string {
 	switch expression {
 	case Contains:
 		return "contains"
-	case NotContains:
-		return "not contains"
+	case NotLike:
+		return "not like"
 	case GreaterThan:
 		return "greater than"
 	case GreaterThanOrEqual:
@@ -209,12 +208,11 @@ func (f *inlineFilterImpl) getGormQueryExpr(formattedField string) (GormQueryExp
 			// args renders to something like: "%value%"
 			Args: fmt.Sprintf(containsArgs, f.value),
 		}, nil
-	case NotContains:
+	case NotLike:
 		return GormQueryExpr{
 			// WHERE field NOT LIKE %value%
-			Query: fmt.Sprintf(notContainsQuery, formattedField),
-			// args renders to something like: "%value%"
-			Args: fmt.Sprintf(notContainsArgs, f.value),
+			Query: fmt.Sprintf(notLikeQuery, formattedField),
+			Args:  f.value,
 		}, nil
 	case GreaterThan:
 		return GormQueryExpr{

--- a/flyteadmin/pkg/common/filters.go
+++ b/flyteadmin/pkg/common/filters.go
@@ -211,7 +211,7 @@ func (f *inlineFilterImpl) getGormQueryExpr(formattedField string) (GormQueryExp
 		}, nil
 	case NotContains:
 		return GormQueryExpr{
-			// WHERE field LIKE %value%
+			// WHERE field NOT LIKE %value%
 			Query: fmt.Sprintf(notContainsQuery, formattedField),
 			// args renders to something like: "%value%"
 			Args: fmt.Sprintf(notContainsArgs, f.value),

--- a/flyteadmin/pkg/common/filters.go
+++ b/flyteadmin/pkg/common/filters.go
@@ -210,7 +210,7 @@ func (f *inlineFilterImpl) getGormQueryExpr(formattedField string) (GormQueryExp
 		}, nil
 	case NotLike:
 		return GormQueryExpr{
-			// WHERE field NOT LIKE %value%
+			// WHERE field NOT LIKE value
 			Query: fmt.Sprintf(notLikeQuery, formattedField),
 			Args:  f.value,
 		}, nil

--- a/flyteadmin/pkg/common/filters_test.go
+++ b/flyteadmin/pkg/common/filters_test.go
@@ -107,6 +107,7 @@ func TestGetGormJoinTableQueryExpr(t *testing.T) {
 
 var expectedArgsForFilters = map[FilterExpression]string{
 	Contains:           "%value%",
+	NotLike:            "value",
 	GreaterThan:        "value",
 	GreaterThanOrEqual: "value",
 	LessThan:           "value",
@@ -168,4 +169,19 @@ func TestWithDefaultValueFilter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "COALESCE(named_entity_metadata.state, 0) = ?", queryExpression.Query)
 	assert.Equal(t, 1, queryExpression.Args)
+}
+
+func TestNotLikeFilter(t *testing.T) {
+	filter, err := NewSingleValueFilter(NamedEntityMetadata, NotLike, "name", ".flytegen%")
+	assert.NoError(t, err)
+
+	queryExpression, err := filter.GetGormQueryExpr()
+	assert.NoError(t, err)
+	assert.Equal(t, "name NOT LIKE ?", queryExpression.Query)
+	assert.Equal(t, ".flytegen%", queryExpression.Args)
+
+	queryExpression, err = filter.GetGormJoinTableQueryExpr("named_entity_metadata")
+	assert.NoError(t, err)
+	assert.Equal(t, "named_entity_metadata.name NOT LIKE ?", queryExpression.Query)
+	assert.Equal(t, ".flytegen%", queryExpression.Args)
 }

--- a/flyteadmin/pkg/manager/impl/execution_manager.go
+++ b/flyteadmin/pkg/manager/impl/execution_manager.go
@@ -480,7 +480,7 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 		return nil, nil, err
 	}
 
-	launchPlan, err := util.CreateOrGetLaunchPlan(ctx, m.db, m.config, taskIdentifier,
+	launchPlan, err := util.CreateOrGetLaunchPlan(ctx, m.db, m.config, m.namedEntityManager, taskIdentifier,
 		workflow.Closure.CompiledWorkflow.Primary.Template.Interface, workflowModel.ID, request.Spec)
 	if err != nil {
 		return nil, nil, err

--- a/flyteadmin/pkg/manager/impl/named_entity_manager.go
+++ b/flyteadmin/pkg/manager/impl/named_entity_manager.go
@@ -25,13 +25,6 @@ import (
 
 const state = "state"
 
-// System-generated workflows are meant to be hidden from the user by default. Therefore we always only show
-// workflow-type named entities that have been user generated only.
-var nonSystemGeneratedWorkflowsFilter, _ = common.NewSingleValueFilter(
-	common.NamedEntityMetadata, common.NotEqual, state, admin.NamedEntityState_SYSTEM_GENERATED)
-var defaultWorkflowsFilter, _ = common.NewWithDefaultValueFilter(
-	strconv.Itoa(int(admin.NamedEntityState_NAMED_ENTITY_ACTIVE)), nonSystemGeneratedWorkflowsFilter)
-
 type NamedEntityMetrics struct {
 	Scope promutils.Scope
 }

--- a/flyteadmin/pkg/manager/impl/named_entity_manager.go
+++ b/flyteadmin/pkg/manager/impl/named_entity_manager.go
@@ -108,8 +108,8 @@ func (m *NamedEntityManager) ListNamedEntities(ctx context.Context, request *adm
 	ctx = contextutils.WithProjectDomain(ctx, request.Project, request.Domain)
 
 	if len(request.Filters) == 0 {
-		// Add implicit active filters ordinarily added by database.
-		request.Filters = fmt.Sprintf("not_contains(name,%s)", ".flytegen")
+		// Add implicit filter to exclude system generated workflows
+		request.Filters = fmt.Sprintf("not_like(name,%s)", ".flytegen%")
 	}
 	// HACK: In order to filter by state (if requested) - we need to amend the filter to use COALESCE
 	// e.g. eq(state, 1) becomes 'WHERE (COALESCE(state, 0) = '1')' since not every NamedEntity necessarily

--- a/flyteadmin/pkg/manager/impl/named_entity_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/named_entity_manager_test.go
@@ -87,7 +87,7 @@ func TestNamedEntityManager_Get_BadRequest(t *testing.T) {
 func TestNamedEntityManager_getQueryFilters(t *testing.T) {
 	repository := getMockRepositoryForNETest()
 	manager := NewNamedEntityManager(repository, getMockConfigForNETest(), mockScope.NewTestScope())
-	updatedFilters, err := manager.(*NamedEntityManager).getQueryFilters(core.ResourceType_TASK, "eq(state, 0)")
+	updatedFilters, err := manager.(*NamedEntityManager).getQueryFilters("eq(state, 0)")
 	assert.NoError(t, err)
 	assert.Len(t, updatedFilters, 1)
 
@@ -97,13 +97,9 @@ func TestNamedEntityManager_getQueryFilters(t *testing.T) {
 	assert.Equal(t, "COALESCE(state, 0) = ?", queryExp.Query)
 	assert.Equal(t, "0", queryExp.Args)
 
-	updatedFilters, err = manager.(*NamedEntityManager).getQueryFilters(core.ResourceType_WORKFLOW, "")
+	updatedFilters, err = manager.(*NamedEntityManager).getQueryFilters("")
 	assert.NoError(t, err)
-	assert.Len(t, updatedFilters, 1)
-	queryExp, err = updatedFilters[0].GetGormQueryExpr()
-	assert.NoError(t, err)
-	assert.Equal(t, "COALESCE(state, 0) <> ?", queryExp.Query)
-	assert.Equal(t, admin.NamedEntityState_SYSTEM_GENERATED, queryExp.Args)
+	assert.Len(t, updatedFilters, 0)
 }
 
 func TestNamedEntityManager_Update(t *testing.T) {

--- a/flyteadmin/pkg/manager/impl/validation/named_entity_validator.go
+++ b/flyteadmin/pkg/manager/impl/validation/named_entity_validator.go
@@ -10,7 +10,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
-var archivableResourceTypes = sets.NewInt32(int32(core.ResourceType_WORKFLOW), int32(core.ResourceType_TASK))
+var archivableResourceTypes = sets.NewInt32(int32(core.ResourceType_WORKFLOW), int32(core.ResourceType_TASK), int32(core.ResourceType_LAUNCH_PLAN))
 
 func ValidateNamedEntityGetRequest(request *admin.NamedEntityGetRequest) error {
 	if err := ValidateResourceType(request.ResourceType); err != nil {

--- a/flyteadmin/pkg/manager/impl/validation/named_entity_validator_test.go
+++ b/flyteadmin/pkg/manager/impl/validation/named_entity_validator_test.go
@@ -109,7 +109,7 @@ func TestValidateNamedEntityUpdateRequest(t *testing.T) {
 		},
 	}))
 	assert.Equal(t, codes.InvalidArgument, ValidateNamedEntityUpdateRequest(&admin.NamedEntityUpdateRequest{
-		ResourceType: core.ResourceType_LAUNCH_PLAN,
+		ResourceType: core.ResourceType_DATASET,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
 			Domain:  "domain",
@@ -132,6 +132,30 @@ func TestValidateNamedEntityUpdateRequest(t *testing.T) {
 	}))
 	assert.Nil(t, ValidateNamedEntityUpdateRequest(&admin.NamedEntityUpdateRequest{
 		ResourceType: core.ResourceType_TASK,
+		Id: &admin.NamedEntityIdentifier{
+			Project: "project",
+			Domain:  "domain",
+			Name:    "name",
+		},
+		Metadata: &admin.NamedEntityMetadata{
+			State: admin.NamedEntityState_NAMED_ENTITY_ARCHIVED,
+		},
+	}))
+
+	assert.Nil(t, ValidateNamedEntityUpdateRequest(&admin.NamedEntityUpdateRequest{
+		ResourceType: core.ResourceType_LAUNCH_PLAN,
+		Id: &admin.NamedEntityIdentifier{
+			Project: "project",
+			Domain:  "domain",
+			Name:    "name",
+		},
+		Metadata: &admin.NamedEntityMetadata{
+			Description: "description",
+		},
+	}))
+
+	assert.Nil(t, ValidateNamedEntityUpdateRequest(&admin.NamedEntityUpdateRequest{
+		ResourceType: core.ResourceType_LAUNCH_PLAN,
 		Id: &admin.NamedEntityIdentifier{
 			Project: "project",
 			Domain:  "domain",


### PR DESCRIPTION
## Why are the changes needed?
Currently, the launch plan page will show generated launch plans, which make users hard to find their launch plan. We should hide them like we do for workflows. 
<img width="1728" alt="Screenshot 2024-11-05 at 4 03 13 PM" src="https://github.com/user-attachments/assets/9d24d587-47d3-4d87-b1e0-d994f2b0ac78">

## What changes were proposed in this pull request?
1. In ListNamedEntities, if no filter provided, filter by name starting with `.flytegen`. I did this instead of filtering by resource state since I would like to avoid a db migration.
2. Allow launchplan type entities being updated.

## How was this patch tested?
1. unit tests
2. integration tests with sandbox

### Screenshots
<img width="1728" alt="Screenshot 2024-11-05 at 4 04 12 PM" src="https://github.com/user-attachments/assets/6be19e17-e70e-43c6-b0fd-f0c96f865605">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
