### PR TITLE
[Docs] Fix doc links to blob literal and type

### DIFF
--- a/docs/user_guide/data_types_and_io/flytefile.md
+++ b/docs/user_guide/data_types_and_io/flytefile.md
@@ -8,9 +8,9 @@
 
 Files are one of the most fundamental entities that users of Python work with,
 and they are fully supported by Flyte. In the IDL, they are known as
-[Blob](https://github.com/flyteorg/flyteidl/blob/master/protos/flyteidl/core/literals.proto#L33)
+[Blob](https://github.com/flyteorg/flyte/blob/master/flyteidl/protos/flyteidl/core/literals.proto#L33)
 literals which are backed by the
-[blob type](https://github.com/flyteorg/flyteidl/blob/master/protos/flyteidl/core/types.proto#L47).
+[blob type](https://github.com/flyteorg/flyte/blob/master/flyteidl/protos/flyteidl/core/types.proto#L73)
 
 Let's assume our mission here is pretty simple. We download a few CSV file
 links, read them with the python built-in {py:class}`csv.DictReader` function,


### PR DESCRIPTION
## Why are the changes needed?
The doc links to blob literal and type are outdated, so an update is needed for correct references.

## What changes were proposed in this pull request?
Fix the doc links based on the new `flyte` project structure, instead of pointing to the [old one](https://github.com/flyteorg/flyteidl/blob/master/protos/flyteidl/core/literals.proto#L33).

* Fixed link to blob literal
![Screenshot 2024-11-03 at 11 38 32 AM](https://github.com/user-attachments/assets/f1eeba6f-a924-4644-b7a6-b613c5800300)

* Fixed link to blob type
![Screenshot 2024-11-03 at 11 40 26 AM](https://github.com/user-attachments/assets/a37300d4-43f3-4546-8786-3e0ce97d0e70)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All commits are signed-off.

## Docs link
https://flyte--5952.org.readthedocs.build/en/5952/user_guide/data_types_and_io/flytefile.html