### PR TITLE
Fix indentation for security block in auth_setup.rst

### DIFF
--- a/docs/deployment/configuration/auth_setup.rst
+++ b/docs/deployment/configuration/auth_setup.rst
@@ -254,15 +254,15 @@ Apply OIDC Configuration
                httpPort: 8088
                grpc:
                  port: 8089
-             security:
-               secure: false
-               useAuth: true
-               allowCors: true
-               allowedOrigins:
-          # Accepting all domains for Sandbox installation
-                 - "*"
-               allowedHeaders:
-                 - "Content-Type"
+               security:
+                 secure: false
+                 useAuth: true
+                 allowCors: true
+                 allowedOrigins:
+            # Accepting all domains for Sandbox installation
+                   - "*"
+                 allowedHeaders:
+                   - "Content-Type"
              auth:
                appAuth:
                  thirdPartyConfig:


### PR DESCRIPTION
I believe `security` belongs under `server`.

Without making this change, the auth didn't work for me. 

I further checked this by noting that 

1. https://github.com/unionai-oss/deploy-flyte/blob/main/environments/gcp/flyte-core/values-gcp-core.yaml#L228 has `security` under `server`
2. the example helm file listed on https://artifacthub.io/packages/helm/flyte/flyte-core also places `security` under `server`: `configmap.adminServer.server.security.useAuth`


## Why are the changes needed?

Wan't able to get auth working without it

## What changes were proposed in this pull request?

put `security` underneath `server`

## How was this patch tested?

Tested it with an on prem deploy.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
