### PR TITLE
Fix remaining misuses of capturing the default file descriptors in flytectl unit tests

### DIFF
--- a/flytectl/cmd/compile/compile_test.go
+++ b/flytectl/cmd/compile/compile_test.go
@@ -6,7 +6,7 @@ import (
 
 	config "github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/compile"
 	cmdCore "github.com/flyteorg/flyte/flytectl/cmd/core"
-	u "github.com/flyteorg/flyte/flytectl/cmd/testutils"
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -29,8 +29,7 @@ func TestCompileCommand(t *testing.T) {
 	// compiling via cobra command
 	compileCfg := config.DefaultCompileConfig
 	compileCfg.File = "testdata/valid-package.tgz"
-	var setup = u.Setup
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 	compileCmd := CreateCompileCommand()["compile"]
 	err := compileCmd.CmdFunc(context.Background(), []string{}, s.CmdCtx)

--- a/flytectl/cmd/compile/compile_test.go
+++ b/flytectl/cmd/compile/compile_test.go
@@ -29,8 +29,7 @@ func TestCompileCommand(t *testing.T) {
 	// compiling via cobra command
 	compileCfg := config.DefaultCompileConfig
 	compileCfg.File = "testdata/valid-package.tgz"
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 	compileCmd := CreateCompileCommand()["compile"]
 	err := compileCmd.CmdFunc(context.Background(), []string{}, s.CmdCtx)
 	assert.Nil(t, err, "compiling via cmd returns err")

--- a/flytectl/cmd/create/create_test.go
+++ b/flytectl/cmd/create/create_test.go
@@ -4,13 +4,10 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
 const testDataFolder = "../testdata/"
-
-var setup = testutils.Setup
 
 func TestCreateCommand(t *testing.T) {
 	createCommand := RemoteCreateCommand()

--- a/flytectl/cmd/create/execution_test.go
+++ b/flytectl/cmd/create/execution_test.go
@@ -19,10 +19,11 @@ type createSuite struct {
 	suite.Suite
 	testutils.TestStruct
 	originalExecConfig ExecutionConfig
+	t                  *testing.T
 }
 
 func (s *createSuite) SetupTest() {
-	s.TestStruct = testutils.Setup()
+	s.TestStruct = testutils.Setup(s.t)
 
 	// TODO: migrate to new command context from testutils
 	s.CmdCtx = cmdCore.NewCommandContext(s.MockClient, s.MockOutStream)
@@ -30,7 +31,6 @@ func (s *createSuite) SetupTest() {
 }
 
 func (s *createSuite) TearDownTest() {
-	defer s.TearDown()
 	orig := s.originalExecConfig
 	executionConfig = &orig
 	s.MockAdminClient.AssertExpectations(s.T())
@@ -331,5 +331,5 @@ func (s *createSuite) Test_CreateTaskExecution_DryRun() {
 }
 
 func TestCreateSuite(t *testing.T) {
-	suite.Run(t, &createSuite{originalExecConfig: *executionConfig})
+	suite.Run(t, &createSuite{originalExecConfig: *executionConfig, t: t})
 }

--- a/flytectl/cmd/create/execution_test.go
+++ b/flytectl/cmd/create/execution_test.go
@@ -22,7 +22,7 @@ type createSuite struct {
 }
 
 func (s *createSuite) SetupTest() {
-	s.TestStruct = setup()
+	s.TestStruct = testutils.Setup()
 
 	// TODO: migrate to new command context from testutils
 	s.CmdCtx = cmdCore.NewCommandContext(s.MockClient, s.MockOutStream)

--- a/flytectl/cmd/create/execution_util_test.go
+++ b/flytectl/cmd/create/execution_util_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/stretchr/testify/assert"
@@ -45,7 +46,7 @@ func createExecutionUtilSetup() {
 }
 
 func TestCreateExecutionForRelaunch(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 
 	createExecutionUtilSetup()
@@ -55,7 +56,7 @@ func TestCreateExecutionForRelaunch(t *testing.T) {
 }
 
 func TestCreateExecutionForRelaunchNotFound(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 
 	createExecutionUtilSetup()
@@ -67,7 +68,7 @@ func TestCreateExecutionForRelaunchNotFound(t *testing.T) {
 }
 
 func TestCreateExecutionForRecovery(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 
 	createExecutionUtilSetup()
@@ -77,7 +78,7 @@ func TestCreateExecutionForRecovery(t *testing.T) {
 }
 
 func TestCreateExecutionForRecoveryNotFound(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 
 	createExecutionUtilSetup()
@@ -89,7 +90,7 @@ func TestCreateExecutionForRecoveryNotFound(t *testing.T) {
 
 func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	t.Run("successful", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -100,7 +101,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 	})
 	t.Run("successful with envs", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -114,7 +115,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 	})
 	t.Run("successful with empty envs", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -128,7 +129,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 	})
 	t.Run("successful with execution Cluster label and envs", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -144,7 +145,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 		assert.Equal(t, "cluster", execCreateRequest.Spec.ExecutionClusterLabel.Value)
 	})
 	t.Run("failed literal conversion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -162,7 +163,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 		assert.Equal(t, fmt.Errorf("parameter [nilparam] has nil Variable"), err)
 	})
 	t.Run("failed fetch", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -173,7 +174,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 		assert.Equal(t, err, errors.New("failed"))
 	})
 	t.Run("with security context", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -190,7 +191,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 
 func TestCreateExecutionRequestForTask(t *testing.T) {
 	t.Run("successful", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -205,7 +206,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 	})
 	t.Run("successful with envs", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -223,7 +224,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 	})
 	t.Run("successful with empty envs", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -241,7 +242,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 	})
 	t.Run("failed literal conversion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -267,7 +268,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 		assert.Equal(t, fmt.Errorf("variable [nilvar] has nil type"), err)
 	})
 	t.Run("failed fetch", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -278,7 +279,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 		assert.Equal(t, err, errors.New("failed"))
 	})
 	t.Run("with security context", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		createExecutionUtilSetup()
@@ -316,7 +317,7 @@ func Test_resolveOverrides(t *testing.T) {
 }
 
 func TestCreateExecutionForRelaunchOverwritingCache(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 
 	createExecutionUtilSetup()

--- a/flytectl/cmd/create/execution_util_test.go
+++ b/flytectl/cmd/create/execution_util_test.go
@@ -46,8 +46,7 @@ func createExecutionUtilSetup() {
 }
 
 func TestCreateExecutionForRelaunch(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	createExecutionUtilSetup()
 	s.MockAdminClient.OnRelaunchExecutionMatch(s.Ctx, relaunchRequest).Return(executionCreateResponse, nil)
@@ -56,8 +55,7 @@ func TestCreateExecutionForRelaunch(t *testing.T) {
 }
 
 func TestCreateExecutionForRelaunchNotFound(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	createExecutionUtilSetup()
 	s.MockAdminClient.OnRelaunchExecutionMatch(s.Ctx, relaunchRequest).Return(nil, errors.New("unknown execution"))
@@ -68,8 +66,7 @@ func TestCreateExecutionForRelaunchNotFound(t *testing.T) {
 }
 
 func TestCreateExecutionForRecovery(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	createExecutionUtilSetup()
 	s.MockAdminClient.OnRecoverExecutionMatch(s.Ctx, recoverRequest).Return(executionCreateResponse, nil)
@@ -78,8 +75,7 @@ func TestCreateExecutionForRecovery(t *testing.T) {
 }
 
 func TestCreateExecutionForRecoveryNotFound(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	createExecutionUtilSetup()
 	s.MockAdminClient.OnRecoverExecutionMatch(s.Ctx, recoverRequest).Return(nil, errors.New("unknown execution"))
@@ -90,8 +86,7 @@ func TestCreateExecutionForRecoveryNotFound(t *testing.T) {
 
 func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 	t.Run("successful", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{}
@@ -101,8 +96,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 	})
 	t.Run("successful with envs", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{}
@@ -115,8 +109,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 	})
 	t.Run("successful with empty envs", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{}
@@ -129,8 +122,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 	})
 	t.Run("successful with execution Cluster label and envs", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{}
@@ -145,8 +137,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 		assert.Equal(t, "cluster", execCreateRequest.Spec.ExecutionClusterLabel.Value)
 	})
 	t.Run("failed literal conversion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		launchPlan := &admin.LaunchPlan{
@@ -163,8 +154,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 		assert.Equal(t, fmt.Errorf("parameter [nilparam] has nil Variable"), err)
 	})
 	t.Run("failed fetch", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		s.FetcherExt.OnFetchLPVersionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("failed"))
@@ -174,8 +164,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 		assert.Equal(t, err, errors.New("failed"))
 	})
 	t.Run("with security context", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		executionConfig.KubeServiceAcct = "default"
@@ -191,8 +180,7 @@ func TestCreateExecutionRequestForWorkflow(t *testing.T) {
 
 func TestCreateExecutionRequestForTask(t *testing.T) {
 	t.Run("successful", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		task := &admin.Task{
@@ -206,8 +194,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 	})
 	t.Run("successful with envs", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		task := &admin.Task{
@@ -224,8 +211,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 	})
 	t.Run("successful with empty envs", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		task := &admin.Task{
@@ -242,8 +228,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 	})
 	t.Run("failed literal conversion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		task := &admin.Task{
@@ -268,8 +253,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 		assert.Equal(t, fmt.Errorf("variable [nilvar] has nil type"), err)
 	})
 	t.Run("failed fetch", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		s.FetcherExt.OnFetchTaskVersionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("failed"))
@@ -279,8 +263,7 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 		assert.Equal(t, err, errors.New("failed"))
 	})
 	t.Run("with security context", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		createExecutionUtilSetup()
 		executionConfig.KubeServiceAcct = "default"
@@ -317,8 +300,7 @@ func Test_resolveOverrides(t *testing.T) {
 }
 
 func TestCreateExecutionForRelaunchOverwritingCache(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	createExecutionUtilSetup()
 	executionConfig.OverwriteCache = true

--- a/flytectl/cmd/create/project_test.go
+++ b/flytectl/cmd/create/project_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/flyteorg/flyte/flytectl/clierrors"
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
 	"github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/project"
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -36,8 +37,9 @@ func createProjectSetup() {
 	project.DefaultProjectConfig.Description = ""
 	config.GetConfig().Project = ""
 }
+
 func TestCreateProjectFunc(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 
 	createProjectSetup()
@@ -54,7 +56,7 @@ func TestCreateProjectFunc(t *testing.T) {
 }
 
 func TestEmptyProjectID(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 
 	createProjectSetup()
@@ -68,7 +70,7 @@ func TestEmptyProjectID(t *testing.T) {
 }
 
 func TestEmptyProjectName(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 
 	createProjectSetup()

--- a/flytectl/cmd/create/project_test.go
+++ b/flytectl/cmd/create/project_test.go
@@ -39,12 +39,10 @@ func createProjectSetup() {
 }
 
 func TestCreateProjectFunc(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	createProjectSetup()
 	defer s.TearDownAndVerify(t, "project created successfully.")
-	defer s.TearDown()
 	project.DefaultProjectConfig.ID = projectValue
 	project.DefaultProjectConfig.Name = projectValue
 	project.DefaultProjectConfig.Labels = map[string]string{}
@@ -56,12 +54,10 @@ func TestCreateProjectFunc(t *testing.T) {
 }
 
 func TestEmptyProjectID(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	createProjectSetup()
 	defer s.TearDownAndVerify(t, "")
-	defer s.TearDown()
 	project.DefaultProjectConfig = &project.ConfigProject{}
 	s.MockAdminClient.OnRegisterProjectMatch(s.Ctx, projectRegisterRequest).Return(nil, nil)
 	err := createProjectsCommand(s.Ctx, []string{}, s.CmdCtx)
@@ -70,12 +66,10 @@ func TestEmptyProjectID(t *testing.T) {
 }
 
 func TestEmptyProjectName(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	createProjectSetup()
 	defer s.TearDownAndVerify(t, "")
-	defer s.TearDown()
 	project.DefaultProjectConfig.ID = projectValue
 	project.DefaultProjectConfig.Labels = map[string]string{}
 	project.DefaultProjectConfig.Description = ""

--- a/flytectl/cmd/delete/delete_test.go
+++ b/flytectl/cmd/delete/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,8 +11,6 @@ const (
 	testDataNonExistentFile = "testdata/non-existent-file"
 	testDataInvalidAttrFile = "testdata/invalid_attribute.yaml"
 )
-
-var setup = testutils.Setup
 
 func TestDeleteCommand(t *testing.T) {
 	deleteCommand := RemoteDeleteCommand()

--- a/flytectl/cmd/delete/execution_test.go
+++ b/flytectl/cmd/delete/execution_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/stretchr/testify/assert"
@@ -32,7 +33,9 @@ func terminateExecutionSetup() {
 }
 
 func TestTerminateExecutionFunc(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	terminateExecutionSetup()
 	terminateExecResponse := &admin.ExecutionTerminateResponse{}
 	s.MockAdminClient.OnTerminateExecutionMatch(s.Ctx, terminateExecRequests[0]).Return(terminateExecResponse, nil)
@@ -45,7 +48,9 @@ func TestTerminateExecutionFunc(t *testing.T) {
 }
 
 func TestTerminateExecutionFuncWithError(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	terminateExecutionSetup()
 	terminateExecResponse := &admin.ExecutionTerminateResponse{}
 	s.MockAdminClient.OnTerminateExecutionMatch(s.Ctx, terminateExecRequests[0]).Return(nil, errors.New("failed to terminate"))
@@ -58,7 +63,9 @@ func TestTerminateExecutionFuncWithError(t *testing.T) {
 }
 
 func TestTerminateExecutionFuncWithPartialSuccess(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	terminateExecutionSetup()
 	terminateExecResponse := &admin.ExecutionTerminateResponse{}
 	s.MockAdminClient.OnTerminateExecutionMatch(s.Ctx, terminateExecRequests[0]).Return(terminateExecResponse, nil)

--- a/flytectl/cmd/delete/execution_test.go
+++ b/flytectl/cmd/delete/execution_test.go
@@ -33,8 +33,7 @@ func terminateExecutionSetup() {
 }
 
 func TestTerminateExecutionFunc(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	terminateExecutionSetup()
 	terminateExecResponse := &admin.ExecutionTerminateResponse{}
@@ -48,8 +47,7 @@ func TestTerminateExecutionFunc(t *testing.T) {
 }
 
 func TestTerminateExecutionFuncWithError(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	terminateExecutionSetup()
 	terminateExecResponse := &admin.ExecutionTerminateResponse{}
@@ -63,8 +61,7 @@ func TestTerminateExecutionFuncWithError(t *testing.T) {
 }
 
 func TestTerminateExecutionFuncWithPartialSuccess(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	terminateExecutionSetup()
 	terminateExecResponse := &admin.ExecutionTerminateResponse{}

--- a/flytectl/cmd/delete/matchable_cluster_resource_attribute_test.go
+++ b/flytectl/cmd/delete/matchable_cluster_resource_attribute_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
 	"github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/clusterresourceattribute"
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -18,7 +19,9 @@ func deleteClusterResourceAttributeSetup() {
 
 func TestDeleteClusterResourceAttributes(t *testing.T) {
 	t.Run("successful project domain attribute deletion commandline", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
 		clusterresourceattribute.DefaultDelConfig.AttrFile = ""
@@ -31,7 +34,9 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("failed project domain attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteClusterResourceAttributeSetup()
 		// No args implying project domain attribute deletion
 		s.DeleterExt.OnDeleteProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -43,7 +48,9 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("successful project domain attribute deletion file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
 		clusterresourceattribute.DefaultDelConfig.AttrFile = "testdata/valid_project_domain_cluster_attribute.yaml"
@@ -56,7 +63,9 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			s.Ctx, "flytesnacks", "development", admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
 		clusterresourceattribute.DefaultDelConfig.AttrFile = ""
@@ -70,7 +79,9 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("failed workflow attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
 		clusterresourceattribute.DefaultDelConfig.AttrFile = ""
@@ -85,7 +96,9 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("successful workflow attribute deletion file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
 		clusterresourceattribute.DefaultDelConfig.AttrFile = "testdata/valid_workflow_cluster_attribute.yaml"
@@ -99,7 +112,9 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
 		clusterresourceattribute.DefaultDelConfig.AttrFile = testDataNonExistentFile
@@ -113,7 +128,9 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
 		clusterresourceattribute.DefaultDelConfig.AttrFile = testDataInvalidAttrFile

--- a/flytectl/cmd/delete/matchable_cluster_resource_attribute_test.go
+++ b/flytectl/cmd/delete/matchable_cluster_resource_attribute_test.go
@@ -19,8 +19,7 @@ func deleteClusterResourceAttributeSetup() {
 
 func TestDeleteClusterResourceAttributes(t *testing.T) {
 	t.Run("successful project domain attribute deletion commandline", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
@@ -34,8 +33,7 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("failed project domain attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteClusterResourceAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -48,8 +46,7 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("successful project domain attribute deletion file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
@@ -63,8 +60,7 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			s.Ctx, "flytesnacks", "development", admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
@@ -79,8 +75,7 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("failed workflow attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
@@ -96,8 +91,7 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("successful workflow attribute deletion file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
@@ -112,8 +106,7 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file
@@ -128,8 +121,7 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteClusterResourceAttributeSetup()
 		// Empty attribute file

--- a/flytectl/cmd/delete/matchable_execution_cluster_label_test.go
+++ b/flytectl/cmd/delete/matchable_execution_cluster_label_test.go
@@ -19,8 +19,7 @@ func deleteExecutionClusterLabelSetup() {
 
 func TestDeleteExecutionClusterLabels(t *testing.T) {
 	t.Run("successful project domain attribute deletion commandline", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
@@ -34,8 +33,7 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("failed project domain attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteExecutionClusterLabelSetup()
 		// No args implying project domain attribute deletion
@@ -48,8 +46,7 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("successful project domain attribute deletion file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
@@ -63,8 +60,7 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			s.Ctx, "flytesnacks", "development", admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
@@ -79,8 +75,7 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("failed workflow attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
@@ -96,8 +91,7 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("successful workflow attribute deletion file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
@@ -112,8 +106,7 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
@@ -128,8 +121,7 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file

--- a/flytectl/cmd/delete/matchable_execution_cluster_label_test.go
+++ b/flytectl/cmd/delete/matchable_execution_cluster_label_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
 	"github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/executionclusterlabel"
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -18,7 +19,9 @@ func deleteExecutionClusterLabelSetup() {
 
 func TestDeleteExecutionClusterLabels(t *testing.T) {
 	t.Run("successful project domain attribute deletion commandline", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
 		executionclusterlabel.DefaultDelConfig.AttrFile = ""
@@ -31,7 +34,9 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("failed project domain attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteExecutionClusterLabelSetup()
 		// No args implying project domain attribute deletion
 		s.DeleterExt.OnDeleteProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -43,7 +48,9 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("successful project domain attribute deletion file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
 		executionclusterlabel.DefaultDelConfig.AttrFile = "testdata/valid_project_domain_execution_cluster_label.yaml"
@@ -56,7 +63,9 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			s.Ctx, "flytesnacks", "development", admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
 		executionclusterlabel.DefaultDelConfig.AttrFile = ""
@@ -70,7 +79,9 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("failed workflow attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
 		executionclusterlabel.DefaultDelConfig.AttrFile = ""
@@ -85,7 +96,9 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("successful workflow attribute deletion file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
 		executionclusterlabel.DefaultDelConfig.AttrFile = "testdata/valid_workflow_execution_cluster_label.yaml"
@@ -99,7 +112,9 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
 		executionclusterlabel.DefaultDelConfig.AttrFile = testDataNonExistentFile
@@ -113,7 +128,9 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteExecutionClusterLabelSetup()
 		// Empty attribute file
 		executionclusterlabel.DefaultDelConfig.AttrFile = testDataInvalidAttrFile

--- a/flytectl/cmd/delete/matchable_execution_queue_attribute_test.go
+++ b/flytectl/cmd/delete/matchable_execution_queue_attribute_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
 	"github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/executionqueueattribute"
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -18,7 +19,9 @@ func deleteExecutionQueueAttributeSetup() {
 
 func TestDeleteExecutionQueueAttributes(t *testing.T) {
 	t.Run("successful project domain attribute deletion commandline", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteExecutionQueueAttributeSetup()
 		// Empty attribute file
 		executionqueueattribute.DefaultDelConfig.AttrFile = ""
@@ -31,7 +34,9 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("failed project domain attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// No args implying project domain attribute deletion
 		s.DeleterExt.OnDeleteProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -43,7 +48,9 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("successful project domain attribute deletion file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		executionqueueattribute.DefaultDelConfig.AttrFile = "testdata/valid_project_domain_execution_queue_attribute.yaml"
@@ -56,7 +63,9 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			s.Ctx, "flytesnacks", "development", admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		executionqueueattribute.DefaultDelConfig.AttrFile = ""
@@ -70,7 +79,9 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("failed workflow attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		executionqueueattribute.DefaultDelConfig.AttrFile = ""
@@ -85,7 +96,9 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("successful workflow attribute deletion file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		executionqueueattribute.DefaultDelConfig.AttrFile = "testdata/valid_workflow_execution_queue_attribute.yaml"
@@ -99,7 +112,9 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		executionqueueattribute.DefaultDelConfig.AttrFile = testDataNonExistentFile
@@ -113,7 +128,9 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		executionqueueattribute.DefaultDelConfig.AttrFile = testDataInvalidAttrFile

--- a/flytectl/cmd/delete/matchable_execution_queue_attribute_test.go
+++ b/flytectl/cmd/delete/matchable_execution_queue_attribute_test.go
@@ -19,8 +19,7 @@ func deleteExecutionQueueAttributeSetup() {
 
 func TestDeleteExecutionQueueAttributes(t *testing.T) {
 	t.Run("successful project domain attribute deletion commandline", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteExecutionQueueAttributeSetup()
 		// Empty attribute file
@@ -34,8 +33,7 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("failed project domain attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -48,8 +46,7 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("successful project domain attribute deletion file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
@@ -63,8 +60,7 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			s.Ctx, "flytesnacks", "development", admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
@@ -79,8 +75,7 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("failed workflow attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
@@ -96,8 +91,7 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("successful workflow attribute deletion file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
@@ -112,8 +106,7 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
@@ -128,8 +121,7 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file

--- a/flytectl/cmd/delete/matchable_plugin_override_test.go
+++ b/flytectl/cmd/delete/matchable_plugin_override_test.go
@@ -19,8 +19,7 @@ func deletePluginOverrideSetup() {
 
 func TestPluginOverride(t *testing.T) {
 	t.Run("successful project domain attribute deletion commandline", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deletePluginOverrideSetup()
 		// Empty attribute file
@@ -34,8 +33,7 @@ func TestPluginOverride(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("failed project domain attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deletePluginOverrideSetup()
 		// No args implying project domain attribute deletion
@@ -48,8 +46,7 @@ func TestPluginOverride(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("successful project domain attribute deletion file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deletePluginOverrideSetup()
 		// Empty attribute file
@@ -63,8 +60,7 @@ func TestPluginOverride(t *testing.T) {
 			s.Ctx, "flytesnacks", "development", admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deletePluginOverrideSetup()
 		// Empty attribute file
@@ -79,8 +75,7 @@ func TestPluginOverride(t *testing.T) {
 			admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("failed workflow attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deletePluginOverrideSetup()
 		// Empty attribute file
@@ -96,8 +91,7 @@ func TestPluginOverride(t *testing.T) {
 			admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("successful workflow attribute deletion file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deletePluginOverrideSetup()
 		// Empty attribute file
@@ -112,8 +106,7 @@ func TestPluginOverride(t *testing.T) {
 			admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deletePluginOverrideSetup()
 		// Empty attribute file
@@ -128,8 +121,7 @@ func TestPluginOverride(t *testing.T) {
 			admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deletePluginOverrideSetup()
 		// Empty attribute file

--- a/flytectl/cmd/delete/matchable_plugin_override_test.go
+++ b/flytectl/cmd/delete/matchable_plugin_override_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
 	pluginoverride "github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/plugin_override"
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -18,7 +19,9 @@ func deletePluginOverrideSetup() {
 
 func TestPluginOverride(t *testing.T) {
 	t.Run("successful project domain attribute deletion commandline", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deletePluginOverrideSetup()
 		// Empty attribute file
 		pluginoverride.DefaultDelConfig.AttrFile = ""
@@ -31,7 +34,9 @@ func TestPluginOverride(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("failed project domain attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deletePluginOverrideSetup()
 		// No args implying project domain attribute deletion
 		s.DeleterExt.OnDeleteProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -43,7 +48,9 @@ func TestPluginOverride(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("successful project domain attribute deletion file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deletePluginOverrideSetup()
 		// Empty attribute file
 		pluginoverride.DefaultDelConfig.AttrFile = "testdata/valid_project_domain_plugin_override.yaml"
@@ -56,7 +63,9 @@ func TestPluginOverride(t *testing.T) {
 			s.Ctx, "flytesnacks", "development", admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deletePluginOverrideSetup()
 		// Empty attribute file
 		pluginoverride.DefaultDelConfig.AttrFile = ""
@@ -70,7 +79,9 @@ func TestPluginOverride(t *testing.T) {
 			admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("failed workflow attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deletePluginOverrideSetup()
 		// Empty attribute file
 		pluginoverride.DefaultDelConfig.AttrFile = ""
@@ -85,7 +96,9 @@ func TestPluginOverride(t *testing.T) {
 			admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("successful workflow attribute deletion file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deletePluginOverrideSetup()
 		// Empty attribute file
 		pluginoverride.DefaultDelConfig.AttrFile = "testdata/valid_workflow_plugin_override.yaml"
@@ -99,7 +112,9 @@ func TestPluginOverride(t *testing.T) {
 			admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deletePluginOverrideSetup()
 		// Empty attribute file
 		pluginoverride.DefaultDelConfig.AttrFile = testDataNonExistentFile
@@ -113,7 +128,9 @@ func TestPluginOverride(t *testing.T) {
 			admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deletePluginOverrideSetup()
 		// Empty attribute file
 		pluginoverride.DefaultDelConfig.AttrFile = testDataInvalidAttrFile

--- a/flytectl/cmd/delete/matchable_task_resource_attribute_test.go
+++ b/flytectl/cmd/delete/matchable_task_resource_attribute_test.go
@@ -19,8 +19,7 @@ func deleteTaskResourceAttributeSetup() {
 
 func TestDeleteTaskResourceAttributes(t *testing.T) {
 	t.Run("successful project domain attribute deletion commandline", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
@@ -34,8 +33,7 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("failed project domain attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -48,8 +46,7 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("successful project domain attribute deletion file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
@@ -63,8 +60,7 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			s.Ctx, "flytesnacks", "development", admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
@@ -79,8 +75,7 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("failed workflow attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
@@ -96,8 +91,7 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("successful workflow attribute deletion file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
@@ -112,8 +106,7 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
@@ -128,8 +121,7 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file

--- a/flytectl/cmd/delete/matchable_task_resource_attribute_test.go
+++ b/flytectl/cmd/delete/matchable_task_resource_attribute_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
 	"github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/taskresourceattribute"
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -18,7 +19,9 @@ func deleteTaskResourceAttributeSetup() {
 
 func TestDeleteTaskResourceAttributes(t *testing.T) {
 	t.Run("successful project domain attribute deletion commandline", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		taskresourceattribute.DefaultDelConfig.AttrFile = ""
@@ -31,7 +34,9 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("failed project domain attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// No args implying project domain attribute deletion
 		s.DeleterExt.OnDeleteProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -43,7 +48,9 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("successful project domain attribute deletion file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		taskresourceattribute.DefaultDelConfig.AttrFile = "testdata/valid_project_domain_task_attribute.yaml"
@@ -56,7 +63,9 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			s.Ctx, "flytesnacks", "development", admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		taskresourceattribute.DefaultDelConfig.AttrFile = ""
@@ -70,7 +79,9 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("failed workflow attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		taskresourceattribute.DefaultDelConfig.AttrFile = ""
@@ -85,7 +96,9 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("successful workflow attribute deletion file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		taskresourceattribute.DefaultDelConfig.AttrFile = "testdata/valid_workflow_task_attribute.yaml"
@@ -99,7 +112,9 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		taskresourceattribute.DefaultDelConfig.AttrFile = testDataNonExistentFile
@@ -113,7 +128,9 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteTaskResourceAttributeSetup()
 		// Empty attribute file
 		taskresourceattribute.DefaultDelConfig.AttrFile = testDataInvalidAttrFile

--- a/flytectl/cmd/delete/matchable_workflow_execution_config_test.go
+++ b/flytectl/cmd/delete/matchable_workflow_execution_config_test.go
@@ -19,8 +19,7 @@ func deleteWorkflowExecutionConfigSetup() {
 
 func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 	t.Run("successful project domain attribute deletion commandline", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
@@ -34,8 +33,7 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("failed project domain attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteWorkflowExecutionConfigSetup()
 		// No args implying project domain attribute deletion
@@ -48,8 +46,7 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("successful project domain attribute deletion file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
@@ -63,8 +60,7 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			s.Ctx, "flytesnacks", "development", admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
@@ -79,8 +75,7 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("failed workflow attribute deletion", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
@@ -96,8 +91,7 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("successful workflow attribute deletion file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
@@ -112,8 +106,7 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
@@ -128,8 +121,7 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file

--- a/flytectl/cmd/delete/matchable_workflow_execution_config_test.go
+++ b/flytectl/cmd/delete/matchable_workflow_execution_config_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
 	"github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/workflowexecutionconfig"
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -18,7 +19,9 @@ func deleteWorkflowExecutionConfigSetup() {
 
 func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 	t.Run("successful project domain attribute deletion commandline", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
 		workflowexecutionconfig.DefaultDelConfig.AttrFile = ""
@@ -31,7 +34,9 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("failed project domain attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteWorkflowExecutionConfigSetup()
 		// No args implying project domain attribute deletion
 		s.DeleterExt.OnDeleteProjectDomainAttributesMatch(mock.Anything, mock.Anything, mock.Anything,
@@ -43,7 +48,9 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			s.Ctx, config.GetConfig().Project, config.GetConfig().Domain, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("successful project domain attribute deletion file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
 		workflowexecutionconfig.DefaultDelConfig.AttrFile = "testdata/valid_project_domain_workflow_execution_config.yaml"
@@ -56,7 +63,9 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			s.Ctx, "flytesnacks", "development", admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
 		workflowexecutionconfig.DefaultDelConfig.AttrFile = ""
@@ -70,7 +79,9 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("failed workflow attribute deletion", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
 		workflowexecutionconfig.DefaultDelConfig.AttrFile = ""
@@ -85,7 +96,9 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("successful workflow attribute deletion file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
 		workflowexecutionconfig.DefaultDelConfig.AttrFile = "testdata/valid_workflow_workflow_execution_config.yaml"
@@ -99,7 +112,9 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
 		workflowexecutionconfig.DefaultDelConfig.AttrFile = testDataNonExistentFile
@@ -113,7 +128,9 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		deleteWorkflowExecutionConfigSetup()
 		// Empty attribute file
 		workflowexecutionconfig.DefaultDelConfig.AttrFile = testDataInvalidAttrFile

--- a/flytectl/cmd/demo/exec_test.go
+++ b/flytectl/cmd/demo/exec_test.go
@@ -50,8 +50,7 @@ func TestDemoClusterExec(t *testing.T) {
 func TestSandboxClusterExecWithoutCmd(t *testing.T) {
 	mockDocker := &mocks.Docker{}
 	reader := bufio.NewReader(strings.NewReader("test"))
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	ctx := s.Ctx
 

--- a/flytectl/cmd/demo/status_test.go
+++ b/flytectl/cmd/demo/status_test.go
@@ -14,16 +14,14 @@ import (
 func TestDemoStatus(t *testing.T) {
 	t.Run("Demo status with zero result", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		mockDocker.OnContainerList(s.Ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		docker.Client = mockDocker
 		err := demoClusterStatus(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 	})
 	t.Run("Demo status with running", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		ctx := s.Ctx
 		mockDocker := &mocks.Docker{}
 		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{

--- a/flytectl/cmd/demo/teardown_test.go
+++ b/flytectl/cmd/demo/teardown_test.go
@@ -80,8 +80,7 @@ func TestTearDownFunc(t *testing.T) {
 func TestTearDownClusterFunc(t *testing.T) {
 	_ = util.SetupFlyteDir()
 	_ = util.WriteIntoFile([]byte("data"), configutil.FlytectlConfig)
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	ctx := s.Ctx
 	mockDocker := &mocks.Docker{}

--- a/flytectl/cmd/get/execution_test.go
+++ b/flytectl/cmd/get/execution_test.go
@@ -29,7 +29,7 @@ func getExecutionSetup() {
 
 func TestListExecutionFunc(t *testing.T) {
 	getExecutionSetup()
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 
 	executionResponse := &admin.Execution{
@@ -92,7 +92,7 @@ func TestListExecutionFuncWithError(t *testing.T) {
 			Phase: core.WorkflowExecution_SUCCEEDED,
 		},
 	}
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 
 	s.FetcherExt.OnListExecutionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("executions NotFound"))
@@ -129,7 +129,7 @@ func TestGetExecutionFunc(t *testing.T) {
 		},
 	}
 	args := []string{executionNameValue}
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 
 	s.FetcherExt.OnFetchExecutionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything).Return(executionResponse, nil)

--- a/flytectl/cmd/get/execution_test.go
+++ b/flytectl/cmd/get/execution_test.go
@@ -29,8 +29,7 @@ func getExecutionSetup() {
 
 func TestListExecutionFunc(t *testing.T) {
 	getExecutionSetup()
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	executionResponse := &admin.Execution{
 		Id: &core.WorkflowExecutionIdentifier{
@@ -92,8 +91,7 @@ func TestListExecutionFuncWithError(t *testing.T) {
 			Phase: core.WorkflowExecution_SUCCEEDED,
 		},
 	}
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	s.FetcherExt.OnListExecutionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("executions NotFound"))
 	err := getExecutionFunc(s.Ctx, []string{}, s.CmdCtx)
@@ -129,8 +127,7 @@ func TestGetExecutionFunc(t *testing.T) {
 		},
 	}
 	args := []string{executionNameValue}
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	s.FetcherExt.OnFetchExecutionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything).Return(executionResponse, nil)
 	err := getExecutionFunc(s.Ctx, args, s.CmdCtx)
@@ -139,8 +136,7 @@ func TestGetExecutionFunc(t *testing.T) {
 }
 
 func TestGetExecutionFuncForDetails(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 	getExecutionSetup()
 	ctx := s.Ctx
 	mockCmdCtx := s.CmdCtx
@@ -156,8 +152,7 @@ func TestGetExecutionFuncForDetails(t *testing.T) {
 
 func TestGetExecutionFuncWithIOData(t *testing.T) {
 	t.Run("successful inputs outputs", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionSetup()
 		ctx := s.Ctx
@@ -222,8 +217,7 @@ func TestGetExecutionFuncWithIOData(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("fetch data error from admin", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionSetup()
 		ctx := s.Ctx
@@ -264,8 +258,7 @@ func TestGetExecutionFuncWithIOData(t *testing.T) {
 
 		args := []string{dummyExec}
 		for _, tt := range tests {
-			s := testutils.Setup()
-			defer s.TearDown()
+			s := testutils.Setup(t)
 
 			config.GetConfig().Output = tt.outputFormat
 			execution.DefaultConfig.NodeID = tt.nodeID
@@ -365,8 +358,7 @@ func TestGetExecutionFuncWithError(t *testing.T) {
 	}
 
 	args := []string{executionNameValue}
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	s.FetcherExt.OnFetchExecutionMatch(s.Ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("execution NotFound"))
 	err := getExecutionFunc(s.Ctx, args, s.CmdCtx)

--- a/flytectl/cmd/get/get_test.go
+++ b/flytectl/cmd/get/get_test.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,8 +17,6 @@ const launchPlanVersionValue = "lp_version"
 const workflowNameValue = "wf_name"
 const workflowVersionValue = "wf_version"
 const testDataFolder = "../testdata/"
-
-var setup = testutils.Setup
 
 const (
 	testDataTempFile            = "temp-output-file"

--- a/flytectl/cmd/get/launch_plan_test.go
+++ b/flytectl/cmd/get/launch_plan_test.go
@@ -215,8 +215,7 @@ func getLaunchPlanSetup() {
 
 func TestGetLaunchPlanFuncWithError(t *testing.T) {
 	t.Run("failure fetch latest", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		getLaunchPlanSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		launchplan.DefaultConfig.Latest = true
@@ -228,8 +227,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching version ", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		getLaunchPlanSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		launchplan.DefaultConfig.Version = "v1"
@@ -241,8 +239,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching all version ", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		getLaunchPlanSetup()
 		launchplan.DefaultConfig.Filter = filters.Filters{}
 		launchplan.DefaultConfig.Filter = filters.Filters{}
@@ -254,8 +251,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching ", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "launchplan1", "dummyProject", "dummyDomain", filters.Filters{}).Return(nil, fmt.Errorf("error fetching all version"))
 		s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceGetRequest).Return(nil, fmt.Errorf("error fetching all version"))
@@ -266,8 +262,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching list", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		getLaunchPlanSetup()
 		argsLp = []string{}
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{}).Return(nil, fmt.Errorf("error fetching all version"))
@@ -278,8 +273,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 }
 
 func TestGetLaunchPlanFunc(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 	getLaunchPlanSetup()
 	s.FetcherExt.OnFetchAllVerOfLPMatch(mock.Anything, mock.Anything, "dummyProject", "dummyDomain", filters.Filters{}).Return(launchPlanListResponse.LaunchPlans, nil)
 	err := getLaunchPlanFunc(s.Ctx, argsLp, s.CmdCtx)
@@ -289,8 +283,7 @@ func TestGetLaunchPlanFunc(t *testing.T) {
 }
 
 func TestGetLaunchPlanFuncLatest(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 	getLaunchPlanSetup()
 	launchplan.DefaultConfig.Latest = true
 	s.FetcherExt.OnFetchLPLatestVersionMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(launchPlan2, nil)
@@ -301,8 +294,7 @@ func TestGetLaunchPlanFuncLatest(t *testing.T) {
 }
 
 func TestGetLaunchPlanWithVersion(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 	getLaunchPlanSetup()
 	launchplan.DefaultConfig.Version = "v2"
 	s.FetcherExt.OnFetchLPVersion(s.Ctx, "launchplan1", "v2", "dummyProject", "dummyDomain").Return(launchPlan2, nil)
@@ -314,8 +306,7 @@ func TestGetLaunchPlanWithVersion(t *testing.T) {
 
 func TestGetLaunchPlans(t *testing.T) {
 	t.Run("no workflow filter", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{}).Return(launchPlanListResponse.LaunchPlans, nil)
 		argsLp = []string{}
@@ -324,8 +315,7 @@ func TestGetLaunchPlans(t *testing.T) {
 		s.TearDownAndVerify(t, `[{"id": {"name": "launchplan1","version": "v2"},"spec": {"workflowId": {"name": "workflow2"},"defaultInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}},{"id": {"name": "launchplan1","version": "v1"},"spec": {"workflowId": {"name": "workflow1"},"defaultInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:00Z"}}]`)
 	})
 	t.Run("workflow filter", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{
 			FieldSelector: "workflow.name=workflow2",
@@ -337,8 +327,7 @@ func TestGetLaunchPlans(t *testing.T) {
 		s.TearDownAndVerify(t, `[{"id": {"name": "launchplan1","version": "v2"},"spec": {"workflowId": {"name": "workflow2"},"defaultInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}},{"id": {"name": "launchplan1","version": "v1"},"spec": {"workflowId": {"name": "workflow1"},"defaultInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:00Z"}}]`)
 	})
 	t.Run("workflow filter error", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		getLaunchPlanSetup()
 		argsLp = []string{}
 		launchplan.DefaultConfig.Workflow = "workflow2"
@@ -350,8 +339,7 @@ func TestGetLaunchPlans(t *testing.T) {
 }
 
 func TestGetLaunchPlansWithExecFile(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 	getLaunchPlanSetup()
 	s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceListRequest).Return(launchPlanListResponse, nil)
 	s.MockAdminClient.OnGetLaunchPlanMatch(s.Ctx, objectGetRequest).Return(launchPlan2, nil)
@@ -386,8 +374,7 @@ workflow: launchplan1
 }
 
 func TestGetLaunchPlanTableFunc(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 	getLaunchPlanSetup()
 	s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceGetRequest).Return(launchPlanListResponse, nil)
 	s.MockAdminClient.OnGetLaunchPlanMatch(s.Ctx, objectGetRequest).Return(launchPlan2, nil)

--- a/flytectl/cmd/get/launch_plan_test.go
+++ b/flytectl/cmd/get/launch_plan_test.go
@@ -215,7 +215,7 @@ func getLaunchPlanSetup() {
 
 func TestGetLaunchPlanFuncWithError(t *testing.T) {
 	t.Run("failure fetch latest", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 		getLaunchPlanSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -228,7 +228,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching version ", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 		getLaunchPlanSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -241,7 +241,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching all version ", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 		getLaunchPlanSetup()
 		launchplan.DefaultConfig.Filter = filters.Filters{}
@@ -254,7 +254,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching ", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "launchplan1", "dummyProject", "dummyDomain", filters.Filters{}).Return(nil, fmt.Errorf("error fetching all version"))
@@ -266,7 +266,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching list", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 		getLaunchPlanSetup()
 		argsLp = []string{}
@@ -278,7 +278,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 }
 
 func TestGetLaunchPlanFunc(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 	getLaunchPlanSetup()
 	s.FetcherExt.OnFetchAllVerOfLPMatch(mock.Anything, mock.Anything, "dummyProject", "dummyDomain", filters.Filters{}).Return(launchPlanListResponse.LaunchPlans, nil)
@@ -289,7 +289,7 @@ func TestGetLaunchPlanFunc(t *testing.T) {
 }
 
 func TestGetLaunchPlanFuncLatest(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
 	defer s.TearDown()
 	getLaunchPlanSetup()
 	launchplan.DefaultConfig.Latest = true
@@ -314,7 +314,7 @@ func TestGetLaunchPlanWithVersion(t *testing.T) {
 
 func TestGetLaunchPlans(t *testing.T) {
 	t.Run("no workflow filter", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{}).Return(launchPlanListResponse.LaunchPlans, nil)
@@ -324,7 +324,7 @@ func TestGetLaunchPlans(t *testing.T) {
 		s.TearDownAndVerify(t, `[{"id": {"name": "launchplan1","version": "v2"},"spec": {"workflowId": {"name": "workflow2"},"defaultInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}},{"id": {"name": "launchplan1","version": "v1"},"spec": {"workflowId": {"name": "workflow1"},"defaultInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:00Z"}}]`)
 	})
 	t.Run("workflow filter", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{
@@ -337,7 +337,7 @@ func TestGetLaunchPlans(t *testing.T) {
 		s.TearDownAndVerify(t, `[{"id": {"name": "launchplan1","version": "v2"},"spec": {"workflowId": {"name": "workflow2"},"defaultInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}},{"id": {"name": "launchplan1","version": "v1"},"spec": {"workflowId": {"name": "workflow1"},"defaultInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"generic": {"var": {"type": {"simple": "STRUCT"},"description": "generic"},"default": {"scalar": {"generic": {"foo": "foo"}}}},"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:00Z"}}]`)
 	})
 	t.Run("workflow filter error", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 		getLaunchPlanSetup()
 		argsLp = []string{}

--- a/flytectl/cmd/get/matchable_cluster_resource_attribute_test.go
+++ b/flytectl/cmd/get/matchable_cluster_resource_attribute_test.go
@@ -47,8 +47,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 		},
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getClusterResourceAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -61,8 +60,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","attributes":{"foo":"bar"}}`)
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getClusterResourceAttributeSetup()
 		clusterresourceattribute.DefaultFetchConfig.AttrFile = testDataTempFile
@@ -76,8 +74,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `wrote the config to file temp-output-file`)
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getClusterResourceAttributeSetup()
 		clusterresourceattribute.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
@@ -92,8 +89,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getClusterResourceAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -107,8 +103,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getClusterResourceAttributeSetup()
 		args := []string{"workflow"}
@@ -122,8 +117,7 @@ func TestGetClusterResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","workflow":"workflow","attributes":{"foo":"bar"}}`)
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getClusterResourceAttributeSetup()
 		args := []string{"workflow"}

--- a/flytectl/cmd/get/matchable_execution_cluster_label_test.go
+++ b/flytectl/cmd/get/matchable_execution_cluster_label_test.go
@@ -47,8 +47,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 		},
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionClusterLabelSetup()
 		// No args implying project domain attribute deletion
@@ -61,8 +60,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","value":"foo"}`)
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionClusterLabelSetup()
 		executionclusterlabel.DefaultFetchConfig.AttrFile = testDataTempFile
@@ -76,8 +74,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 		s.TearDownAndVerify(t, `wrote the config to file temp-output-file`)
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionClusterLabelSetup()
 		executionclusterlabel.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
@@ -92,8 +89,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("failed to get project domain attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionClusterLabelSetup()
 		// No args implying project domain attribute deletion
@@ -107,8 +103,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionClusterLabelSetup()
 		args := []string{"workflow"}
@@ -122,8 +117,7 @@ func TestGetExecutionClusterLabel(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","workflow":"workflow","value":"foo"}`)
 	})
 	t.Run("failed to get workflow attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionClusterLabelSetup()
 		args := []string{"workflow"}

--- a/flytectl/cmd/get/matchable_execution_queue_attribute_test.go
+++ b/flytectl/cmd/get/matchable_execution_queue_attribute_test.go
@@ -47,8 +47,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 		},
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionQueueAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -61,8 +60,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","tags":["foo","bar"]}`)
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionQueueAttributeSetup()
 		executionqueueattribute.DefaultFetchConfig.AttrFile = testDataTempFile
@@ -76,8 +74,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `wrote the config to file temp-output-file`)
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionQueueAttributeSetup()
 		executionqueueattribute.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
@@ -92,8 +89,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionQueueAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -107,8 +103,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionQueueAttributeSetup()
 		args := []string{"workflow"}
@@ -122,8 +117,7 @@ func TestGetExecutionQueueAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","workflow":"workflow","tags":["foo","bar"]}`)
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getExecutionQueueAttributeSetup()
 		args := []string{"workflow"}

--- a/flytectl/cmd/get/matchable_plugin_override_test.go
+++ b/flytectl/cmd/get/matchable_plugin_override_test.go
@@ -59,8 +59,7 @@ func TestGetPluginOverride(t *testing.T) {
 		},
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getPluginOverrideSetup()
 		// No args implying project domain attribute deletion
@@ -73,8 +72,7 @@ func TestGetPluginOverride(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","overrides":[{"task_type":"python_task","plugin_id":["plugin-override1","plugin-override2"]},{"task_type":"java_task","plugin_id":["plugin-override3","plugin-override3"],"missing_plugin_behavior":1}]}`)
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getPluginOverrideSetup()
 		pluginoverride.DefaultFetchConfig.AttrFile = testDataTempFile
@@ -88,8 +86,7 @@ func TestGetPluginOverride(t *testing.T) {
 		s.TearDownAndVerify(t, `wrote the config to file temp-output-file`)
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getPluginOverrideSetup()
 		pluginoverride.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
@@ -104,8 +101,7 @@ func TestGetPluginOverride(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getPluginOverrideSetup()
 		// No args implying project domain attribute deletion
@@ -119,8 +115,7 @@ func TestGetPluginOverride(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getPluginOverrideSetup()
 		args := []string{"workflow"}
@@ -133,8 +128,7 @@ func TestGetPluginOverride(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","workflow":"workflow","overrides":[{"task_type":"python_task","plugin_id":["plugin-override1","plugin-override2"]},{"task_type":"java_task","plugin_id":["plugin-override3","plugin-override3"],"missing_plugin_behavior":1}]}`)
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getPluginOverrideSetup()
 		args := []string{"workflow"}

--- a/flytectl/cmd/get/matchable_task_resource_attribute_test.go
+++ b/flytectl/cmd/get/matchable_task_resource_attribute_test.go
@@ -54,8 +54,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 		},
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getTaskResourceAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -68,8 +67,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","defaults":{"cpu":"1","memory":"150Mi"},"limits":{"cpu":"2","memory":"350Mi"}}`)
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getTaskResourceAttributeSetup()
 		taskresourceattribute.DefaultFetchConfig.AttrFile = testDataTempFile
@@ -83,8 +81,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `wrote the config to file temp-output-file`)
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getTaskResourceAttributeSetup()
 		taskresourceattribute.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
@@ -99,8 +96,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getTaskResourceAttributeSetup()
 		// No args implying project domain attribute deletion
@@ -114,8 +110,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getTaskResourceAttributeSetup()
 		args := []string{"workflow"}
@@ -129,8 +124,7 @@ func TestGetTaskResourceAttributes(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","workflow":"workflow","defaults":{"cpu":"1","memory":"150Mi"},"limits":{"cpu":"2","memory":"350Mi"}}`)
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getTaskResourceAttributeSetup()
 		args := []string{"workflow"}

--- a/flytectl/cmd/get/matchable_workflow_execution_config_test.go
+++ b/flytectl/cmd/get/matchable_workflow_execution_config_test.go
@@ -47,8 +47,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 		},
 	}
 	t.Run("successful get project domain attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getWorkflowExecutionConfigSetup()
 		// No args implying project domain attribute deletion
@@ -61,8 +60,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","max_parallelism":5}`)
 	})
 	t.Run("successful get project domain attribute and write to file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getWorkflowExecutionConfigSetup()
 		workflowexecutionconfig.DefaultFetchConfig.AttrFile = testDataTempFile
@@ -76,8 +74,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 		s.TearDownAndVerify(t, `wrote the config to file temp-output-file`)
 	})
 	t.Run("successful get project domain attribute and write to file failure", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getWorkflowExecutionConfigSetup()
 		workflowexecutionconfig.DefaultFetchConfig.AttrFile = testDataNotExistentTempFile
@@ -92,8 +89,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("failed get project domain attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getWorkflowExecutionConfigSetup()
 		// No args implying project domain attribute deletion
@@ -107,8 +103,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 		s.TearDownAndVerify(t, ``)
 	})
 	t.Run("successful get workflow attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getWorkflowExecutionConfigSetup()
 		args := []string{"workflow"}
@@ -122,8 +117,7 @@ func TestGetWorkflowExecutionConfig(t *testing.T) {
 		s.TearDownAndVerify(t, `{"project":"dummyProject","domain":"dummyDomain","workflow":"workflow","max_parallelism":5}`)
 	})
 	t.Run("failed get workflow attribute", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getWorkflowExecutionConfigSetup()
 		args := []string{"workflow"}

--- a/flytectl/cmd/get/node_execution_test.go
+++ b/flytectl/cmd/get/node_execution_test.go
@@ -158,8 +158,7 @@ func createDummyTaskExecutionForNode(nodeID string, taskID string) *admin.TaskEx
 
 func TestGetExecutionDetails(t *testing.T) {
 	t.Run("successful get details default view", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		ctx := s.Ctx
 		mockCmdCtx := s.CmdCtx
@@ -226,8 +225,7 @@ func TestGetExecutionDetails(t *testing.T) {
 	})
 
 	t.Run("successful get details default view for node-id", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		ctx := s.Ctx
 		mockCmdCtx := s.CmdCtx
@@ -291,8 +289,7 @@ func TestGetExecutionDetails(t *testing.T) {
 	})
 
 	t.Run("failure task exec fetch", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		ctx := s.Ctx
 		mockCmdCtx := s.CmdCtx

--- a/flytectl/cmd/get/project_test.go
+++ b/flytectl/cmd/get/project_test.go
@@ -51,8 +51,7 @@ func getProjectSetup() {
 }
 
 func TestListProjectFunc(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	getProjectSetup()
 	project.DefaultConfig.Filter = filters.Filters{}
@@ -65,8 +64,7 @@ func TestListProjectFunc(t *testing.T) {
 }
 
 func TestGetProjectFunc(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	getProjectSetup()
 	argsProject = []string{}
@@ -80,8 +78,7 @@ func TestGetProjectFunc(t *testing.T) {
 }
 
 func TestGetProjectFuncError(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	getProjectSetup()
 	project.DefaultConfig.Filter = filters.Filters{

--- a/flytectl/cmd/get/task_test.go
+++ b/flytectl/cmd/get/task_test.go
@@ -170,7 +170,7 @@ func getTaskSetup() {
 
 func TestGetTaskFuncWithError(t *testing.T) {
 	t.Run("failure fetch latest", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		getTaskSetup()
@@ -184,7 +184,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching version ", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		getTaskSetup()
@@ -198,7 +198,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching all version ", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		getTaskSetup()
@@ -211,7 +211,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching ", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		getLaunchPlanSetup()
@@ -225,7 +225,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching list task", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		getLaunchPlanSetup()

--- a/flytectl/cmd/get/task_test.go
+++ b/flytectl/cmd/get/task_test.go
@@ -170,8 +170,7 @@ func getTaskSetup() {
 
 func TestGetTaskFuncWithError(t *testing.T) {
 	t.Run("failure fetch latest", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getTaskSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -184,8 +183,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching version ", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getTaskSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -198,8 +196,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching all version ", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getTaskSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -211,8 +208,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching ", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getLaunchPlanSetup()
 		s.MockAdminClient.OnListTasksMatch(s.Ctx, resourceListRequestTask).Return(nil, fmt.Errorf("error fetching all version"))
@@ -225,8 +221,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching list task", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getLaunchPlanSetup()
 		taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -242,8 +237,7 @@ func TestGetTaskFuncWithError(t *testing.T) {
 }
 
 func TestGetTaskFunc(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -329,8 +323,7 @@ func TestGetTaskFunc(t *testing.T) {
 }
 
 func TestGetTaskFuncWithTable(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -355,8 +348,7 @@ func TestGetTaskFuncWithTable(t *testing.T) {
 }
 
 func TestGetTaskFuncLatest(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -406,8 +398,7 @@ func TestGetTaskFuncLatest(t *testing.T) {
 }
 
 func TestGetTaskWithVersion(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -458,8 +449,7 @@ func TestGetTaskWithVersion(t *testing.T) {
 }
 
 func TestGetTasks(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}
@@ -473,8 +463,7 @@ func TestGetTasks(t *testing.T) {
 }
 
 func TestGetTasksFilters(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{
@@ -498,8 +487,7 @@ func TestGetTasksFilters(t *testing.T) {
 }
 
 func TestGetTaskWithExecFile(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	getTaskSetup()
 	s.MockAdminClient.OnListTasksMatch(s.Ctx, resourceListRequestTask).Return(taskListResponse, nil)

--- a/flytectl/cmd/get/workflow_test.go
+++ b/flytectl/cmd/get/workflow_test.go
@@ -93,8 +93,7 @@ func getWorkflowSetup() {
 
 func TestGetWorkflowFuncWithError(t *testing.T) {
 	t.Run("failure fetch latest", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getWorkflowSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -105,8 +104,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching version ", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getWorkflowSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -118,8 +116,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching all version ", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getWorkflowSetup()
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
@@ -130,8 +127,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching ", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getWorkflowSetup()
 		workflow.DefaultConfig.Latest = true
@@ -143,8 +139,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 	})
 
 	t.Run("fetching all workflow success", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getWorkflowSetup()
 		var args []string
@@ -155,8 +150,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 	})
 
 	t.Run("fetching all workflow error", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		getWorkflowSetup()
 		var args []string
@@ -169,8 +163,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 }
 
 func TestGetWorkflowFuncLatestWithTable(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	getWorkflowSetup()
 	workflow.DefaultConfig.Latest = true
@@ -189,8 +182,7 @@ func TestGetWorkflowFuncLatestWithTable(t *testing.T) {
 }
 
 func TestListWorkflowFuncWithTable(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	getWorkflowSetup()
 	workflow.DefaultConfig.Filter = filters.Filters{}

--- a/flytectl/cmd/get/workflow_test.go
+++ b/flytectl/cmd/get/workflow_test.go
@@ -93,7 +93,7 @@ func getWorkflowSetup() {
 
 func TestGetWorkflowFuncWithError(t *testing.T) {
 	t.Run("failure fetch latest", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		getWorkflowSetup()
@@ -105,7 +105,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching version ", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		getWorkflowSetup()
@@ -118,7 +118,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 	})
 
 	t.Run("failure fetching all version ", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		getWorkflowSetup()
@@ -143,7 +143,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 	})
 
 	t.Run("fetching all workflow success", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		getWorkflowSetup()
@@ -155,7 +155,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 	})
 
 	t.Run("fetching all workflow error", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
 		defer s.TearDown()
 
 		getWorkflowSetup()

--- a/flytectl/cmd/register/examples_test.go
+++ b/flytectl/cmd/register/examples_test.go
@@ -3,18 +3,23 @@ package register
 import (
 	"testing"
 
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRegisterExamplesFunc(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	registerFilesSetup()
 	args := []string{""}
 	err := registerExamplesFunc(s.Ctx, args, s.CmdCtx)
 	assert.NotNil(t, err)
 }
 func TestRegisterExamplesFuncErr(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	registerFilesSetup()
 	flytesnacks = "testingsnacks"
 	args := []string{""}

--- a/flytectl/cmd/register/examples_test.go
+++ b/flytectl/cmd/register/examples_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestRegisterExamplesFunc(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	registerFilesSetup()
 	args := []string{""}
@@ -17,8 +16,7 @@ func TestRegisterExamplesFunc(t *testing.T) {
 	assert.NotNil(t, err)
 }
 func TestRegisterExamplesFuncErr(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	registerFilesSetup()
 	flytesnacks = "testingsnacks"

--- a/flytectl/cmd/register/files_test.go
+++ b/flytectl/cmd/register/files_test.go
@@ -23,8 +23,7 @@ const (
 
 func TestRegisterFromFiles(t *testing.T) {
 	t.Run("Valid registration", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		rconfig.DefaultFilesConfig.Archive = true
@@ -37,8 +36,7 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Valid fast registration", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
@@ -64,8 +62,7 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Register a workflow with a failure node", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
@@ -91,8 +88,7 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Failed fast registration while uploading the codebase", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
@@ -114,8 +110,7 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Failed registration because of invalid files", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
@@ -136,8 +131,7 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("Failure registration of fast serialize", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
@@ -161,8 +155,7 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.Equal(t, fmt.Errorf("failed"), err)
 	})
 	t.Run("Failure registration of fast serialize continue on error", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
@@ -187,8 +180,7 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.Equal(t, fmt.Errorf("failed"), err)
 	})
 	t.Run("Valid registration of fast serialize", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
@@ -213,8 +205,7 @@ func TestRegisterFromFiles(t *testing.T) {
 	})
 
 	t.Run("Registration with proto files ", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()

--- a/flytectl/cmd/register/files_test.go
+++ b/flytectl/cmd/register/files_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
 	rconfig "github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/register"
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyte/flyteidl/clients/go/admin/mocks"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 	"github.com/flyteorg/flyte/flytestdlib/contextutils"
@@ -22,7 +23,9 @@ const (
 
 func TestRegisterFromFiles(t *testing.T) {
 	t.Run("Valid registration", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		rconfig.DefaultFilesConfig.Archive = true
 		args := []string{"testdata/valid-parent-folder-register.tar"}
@@ -34,7 +37,9 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Valid fast registration", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
 		registerFilesSetup()
@@ -59,7 +64,9 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Register a workflow with a failure node", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
 		registerFilesSetup()
@@ -84,7 +91,9 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Failed fast registration while uploading the codebase", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
@@ -105,7 +114,9 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Failed registration because of invalid files", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
@@ -125,7 +136,9 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("Failure registration of fast serialize", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
@@ -148,7 +161,9 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.Equal(t, fmt.Errorf("failed"), err)
 	})
 	t.Run("Failure registration of fast serialize continue on error", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
@@ -172,7 +187,9 @@ func TestRegisterFromFiles(t *testing.T) {
 		assert.Equal(t, fmt.Errorf("failed"), err)
 	})
 	t.Run("Valid registration of fast serialize", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
@@ -196,7 +213,9 @@ func TestRegisterFromFiles(t *testing.T) {
 	})
 
 	t.Run("Registration with proto files ", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)

--- a/flytectl/cmd/register/register_test.go
+++ b/flytectl/cmd/register/register_test.go
@@ -6,15 +6,12 @@ import (
 	"sort"
 	"testing"
 
-	u "github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
 	GetDoFunc func(req *http.Request) (*http.Response, error)
 )
-
-var setup = u.Setup
 
 func TestRegisterCommand(t *testing.T) {
 	registerCommand := RemoteRegisterCommand()

--- a/flytectl/cmd/register/register_util_test.go
+++ b/flytectl/cmd/register/register_util_test.go
@@ -62,8 +62,7 @@ func registerFilesSetup() {
 }
 
 func TestGetSortedArchivedFileWithParentFolderList(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
@@ -81,8 +80,7 @@ func TestGetSortedArchivedFileWithParentFolderList(t *testing.T) {
 }
 
 func TestGetSortedArchivedFileList(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
@@ -100,8 +98,7 @@ func TestGetSortedArchivedFileList(t *testing.T) {
 }
 
 func TestGetSortedArchivedFileUnorderedList(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
@@ -119,8 +116,7 @@ func TestGetSortedArchivedFileUnorderedList(t *testing.T) {
 }
 
 func TestGetSortedArchivedCorruptedFileList(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
@@ -134,8 +130,7 @@ func TestGetSortedArchivedCorruptedFileList(t *testing.T) {
 }
 
 func TestGetSortedArchivedTgzList(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
@@ -153,8 +148,7 @@ func TestGetSortedArchivedTgzList(t *testing.T) {
 }
 
 func TestGetSortedArchivedCorruptedTgzFileList(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	rconfig.DefaultFilesConfig.Archive = true
 	args := []string{"testdata/invalid.tgz"}
@@ -167,8 +161,7 @@ func TestGetSortedArchivedCorruptedTgzFileList(t *testing.T) {
 }
 
 func TestGetSortedArchivedInvalidArchiveFileList(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
@@ -183,8 +176,7 @@ func TestGetSortedArchivedInvalidArchiveFileList(t *testing.T) {
 }
 
 func TestGetSortedArchivedFileThroughInvalidHttpList(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	rconfig.DefaultFilesConfig.Archive = true
 	args := []string{"http://invalidhost:invalidport/testdata/valid-register.tar"}
@@ -197,8 +189,7 @@ func TestGetSortedArchivedFileThroughInvalidHttpList(t *testing.T) {
 }
 
 func TestGetSortedArchivedFileThroughValidHttpList(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
@@ -216,8 +207,7 @@ func TestGetSortedArchivedFileThroughValidHttpList(t *testing.T) {
 }
 
 func TestGetSortedArchivedFileThroughValidHttpWithNullContextList(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	testutils.Setup(t)
 
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
@@ -241,8 +231,7 @@ func Test_getTotalSize(t *testing.T) {
 
 func TestRegisterFile(t *testing.T) {
 	t.Run("Successful run", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		s.MockAdminClient.OnCreateTaskMatch(mock.Anything, mock.Anything).Return(nil, nil)
@@ -253,8 +242,7 @@ func TestRegisterFile(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Failed Scheduled launch plan registration", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		s.MockAdminClient.OnCreateLaunchPlanMatch(mock.Anything, mock.Anything).Return(nil, nil)
@@ -309,8 +297,7 @@ func TestRegisterFile(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("Non existent file", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		args := []string{"testdata/non-existent.pb"}
@@ -322,8 +309,7 @@ func TestRegisterFile(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("unmarhal failure", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		args := []string{"testdata/valid-register.tar"}
@@ -335,8 +321,7 @@ func TestRegisterFile(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("AlreadyExists", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		s.MockAdminClient.OnCreateTaskMatch(mock.Anything, mock.Anything).Return(nil,
@@ -350,8 +335,7 @@ func TestRegisterFile(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Registration Error", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		s.MockAdminClient.OnCreateTaskMatch(mock.Anything, mock.Anything).Return(nil,
@@ -368,8 +352,7 @@ func TestRegisterFile(t *testing.T) {
 
 func TestHydrateLaunchPlanSpec(t *testing.T) {
 	t.Run("IamRole override", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		testutils.Setup(t)
 
 		registerFilesSetup()
 		rconfig.DefaultFilesConfig.AssumableIamRole = "iamRole"
@@ -411,8 +394,7 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 
 func TestUploadFastRegisterArtifact(t *testing.T) {
 	t.Run("Successful upload", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
@@ -431,8 +413,7 @@ func TestUploadFastRegisterArtifact(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Failed upload", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
@@ -511,8 +492,7 @@ func TestGetAllFlytesnacksExample(t *testing.T) {
 
 func TestRegister(t *testing.T) {
 	t.Run("Failed to register", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		node := &admin.NodeExecution{}
@@ -726,16 +706,14 @@ func TestLeftDiff(t *testing.T) {
 func TestValidateLaunchSpec(t *testing.T) {
 	ctx := context.Background()
 	t.Run("nil launchplan spec", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		err := validateLaunchSpec(ctx, nil, s.CmdCtx)
 		assert.Nil(t, err)
 	})
 	t.Run("launchplan spec with nil workflow id", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		lpSpec := &admin.LaunchPlanSpec{}
@@ -743,8 +721,7 @@ func TestValidateLaunchSpec(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("launchplan spec with empty metadata", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		lpSpec := &admin.LaunchPlanSpec{
@@ -759,8 +736,7 @@ func TestValidateLaunchSpec(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("launchplan spec with metadata and empty schedule", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		lpSpec := &admin.LaunchPlanSpec{
@@ -776,8 +752,7 @@ func TestValidateLaunchSpec(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("validate spec failed to fetch workflow", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 
@@ -803,8 +778,7 @@ func TestValidateLaunchSpec(t *testing.T) {
 		assert.Equal(t, "failed", err.Error())
 	})
 	t.Run("failed to fetch workflow", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 
@@ -827,8 +801,7 @@ func TestValidateLaunchSpec(t *testing.T) {
 		assert.Equal(t, "failed", err.Error())
 	})
 	t.Run("launchplan spec missing required param schedule", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		variableMap := map[string]*core.Variable{
@@ -891,8 +864,7 @@ func TestValidateLaunchSpec(t *testing.T) {
 		assert.Contains(t, err.Error(), "param values are missing on scheduled workflow for the following params")
 	})
 	t.Run("launchplan spec non empty schedule default param success", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		variableMap := map[string]*core.Variable{
@@ -998,8 +970,7 @@ func TestValidateLaunchSpec(t *testing.T) {
 	})
 
 	t.Run("launchplan spec non empty schedule required param without value fail", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		registerFilesSetup()
 		variableMap := map[string]*core.Variable{

--- a/flytectl/cmd/register/register_util_test.go
+++ b/flytectl/cmd/register/register_util_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	rconfig "github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/register"
+	"github.com/flyteorg/flyte/flytectl/cmd/testutils"
 	ghMocks "github.com/flyteorg/flyte/flytectl/pkg/github/mocks"
 	"github.com/flyteorg/flyte/flyteidl/clients/go/admin/mocks"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
@@ -61,7 +62,9 @@ func registerFilesSetup() {
 }
 
 func TestGetSortedArchivedFileWithParentFolderList(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
 	args := []string{"testdata/valid-parent-folder-register.tar"}
@@ -78,7 +81,9 @@ func TestGetSortedArchivedFileWithParentFolderList(t *testing.T) {
 }
 
 func TestGetSortedArchivedFileList(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
 	args := []string{"testdata/valid-register.tar"}
@@ -95,7 +100,9 @@ func TestGetSortedArchivedFileList(t *testing.T) {
 }
 
 func TestGetSortedArchivedFileUnorderedList(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
 	args := []string{"testdata/valid-unordered-register.tar"}
@@ -112,7 +119,9 @@ func TestGetSortedArchivedFileUnorderedList(t *testing.T) {
 }
 
 func TestGetSortedArchivedCorruptedFileList(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
 	args := []string{"testdata/invalid.tar"}
@@ -125,7 +134,9 @@ func TestGetSortedArchivedCorruptedFileList(t *testing.T) {
 }
 
 func TestGetSortedArchivedTgzList(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
 	args := []string{"testdata/valid-register.tgz"}
@@ -142,7 +153,9 @@ func TestGetSortedArchivedTgzList(t *testing.T) {
 }
 
 func TestGetSortedArchivedCorruptedTgzFileList(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	rconfig.DefaultFilesConfig.Archive = true
 	args := []string{"testdata/invalid.tgz"}
 	fileList, tmpDir, err := GetSerializeOutputFiles(s.Ctx, args, rconfig.DefaultFilesConfig.Archive)
@@ -154,7 +167,9 @@ func TestGetSortedArchivedCorruptedTgzFileList(t *testing.T) {
 }
 
 func TestGetSortedArchivedInvalidArchiveFileList(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
 	args := []string{"testdata/invalid-extension-register.zip"}
@@ -168,7 +183,9 @@ func TestGetSortedArchivedInvalidArchiveFileList(t *testing.T) {
 }
 
 func TestGetSortedArchivedFileThroughInvalidHttpList(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	rconfig.DefaultFilesConfig.Archive = true
 	args := []string{"http://invalidhost:invalidport/testdata/valid-register.tar"}
 	fileList, tmpDir, err := GetSerializeOutputFiles(s.Ctx, args, rconfig.DefaultFilesConfig.Archive)
@@ -180,7 +197,9 @@ func TestGetSortedArchivedFileThroughInvalidHttpList(t *testing.T) {
 }
 
 func TestGetSortedArchivedFileThroughValidHttpList(t *testing.T) {
-	s := setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
 	args := []string{"http://dummyhost:80/testdata/valid-register.tar"}
@@ -197,7 +216,9 @@ func TestGetSortedArchivedFileThroughValidHttpList(t *testing.T) {
 }
 
 func TestGetSortedArchivedFileThroughValidHttpWithNullContextList(t *testing.T) {
-	setup()
+	s := testutils.Setup()
+	defer s.TearDown()
+
 	registerFilesSetup()
 	rconfig.DefaultFilesConfig.Archive = true
 	args := []string{"http://dummyhost:80/testdata/valid-register.tar"}
@@ -220,7 +241,9 @@ func Test_getTotalSize(t *testing.T) {
 
 func TestRegisterFile(t *testing.T) {
 	t.Run("Successful run", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		s.MockAdminClient.OnCreateTaskMatch(mock.Anything, mock.Anything).Return(nil, nil)
 		args := []string{"testdata/69_core.flyte_basics.lp.greet_1.pb"}
@@ -230,7 +253,9 @@ func TestRegisterFile(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Failed Scheduled launch plan registration", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		s.MockAdminClient.OnCreateLaunchPlanMatch(mock.Anything, mock.Anything).Return(nil, nil)
 		variableMap := map[string]*core.Variable{
@@ -284,7 +309,9 @@ func TestRegisterFile(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("Non existent file", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		args := []string{"testdata/non-existent.pb"}
 		var registerResults []Result
@@ -295,7 +322,9 @@ func TestRegisterFile(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("unmarhal failure", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		args := []string{"testdata/valid-register.tar"}
 		var registerResults []Result
@@ -306,7 +335,9 @@ func TestRegisterFile(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("AlreadyExists", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		s.MockAdminClient.OnCreateTaskMatch(mock.Anything, mock.Anything).Return(nil,
 			status.Error(codes.AlreadyExists, "AlreadyExists"))
@@ -319,7 +350,9 @@ func TestRegisterFile(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Registration Error", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		s.MockAdminClient.OnCreateTaskMatch(mock.Anything, mock.Anything).Return(nil,
 			status.Error(codes.InvalidArgument, "Invalid"))
@@ -335,7 +368,9 @@ func TestRegisterFile(t *testing.T) {
 
 func TestHydrateLaunchPlanSpec(t *testing.T) {
 	t.Run("IamRole override", func(t *testing.T) {
-		setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		rconfig.DefaultFilesConfig.AssumableIamRole = "iamRole"
 		lpSpec := &admin.LaunchPlanSpec{}
@@ -376,7 +411,9 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 
 func TestUploadFastRegisterArtifact(t *testing.T) {
 	t.Run("Successful upload", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
 		store, err := storage.NewDataStore(&storage.Config{
@@ -394,7 +431,9 @@ func TestUploadFastRegisterArtifact(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("Failed upload", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
 		store, err := storage.NewDataStore(&storage.Config{
@@ -472,7 +511,9 @@ func TestGetAllFlytesnacksExample(t *testing.T) {
 
 func TestRegister(t *testing.T) {
 	t.Run("Failed to register", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		node := &admin.NodeExecution{}
 		err := register(s.Ctx, node, s.CmdCtx, rconfig.DefaultFilesConfig.DryRun, rconfig.DefaultFilesConfig.EnableSchedule)
@@ -685,20 +726,26 @@ func TestLeftDiff(t *testing.T) {
 func TestValidateLaunchSpec(t *testing.T) {
 	ctx := context.Background()
 	t.Run("nil launchplan spec", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		err := validateLaunchSpec(ctx, nil, s.CmdCtx)
 		assert.Nil(t, err)
 	})
 	t.Run("launchplan spec with nil workflow id", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		lpSpec := &admin.LaunchPlanSpec{}
 		err := validateLaunchSpec(ctx, lpSpec, s.CmdCtx)
 		assert.Nil(t, err)
 	})
 	t.Run("launchplan spec with empty metadata", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		lpSpec := &admin.LaunchPlanSpec{
 			WorkflowId: &core.Identifier{
@@ -712,7 +759,9 @@ func TestValidateLaunchSpec(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("launchplan spec with metadata and empty schedule", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		lpSpec := &admin.LaunchPlanSpec{
 			WorkflowId: &core.Identifier{
@@ -727,7 +776,9 @@ func TestValidateLaunchSpec(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("validate spec failed to fetch workflow", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 
 		s.FetcherExt.OnFetchWorkflowVersionMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("failed"))
@@ -752,7 +803,9 @@ func TestValidateLaunchSpec(t *testing.T) {
 		assert.Equal(t, "failed", err.Error())
 	})
 	t.Run("failed to fetch workflow", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 
 		s.FetcherExt.OnFetchWorkflowVersionMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("failed"))
@@ -774,7 +827,9 @@ func TestValidateLaunchSpec(t *testing.T) {
 		assert.Equal(t, "failed", err.Error())
 	})
 	t.Run("launchplan spec missing required param schedule", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		variableMap := map[string]*core.Variable{
 			"var1": {
@@ -836,7 +891,9 @@ func TestValidateLaunchSpec(t *testing.T) {
 		assert.Contains(t, err.Error(), "param values are missing on scheduled workflow for the following params")
 	})
 	t.Run("launchplan spec non empty schedule default param success", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		variableMap := map[string]*core.Variable{
 			"var1": {
@@ -941,7 +998,9 @@ func TestValidateLaunchSpec(t *testing.T) {
 	})
 
 	t.Run("launchplan spec non empty schedule required param without value fail", func(t *testing.T) {
-		s := setup()
+		s := testutils.Setup()
+		defer s.TearDown()
+
 		registerFilesSetup()
 		variableMap := map[string]*core.Variable{
 			"var1": {

--- a/flytectl/cmd/sandbox/exec_test.go
+++ b/flytectl/cmd/sandbox/exec_test.go
@@ -50,8 +50,7 @@ func TestSandboxClusterExec(t *testing.T) {
 func TestSandboxClusterExecWithoutCmd(t *testing.T) {
 	mockDocker := &mocks.Docker{}
 	reader := bufio.NewReader(strings.NewReader("test"))
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 	ctx := s.Ctx
 
 	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{

--- a/flytectl/cmd/sandbox/exec_test.go
+++ b/flytectl/cmd/sandbox/exec_test.go
@@ -51,6 +51,7 @@ func TestSandboxClusterExecWithoutCmd(t *testing.T) {
 	mockDocker := &mocks.Docker{}
 	reader := bufio.NewReader(strings.NewReader("test"))
 	s := testutils.Setup()
+	defer s.TearDown()
 	ctx := s.Ctx
 
 	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{

--- a/flytectl/cmd/sandbox/status_test.go
+++ b/flytectl/cmd/sandbox/status_test.go
@@ -15,6 +15,7 @@ func TestSandboxStatus(t *testing.T) {
 	t.Run("Sandbox status with zero result", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		s := testutils.Setup()
+		defer s.TearDown()
 		mockDocker.OnContainerList(s.Ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		docker.Client = mockDocker
 		err := sandboxClusterStatus(s.Ctx, []string{}, s.CmdCtx)
@@ -22,6 +23,7 @@ func TestSandboxStatus(t *testing.T) {
 	})
 	t.Run("Sandbox status with running sandbox", func(t *testing.T) {
 		s := testutils.Setup()
+		defer s.TearDown()
 		ctx := s.Ctx
 		mockDocker := &mocks.Docker{}
 		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{

--- a/flytectl/cmd/sandbox/status_test.go
+++ b/flytectl/cmd/sandbox/status_test.go
@@ -14,16 +14,14 @@ import (
 func TestSandboxStatus(t *testing.T) {
 	t.Run("Sandbox status with zero result", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		mockDocker.OnContainerList(s.Ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		docker.Client = mockDocker
 		err := sandboxClusterStatus(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 	})
 	t.Run("Sandbox status with running sandbox", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		ctx := s.Ctx
 		mockDocker := &mocks.Docker{}
 		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{

--- a/flytectl/cmd/sandbox/teardown_test.go
+++ b/flytectl/cmd/sandbox/teardown_test.go
@@ -21,6 +21,7 @@ func TestTearDownClusterFunc(t *testing.T) {
 	_ = util.SetupFlyteDir()
 	_ = util.WriteIntoFile([]byte("data"), configutil.FlytectlConfig)
 	s := testutils.Setup()
+	defer s.TearDown()
 	ctx := s.Ctx
 	mockDocker := &mocks.Docker{}
 	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(containers, nil)

--- a/flytectl/cmd/sandbox/teardown_test.go
+++ b/flytectl/cmd/sandbox/teardown_test.go
@@ -20,8 +20,7 @@ func TestTearDownClusterFunc(t *testing.T) {
 	var containers []types.Container
 	_ = util.SetupFlyteDir()
 	_ = util.WriteIntoFile([]byte("data"), configutil.FlytectlConfig)
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 	ctx := s.Ctx
 	mockDocker := &mocks.Docker{}
 	mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return(containers, nil)

--- a/flytectl/cmd/testutils/test_utils.go
+++ b/flytectl/cmd/testutils/test_utils.go
@@ -41,8 +41,7 @@ type TestStruct struct {
 	Stderr          *os.File
 }
 
-// Make sure to call TearDown after using this function
-func Setup() (s TestStruct) {
+func Setup(t *testing.T) (s TestStruct) {
 	s.Ctx = context.Background()
 	s.Reader, s.Writer, s.Err = os.Pipe()
 	if s.Err != nil {
@@ -67,12 +66,13 @@ func Setup() (s TestStruct) {
 	config.GetConfig().Domain = domainValue
 	config.GetConfig().Output = output
 
-	return s
-}
+	// We need to make sure that the original final descriptors are restored after the test
+	t.Cleanup(func() {
+		os.Stdout = s.StdOut
+		os.Stderr = s.Stderr
+	})
 
-func (s *TestStruct) TearDown() {
-	os.Stdout = s.StdOut
-	os.Stderr = s.Stderr
+	return s
 }
 
 // TearDownAndVerify TODO: Change this to verify log lines from context

--- a/flytectl/cmd/update/execution_test.go
+++ b/flytectl/cmd/update/execution_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestExecutionCanBeActivated(t *testing.T) {
 	testExecutionUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *execution.UpdateConfig, execution *admin.Execution) {
 			execution.Closure.StateChangeDetails.State = admin.ExecutionState_EXECUTION_ARCHIVED
 			config.Activate = true
@@ -34,6 +35,7 @@ func TestExecutionCanBeActivated(t *testing.T) {
 
 func TestExecutionCanBeArchived(t *testing.T) {
 	testExecutionUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *execution.UpdateConfig, execution *admin.Execution) {
 			execution.Closure.StateChangeDetails.State = admin.ExecutionState_EXECUTION_ACTIVE
 			config.Archive = true
@@ -52,6 +54,7 @@ func TestExecutionCanBeArchived(t *testing.T) {
 
 func TestExecutionCannotBeActivatedAndArchivedAtTheSameTime(t *testing.T) {
 	testExecutionUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *execution.UpdateConfig, execution *admin.Execution) {
 			config.Activate = true
 			config.Archive = true
@@ -64,6 +67,7 @@ func TestExecutionCannotBeActivatedAndArchivedAtTheSameTime(t *testing.T) {
 
 func TestExecutionUpdateDoesNothingWhenThereAreNoChanges(t *testing.T) {
 	testExecutionUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *execution.UpdateConfig, execution *admin.Execution) {
 			execution.Closure.StateChangeDetails.State = admin.ExecutionState_EXECUTION_ACTIVE
 			config.Activate = true
@@ -77,6 +81,7 @@ func TestExecutionUpdateDoesNothingWhenThereAreNoChanges(t *testing.T) {
 
 func TestExecutionUpdateWithoutForceFlagFails(t *testing.T) {
 	testExecutionUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *execution.UpdateConfig, execution *admin.Execution) {
 			execution.Closure.StateChangeDetails.State = admin.ExecutionState_EXECUTION_ARCHIVED
 			config.Activate = true
@@ -90,6 +95,7 @@ func TestExecutionUpdateWithoutForceFlagFails(t *testing.T) {
 
 func TestExecutionUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 	testExecutionUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *execution.UpdateConfig, execution *admin.Execution) {
 			execution.Closure.StateChangeDetails.State = admin.ExecutionState_EXECUTION_ARCHIVED
 			config.Activate = true
@@ -104,6 +110,7 @@ func TestExecutionUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 func TestForceFlagIsIgnoredWithDryRunDuringExecutionUpdate(t *testing.T) {
 	t.Run("without --force", func(t *testing.T) {
 		testExecutionUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *execution.UpdateConfig, execution *admin.Execution) {
 				execution.Closure.StateChangeDetails.State = admin.ExecutionState_EXECUTION_ARCHIVED
 				config.Activate = true
@@ -119,6 +126,7 @@ func TestForceFlagIsIgnoredWithDryRunDuringExecutionUpdate(t *testing.T) {
 
 	t.Run("with --force", func(t *testing.T) {
 		testExecutionUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *execution.UpdateConfig, execution *admin.Execution) {
 				execution.Closure.StateChangeDetails.State = admin.ExecutionState_EXECUTION_ARCHIVED
 				config.Activate = true
@@ -135,6 +143,7 @@ func TestForceFlagIsIgnoredWithDryRunDuringExecutionUpdate(t *testing.T) {
 
 func TestExecutionUpdateFailsWhenExecutionDoesNotExist(t *testing.T) {
 	testExecutionUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, execution *admin.Execution) {
 			s.FetcherExt.
 				OnFetchExecution(s.Ctx, execution.Id.Name, execution.Id.Project, execution.Id.Domain).
@@ -153,6 +162,7 @@ func TestExecutionUpdateFailsWhenExecutionDoesNotExist(t *testing.T) {
 
 func TestExecutionUpdateFailsWhenAdminClientFails(t *testing.T) {
 	testExecutionUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, execution *admin.Execution) {
 			s.FetcherExt.
 				OnFetchExecution(s.Ctx, execution.Id.Name, execution.Id.Project, execution.Id.Domain).
@@ -174,8 +184,7 @@ func TestExecutionUpdateFailsWhenAdminClientFails(t *testing.T) {
 }
 
 func TestExecutionUpdateRequiresExecutionName(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	err := updateExecutionFunc(s.Ctx, nil, s.CmdCtx)
 
@@ -183,10 +192,12 @@ func TestExecutionUpdateRequiresExecutionName(t *testing.T) {
 }
 
 func testExecutionUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *execution.UpdateConfig, execution *admin.Execution),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testExecutionUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, execution *admin.Execution) {
 			s.FetcherExt.
 				OnFetchExecution(s.Ctx, execution.Id.Name, execution.Id.Project, execution.Id.Domain).
@@ -201,12 +212,12 @@ func testExecutionUpdate(
 }
 
 func testExecutionUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, execution *admin.Execution),
 	setup func(s *testutils.TestStruct, config *execution.UpdateConfig, execution *admin.Execution),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	target := newTestExecution()
 
@@ -217,7 +228,6 @@ func testExecutionUpdateWithMockSetup(
 	execution.UConfig = &execution.UpdateConfig{}
 	if setup != nil {
 		setup(&s, execution.UConfig, target)
-		defer s.TearDown()
 	}
 
 	args := []string{target.Id.Name}

--- a/flytectl/cmd/update/launch_plan_meta_test.go
+++ b/flytectl/cmd/update/launch_plan_meta_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestLaunchPlanMetadataCanBeActivated(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_LAUNCH_PLAN,
+	testNamedEntityUpdate(t, core.ResourceType_LAUNCH_PLAN,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 			config.Activate = true
@@ -31,7 +31,7 @@ func TestLaunchPlanMetadataCanBeActivated(t *testing.T) {
 }
 
 func TestLaunchPlanMetadataCanBeArchived(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_LAUNCH_PLAN,
+	testNamedEntityUpdate(t, core.ResourceType_LAUNCH_PLAN,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ACTIVE
 			config.Archive = true
@@ -49,7 +49,7 @@ func TestLaunchPlanMetadataCanBeArchived(t *testing.T) {
 }
 
 func TestLaunchPlanMetadataCannotBeActivatedAndArchivedAtTheSameTime(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_LAUNCH_PLAN,
+	testNamedEntityUpdate(t, core.ResourceType_LAUNCH_PLAN,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			config.Activate = true
 			config.Archive = true
@@ -61,7 +61,7 @@ func TestLaunchPlanMetadataCannotBeActivatedAndArchivedAtTheSameTime(t *testing.
 }
 
 func TestLaunchPlanMetadataUpdateDoesNothingWhenThereAreNoChanges(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_LAUNCH_PLAN,
+	testNamedEntityUpdate(t, core.ResourceType_LAUNCH_PLAN,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ACTIVE
 			config.Activate = true
@@ -74,7 +74,7 @@ func TestLaunchPlanMetadataUpdateDoesNothingWhenThereAreNoChanges(t *testing.T) 
 }
 
 func TestLaunchPlanMetadataUpdateWithoutForceFlagFails(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_LAUNCH_PLAN,
+	testNamedEntityUpdate(t, core.ResourceType_LAUNCH_PLAN,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 			config.Activate = true
@@ -87,7 +87,7 @@ func TestLaunchPlanMetadataUpdateWithoutForceFlagFails(t *testing.T) {
 }
 
 func TestLaunchPlanMetadataUpdateDoesNothingWithDryRunFlag(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_LAUNCH_PLAN,
+	testNamedEntityUpdate(t, core.ResourceType_LAUNCH_PLAN,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 			config.Activate = true
@@ -101,7 +101,7 @@ func TestLaunchPlanMetadataUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 func TestForceFlagIsIgnoredWithDryRunDuringLaunchPlanMetadataUpdate(t *testing.T) {
 	t.Run("without --force", func(t *testing.T) {
-		testNamedEntityUpdate(core.ResourceType_LAUNCH_PLAN,
+		testNamedEntityUpdate(t, core.ResourceType_LAUNCH_PLAN,
 			/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 				namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 				config.Activate = true
@@ -116,7 +116,7 @@ func TestForceFlagIsIgnoredWithDryRunDuringLaunchPlanMetadataUpdate(t *testing.T
 	})
 
 	t.Run("with --force", func(t *testing.T) {
-		testNamedEntityUpdate(core.ResourceType_LAUNCH_PLAN,
+		testNamedEntityUpdate(t, core.ResourceType_LAUNCH_PLAN,
 			/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 				namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 				config.Activate = true
@@ -133,6 +133,7 @@ func TestForceFlagIsIgnoredWithDryRunDuringLaunchPlanMetadataUpdate(t *testing.T
 
 func TestLaunchPlanMetadataUpdateFailsWhenLaunchPlanDoesNotExist(t *testing.T) {
 	testNamedEntityUpdateWithMockSetup(
+		t,
 		core.ResourceType_LAUNCH_PLAN,
 		/* mockSetup */ func(s *testutils.TestStruct, namedEntity *admin.NamedEntity) {
 			s.MockAdminClient.
@@ -154,6 +155,7 @@ func TestLaunchPlanMetadataUpdateFailsWhenLaunchPlanDoesNotExist(t *testing.T) {
 
 func TestLaunchPlanMetadataUpdateFailsWhenAdminClientFails(t *testing.T) {
 	testNamedEntityUpdateWithMockSetup(
+		t,
 		core.ResourceType_LAUNCH_PLAN,
 		/* mockSetup */ func(s *testutils.TestStruct, namedEntity *admin.NamedEntity) {
 			s.MockAdminClient.
@@ -178,8 +180,7 @@ func TestLaunchPlanMetadataUpdateFailsWhenAdminClientFails(t *testing.T) {
 }
 
 func TestLaunchPlanMetadataUpdateRequiresLaunchPlanName(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	config := &NamedEntityConfig{}
 

--- a/flytectl/cmd/update/launch_plan_test.go
+++ b/flytectl/cmd/update/launch_plan_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestLaunchPlanCanBeActivated(t *testing.T) {
 	testLaunchPlanUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *launchplan.UpdateConfig, launchplan *admin.LaunchPlan) {
 			launchplan.Closure.State = admin.LaunchPlanState_INACTIVE
 			config.Activate = true
@@ -34,6 +35,7 @@ func TestLaunchPlanCanBeActivated(t *testing.T) {
 
 func TestLaunchPlanCanBeArchived(t *testing.T) {
 	testLaunchPlanUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *launchplan.UpdateConfig, launchplan *admin.LaunchPlan) {
 			launchplan.Closure.State = admin.LaunchPlanState_ACTIVE
 			config.Archive = true
@@ -52,6 +54,7 @@ func TestLaunchPlanCanBeArchived(t *testing.T) {
 
 func TestLaunchPlanCanBeDeactivated(t *testing.T) {
 	testLaunchPlanUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *launchplan.UpdateConfig, launchplan *admin.LaunchPlan) {
 			launchplan.Closure.State = admin.LaunchPlanState_ACTIVE
 			config.Deactivate = true
@@ -70,6 +73,7 @@ func TestLaunchPlanCanBeDeactivated(t *testing.T) {
 
 func TestLaunchPlanCannotBeActivatedAndDeactivatedAtTheSameTime(t *testing.T) {
 	testLaunchPlanUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *launchplan.UpdateConfig, launchplan *admin.LaunchPlan) {
 			config.Activate = true
 			config.Deactivate = true
@@ -82,6 +86,7 @@ func TestLaunchPlanCannotBeActivatedAndDeactivatedAtTheSameTime(t *testing.T) {
 
 func TestLaunchPlanUpdateDoesNothingWhenThereAreNoChanges(t *testing.T) {
 	testLaunchPlanUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *launchplan.UpdateConfig, launchplan *admin.LaunchPlan) {
 			launchplan.Closure.State = admin.LaunchPlanState_ACTIVE
 			config.Activate = true
@@ -95,6 +100,7 @@ func TestLaunchPlanUpdateDoesNothingWhenThereAreNoChanges(t *testing.T) {
 
 func TestLaunchPlanUpdateWithoutForceFlagFails(t *testing.T) {
 	testLaunchPlanUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *launchplan.UpdateConfig, launchplan *admin.LaunchPlan) {
 			launchplan.Closure.State = admin.LaunchPlanState_INACTIVE
 			config.Activate = true
@@ -108,6 +114,7 @@ func TestLaunchPlanUpdateWithoutForceFlagFails(t *testing.T) {
 
 func TestLaunchPlanUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 	testLaunchPlanUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *launchplan.UpdateConfig, launchplan *admin.LaunchPlan) {
 			launchplan.Closure.State = admin.LaunchPlanState_INACTIVE
 			config.Activate = true
@@ -122,6 +129,7 @@ func TestLaunchPlanUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 func TestForceFlagIsIgnoredWithDryRunDuringLaunchPlanUpdate(t *testing.T) {
 	t.Run("without --force", func(t *testing.T) {
 		testLaunchPlanUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *launchplan.UpdateConfig, launchplan *admin.LaunchPlan) {
 				launchplan.Closure.State = admin.LaunchPlanState_INACTIVE
 				config.Activate = true
@@ -137,6 +145,7 @@ func TestForceFlagIsIgnoredWithDryRunDuringLaunchPlanUpdate(t *testing.T) {
 
 	t.Run("with --force", func(t *testing.T) {
 		testLaunchPlanUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *launchplan.UpdateConfig, launchplan *admin.LaunchPlan) {
 				launchplan.Closure.State = admin.LaunchPlanState_INACTIVE
 				config.Activate = true
@@ -153,6 +162,7 @@ func TestForceFlagIsIgnoredWithDryRunDuringLaunchPlanUpdate(t *testing.T) {
 
 func TestLaunchPlanUpdateFailsWhenLaunchPlanDoesNotExist(t *testing.T) {
 	testLaunchPlanUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, launchplan *admin.LaunchPlan) {
 			s.MockAdminClient.
 				OnGetLaunchPlanMatch(
@@ -173,6 +183,7 @@ func TestLaunchPlanUpdateFailsWhenLaunchPlanDoesNotExist(t *testing.T) {
 
 func TestLaunchPlanUpdateFailsWhenAdminClientFails(t *testing.T) {
 	testLaunchPlanUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, launchplan *admin.LaunchPlan) {
 			s.MockAdminClient.
 				OnGetLaunchPlanMatch(
@@ -196,8 +207,7 @@ func TestLaunchPlanUpdateFailsWhenAdminClientFails(t *testing.T) {
 }
 
 func TestLaunchPlanUpdateRequiresLaunchPlanName(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	launchplan.UConfig = &launchplan.UpdateConfig{}
 
@@ -211,8 +221,7 @@ func TestLaunchPlanUpdateRequiresLaunchPlanName(t *testing.T) {
 }
 
 func TestLaunchPlanUpdateRequiresLaunchPlanVersion(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	launchplan.UConfig = &launchplan.UpdateConfig{}
 
@@ -226,10 +235,12 @@ func TestLaunchPlanUpdateRequiresLaunchPlanVersion(t *testing.T) {
 }
 
 func testLaunchPlanUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *launchplan.UpdateConfig, launchplan *admin.LaunchPlan),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testLaunchPlanUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, launchplan *admin.LaunchPlan) {
 			s.MockAdminClient.
 				OnGetLaunchPlanMatch(
@@ -246,12 +257,12 @@ func testLaunchPlanUpdate(
 }
 
 func testLaunchPlanUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, launchplan *admin.LaunchPlan),
 	setup func(s *testutils.TestStruct, config *launchplan.UpdateConfig, launchplan *admin.LaunchPlan),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	target := newTestLaunchPlan()
 
@@ -262,7 +273,6 @@ func testLaunchPlanUpdateWithMockSetup(
 	launchplan.UConfig = &launchplan.UpdateConfig{}
 	if setup != nil {
 		setup(&s, launchplan.UConfig, target)
-		defer s.TearDown()
 	}
 
 	args := []string{target.Id.Name}

--- a/flytectl/cmd/update/matchable_cluster_resource_attribute_test.go
+++ b/flytectl/cmd/update/matchable_cluster_resource_attribute_test.go
@@ -20,6 +20,7 @@ const (
 
 func TestClusterResourceAttributeUpdateRequiresAttributeFile(t *testing.T) {
 	testWorkflowClusterResourceAttributeUpdate(
+		t,
 		/* setup */ nil,
 		/* assert */ func(s *testutils.TestStruct, err error) {
 			assert.ErrorContains(t, err, "attrFile is mandatory")
@@ -29,6 +30,7 @@ func TestClusterResourceAttributeUpdateRequiresAttributeFile(t *testing.T) {
 
 func TestClusterResourceAttributeUpdateFailsWhenAttributeFileDoesNotExist(t *testing.T) {
 	testWorkflowClusterResourceAttributeUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 			config.AttrFile = testDataNonExistentFile
 			config.Force = true
@@ -42,6 +44,7 @@ func TestClusterResourceAttributeUpdateFailsWhenAttributeFileDoesNotExist(t *tes
 
 func TestClusterResourceAttributeUpdateFailsWhenAttributeFileIsMalformed(t *testing.T) {
 	testWorkflowClusterResourceAttributeUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 			config.AttrFile = testDataInvalidAttrFile
 			config.Force = true
@@ -56,6 +59,7 @@ func TestClusterResourceAttributeUpdateFailsWhenAttributeFileIsMalformed(t *test
 func TestClusterResourceAttributeUpdateHappyPath(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowClusterResourceAttributesFilePath
 				config.Force = true
@@ -69,6 +73,7 @@ func TestClusterResourceAttributeUpdateHappyPath(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainClusterResourceAttributesFilePath
 				config.Force = true
@@ -82,6 +87,7 @@ func TestClusterResourceAttributeUpdateHappyPath(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectClusterResourceAttributesFilePath
 				config.Force = true
@@ -97,6 +103,7 @@ func TestClusterResourceAttributeUpdateHappyPath(t *testing.T) {
 func TestClusterResourceAttributeUpdateFailsWithoutForceFlag(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowClusterResourceAttributesFilePath
 				config.Force = false
@@ -109,6 +116,7 @@ func TestClusterResourceAttributeUpdateFailsWithoutForceFlag(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainClusterResourceAttributesFilePath
 				config.Force = false
@@ -121,6 +129,7 @@ func TestClusterResourceAttributeUpdateFailsWithoutForceFlag(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectClusterResourceAttributesFilePath
 				config.Force = false
@@ -135,6 +144,7 @@ func TestClusterResourceAttributeUpdateFailsWithoutForceFlag(t *testing.T) {
 func TestClusterResourceAttributeUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowClusterResourceAttributesFilePath
 				config.DryRun = true
@@ -147,6 +157,7 @@ func TestClusterResourceAttributeUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainClusterResourceAttributesFilePath
 				config.DryRun = true
@@ -159,6 +170,7 @@ func TestClusterResourceAttributeUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectClusterResourceAttributesFilePath
 				config.DryRun = true
@@ -173,6 +185,7 @@ func TestClusterResourceAttributeUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 func TestClusterResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 	t.Run("workflow without --force", func(t *testing.T) {
 		testWorkflowClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowClusterResourceAttributesFilePath
 				config.Force = false
@@ -186,6 +199,7 @@ func TestClusterResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) 
 
 	t.Run("workflow with --force", func(t *testing.T) {
 		testWorkflowClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowClusterResourceAttributesFilePath
 				config.Force = true
@@ -199,6 +213,7 @@ func TestClusterResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) 
 
 	t.Run("domain without --force", func(t *testing.T) {
 		testProjectDomainClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainClusterResourceAttributesFilePath
 				config.Force = false
@@ -212,6 +227,7 @@ func TestClusterResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) 
 
 	t.Run("domain with --force", func(t *testing.T) {
 		testProjectDomainClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainClusterResourceAttributesFilePath
 				config.Force = true
@@ -225,6 +241,7 @@ func TestClusterResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) 
 
 	t.Run("project without --force", func(t *testing.T) {
 		testProjectClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectClusterResourceAttributesFilePath
 				config.Force = false
@@ -238,6 +255,7 @@ func TestClusterResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) 
 
 	t.Run("project with --force", func(t *testing.T) {
 		testProjectClusterResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectClusterResourceAttributesFilePath
 				config.Force = true
@@ -253,6 +271,7 @@ func TestClusterResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) 
 func TestClusterResourceAttributeUpdateSucceedsWhenAttributesDoNotExist(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowClusterResourceAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 				s.FetcherExt.
 					OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_CLUSTER_RESOURCE).
@@ -274,6 +293,7 @@ func TestClusterResourceAttributeUpdateSucceedsWhenAttributesDoNotExist(t *testi
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainClusterResourceAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 				s.FetcherExt.
 					OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_CLUSTER_RESOURCE).
@@ -295,6 +315,7 @@ func TestClusterResourceAttributeUpdateSucceedsWhenAttributesDoNotExist(t *testi
 
 	t.Run("project", func(t *testing.T) {
 		testProjectClusterResourceAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 				s.FetcherExt.
 					OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_CLUSTER_RESOURCE).
@@ -318,6 +339,7 @@ func TestClusterResourceAttributeUpdateSucceedsWhenAttributesDoNotExist(t *testi
 func TestClusterResourceAttributeUpdateFailsWhenAdminClientFails(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowClusterResourceAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 				s.FetcherExt.
 					OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_CLUSTER_RESOURCE).
@@ -338,6 +360,7 @@ func TestClusterResourceAttributeUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainClusterResourceAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 				s.FetcherExt.
 					OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_CLUSTER_RESOURCE).
@@ -358,6 +381,7 @@ func TestClusterResourceAttributeUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectClusterResourceAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 				s.FetcherExt.
 					OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_CLUSTER_RESOURCE).
@@ -378,10 +402,12 @@ func TestClusterResourceAttributeUpdateFailsWhenAdminClientFails(t *testing.T) {
 }
 
 func testWorkflowClusterResourceAttributeUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testWorkflowClusterResourceAttributeUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 			s.FetcherExt.
 				OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_CLUSTER_RESOURCE).
@@ -396,12 +422,12 @@ func testWorkflowClusterResourceAttributeUpdate(
 }
 
 func testWorkflowClusterResourceAttributeUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.WorkflowAttributes),
 	setup func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	clusterresourceattribute.DefaultUpdateConfig = &clusterresourceattribute.AttrUpdateConfig{}
 	target := newTestWorkflowClusterResourceAttribute()
@@ -412,7 +438,6 @@ func testWorkflowClusterResourceAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, clusterresourceattribute.DefaultUpdateConfig, target)
-		defer s.TearDown()
 	}
 
 	err := updateClusterResourceAttributesFunc(s.Ctx, nil, s.CmdCtx)
@@ -446,10 +471,12 @@ func newTestWorkflowClusterResourceAttribute() *admin.WorkflowAttributes {
 }
 
 func testProjectClusterResourceAttributeUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectClusterResourceAttributeUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 			s.FetcherExt.
 				OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_CLUSTER_RESOURCE).
@@ -464,12 +491,12 @@ func testProjectClusterResourceAttributeUpdate(
 }
 
 func testProjectClusterResourceAttributeUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.ProjectAttributes),
 	setup func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	clusterresourceattribute.DefaultUpdateConfig = &clusterresourceattribute.AttrUpdateConfig{}
 	target := newTestProjectClusterResourceAttribute()
@@ -480,7 +507,6 @@ func testProjectClusterResourceAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, clusterresourceattribute.DefaultUpdateConfig, target)
-		defer s.TearDown()
 	}
 
 	err := updateClusterResourceAttributesFunc(s.Ctx, nil, s.CmdCtx)
@@ -512,10 +538,12 @@ func newTestProjectClusterResourceAttribute() *admin.ProjectAttributes {
 }
 
 func testProjectDomainClusterResourceAttributeUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectDomainClusterResourceAttributeUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 			s.FetcherExt.
 				OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_CLUSTER_RESOURCE).
@@ -530,12 +558,12 @@ func testProjectDomainClusterResourceAttributeUpdate(
 }
 
 func testProjectDomainClusterResourceAttributeUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes),
 	setup func(s *testutils.TestStruct, config *clusterresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	clusterresourceattribute.DefaultUpdateConfig = &clusterresourceattribute.AttrUpdateConfig{}
 	target := newTestProjectDomainClusterResourceAttribute()
@@ -546,7 +574,6 @@ func testProjectDomainClusterResourceAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, clusterresourceattribute.DefaultUpdateConfig, target)
-		defer s.TearDown()
 	}
 
 	err := updateClusterResourceAttributesFunc(s.Ctx, nil, s.CmdCtx)

--- a/flytectl/cmd/update/matchable_cluster_resource_attribute_test.go
+++ b/flytectl/cmd/update/matchable_cluster_resource_attribute_test.go
@@ -535,6 +535,8 @@ func testProjectDomainClusterResourceAttributeUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	clusterresourceattribute.DefaultUpdateConfig = &clusterresourceattribute.AttrUpdateConfig{}
 	target := newTestProjectDomainClusterResourceAttribute()
 

--- a/flytectl/cmd/update/matchable_execution_cluster_label_test.go
+++ b/flytectl/cmd/update/matchable_execution_cluster_label_test.go
@@ -20,6 +20,7 @@ const (
 
 func TestExecutionClusterLabelUpdateRequiresAttributeFile(t *testing.T) {
 	testWorkflowExecutionClusterLabelUpdate(
+		t,
 		/* setup */ nil,
 		/* assert */ func(s *testutils.TestStruct, err error) {
 			assert.ErrorContains(t, err, "attrFile is mandatory")
@@ -29,6 +30,7 @@ func TestExecutionClusterLabelUpdateRequiresAttributeFile(t *testing.T) {
 
 func TestExecutionClusterLabelUpdateFailsWhenAttributeFileDoesNotExist(t *testing.T) {
 	testWorkflowExecutionClusterLabelUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 			config.AttrFile = testDataNonExistentFile
 			config.Force = true
@@ -42,6 +44,7 @@ func TestExecutionClusterLabelUpdateFailsWhenAttributeFileDoesNotExist(t *testin
 
 func TestExecutionClusterLabelUpdateFailsWhenAttributeFileIsMalformed(t *testing.T) {
 	testWorkflowExecutionClusterLabelUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 			config.AttrFile = testDataInvalidAttrFile
 			config.Force = true
@@ -56,6 +59,7 @@ func TestExecutionClusterLabelUpdateFailsWhenAttributeFileIsMalformed(t *testing
 func TestExecutionClusterLabelUpdateHappyPath(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionClusterLabelFilePath
 				config.Force = true
@@ -69,6 +73,7 @@ func TestExecutionClusterLabelUpdateHappyPath(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainExecutionClusterLabelFilePath
 				config.Force = true
@@ -82,6 +87,7 @@ func TestExecutionClusterLabelUpdateHappyPath(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectExecutionClusterLabelFilePath
 				config.Force = true
@@ -97,6 +103,7 @@ func TestExecutionClusterLabelUpdateHappyPath(t *testing.T) {
 func TestExecutionClusterLabelUpdateFailsWithoutForceFlag(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionClusterLabelFilePath
 				config.Force = false
@@ -109,6 +116,7 @@ func TestExecutionClusterLabelUpdateFailsWithoutForceFlag(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainExecutionClusterLabelFilePath
 				config.Force = false
@@ -121,6 +129,7 @@ func TestExecutionClusterLabelUpdateFailsWithoutForceFlag(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectExecutionClusterLabelFilePath
 				config.Force = false
@@ -135,6 +144,7 @@ func TestExecutionClusterLabelUpdateFailsWithoutForceFlag(t *testing.T) {
 func TestExecutionClusterLabelUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionClusterLabelFilePath
 				config.DryRun = true
@@ -147,6 +157,7 @@ func TestExecutionClusterLabelUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainExecutionClusterLabelFilePath
 				config.DryRun = true
@@ -159,6 +170,7 @@ func TestExecutionClusterLabelUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectExecutionClusterLabelFilePath
 				config.DryRun = true
@@ -173,6 +185,7 @@ func TestExecutionClusterLabelUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 func TestExecutionClusterLabelUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 	t.Run("workflow without --force", func(t *testing.T) {
 		testWorkflowExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionClusterLabelFilePath
 				config.Force = false
@@ -186,6 +199,7 @@ func TestExecutionClusterLabelUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("workflow with --force", func(t *testing.T) {
 		testWorkflowExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionClusterLabelFilePath
 				config.Force = true
@@ -199,6 +213,7 @@ func TestExecutionClusterLabelUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("domain without --force", func(t *testing.T) {
 		testProjectDomainExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainExecutionClusterLabelFilePath
 				config.Force = false
@@ -212,6 +227,7 @@ func TestExecutionClusterLabelUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("domain with --force", func(t *testing.T) {
 		testProjectDomainExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainExecutionClusterLabelFilePath
 				config.Force = true
@@ -225,6 +241,7 @@ func TestExecutionClusterLabelUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("project without --force", func(t *testing.T) {
 		testProjectExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectExecutionClusterLabelFilePath
 				config.Force = false
@@ -238,6 +255,7 @@ func TestExecutionClusterLabelUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("project with --force", func(t *testing.T) {
 		testProjectExecutionClusterLabelUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectExecutionClusterLabelFilePath
 				config.Force = true
@@ -253,6 +271,7 @@ func TestExecutionClusterLabelUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 func TestExecutionClusterLabelUpdateSucceedsWhenAttributesDoNotExist(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionClusterLabelUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 				s.FetcherExt.
 					OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_EXECUTION_CLUSTER_LABEL).
@@ -274,6 +293,7 @@ func TestExecutionClusterLabelUpdateSucceedsWhenAttributesDoNotExist(t *testing.
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainExecutionClusterLabelUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 				s.FetcherExt.
 					OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_EXECUTION_CLUSTER_LABEL).
@@ -295,6 +315,7 @@ func TestExecutionClusterLabelUpdateSucceedsWhenAttributesDoNotExist(t *testing.
 
 	t.Run("project", func(t *testing.T) {
 		testProjectExecutionClusterLabelUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 				s.FetcherExt.
 					OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_EXECUTION_CLUSTER_LABEL).
@@ -318,6 +339,7 @@ func TestExecutionClusterLabelUpdateSucceedsWhenAttributesDoNotExist(t *testing.
 func TestExecutionClusterLabelUpdateFailsWhenAdminClientFails(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionClusterLabelUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 				s.FetcherExt.
 					OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_EXECUTION_CLUSTER_LABEL).
@@ -338,6 +360,7 @@ func TestExecutionClusterLabelUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainExecutionClusterLabelUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 				s.FetcherExt.
 					OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_EXECUTION_CLUSTER_LABEL).
@@ -358,6 +381,7 @@ func TestExecutionClusterLabelUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectExecutionClusterLabelUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 				s.FetcherExt.
 					OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_EXECUTION_CLUSTER_LABEL).
@@ -378,10 +402,12 @@ func TestExecutionClusterLabelUpdateFailsWhenAdminClientFails(t *testing.T) {
 }
 
 func testWorkflowExecutionClusterLabelUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.WorkflowAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testWorkflowExecutionClusterLabelUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 			s.FetcherExt.
 				OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_EXECUTION_CLUSTER_LABEL).
@@ -396,12 +422,12 @@ func testWorkflowExecutionClusterLabelUpdate(
 }
 
 func testWorkflowExecutionClusterLabelUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.WorkflowAttributes),
 	setup func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.WorkflowAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	executionclusterlabel.DefaultUpdateConfig = &executionclusterlabel.AttrUpdateConfig{}
 	target := newTestWorkflowExecutionClusterLabel()
@@ -441,10 +467,12 @@ func newTestWorkflowExecutionClusterLabel() *admin.WorkflowAttributes {
 }
 
 func testProjectExecutionClusterLabelUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectExecutionClusterLabelUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 			s.FetcherExt.
 				OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_EXECUTION_CLUSTER_LABEL).
@@ -459,12 +487,12 @@ func testProjectExecutionClusterLabelUpdate(
 }
 
 func testProjectExecutionClusterLabelUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.ProjectAttributes),
 	setup func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	executionclusterlabel.DefaultUpdateConfig = &executionclusterlabel.AttrUpdateConfig{}
 	target := newTestProjectExecutionClusterLabel()
@@ -502,10 +530,12 @@ func newTestProjectExecutionClusterLabel() *admin.ProjectAttributes {
 }
 
 func testProjectDomainExecutionClusterLabelUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectDomainAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectDomainExecutionClusterLabelUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 			s.FetcherExt.
 				OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_EXECUTION_CLUSTER_LABEL).
@@ -520,12 +550,12 @@ func testProjectDomainExecutionClusterLabelUpdate(
 }
 
 func testProjectDomainExecutionClusterLabelUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes),
 	setup func(s *testutils.TestStruct, config *executionclusterlabel.AttrUpdateConfig, target *admin.ProjectDomainAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	executionclusterlabel.DefaultUpdateConfig = &executionclusterlabel.AttrUpdateConfig{}
 	target := newTestProjectDomainExecutionClusterLabel()

--- a/flytectl/cmd/update/matchable_execution_cluster_label_test.go
+++ b/flytectl/cmd/update/matchable_execution_cluster_label_test.go
@@ -401,6 +401,8 @@ func testWorkflowExecutionClusterLabelUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	executionclusterlabel.DefaultUpdateConfig = &executionclusterlabel.AttrUpdateConfig{}
 	target := newTestWorkflowExecutionClusterLabel()
 
@@ -462,6 +464,8 @@ func testProjectExecutionClusterLabelUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	executionclusterlabel.DefaultUpdateConfig = &executionclusterlabel.AttrUpdateConfig{}
 	target := newTestProjectExecutionClusterLabel()
 
@@ -521,6 +525,8 @@ func testProjectDomainExecutionClusterLabelUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	executionclusterlabel.DefaultUpdateConfig = &executionclusterlabel.AttrUpdateConfig{}
 	target := newTestProjectDomainExecutionClusterLabel()
 

--- a/flytectl/cmd/update/matchable_execution_queue_attribute_test.go
+++ b/flytectl/cmd/update/matchable_execution_queue_attribute_test.go
@@ -401,6 +401,8 @@ func testWorkflowExecutionQueueAttributeUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	executionqueueattribute.DefaultUpdateConfig = &executionqueueattribute.AttrUpdateConfig{}
 	target := newTestWorkflowExecutionQueueAttribute()
 
@@ -533,6 +535,8 @@ func testProjectDomainExecutionQueueAttributeUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	executionqueueattribute.DefaultUpdateConfig = &executionqueueattribute.AttrUpdateConfig{}
 	target := newTestProjectDomainExecutionQueueAttribute()
 

--- a/flytectl/cmd/update/matchable_execution_queue_attribute_test.go
+++ b/flytectl/cmd/update/matchable_execution_queue_attribute_test.go
@@ -20,6 +20,7 @@ const (
 
 func TestExecutionQueueAttributeUpdateRequiresAttributeFile(t *testing.T) {
 	testWorkflowExecutionQueueAttributeUpdate(
+		t,
 		/* setup */ nil,
 		/* assert */ func(s *testutils.TestStruct, err error) {
 			assert.ErrorContains(t, err, "attrFile is mandatory")
@@ -29,6 +30,7 @@ func TestExecutionQueueAttributeUpdateRequiresAttributeFile(t *testing.T) {
 
 func TestExecutionQueueAttributeUpdateFailsWhenAttributeFileDoesNotExist(t *testing.T) {
 	testWorkflowExecutionQueueAttributeUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 			config.AttrFile = testDataNonExistentFile
 			config.Force = true
@@ -42,6 +44,7 @@ func TestExecutionQueueAttributeUpdateFailsWhenAttributeFileDoesNotExist(t *test
 
 func TestExecutionQueueAttributeUpdateFailsWhenAttributeFileIsMalformed(t *testing.T) {
 	testWorkflowExecutionQueueAttributeUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 			config.AttrFile = testDataInvalidAttrFile
 			config.Force = true
@@ -56,6 +59,7 @@ func TestExecutionQueueAttributeUpdateFailsWhenAttributeFileIsMalformed(t *testi
 func TestExecutionQueueAttributeUpdateHappyPath(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionQueueMatchableAttributesFilePath
 				config.Force = true
@@ -69,6 +73,7 @@ func TestExecutionQueueAttributeUpdateHappyPath(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainExecutionQueueMatchableAttributeFilePath
 				config.Force = true
@@ -82,6 +87,7 @@ func TestExecutionQueueAttributeUpdateHappyPath(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectExecutionQueueMatchableAttributeFilePath
 				config.Force = true
@@ -97,6 +103,7 @@ func TestExecutionQueueAttributeUpdateHappyPath(t *testing.T) {
 func TestExecutionQueueAttributeUpdateFailsWithoutForceFlag(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionQueueMatchableAttributesFilePath
 				config.Force = false
@@ -109,6 +116,7 @@ func TestExecutionQueueAttributeUpdateFailsWithoutForceFlag(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainExecutionQueueMatchableAttributeFilePath
 				config.Force = false
@@ -121,6 +129,7 @@ func TestExecutionQueueAttributeUpdateFailsWithoutForceFlag(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectExecutionQueueMatchableAttributeFilePath
 				config.Force = false
@@ -135,6 +144,7 @@ func TestExecutionQueueAttributeUpdateFailsWithoutForceFlag(t *testing.T) {
 func TestExecutionQueueAttributeUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionQueueMatchableAttributesFilePath
 				config.DryRun = true
@@ -147,6 +157,7 @@ func TestExecutionQueueAttributeUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainExecutionQueueMatchableAttributeFilePath
 				config.DryRun = true
@@ -159,6 +170,7 @@ func TestExecutionQueueAttributeUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectExecutionQueueMatchableAttributeFilePath
 				config.DryRun = true
@@ -173,6 +185,7 @@ func TestExecutionQueueAttributeUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 func TestExecutionQueueAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 	t.Run("workflow without --force", func(t *testing.T) {
 		testWorkflowExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionQueueMatchableAttributesFilePath
 				config.Force = false
@@ -186,6 +199,7 @@ func TestExecutionQueueAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("workflow with --force", func(t *testing.T) {
 		testWorkflowExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionQueueMatchableAttributesFilePath
 				config.Force = true
@@ -199,6 +213,7 @@ func TestExecutionQueueAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("domain without --force", func(t *testing.T) {
 		testProjectDomainExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainExecutionQueueMatchableAttributeFilePath
 				config.Force = false
@@ -212,6 +227,7 @@ func TestExecutionQueueAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("domain with --force", func(t *testing.T) {
 		testProjectDomainExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainExecutionQueueMatchableAttributeFilePath
 				config.Force = true
@@ -225,6 +241,7 @@ func TestExecutionQueueAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("project without --force", func(t *testing.T) {
 		testProjectExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectExecutionQueueMatchableAttributeFilePath
 				config.Force = false
@@ -238,6 +255,7 @@ func TestExecutionQueueAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("project with --force", func(t *testing.T) {
 		testProjectExecutionQueueAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectExecutionQueueMatchableAttributeFilePath
 				config.Force = true
@@ -253,6 +271,7 @@ func TestExecutionQueueAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 func TestExecutionQueueAttributeUpdateSucceedsWhenAttributesDoNotExist(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionQueueAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 				s.FetcherExt.
 					OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_EXECUTION_QUEUE).
@@ -274,6 +293,7 @@ func TestExecutionQueueAttributeUpdateSucceedsWhenAttributesDoNotExist(t *testin
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainExecutionQueueAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 				s.FetcherExt.
 					OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_EXECUTION_QUEUE).
@@ -295,6 +315,7 @@ func TestExecutionQueueAttributeUpdateSucceedsWhenAttributesDoNotExist(t *testin
 
 	t.Run("project", func(t *testing.T) {
 		testProjectExecutionQueueAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 				s.FetcherExt.
 					OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_EXECUTION_QUEUE).
@@ -318,6 +339,7 @@ func TestExecutionQueueAttributeUpdateSucceedsWhenAttributesDoNotExist(t *testin
 func TestExecutionQueueAttributeUpdateFailsWhenAdminClientFails(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionQueueAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 				s.FetcherExt.
 					OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_EXECUTION_QUEUE).
@@ -338,6 +360,7 @@ func TestExecutionQueueAttributeUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainExecutionQueueAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 				s.FetcherExt.
 					OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_EXECUTION_QUEUE).
@@ -358,6 +381,7 @@ func TestExecutionQueueAttributeUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectExecutionQueueAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 				s.FetcherExt.
 					OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_EXECUTION_QUEUE).
@@ -378,10 +402,12 @@ func TestExecutionQueueAttributeUpdateFailsWhenAdminClientFails(t *testing.T) {
 }
 
 func testWorkflowExecutionQueueAttributeUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.WorkflowAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testWorkflowExecutionQueueAttributeUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 			s.FetcherExt.
 				OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_EXECUTION_QUEUE).
@@ -396,12 +422,12 @@ func testWorkflowExecutionQueueAttributeUpdate(
 }
 
 func testWorkflowExecutionQueueAttributeUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.WorkflowAttributes),
 	setup func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.WorkflowAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	executionqueueattribute.DefaultUpdateConfig = &executionqueueattribute.AttrUpdateConfig{}
 	target := newTestWorkflowExecutionQueueAttribute()
@@ -412,7 +438,6 @@ func testWorkflowExecutionQueueAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, executionqueueattribute.DefaultUpdateConfig, target)
-		defer s.TearDown()
 	}
 
 	err := updateExecutionQueueAttributesFunc(s.Ctx, nil, s.CmdCtx)
@@ -446,10 +471,12 @@ func newTestWorkflowExecutionQueueAttribute() *admin.WorkflowAttributes {
 }
 
 func testProjectExecutionQueueAttributeUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectExecutionQueueAttributeUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 			s.FetcherExt.
 				OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_EXECUTION_QUEUE).
@@ -464,12 +491,12 @@ func testProjectExecutionQueueAttributeUpdate(
 }
 
 func testProjectExecutionQueueAttributeUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.ProjectAttributes),
 	setup func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	executionqueueattribute.DefaultUpdateConfig = &executionqueueattribute.AttrUpdateConfig{}
 	target := newTestProjectExecutionQueueAttribute()
@@ -480,7 +507,6 @@ func testProjectExecutionQueueAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, executionqueueattribute.DefaultUpdateConfig, target)
-		defer s.TearDown()
 	}
 
 	err := updateExecutionQueueAttributesFunc(s.Ctx, nil, s.CmdCtx)
@@ -512,10 +538,12 @@ func newTestProjectExecutionQueueAttribute() *admin.ProjectAttributes {
 }
 
 func testProjectDomainExecutionQueueAttributeUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectDomainExecutionQueueAttributeUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 			s.FetcherExt.
 				OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_EXECUTION_QUEUE).
@@ -530,12 +558,12 @@ func testProjectDomainExecutionQueueAttributeUpdate(
 }
 
 func testProjectDomainExecutionQueueAttributeUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes),
 	setup func(s *testutils.TestStruct, config *executionqueueattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	executionqueueattribute.DefaultUpdateConfig = &executionqueueattribute.AttrUpdateConfig{}
 	target := newTestProjectDomainExecutionQueueAttribute()
@@ -546,7 +574,6 @@ func testProjectDomainExecutionQueueAttributeUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, executionqueueattribute.DefaultUpdateConfig, target)
-		defer s.TearDown()
 	}
 
 	err := updateExecutionQueueAttributesFunc(s.Ctx, nil, s.CmdCtx)

--- a/flytectl/cmd/update/matchable_plugin_override_test.go
+++ b/flytectl/cmd/update/matchable_plugin_override_test.go
@@ -401,6 +401,8 @@ func testWorkflowPluginOverrideUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	pluginoverride.DefaultUpdateConfig = &pluginoverride.AttrUpdateConfig{}
 	target := newTestWorkflowPluginOverride()
 
@@ -472,6 +474,8 @@ func testProjectPluginOverrideUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	pluginoverride.DefaultUpdateConfig = &pluginoverride.AttrUpdateConfig{}
 	target := newTestProjectPluginOverride()
 
@@ -541,6 +545,8 @@ func testProjectDomainPluginOverrideUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	pluginoverride.DefaultUpdateConfig = &pluginoverride.AttrUpdateConfig{}
 	target := newTestProjectDomainPluginOverride()
 

--- a/flytectl/cmd/update/matchable_plugin_override_test.go
+++ b/flytectl/cmd/update/matchable_plugin_override_test.go
@@ -20,6 +20,7 @@ const (
 
 func TestPluginOverrideUpdateRequiresAttributeFile(t *testing.T) {
 	testWorkflowPluginOverrideUpdate(
+		t,
 		/* setup */ nil,
 		/* assert */ func(s *testutils.TestStruct, err error) {
 			assert.ErrorContains(t, err, "attrFile is mandatory")
@@ -29,6 +30,7 @@ func TestPluginOverrideUpdateRequiresAttributeFile(t *testing.T) {
 
 func TestPluginOverrideUpdateFailsWhenAttributeFileDoesNotExist(t *testing.T) {
 	testWorkflowPluginOverrideUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 			config.AttrFile = testDataNonExistentFile
 			config.Force = true
@@ -42,6 +44,7 @@ func TestPluginOverrideUpdateFailsWhenAttributeFileDoesNotExist(t *testing.T) {
 
 func TestPluginOverrideUpdateFailsWhenAttributeFileIsMalformed(t *testing.T) {
 	testWorkflowPluginOverrideUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 			config.AttrFile = testDataInvalidAttrFile
 			config.Force = true
@@ -56,6 +59,7 @@ func TestPluginOverrideUpdateFailsWhenAttributeFileIsMalformed(t *testing.T) {
 func TestPluginOverrideUpdateHappyPath(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowPluginOverrideFilePath
 				config.Force = true
@@ -69,6 +73,7 @@ func TestPluginOverrideUpdateHappyPath(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainPluginOverrideFilePath
 				config.Force = true
@@ -82,6 +87,7 @@ func TestPluginOverrideUpdateHappyPath(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectPluginOverrideFilePath
 				config.Force = true
@@ -97,6 +103,7 @@ func TestPluginOverrideUpdateHappyPath(t *testing.T) {
 func TestPluginOverrideUpdateFailsWithoutForceFlag(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowPluginOverrideFilePath
 				config.Force = false
@@ -109,6 +116,7 @@ func TestPluginOverrideUpdateFailsWithoutForceFlag(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainPluginOverrideFilePath
 				config.Force = false
@@ -121,6 +129,7 @@ func TestPluginOverrideUpdateFailsWithoutForceFlag(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectPluginOverrideFilePath
 				config.Force = false
@@ -135,6 +144,7 @@ func TestPluginOverrideUpdateFailsWithoutForceFlag(t *testing.T) {
 func TestPluginOverrideUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowPluginOverrideFilePath
 				config.DryRun = true
@@ -147,6 +157,7 @@ func TestPluginOverrideUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainPluginOverrideFilePath
 				config.DryRun = true
@@ -159,6 +170,7 @@ func TestPluginOverrideUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectPluginOverrideFilePath
 				config.DryRun = true
@@ -173,6 +185,7 @@ func TestPluginOverrideUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 func TestPluginOverrideUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 	t.Run("workflow without --force", func(t *testing.T) {
 		testWorkflowPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowPluginOverrideFilePath
 				config.Force = false
@@ -186,6 +199,7 @@ func TestPluginOverrideUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("workflow with --force", func(t *testing.T) {
 		testWorkflowPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowPluginOverrideFilePath
 				config.Force = true
@@ -199,6 +213,7 @@ func TestPluginOverrideUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("domain without --force", func(t *testing.T) {
 		testProjectDomainPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainPluginOverrideFilePath
 				config.Force = false
@@ -212,6 +227,7 @@ func TestPluginOverrideUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("domain with --force", func(t *testing.T) {
 		testProjectDomainPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainPluginOverrideFilePath
 				config.Force = true
@@ -225,6 +241,7 @@ func TestPluginOverrideUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("project without --force", func(t *testing.T) {
 		testProjectPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectPluginOverrideFilePath
 				config.Force = false
@@ -238,6 +255,7 @@ func TestPluginOverrideUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("project with --force", func(t *testing.T) {
 		testProjectPluginOverrideUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectPluginOverrideFilePath
 				config.Force = true
@@ -253,6 +271,7 @@ func TestPluginOverrideUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 func TestPluginOverrideUpdateSucceedsWhenAttributesDoNotExist(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowPluginOverrideUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 				s.FetcherExt.
 					OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_PLUGIN_OVERRIDE).
@@ -274,6 +293,7 @@ func TestPluginOverrideUpdateSucceedsWhenAttributesDoNotExist(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainPluginOverrideUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 				s.FetcherExt.
 					OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_PLUGIN_OVERRIDE).
@@ -295,6 +315,7 @@ func TestPluginOverrideUpdateSucceedsWhenAttributesDoNotExist(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectPluginOverrideUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 				s.FetcherExt.
 					OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_PLUGIN_OVERRIDE).
@@ -318,6 +339,7 @@ func TestPluginOverrideUpdateSucceedsWhenAttributesDoNotExist(t *testing.T) {
 func TestPluginOverrideUpdateFailsWhenAdminClientFails(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowPluginOverrideUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 				s.FetcherExt.
 					OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_PLUGIN_OVERRIDE).
@@ -338,6 +360,7 @@ func TestPluginOverrideUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainPluginOverrideUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 				s.FetcherExt.
 					OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_PLUGIN_OVERRIDE).
@@ -358,6 +381,7 @@ func TestPluginOverrideUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectPluginOverrideUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 				s.FetcherExt.
 					OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_PLUGIN_OVERRIDE).
@@ -378,10 +402,12 @@ func TestPluginOverrideUpdateFailsWhenAdminClientFails(t *testing.T) {
 }
 
 func testWorkflowPluginOverrideUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.WorkflowAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testWorkflowPluginOverrideUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 			s.FetcherExt.
 				OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_PLUGIN_OVERRIDE).
@@ -396,12 +422,12 @@ func testWorkflowPluginOverrideUpdate(
 }
 
 func testWorkflowPluginOverrideUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.WorkflowAttributes),
 	setup func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.WorkflowAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	pluginoverride.DefaultUpdateConfig = &pluginoverride.AttrUpdateConfig{}
 	target := newTestWorkflowPluginOverride()
@@ -451,10 +477,12 @@ func newTestWorkflowPluginOverride() *admin.WorkflowAttributes {
 }
 
 func testProjectPluginOverrideUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectPluginOverrideUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 			s.FetcherExt.
 				OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_PLUGIN_OVERRIDE).
@@ -469,12 +497,12 @@ func testProjectPluginOverrideUpdate(
 }
 
 func testProjectPluginOverrideUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.ProjectAttributes),
 	setup func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	pluginoverride.DefaultUpdateConfig = &pluginoverride.AttrUpdateConfig{}
 	target := newTestProjectPluginOverride()
@@ -522,10 +550,12 @@ func newTestProjectPluginOverride() *admin.ProjectAttributes {
 }
 
 func testProjectDomainPluginOverrideUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectDomainAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectDomainPluginOverrideUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 			s.FetcherExt.
 				OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_PLUGIN_OVERRIDE).
@@ -540,12 +570,12 @@ func testProjectDomainPluginOverrideUpdate(
 }
 
 func testProjectDomainPluginOverrideUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes),
 	setup func(s *testutils.TestStruct, config *pluginoverride.AttrUpdateConfig, target *admin.ProjectDomainAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	pluginoverride.DefaultUpdateConfig = &pluginoverride.AttrUpdateConfig{}
 	target := newTestProjectDomainPluginOverride()

--- a/flytectl/cmd/update/matchable_task_resource_attribute_test.go
+++ b/flytectl/cmd/update/matchable_task_resource_attribute_test.go
@@ -401,6 +401,8 @@ func testWorkflowTaskResourceAttributeUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	taskresourceattribute.DefaultUpdateConfig = &taskresourceattribute.AttrUpdateConfig{}
 	target := newTestWorkflowTaskResourceAttribute()
 
@@ -465,6 +467,8 @@ func testProjectTaskResourceAttributeUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	taskresourceattribute.DefaultUpdateConfig = &taskresourceattribute.AttrUpdateConfig{}
 	target := newTestProjectTaskResourceAttribute()
 
@@ -527,6 +531,8 @@ func testProjectDomainTaskResourceAttributeUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	taskresourceattribute.DefaultUpdateConfig = &taskresourceattribute.AttrUpdateConfig{}
 	target := newTestProjectDomainTaskResourceAttribute()
 

--- a/flytectl/cmd/update/matchable_task_resource_attribute_test.go
+++ b/flytectl/cmd/update/matchable_task_resource_attribute_test.go
@@ -20,6 +20,7 @@ const (
 
 func TestTaskResourceAttributeUpdateRequiresAttributeFile(t *testing.T) {
 	testWorkflowTaskResourceAttributeUpdate(
+		t,
 		/* setup */ nil,
 		/* assert */ func(s *testutils.TestStruct, err error) {
 			assert.ErrorContains(t, err, "attrFile is mandatory")
@@ -29,6 +30,7 @@ func TestTaskResourceAttributeUpdateRequiresAttributeFile(t *testing.T) {
 
 func TestTaskResourceAttributeUpdateFailsWhenAttributeFileDoesNotExist(t *testing.T) {
 	testWorkflowTaskResourceAttributeUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 			config.AttrFile = testDataNonExistentFile
 			config.Force = true
@@ -42,6 +44,7 @@ func TestTaskResourceAttributeUpdateFailsWhenAttributeFileDoesNotExist(t *testin
 
 func TestTaskResourceAttributeUpdateFailsWhenAttributeFileIsMalformed(t *testing.T) {
 	testWorkflowTaskResourceAttributeUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 			config.AttrFile = testDataInvalidAttrFile
 			config.Force = true
@@ -56,6 +59,7 @@ func TestTaskResourceAttributeUpdateFailsWhenAttributeFileIsMalformed(t *testing
 func TestTaskResourceAttributeUpdateHappyPath(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowTaskAttributesFilePath
 				config.Force = true
@@ -69,6 +73,7 @@ func TestTaskResourceAttributeUpdateHappyPath(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainTaskAttributesFilePath
 				config.Force = true
@@ -82,6 +87,7 @@ func TestTaskResourceAttributeUpdateHappyPath(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectTaskAttributesFilePath
 				config.Force = true
@@ -97,6 +103,7 @@ func TestTaskResourceAttributeUpdateHappyPath(t *testing.T) {
 func TestTaskResourceAttributeUpdateFailsWithoutForceFlag(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowTaskAttributesFilePath
 				config.Force = false
@@ -109,6 +116,7 @@ func TestTaskResourceAttributeUpdateFailsWithoutForceFlag(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainTaskAttributesFilePath
 				config.Force = false
@@ -121,6 +129,7 @@ func TestTaskResourceAttributeUpdateFailsWithoutForceFlag(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectTaskAttributesFilePath
 				config.Force = false
@@ -135,6 +144,7 @@ func TestTaskResourceAttributeUpdateFailsWithoutForceFlag(t *testing.T) {
 func TestTaskResourceAttributeUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowTaskAttributesFilePath
 				config.DryRun = true
@@ -147,6 +157,7 @@ func TestTaskResourceAttributeUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainTaskAttributesFilePath
 				config.DryRun = true
@@ -159,6 +170,7 @@ func TestTaskResourceAttributeUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectTaskAttributesFilePath
 				config.DryRun = true
@@ -173,6 +185,7 @@ func TestTaskResourceAttributeUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 func TestTaskResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 	t.Run("workflow without --force", func(t *testing.T) {
 		testWorkflowTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowTaskAttributesFilePath
 				config.Force = false
@@ -186,6 +199,7 @@ func TestTaskResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("workflow with --force", func(t *testing.T) {
 		testWorkflowTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowTaskAttributesFilePath
 				config.Force = true
@@ -199,6 +213,7 @@ func TestTaskResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("domain without --force", func(t *testing.T) {
 		testProjectDomainTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainTaskAttributesFilePath
 				config.Force = false
@@ -212,6 +227,7 @@ func TestTaskResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("domain with --force", func(t *testing.T) {
 		testProjectDomainTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainTaskAttributesFilePath
 				config.Force = true
@@ -225,6 +241,7 @@ func TestTaskResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("project without --force", func(t *testing.T) {
 		testProjectTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectTaskAttributesFilePath
 				config.Force = false
@@ -238,6 +255,7 @@ func TestTaskResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("project with --force", func(t *testing.T) {
 		testProjectTaskResourceAttributeUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectTaskAttributesFilePath
 				config.Force = true
@@ -253,6 +271,7 @@ func TestTaskResourceAttributeUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 func TestTaskResourceAttributeUpdateSucceedsWhenAttributesDoNotExist(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowTaskResourceAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 				s.FetcherExt.
 					OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_TASK_RESOURCE).
@@ -274,6 +293,7 @@ func TestTaskResourceAttributeUpdateSucceedsWhenAttributesDoNotExist(t *testing.
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainTaskResourceAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 				s.FetcherExt.
 					OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_TASK_RESOURCE).
@@ -295,6 +315,7 @@ func TestTaskResourceAttributeUpdateSucceedsWhenAttributesDoNotExist(t *testing.
 
 	t.Run("project", func(t *testing.T) {
 		testProjectTaskResourceAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 				s.FetcherExt.
 					OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_TASK_RESOURCE).
@@ -318,6 +339,7 @@ func TestTaskResourceAttributeUpdateSucceedsWhenAttributesDoNotExist(t *testing.
 func TestTaskResourceAttributeUpdateFailsWhenAdminClientFails(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowTaskResourceAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 				s.FetcherExt.
 					OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_TASK_RESOURCE).
@@ -338,6 +360,7 @@ func TestTaskResourceAttributeUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainTaskResourceAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 				s.FetcherExt.
 					OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_TASK_RESOURCE).
@@ -358,6 +381,7 @@ func TestTaskResourceAttributeUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectTaskResourceAttributeUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 				s.FetcherExt.
 					OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_TASK_RESOURCE).
@@ -378,10 +402,12 @@ func TestTaskResourceAttributeUpdateFailsWhenAdminClientFails(t *testing.T) {
 }
 
 func testWorkflowTaskResourceAttributeUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testWorkflowTaskResourceAttributeUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 			s.FetcherExt.
 				OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_TASK_RESOURCE).
@@ -396,12 +422,12 @@ func testWorkflowTaskResourceAttributeUpdate(
 }
 
 func testWorkflowTaskResourceAttributeUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.WorkflowAttributes),
 	setup func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.WorkflowAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	taskresourceattribute.DefaultUpdateConfig = &taskresourceattribute.AttrUpdateConfig{}
 	target := newTestWorkflowTaskResourceAttribute()
@@ -444,10 +470,12 @@ func newTestWorkflowTaskResourceAttribute() *admin.WorkflowAttributes {
 }
 
 func testProjectTaskResourceAttributeUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectTaskResourceAttributeUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 			s.FetcherExt.
 				OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_TASK_RESOURCE).
@@ -462,12 +490,12 @@ func testProjectTaskResourceAttributeUpdate(
 }
 
 func testProjectTaskResourceAttributeUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.ProjectAttributes),
 	setup func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	taskresourceattribute.DefaultUpdateConfig = &taskresourceattribute.AttrUpdateConfig{}
 	target := newTestProjectTaskResourceAttribute()
@@ -508,10 +536,12 @@ func newTestProjectTaskResourceAttribute() *admin.ProjectAttributes {
 }
 
 func testProjectDomainTaskResourceAttributeUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectDomainTaskResourceAttributeUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 			s.FetcherExt.
 				OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_TASK_RESOURCE).
@@ -526,12 +556,12 @@ func testProjectDomainTaskResourceAttributeUpdate(
 }
 
 func testProjectDomainTaskResourceAttributeUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes),
 	setup func(s *testutils.TestStruct, config *taskresourceattribute.AttrUpdateConfig, target *admin.ProjectDomainAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	taskresourceattribute.DefaultUpdateConfig = &taskresourceattribute.AttrUpdateConfig{}
 	target := newTestProjectDomainTaskResourceAttribute()

--- a/flytectl/cmd/update/matchable_workflow_execution_config_test.go
+++ b/flytectl/cmd/update/matchable_workflow_execution_config_test.go
@@ -20,6 +20,7 @@ const (
 
 func TestWorkflowExecutionConfigUpdateRequiresAttributeFile(t *testing.T) {
 	testWorkflowExecutionConfigUpdate(
+		t,
 		/* setup */ nil,
 		/* assert */ func(s *testutils.TestStruct, err error) {
 			assert.ErrorContains(t, err, "attrFile is mandatory")
@@ -29,6 +30,7 @@ func TestWorkflowExecutionConfigUpdateRequiresAttributeFile(t *testing.T) {
 
 func TestWorkflowExecutionConfigUpdateFailsWhenAttributeFileDoesNotExist(t *testing.T) {
 	testWorkflowExecutionConfigUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 			config.AttrFile = testDataNonExistentFile
 			config.Force = true
@@ -42,6 +44,7 @@ func TestWorkflowExecutionConfigUpdateFailsWhenAttributeFileDoesNotExist(t *test
 
 func TestWorkflowExecutionConfigUpdateFailsWhenAttributeFileIsMalformed(t *testing.T) {
 	testWorkflowExecutionConfigUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 			config.AttrFile = testDataInvalidAttrFile
 			config.Force = true
@@ -56,6 +59,7 @@ func TestWorkflowExecutionConfigUpdateFailsWhenAttributeFileIsMalformed(t *testi
 func TestWorkflowExecutionConfigUpdateHappyPath(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionConfigFilePath
 				config.Force = true
@@ -69,6 +73,7 @@ func TestWorkflowExecutionConfigUpdateHappyPath(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainWorkflowExecutionConfigFilePath
 				config.Force = true
@@ -82,6 +87,7 @@ func TestWorkflowExecutionConfigUpdateHappyPath(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectWorkflowExecutionConfigFilePath
 				config.Force = true
@@ -97,6 +103,7 @@ func TestWorkflowExecutionConfigUpdateHappyPath(t *testing.T) {
 func TestWorkflowExecutionConfigUpdateFailsWithoutForceFlag(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionConfigFilePath
 				config.Force = false
@@ -109,6 +116,7 @@ func TestWorkflowExecutionConfigUpdateFailsWithoutForceFlag(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainWorkflowExecutionConfigFilePath
 				config.Force = false
@@ -121,6 +129,7 @@ func TestWorkflowExecutionConfigUpdateFailsWithoutForceFlag(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectWorkflowExecutionConfigFilePath
 				config.Force = false
@@ -135,6 +144,7 @@ func TestWorkflowExecutionConfigUpdateFailsWithoutForceFlag(t *testing.T) {
 func TestWorkflowExecutionConfigUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionConfigFilePath
 				config.DryRun = true
@@ -147,6 +157,7 @@ func TestWorkflowExecutionConfigUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainWorkflowExecutionConfigFilePath
 				config.DryRun = true
@@ -159,6 +170,7 @@ func TestWorkflowExecutionConfigUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectWorkflowExecutionConfigFilePath
 				config.DryRun = true
@@ -173,6 +185,7 @@ func TestWorkflowExecutionConfigUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 func TestWorkflowExecutionConfigUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 	t.Run("workflow without --force", func(t *testing.T) {
 		testWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionConfigFilePath
 				config.Force = false
@@ -186,6 +199,7 @@ func TestWorkflowExecutionConfigUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("workflow with --force", func(t *testing.T) {
 		testWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.WorkflowAttributes) {
 				config.AttrFile = validWorkflowExecutionConfigFilePath
 				config.Force = true
@@ -199,6 +213,7 @@ func TestWorkflowExecutionConfigUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("domain without --force", func(t *testing.T) {
 		testProjectDomainWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainWorkflowExecutionConfigFilePath
 				config.Force = false
@@ -212,6 +227,7 @@ func TestWorkflowExecutionConfigUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("domain with --force", func(t *testing.T) {
 		testProjectDomainWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectDomainAttributes) {
 				config.AttrFile = validProjectDomainWorkflowExecutionConfigFilePath
 				config.Force = true
@@ -225,6 +241,7 @@ func TestWorkflowExecutionConfigUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("project without --force", func(t *testing.T) {
 		testProjectWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectWorkflowExecutionConfigFilePath
 				config.Force = false
@@ -238,6 +255,7 @@ func TestWorkflowExecutionConfigUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 
 	t.Run("project with --force", func(t *testing.T) {
 		testProjectWorkflowExecutionConfigUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectAttributes) {
 				config.AttrFile = validProjectWorkflowExecutionConfigFilePath
 				config.Force = true
@@ -253,6 +271,7 @@ func TestWorkflowExecutionConfigUpdateIgnoresForceFlagWithDryRun(t *testing.T) {
 func TestWorkflowExecutionConfigUpdateSucceedsWhenAttributesDoNotExist(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionConfigUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 				s.FetcherExt.
 					OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG).
@@ -274,6 +293,7 @@ func TestWorkflowExecutionConfigUpdateSucceedsWhenAttributesDoNotExist(t *testin
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainWorkflowExecutionConfigUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 				s.FetcherExt.
 					OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG).
@@ -295,6 +315,7 @@ func TestWorkflowExecutionConfigUpdateSucceedsWhenAttributesDoNotExist(t *testin
 
 	t.Run("project", func(t *testing.T) {
 		testProjectWorkflowExecutionConfigUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 				s.FetcherExt.
 					OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG).
@@ -318,6 +339,7 @@ func TestWorkflowExecutionConfigUpdateSucceedsWhenAttributesDoNotExist(t *testin
 func TestWorkflowExecutionConfigUpdateFailsWhenAdminClientFails(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		testWorkflowExecutionConfigUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 				s.FetcherExt.
 					OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG).
@@ -338,6 +360,7 @@ func TestWorkflowExecutionConfigUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		testProjectDomainWorkflowExecutionConfigUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 				s.FetcherExt.
 					OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG).
@@ -358,6 +381,7 @@ func TestWorkflowExecutionConfigUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 	t.Run("project", func(t *testing.T) {
 		testProjectWorkflowExecutionConfigUpdateWithMockSetup(
+			t,
 			/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 				s.FetcherExt.
 					OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG).
@@ -378,10 +402,12 @@ func TestWorkflowExecutionConfigUpdateFailsWhenAdminClientFails(t *testing.T) {
 }
 
 func testWorkflowExecutionConfigUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.WorkflowAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testWorkflowExecutionConfigUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.WorkflowAttributes) {
 			s.FetcherExt.
 				OnFetchWorkflowAttributesMatch(s.Ctx, target.Project, target.Domain, target.Workflow, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG).
@@ -396,12 +422,12 @@ func testWorkflowExecutionConfigUpdate(
 }
 
 func testWorkflowExecutionConfigUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.WorkflowAttributes),
 	setup func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.WorkflowAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	workflowexecutionconfig.DefaultUpdateConfig = &workflowexecutionconfig.AttrUpdateConfig{}
 	target := newTestWorkflowExecutionConfig()
@@ -448,10 +474,12 @@ func newTestWorkflowExecutionConfig() *admin.WorkflowAttributes {
 }
 
 func testProjectWorkflowExecutionConfigUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectWorkflowExecutionConfigUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectAttributes) {
 			s.FetcherExt.
 				OnFetchProjectAttributesMatch(s.Ctx, target.Project, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG).
@@ -466,12 +494,12 @@ func testProjectWorkflowExecutionConfigUpdate(
 }
 
 func testProjectWorkflowExecutionConfigUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.ProjectAttributes),
 	setup func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	workflowexecutionconfig.DefaultUpdateConfig = &workflowexecutionconfig.AttrUpdateConfig{}
 	target := newTestProjectWorkflowExecutionConfig()
@@ -516,10 +544,12 @@ func newTestProjectWorkflowExecutionConfig() *admin.ProjectAttributes {
 }
 
 func testProjectDomainWorkflowExecutionConfigUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectDomainAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectDomainWorkflowExecutionConfigUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes) {
 			s.FetcherExt.
 				OnFetchProjectDomainAttributesMatch(s.Ctx, target.Project, target.Domain, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG).
@@ -534,12 +564,12 @@ func testProjectDomainWorkflowExecutionConfigUpdate(
 }
 
 func testProjectDomainWorkflowExecutionConfigUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, target *admin.ProjectDomainAttributes),
 	setup func(s *testutils.TestStruct, config *workflowexecutionconfig.AttrUpdateConfig, target *admin.ProjectDomainAttributes),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	workflowexecutionconfig.DefaultUpdateConfig = &workflowexecutionconfig.AttrUpdateConfig{}
 	target := newTestProjectDomainWorkflowExecutionConfig()

--- a/flytectl/cmd/update/matchable_workflow_execution_config_test.go
+++ b/flytectl/cmd/update/matchable_workflow_execution_config_test.go
@@ -401,6 +401,8 @@ func testWorkflowExecutionConfigUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	workflowexecutionconfig.DefaultUpdateConfig = &workflowexecutionconfig.AttrUpdateConfig{}
 	target := newTestWorkflowExecutionConfig()
 
@@ -469,6 +471,8 @@ func testProjectWorkflowExecutionConfigUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	workflowexecutionconfig.DefaultUpdateConfig = &workflowexecutionconfig.AttrUpdateConfig{}
 	target := newTestProjectWorkflowExecutionConfig()
 
@@ -535,6 +539,8 @@ func testProjectDomainWorkflowExecutionConfigUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	workflowexecutionconfig.DefaultUpdateConfig = &workflowexecutionconfig.AttrUpdateConfig{}
 	target := newTestProjectDomainWorkflowExecutionConfig()
 

--- a/flytectl/cmd/update/named_entity_test.go
+++ b/flytectl/cmd/update/named_entity_test.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"fmt"
+	"testing"
 
 	"github.com/flyteorg/flyte/flytectl/cmd/config"
 	cmdCore "github.com/flyteorg/flyte/flytectl/cmd/core"
@@ -13,11 +14,13 @@ import (
 )
 
 func testNamedEntityUpdate(
+	t *testing.T,
 	resourceType core.ResourceType,
 	setup func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testNamedEntityUpdateWithMockSetup(
+		t,
 		resourceType,
 		/* mockSetup */ func(s *testutils.TestStruct, namedEntity *admin.NamedEntity) {
 			s.MockAdminClient.
@@ -35,13 +38,13 @@ func testNamedEntityUpdate(
 }
 
 func testNamedEntityUpdateWithMockSetup(
+	t *testing.T,
 	resourceType core.ResourceType,
 	mockSetup func(s *testutils.TestStruct, namedEntity *admin.NamedEntity),
 	setup func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	config := &NamedEntityConfig{}
 	target := newTestNamedEntity(resourceType)
@@ -52,7 +55,6 @@ func testNamedEntityUpdateWithMockSetup(
 
 	if setup != nil {
 		setup(&s, config, target)
-		defer s.TearDown()
 	}
 
 	updateMetadataFactory := getUpdateMetadataFactory(resourceType)

--- a/flytectl/cmd/update/project_test.go
+++ b/flytectl/cmd/update/project_test.go
@@ -226,6 +226,8 @@ func testProjectUpdateWithMockSetup(
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	target := newTestProject()
 
 	if mockSetup != nil {

--- a/flytectl/cmd/update/project_test.go
+++ b/flytectl/cmd/update/project_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestProjectCanBeActivated(t *testing.T) {
 	testProjectUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *project.ConfigProject, project *admin.Project) {
 			project.State = admin.Project_ARCHIVED
 			config.Activate = true
@@ -33,6 +34,7 @@ func TestProjectCanBeActivated(t *testing.T) {
 
 func TestProjectCanBeArchived(t *testing.T) {
 	testProjectUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *project.ConfigProject, project *admin.Project) {
 			project.State = admin.Project_ACTIVE
 			config.Archive = true
@@ -51,6 +53,7 @@ func TestProjectCanBeArchived(t *testing.T) {
 
 func TestProjectCannotBeActivatedAndArchivedAtTheSameTime(t *testing.T) {
 	testProjectUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *project.ConfigProject, project *admin.Project) {
 			config.Activate = true
 			config.Archive = true
@@ -63,6 +66,7 @@ func TestProjectCannotBeActivatedAndArchivedAtTheSameTime(t *testing.T) {
 
 func TestProjectUpdateDoesNothingWhenThereAreNoChanges(t *testing.T) {
 	testProjectUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *project.ConfigProject, project *admin.Project) {
 			project.State = admin.Project_ACTIVE
 			config.Activate = true
@@ -76,6 +80,7 @@ func TestProjectUpdateDoesNothingWhenThereAreNoChanges(t *testing.T) {
 
 func TestProjectUpdateWithoutForceFlagFails(t *testing.T) {
 	testProjectUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *project.ConfigProject, project *admin.Project) {
 			project.State = admin.Project_ARCHIVED
 			config.Activate = true
@@ -89,6 +94,7 @@ func TestProjectUpdateWithoutForceFlagFails(t *testing.T) {
 
 func TestProjectUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 	testProjectUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *project.ConfigProject, project *admin.Project) {
 			project.State = admin.Project_ARCHIVED
 			config.Activate = true
@@ -103,6 +109,7 @@ func TestProjectUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 func TestForceFlagIsIgnoredWithDryRunDuringProjectUpdate(t *testing.T) {
 	t.Run("without --force", func(t *testing.T) {
 		testProjectUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *project.ConfigProject, project *admin.Project) {
 				project.State = admin.Project_ARCHIVED
 				config.Activate = true
@@ -118,6 +125,7 @@ func TestForceFlagIsIgnoredWithDryRunDuringProjectUpdate(t *testing.T) {
 
 	t.Run("with --force", func(t *testing.T) {
 		testProjectUpdate(
+			t,
 			/* setup */ func(s *testutils.TestStruct, config *project.ConfigProject, project *admin.Project) {
 				project.State = admin.Project_ARCHIVED
 				config.Activate = true
@@ -134,6 +142,7 @@ func TestForceFlagIsIgnoredWithDryRunDuringProjectUpdate(t *testing.T) {
 
 func TestProjectUpdateFailsWhenProjectDoesNotExist(t *testing.T) {
 	testProjectUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, project *admin.Project) {
 			s.FetcherExt.
 				OnGetProjectByID(s.Ctx, project.Id).
@@ -152,6 +161,7 @@ func TestProjectUpdateFailsWhenProjectDoesNotExist(t *testing.T) {
 
 func TestProjectUpdateFailsWhenAdminClientFails(t *testing.T) {
 	testProjectUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, project *admin.Project) {
 			s.FetcherExt.
 				OnGetProjectByID(s.Ctx, project.Id).
@@ -174,6 +184,7 @@ func TestProjectUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 func TestProjectUpdateRequiresProjectId(t *testing.T) {
 	testProjectUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *project.ConfigProject, project *admin.Project) {
 			config.ID = ""
 		},
@@ -184,6 +195,7 @@ func TestProjectUpdateRequiresProjectId(t *testing.T) {
 
 func TestProjectUpdateDoesNotActivateArchivedProject(t *testing.T) {
 	testProjectUpdate(
+		t,
 		/* setup */ func(s *testutils.TestStruct, config *project.ConfigProject, project *admin.Project) {
 			project.State = admin.Project_ARCHIVED
 			config.Activate = false
@@ -203,10 +215,12 @@ func TestProjectUpdateDoesNotActivateArchivedProject(t *testing.T) {
 }
 
 func testProjectUpdate(
+	t *testing.T,
 	setup func(s *testutils.TestStruct, config *project.ConfigProject, project *admin.Project),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
 	testProjectUpdateWithMockSetup(
+		t,
 		/* mockSetup */ func(s *testutils.TestStruct, project *admin.Project) {
 			s.FetcherExt.
 				OnGetProjectByID(s.Ctx, project.Id).
@@ -221,12 +235,12 @@ func testProjectUpdate(
 }
 
 func testProjectUpdateWithMockSetup(
+	t *testing.T,
 	mockSetup func(s *testutils.TestStruct, project *admin.Project),
 	setup func(s *testutils.TestStruct, config *project.ConfigProject, project *admin.Project),
 	asserter func(s *testutils.TestStruct, err error),
 ) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	target := newTestProject()
 

--- a/flytectl/cmd/update/task_meta_test.go
+++ b/flytectl/cmd/update/task_meta_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTaskMetadataCanBeActivated(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_TASK,
+	testNamedEntityUpdate(t, core.ResourceType_TASK,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 			config.Activate = true
@@ -31,7 +31,7 @@ func TestTaskMetadataCanBeActivated(t *testing.T) {
 }
 
 func TestTaskMetadataCanBeArchived(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_TASK,
+	testNamedEntityUpdate(t, core.ResourceType_TASK,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ACTIVE
 			config.Archive = true
@@ -49,7 +49,7 @@ func TestTaskMetadataCanBeArchived(t *testing.T) {
 }
 
 func TestTaskMetadataCannotBeActivatedAndArchivedAtTheSameTime(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_TASK,
+	testNamedEntityUpdate(t, core.ResourceType_TASK,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			config.Activate = true
 			config.Archive = true
@@ -61,7 +61,7 @@ func TestTaskMetadataCannotBeActivatedAndArchivedAtTheSameTime(t *testing.T) {
 }
 
 func TestTaskMetadataUpdateDoesNothingWhenThereAreNoChanges(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_TASK,
+	testNamedEntityUpdate(t, core.ResourceType_TASK,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ACTIVE
 			config.Activate = true
@@ -74,7 +74,7 @@ func TestTaskMetadataUpdateDoesNothingWhenThereAreNoChanges(t *testing.T) {
 }
 
 func TestTaskMetadataUpdateWithoutForceFlagFails(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_TASK,
+	testNamedEntityUpdate(t, core.ResourceType_TASK,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 			config.Activate = true
@@ -87,7 +87,7 @@ func TestTaskMetadataUpdateWithoutForceFlagFails(t *testing.T) {
 }
 
 func TestTaskMetadataUpdateDoesNothingWithDryRunFlag(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_TASK,
+	testNamedEntityUpdate(t, core.ResourceType_TASK,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 			config.Activate = true
@@ -101,7 +101,7 @@ func TestTaskMetadataUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 func TestForceFlagIsIgnoredWithDryRunDuringTaskMetadataUpdate(t *testing.T) {
 	t.Run("without --force", func(t *testing.T) {
-		testNamedEntityUpdate(core.ResourceType_TASK,
+		testNamedEntityUpdate(t, core.ResourceType_TASK,
 			/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 				namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 				config.Activate = true
@@ -116,7 +116,7 @@ func TestForceFlagIsIgnoredWithDryRunDuringTaskMetadataUpdate(t *testing.T) {
 	})
 
 	t.Run("with --force", func(t *testing.T) {
-		testNamedEntityUpdate(core.ResourceType_TASK,
+		testNamedEntityUpdate(t, core.ResourceType_TASK,
 			/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 				namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 				config.Activate = true
@@ -133,6 +133,7 @@ func TestForceFlagIsIgnoredWithDryRunDuringTaskMetadataUpdate(t *testing.T) {
 
 func TestTaskMetadataUpdateFailsWhenTaskDoesNotExist(t *testing.T) {
 	testNamedEntityUpdateWithMockSetup(
+		t,
 		core.ResourceType_TASK,
 		/* mockSetup */ func(s *testutils.TestStruct, namedEntity *admin.NamedEntity) {
 			s.MockAdminClient.
@@ -154,6 +155,7 @@ func TestTaskMetadataUpdateFailsWhenTaskDoesNotExist(t *testing.T) {
 
 func TestTaskMetadataUpdateFailsWhenAdminClientFails(t *testing.T) {
 	testNamedEntityUpdateWithMockSetup(
+		t,
 		core.ResourceType_TASK,
 		/* mockSetup */ func(s *testutils.TestStruct, namedEntity *admin.NamedEntity) {
 			s.MockAdminClient.
@@ -178,8 +180,7 @@ func TestTaskMetadataUpdateFailsWhenAdminClientFails(t *testing.T) {
 }
 
 func TestTaskMetadataUpdateRequiresTaskName(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	config := &NamedEntityConfig{}
 

--- a/flytectl/cmd/update/workflow_meta_test.go
+++ b/flytectl/cmd/update/workflow_meta_test.go
@@ -179,6 +179,8 @@ func TestWorkflowMetadataUpdateFailsWhenAdminClientFails(t *testing.T) {
 
 func TestWorkflowMetadataUpdateRequiresWorkflowName(t *testing.T) {
 	s := testutils.Setup()
+	defer s.TearDown()
+
 	config := &NamedEntityConfig{}
 
 	err := getUpdateWorkflowFunc(config)(s.Ctx, nil, s.CmdCtx)

--- a/flytectl/cmd/update/workflow_meta_test.go
+++ b/flytectl/cmd/update/workflow_meta_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestWorkflowMetadataCanBeActivated(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_WORKFLOW,
+	testNamedEntityUpdate(
+		t,
+		core.ResourceType_WORKFLOW,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 			config.Activate = true
@@ -31,7 +33,9 @@ func TestWorkflowMetadataCanBeActivated(t *testing.T) {
 }
 
 func TestWorkflowMetadataCanBeArchived(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_WORKFLOW,
+	testNamedEntityUpdate(
+		t,
+		core.ResourceType_WORKFLOW,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ACTIVE
 			config.Archive = true
@@ -49,7 +53,9 @@ func TestWorkflowMetadataCanBeArchived(t *testing.T) {
 }
 
 func TestWorkflowMetadataCannotBeActivatedAndArchivedAtTheSameTime(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_WORKFLOW,
+	testNamedEntityUpdate(
+		t,
+		core.ResourceType_WORKFLOW,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			config.Activate = true
 			config.Archive = true
@@ -61,7 +67,9 @@ func TestWorkflowMetadataCannotBeActivatedAndArchivedAtTheSameTime(t *testing.T)
 }
 
 func TestWorkflowMetadataUpdateDoesNothingWhenThereAreNoChanges(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_WORKFLOW,
+	testNamedEntityUpdate(
+		t,
+		core.ResourceType_WORKFLOW,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ACTIVE
 			config.Activate = true
@@ -74,7 +82,9 @@ func TestWorkflowMetadataUpdateDoesNothingWhenThereAreNoChanges(t *testing.T) {
 }
 
 func TestWorkflowMetadataUpdateWithoutForceFlagFails(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_WORKFLOW,
+	testNamedEntityUpdate(
+		t,
+		core.ResourceType_WORKFLOW,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 			config.Activate = true
@@ -87,7 +97,9 @@ func TestWorkflowMetadataUpdateWithoutForceFlagFails(t *testing.T) {
 }
 
 func TestWorkflowMetadataUpdateDoesNothingWithDryRunFlag(t *testing.T) {
-	testNamedEntityUpdate(core.ResourceType_WORKFLOW,
+	testNamedEntityUpdate(
+		t,
+		core.ResourceType_WORKFLOW,
 		/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 			namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 			config.Activate = true
@@ -101,7 +113,9 @@ func TestWorkflowMetadataUpdateDoesNothingWithDryRunFlag(t *testing.T) {
 
 func TestForceFlagIsIgnoredWithDryRunDuringWorkflowMetadataUpdate(t *testing.T) {
 	t.Run("without --force", func(t *testing.T) {
-		testNamedEntityUpdate(core.ResourceType_WORKFLOW,
+		testNamedEntityUpdate(
+			t,
+			core.ResourceType_WORKFLOW,
 			/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 				namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 				config.Activate = true
@@ -116,7 +130,9 @@ func TestForceFlagIsIgnoredWithDryRunDuringWorkflowMetadataUpdate(t *testing.T) 
 	})
 
 	t.Run("with --force", func(t *testing.T) {
-		testNamedEntityUpdate(core.ResourceType_WORKFLOW,
+		testNamedEntityUpdate(
+			t,
+			core.ResourceType_WORKFLOW,
 			/* setup */ func(s *testutils.TestStruct, config *NamedEntityConfig, namedEntity *admin.NamedEntity) {
 				namedEntity.Metadata.State = admin.NamedEntityState_NAMED_ENTITY_ARCHIVED
 				config.Activate = true
@@ -133,6 +149,7 @@ func TestForceFlagIsIgnoredWithDryRunDuringWorkflowMetadataUpdate(t *testing.T) 
 
 func TestWorkflowMetadataUpdateFailsWhenWorkflowDoesNotExist(t *testing.T) {
 	testNamedEntityUpdateWithMockSetup(
+		t,
 		core.ResourceType_WORKFLOW,
 		/* mockSetup */ func(s *testutils.TestStruct, namedEntity *admin.NamedEntity) {
 			s.MockAdminClient.
@@ -154,6 +171,7 @@ func TestWorkflowMetadataUpdateFailsWhenWorkflowDoesNotExist(t *testing.T) {
 
 func TestWorkflowMetadataUpdateFailsWhenAdminClientFails(t *testing.T) {
 	testNamedEntityUpdateWithMockSetup(
+		t,
 		core.ResourceType_WORKFLOW,
 		/* mockSetup */ func(s *testutils.TestStruct, namedEntity *admin.NamedEntity) {
 			s.MockAdminClient.
@@ -178,8 +196,7 @@ func TestWorkflowMetadataUpdateFailsWhenAdminClientFails(t *testing.T) {
 }
 
 func TestWorkflowMetadataUpdateRequiresWorkflowName(t *testing.T) {
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 
 	config := &NamedEntityConfig{}
 

--- a/flytectl/cmd/upgrade/upgrade_test.go
+++ b/flytectl/cmd/upgrade/upgrade_test.go
@@ -105,6 +105,8 @@ func TestSelfUpgrade(t *testing.T) {
 	goos = platformutil.Linux
 	t.Run("Successful upgrade", func(t *testing.T) {
 		s := testutils.Setup()
+		defer s.TearDown()
+
 		stdlibversion.Build = ""
 		stdlibversion.BuildTime = ""
 		stdlibversion.Version = version
@@ -119,6 +121,8 @@ func TestSelfUpgradeError(t *testing.T) {
 	goos = platformutil.Linux
 	t.Run("Successful upgrade", func(t *testing.T) {
 		s := testutils.Setup()
+		defer s.TearDown()
+
 		stdlibversion.Build = ""
 		stdlibversion.BuildTime = ""
 		stdlibversion.Version = "v"
@@ -134,6 +138,8 @@ func TestSelfUpgradeRollback(t *testing.T) {
 	goos = platformutil.Linux
 	t.Run("Successful rollback", func(t *testing.T) {
 		s := testutils.Setup()
+		defer s.TearDown()
+
 		var args = []string{rollBackSubCommand}
 		stdlibversion.Build = ""
 		stdlibversion.BuildTime = ""
@@ -143,6 +149,8 @@ func TestSelfUpgradeRollback(t *testing.T) {
 
 	t.Run("Successful rollback failed", func(t *testing.T) {
 		s := testutils.Setup()
+		defer s.TearDown()
+
 		var args = []string{rollBackSubCommand}
 		stdlibversion.Build = ""
 		stdlibversion.BuildTime = ""
@@ -152,6 +160,8 @@ func TestSelfUpgradeRollback(t *testing.T) {
 
 	t.Run("Successful rollback for windows", func(t *testing.T) {
 		s := testutils.Setup()
+		defer s.TearDown()
+
 		var args = []string{rollBackSubCommand}
 		stdlibversion.Build = ""
 		stdlibversion.BuildTime = ""
@@ -162,6 +172,8 @@ func TestSelfUpgradeRollback(t *testing.T) {
 
 	t.Run("Successful rollback for windows", func(t *testing.T) {
 		s := testutils.Setup()
+		defer s.TearDown()
+
 		var args = []string{rollBackSubCommand}
 		stdlibversion.Build = ""
 		stdlibversion.BuildTime = ""

--- a/flytectl/cmd/upgrade/upgrade_test.go
+++ b/flytectl/cmd/upgrade/upgrade_test.go
@@ -104,8 +104,7 @@ func TestSelfUpgrade(t *testing.T) {
 	github.FlytectlReleaseConfig.OverrideExecutable = tempExt
 	goos = platformutil.Linux
 	t.Run("Successful upgrade", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		stdlibversion.Build = ""
 		stdlibversion.BuildTime = ""
@@ -120,8 +119,7 @@ func TestSelfUpgradeError(t *testing.T) {
 	github.FlytectlReleaseConfig.OverrideExecutable = tempExt
 	goos = platformutil.Linux
 	t.Run("Successful upgrade", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		stdlibversion.Build = ""
 		stdlibversion.BuildTime = ""
@@ -137,8 +135,7 @@ func TestSelfUpgradeRollback(t *testing.T) {
 	github.FlytectlReleaseConfig.OverrideExecutable = tempExt
 	goos = platformutil.Linux
 	t.Run("Successful rollback", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		var args = []string{rollBackSubCommand}
 		stdlibversion.Build = ""
@@ -148,8 +145,7 @@ func TestSelfUpgradeRollback(t *testing.T) {
 	})
 
 	t.Run("Successful rollback failed", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		var args = []string{rollBackSubCommand}
 		stdlibversion.Build = ""
@@ -159,8 +155,7 @@ func TestSelfUpgradeRollback(t *testing.T) {
 	})
 
 	t.Run("Successful rollback for windows", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		var args = []string{rollBackSubCommand}
 		stdlibversion.Build = ""
@@ -171,8 +166,7 @@ func TestSelfUpgradeRollback(t *testing.T) {
 	})
 
 	t.Run("Successful rollback for windows", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 
 		var args = []string{rollBackSubCommand}
 		stdlibversion.Build = ""

--- a/flytectl/cmd/version/version_test.go
+++ b/flytectl/cmd/version/version_test.go
@@ -54,8 +54,7 @@ func TestVersionCommand(t *testing.T) {
 
 func TestVersionCommandFunc(t *testing.T) {
 	ctx := context.Background()
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 	stdlibversion.Build = ""
 	stdlibversion.BuildTime = ""
 	stdlibversion.Version = testVersion
@@ -67,8 +66,7 @@ func TestVersionCommandFunc(t *testing.T) {
 
 func TestVersionCommandFuncError(t *testing.T) {
 	ctx := context.Background()
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 	stdlibversion.Build = ""
 	stdlibversion.BuildTime = ""
 	stdlibversion.Version = "v"
@@ -80,8 +78,7 @@ func TestVersionCommandFuncError(t *testing.T) {
 
 func TestVersionCommandFuncErr(t *testing.T) {
 	ctx := context.Background()
-	s := testutils.Setup()
-	defer s.TearDown()
+	s := testutils.Setup(t)
 	stdlibversion.Build = ""
 	stdlibversion.BuildTime = ""
 	stdlibversion.Version = testVersion

--- a/flytectl/pkg/sandbox/status_test.go
+++ b/flytectl/pkg/sandbox/status_test.go
@@ -14,15 +14,13 @@ import (
 func TestSandboxStatus(t *testing.T) {
 	t.Run("Sandbox status with zero result", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		mockDocker.OnContainerList(s.Ctx, container.ListOptions{All: true}).Return([]types.Container{}, nil)
 		err := PrintStatus(s.Ctx, mockDocker)
 		assert.Nil(t, err)
 	})
 	t.Run("Sandbox status with running sandbox", func(t *testing.T) {
-		s := testutils.Setup()
-		defer s.TearDown()
+		s := testutils.Setup(t)
 		ctx := s.Ctx
 		mockDocker := &mocks.Docker{}
 		mockDocker.OnContainerList(ctx, container.ListOptions{All: true}).Return([]types.Container{

--- a/flytepropeller/pkg/controller/nodes/executor.go
+++ b/flytepropeller/pkg/controller/nodes/executor.go
@@ -754,8 +754,16 @@ func (c *nodeExecutor) preExecute(ctx context.Context, dag executors.DAGStructur
 			dataDir := nodeStatus.GetDataDir()
 			t := c.metrics.NodeInputGatherLatency.Start(ctx)
 			defer t.Stop()
-			// Can execute
 			var err error
+			taskTemplate, err := nCtx.TaskReader().Read(ctx)
+			if err != nil {
+				c.metrics.ResolutionFailure.Inc(ctx)
+				logger.Warningf(ctx, "Failed to read task template for Node. Error [%v]", err)
+				return handler.PhaseInfoFailure(core.ExecutionError_SYSTEM, "TaskTemplateReadFailure", err.Error(), nil), nil
+			}
+			inputsInterface := taskTemplate.Interface.Inputs
+			inputsInterface["abc"].Type
+			// Can execute
 			nodeInputs, err = Resolve(ctx, c.outputResolver, nCtx.ContextualNodeLookup(), node.GetID(), node.GetInputBindings())
 			// TODO we need to handle retryable, network errors here!!
 			if err != nil {

--- a/flytepropeller/pkg/controller/nodes/executor.go
+++ b/flytepropeller/pkg/controller/nodes/executor.go
@@ -754,16 +754,8 @@ func (c *nodeExecutor) preExecute(ctx context.Context, dag executors.DAGStructur
 			dataDir := nodeStatus.GetDataDir()
 			t := c.metrics.NodeInputGatherLatency.Start(ctx)
 			defer t.Stop()
-			var err error
-			taskTemplate, err := nCtx.TaskReader().Read(ctx)
-			if err != nil {
-				c.metrics.ResolutionFailure.Inc(ctx)
-				logger.Warningf(ctx, "Failed to read task template for Node. Error [%v]", err)
-				return handler.PhaseInfoFailure(core.ExecutionError_SYSTEM, "TaskTemplateReadFailure", err.Error(), nil), nil
-			}
-			inputsInterface := taskTemplate.Interface.Inputs
-			inputsInterface["abc"].Type
 			// Can execute
+			var err error
 			nodeInputs, err = Resolve(ctx, c.outputResolver, nCtx.ContextualNodeLookup(), node.GetID(), node.GetInputBindings())
 			// TODO we need to handle retryable, network errors here!!
 			if err != nil {


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/5937

## Why are the changes needed?
https://github.com/flyteorg/flyte/pull/5325 didn't fix all the misuses of the capturing of stdout+stderr in unit tests. This PR fixes the remaining cases.

## What changes were proposed in this pull request?
~We add the teardown as a defer statement to all uses of `testutils.Setup`. 
Notice that in most cases we use barebones tests, which don't have a central place for setup/teardowns, so even though there's a comment explaining that `Teardown` has to be invoked, there's no automated way, at least to my knowledge, to do that.~

edit: as [suggested](https://github.com/flyteorg/flyte/pull/5950#issuecomment-2452695075) by @Sovietaced , we can leverage the setup call to hookup the call to cleanup (to restore stdout and stderr).

## How was this patch tested?
Confirmed that tests ran successfully Ran unit tests in a loop a few times:
```
❯ for i in {1..100}; do
  go test -count=1 -cover ./... -race || break;
done
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
