### PR TITLE
Reduce where clause fanout when updating workflow, node & task executions

### DIFF
--- a/flyteadmin/pkg/repositories/gormimpl/common.go
+++ b/flyteadmin/pkg/repositories/gormimpl/common.go
@@ -115,3 +115,7 @@ func applyScopedFilters(tx *gorm.DB, inlineFilters []common.InlineFilter, mapFil
 	}
 	return tx, nil
 }
+
+func getIdFilter(id uint) (query string, args interface{}) {
+	return fmt.Sprintf("%s = ?", ID), id
+}

--- a/flyteadmin/pkg/repositories/gormimpl/common.go
+++ b/flyteadmin/pkg/repositories/gormimpl/common.go
@@ -116,6 +116,6 @@ func applyScopedFilters(tx *gorm.DB, inlineFilters []common.InlineFilter, mapFil
 	return tx, nil
 }
 
-func getIdFilter(id uint) (query string, args interface{}) {
+func getIDFilter(id uint) (query string, args interface{}) {
 	return fmt.Sprintf("%s = ?", ID), id
 }

--- a/flyteadmin/pkg/repositories/gormimpl/execution_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/execution_repo.go
@@ -68,7 +68,7 @@ func (r *ExecutionRepo) Get(ctx context.Context, input interfaces.Identifier) (m
 
 func (r *ExecutionRepo) Update(ctx context.Context, execution models.Execution) error {
 	timer := r.metrics.UpdateDuration.Start()
-	tx := r.db.WithContext(ctx).Model(&execution).Updates(execution)
+	tx := r.db.WithContext(ctx).Model(&models.Execution{}).Where(getIdFilter(execution.ID)).Updates(execution)
 	timer.Stop()
 	if err := tx.Error; err != nil {
 		return r.errorTransformer.ToFlyteAdminError(err)

--- a/flyteadmin/pkg/repositories/gormimpl/execution_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/execution_repo.go
@@ -68,7 +68,7 @@ func (r *ExecutionRepo) Get(ctx context.Context, input interfaces.Identifier) (m
 
 func (r *ExecutionRepo) Update(ctx context.Context, execution models.Execution) error {
 	timer := r.metrics.UpdateDuration.Start()
-	tx := r.db.WithContext(ctx).Model(&models.Execution{}).Where(getIdFilter(execution.ID)).Updates(execution)
+	tx := r.db.WithContext(ctx).Model(&models.Execution{}).Where(getIDFilter(execution.ID)).Updates(execution)
 	timer.Stop()
 	if err := tx.Error; err != nil {
 		return r.errorTransformer.ToFlyteAdminError(err)

--- a/flyteadmin/pkg/repositories/gormimpl/execution_repo_test.go
+++ b/flyteadmin/pkg/repositories/gormimpl/execution_repo_test.go
@@ -59,10 +59,7 @@ func TestUpdateExecution(t *testing.T) {
 	updated := false
 
 	// Only match on queries that append expected filters
-	GlobalMock.NewMock().WithQuery(`UPDATE "executions" SET "updated_at"=$1,"execution_project"=$2,` +
-		`"execution_domain"=$3,"execution_name"=$4,"launch_plan_id"=$5,"workflow_id"=$6,"phase"=$7,"closure"=$8,` +
-		`"spec"=$9,"started_at"=$10,"execution_created_at"=$11,"execution_updated_at"=$12,"duration"=$13 WHERE "` +
-		`execution_project" = $14 AND "execution_domain" = $15 AND "execution_name" = $16`).WithCallback(
+	GlobalMock.NewMock().WithQuery(`UPDATE "executions" SET "updated_at"=$1,"execution_project"=$2,"execution_domain"=$3,"execution_name"=$4,"launch_plan_id"=$5,"workflow_id"=$6,"phase"=$7,"closure"=$8,"spec"=$9,"started_at"=$10,"execution_created_at"=$11,"execution_updated_at"=$12,"duration"=$13 WHERE id = $14`).WithCallback(
 		func(s string, values []driver.NamedValue) {
 			updated = true
 		},

--- a/flyteadmin/pkg/repositories/gormimpl/node_execution_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/node_execution_repo.go
@@ -97,7 +97,7 @@ func (r *NodeExecutionRepo) GetWithChildren(ctx context.Context, input interface
 
 func (r *NodeExecutionRepo) Update(ctx context.Context, nodeExecution *models.NodeExecution) error {
 	timer := r.metrics.UpdateDuration.Start()
-	tx := r.db.WithContext(ctx).Model(&models.NodeExecution{}).Where(getIdFilter(nodeExecution.ID)).Updates(nodeExecution)
+	tx := r.db.WithContext(ctx).Model(&models.NodeExecution{}).Where(getIDFilter(nodeExecution.ID)).Updates(nodeExecution)
 	timer.Stop()
 	if err := tx.Error; err != nil {
 		return r.errorTransformer.ToFlyteAdminError(err)

--- a/flyteadmin/pkg/repositories/gormimpl/node_execution_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/node_execution_repo.go
@@ -97,7 +97,7 @@ func (r *NodeExecutionRepo) GetWithChildren(ctx context.Context, input interface
 
 func (r *NodeExecutionRepo) Update(ctx context.Context, nodeExecution *models.NodeExecution) error {
 	timer := r.metrics.UpdateDuration.Start()
-	tx := r.db.WithContext(ctx).Model(&nodeExecution).Updates(nodeExecution)
+	tx := r.db.WithContext(ctx).Model(&models.NodeExecution{}).Where(getIdFilter(nodeExecution.ID)).Updates(nodeExecution)
 	timer.Stop()
 	if err := tx.Error; err != nil {
 		return r.errorTransformer.ToFlyteAdminError(err)

--- a/flyteadmin/pkg/repositories/gormimpl/node_execution_repo_test.go
+++ b/flyteadmin/pkg/repositories/gormimpl/node_execution_repo_test.go
@@ -64,7 +64,7 @@ func TestUpdateNodeExecution(t *testing.T) {
 	GlobalMock := mocket.Catcher.Reset()
 	// Only match on queries that append the name filter
 	nodeExecutionQuery := GlobalMock.NewMock()
-	nodeExecutionQuery.WithQuery(`UPDATE "node_executions" SET "id"=$1,"updated_at"=$2,"execution_project"=$3,"execution_domain"=$4,"execution_name"=$5,"node_id"=$6,"phase"=$7,"input_uri"=$8,"closure"=$9,"started_at"=$10,"node_execution_created_at"=$11,"node_execution_updated_at"=$12,"duration"=$13 WHERE "execution_project" = $14 AND "execution_domain" = $15 AND "execution_name" = $16 AND "node_id" = $17`)
+	nodeExecutionQuery.WithQuery(`UPDATE "node_executions" SET "id"=$1,"updated_at"=$2,"execution_project"=$3,"execution_domain"=$4,"execution_name"=$5,"node_id"=$6,"phase"=$7,"input_uri"=$8,"closure"=$9,"started_at"=$10,"node_execution_created_at"=$11,"node_execution_updated_at"=$12,"duration"=$13 WHERE id = $14`)
 	err := nodeExecutionRepo.Update(context.Background(),
 		&models.NodeExecution{
 			BaseModel: models.BaseModel{ID: 1},

--- a/flyteadmin/pkg/repositories/gormimpl/task_execution_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/task_execution_repo.go
@@ -81,7 +81,8 @@ func (r *TaskExecutionRepo) Get(ctx context.Context, input interfaces.GetTaskExe
 
 func (r *TaskExecutionRepo) Update(ctx context.Context, execution models.TaskExecution) error {
 	timer := r.metrics.UpdateDuration.Start()
-	tx := r.db.WithContext(ctx).WithContext(ctx).Save(&execution)
+	tx := r.db.WithContext(ctx).Model(&models.TaskExecution{}).Where(getIdFilter(execution.ID)).
+		Updates(&execution)
 	timer.Stop()
 
 	if err := tx.Error; err != nil {

--- a/flyteadmin/pkg/repositories/gormimpl/task_execution_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/task_execution_repo.go
@@ -81,7 +81,7 @@ func (r *TaskExecutionRepo) Get(ctx context.Context, input interfaces.GetTaskExe
 
 func (r *TaskExecutionRepo) Update(ctx context.Context, execution models.TaskExecution) error {
 	timer := r.metrics.UpdateDuration.Start()
-	tx := r.db.WithContext(ctx).Model(&models.TaskExecution{}).Where(getIdFilter(execution.ID)).
+	tx := r.db.WithContext(ctx).Model(&models.TaskExecution{}).Where(getIDFilter(execution.ID)).
 		Updates(&execution)
 	timer.Stop()
 

--- a/flyteadmin/pkg/repositories/gormimpl/task_execution_repo_test.go
+++ b/flyteadmin/pkg/repositories/gormimpl/task_execution_repo_test.go
@@ -85,7 +85,7 @@ func TestUpdateTaskExecution(t *testing.T) {
 	GlobalMock.Logging = true
 
 	taskExecutionQuery := GlobalMock.NewMock()
-	taskExecutionQuery.WithQuery(`UPDATE "task_executions" SET "id"=$1,"created_at"=$2,"updated_at"=$3,"deleted_at"=$4,"phase"=$5,"phase_version"=$6,"input_uri"=$7,"closure"=$8,"started_at"=$9,"task_execution_created_at"=$10,"task_execution_updated_at"=$11,"duration"=$12 WHERE "project" = $13 AND "domain" = $14 AND "name" = $15 AND "version" = $16 AND "execution_project" = $17 AND "execution_domain" = $18 AND "execution_name" = $19 AND "node_id" = $20 AND "retry_attempt" = $21`)
+	taskExecutionQuery.WithQuery(`UPDATE "task_executions" SET "updated_at"=$1,"project"=$2,"domain"=$3,"name"=$4,"version"=$5,"execution_project"=$6,"execution_domain"=$7,"execution_name"=$8,"node_id"=$9,"retry_attempt"=$10,"phase"=$11,"input_uri"=$12,"closure"=$13,"started_at"=$14,"task_execution_created_at"=$15,"task_execution_updated_at"=$16,"duration"=$17 WHERE id = $18`)
 	err := taskExecutionRepo.Update(context.Background(), testTaskExecution)
 	assert.NoError(t, err)
 	assert.True(t, taskExecutionQuery.Triggered)


### PR DESCRIPTION
## Why are the changes needed?
In the executions path, performant updates are important since propeller sends executions events and doesn't proceed with the execution until the event is properly acked.

We've observed a performance increase (3x) for updating task executions in particular (which have 9!! primary keys) so that generated gorm adds a where clause for each primary key and this results in noticeably slower queries compared to updating on the unique BaseModel indexed [Id](https://github.com/flyteorg/flyte/blob/732b42e291baac16e82c2c1a110fe0a9a908bb42/flyteadmin/pkg/repositories/models/base_model.go#L15) field.

## What changes were proposed in this pull request?

I'm only updating executions tables here (workflow, node and task) because they're in the hot path. Inventory like tasks and workflows can't be updated, launch plan state can but the perf requirements there are lower and the expected table size for static inventory is usually much lower than for executions

We can always assume the model has the `id` filled out because we fetch it before updating
- executions: https://github.com/unionai/flyte/blob/d2f1c2ac3670e45494a60d5653d9bc0c40ec1f9c/flyteadmin/pkg/manager/impl/execution_manager.go#L1931
- node executions: https://github.com/unionai/flyte/blob/d2f1c2ac3670e45494a60d5653d9bc0c40ec1f9c/flyteadmin/pkg/manager/impl/node_execution_manager.go#L258-L274
- task executions: https://github.com/unionai/flyte/blob/d2f1c2ac3670e45494a60d5653d9bc0c40ec1f9c/flyteadmin/pkg/manager/impl/task_execution_manager.go#L155-L189

## How was this patch tested?

Tested on sandbox. Verified executions progressed and I could interact with the console. Verified dumped SQL showed updated query.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
