### PR TITLE
How to verify that the grpc service of flyteadmin works as expected

### DIFF
--- a/docs/community/troubleshoot.rst
+++ b/docs/community/troubleshoot.rst
@@ -180,7 +180,9 @@ Please add ``spark`` to the list of `enabled-plugins` in the config yaml file. F
 ``authentication handshake failed: x509: "Kubernetes Ingress Controller Fake Certificate" certificate is not trusted"`` when deploying flyte-core to your own kubernetes cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Please enable ``tls`` in the ingress configuration of your Kubernetes cluster:
+This issue is caused by TLS being disabled in your Kubernetes cluster. You can resolve the problem by following these steps:
+
+Enable ``tls`` in the ``values.yaml`` ingress configuration of flyte-core in order to expose gRPC service at 443 port:
 
 .. code-block:: yaml
   ingress:
@@ -193,13 +195,13 @@ Please enable ``tls`` in the ingress configuration of your Kubernetes cluster:
       <http://ingress.kubernetes.io/default-backend-redirect|ingress.kubernetes.io/default-backend-redirect>: "/console"
       <http://kubernetes.io/ingress.class|kubernetes.io/ingress.class>: haproxy
     tls:
-      enabled: true
+      enabled: true # enable tls
 
-Moreover, disable ``insecure`` in your ``flytectl`` client config.yaml:
+Disable ``insecure`` in your ``flytectl`` client config.yaml:
 
 .. code-block:: yaml
   admin:
   endpoint: dns:///example.com
   authType: Pkce
-  insecure: false
+  insecure: false # disable insecure in flytectl
   insecureSkipVerify: true

--- a/docs/community/troubleshoot.rst
+++ b/docs/community/troubleshoot.rst
@@ -176,3 +176,30 @@ Please add ``spark`` to the list of `enabled-plugins` in the config yaml file. F
       default-for-task-types:
         - container: container
         - container_array: K8S-ARRAY
+
+``authentication handshake failed: x509: "Kubernetes Ingress Controller Fake Certificate" certificate is not trusted"`` when deploying flyte-core to your own kubernetes cluster
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Please enable ``tls`` in the ingress configuration of your Kubernetes cluster:
+
+.. code-block:: yaml
+  ingress:
+    host: <http://example.com|example.com>
+    separateGrpcIngress: true
+    separateGrpcIngressAnnotations:
+      <http://ingress.kubernetes.io/backend-protocol|ingress.kubernetes.io/backend-protocol>: "grpc"
+    annotations:
+      <http://ingress.kubernetes.io/app-root|ingress.kubernetes.io/app-root>: "/console"
+      <http://ingress.kubernetes.io/default-backend-redirect|ingress.kubernetes.io/default-backend-redirect>: "/console"
+      <http://kubernetes.io/ingress.class|kubernetes.io/ingress.class>: haproxy
+    tls:
+      enabled: true
+
+Moreover, disable ``insecure`` in your ``flytectl`` client config.yaml:
+
+.. code-block:: yaml
+  admin:
+  endpoint: dns:///example.com
+  authType: Pkce
+  insecure: false
+  insecureSkipVerify: true

--- a/docs/community/troubleshoot.rst
+++ b/docs/community/troubleshoot.rst
@@ -185,6 +185,7 @@ This issue is caused by TLS being disabled in your Kubernetes cluster. You can r
 Enable ``tls`` in the ``values.yaml`` ingress configuration of flyte-core in order to expose gRPC service at 443 port:
 
 .. code-block:: yaml
+
   ingress:
     host: <http://example.com|example.com>
     separateGrpcIngress: true
@@ -200,6 +201,7 @@ Enable ``tls`` in the ``values.yaml`` ingress configuration of flyte-core in ord
 Disable ``insecure`` in your ``flytectl`` client config.yaml:
 
 .. code-block:: yaml
+  
   admin:
   endpoint: dns:///example.com
   authType: Pkce

--- a/docs/community/troubleshoot.rst
+++ b/docs/community/troubleshoot.rst
@@ -182,7 +182,7 @@ Please add ``spark`` to the list of `enabled-plugins` in the config yaml file. F
 
 This issue is caused by TLS being disabled in your Kubernetes cluster. You can resolve the problem by following these steps:
 
-Enable ``tls`` in the ``values.yaml`` ingress configuration of flyte-core in order to expose gRPC service at 443 port:
+- Enable ``tls`` in the ``values.yaml`` ingress configuration of flyte-core in order to expose gRPC service at 443 port:
 
 .. code-block:: yaml
 
@@ -198,10 +198,10 @@ Enable ``tls`` in the ``values.yaml`` ingress configuration of flyte-core in ord
     tls:
       enabled: true # enable tls
 
-Disable ``insecure`` in your ``flytectl`` client config.yaml:
+- Disable ``insecure`` in your ``flytectl`` client config.yaml:
 
 .. code-block:: yaml
-  
+
   admin:
   endpoint: dns:///example.com
   authType: Pkce


### PR DESCRIPTION
## Tracking issue
Closes #3163 
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?
In this [discussion](https://discuss.flyte.org/t/8152768/Hi-Community-is-there-any-simple-approach-to-verify-the-GRPC), a user encountered a TLS certificate issue while registering a workflow to the Flyte-core k8s cluster. The root cause was TLS not being enabled in the Kubernetes cluster’s Ingress controller. It is recommended to add this debug information to the troubleshooting guide documentation.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Add information about flyte-core k8s ingress TLS config in the trouble shooting DOC.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [X] All commits are signed-off.

## Docs link
https://flyte--5955.org.readthedocs.build/en/5955/community/troubleshoot.html
<!-- Add documentation link built by CI jobs here, and specify the changed place -->
