### PR TITLE
Fix: customize demo cluster port

### DIFF
--- a/flytectl/cmd/config/subcommand/sandbox/config_flags.go
+++ b/flytectl/cmd/config/subcommand/sandbox/config_flags.go
@@ -62,5 +62,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.BoolVar(&DefaultConfig.Dev, fmt.Sprintf("%v%v", prefix, "dev"), DefaultConfig.Dev, "Optional. Only start minio and postgres in the sandbox.")
 	cmdFlags.BoolVar(&DefaultConfig.DryRun, fmt.Sprintf("%v%v", prefix, "dryRun"), DefaultConfig.DryRun, "Optional. Only print the docker commands to bring up flyte sandbox/demo container.This will still call github api's to get the latest flyte release to use'")
 	cmdFlags.BoolVar(&DefaultConfig.Force, fmt.Sprintf("%v%v", prefix, "force"), DefaultConfig.Force, "Optional. Forcefully delete existing sandbox cluster if it exists.")
+	cmdFlags.StringVar(&DefaultConfig.Port, fmt.Sprintf("%v%v", prefix, "port"), DefaultConfig.Port, "Optional. Specify the port for the sandbox.")
 	return cmdFlags
 }

--- a/flytectl/cmd/config/subcommand/sandbox/config_flags.go
+++ b/flytectl/cmd/config/subcommand/sandbox/config_flags.go
@@ -62,6 +62,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.BoolVar(&DefaultConfig.Dev, fmt.Sprintf("%v%v", prefix, "dev"), DefaultConfig.Dev, "Optional. Only start minio and postgres in the sandbox.")
 	cmdFlags.BoolVar(&DefaultConfig.DryRun, fmt.Sprintf("%v%v", prefix, "dryRun"), DefaultConfig.DryRun, "Optional. Only print the docker commands to bring up flyte sandbox/demo container.This will still call github api's to get the latest flyte release to use'")
 	cmdFlags.BoolVar(&DefaultConfig.Force, fmt.Sprintf("%v%v", prefix, "force"), DefaultConfig.Force, "Optional. Forcefully delete existing sandbox cluster if it exists.")
-	cmdFlags.StringVar(&DefaultConfig.Port, fmt.Sprintf("%v%v", prefix, "port"), DefaultConfig.Port, "Optional. Specify the port for the sandbox.")
+	cmdFlags.StringVar(&DefaultConfig.Port, fmt.Sprintf("%v%v", prefix, "port"), DefaultConfig.Port, "Optional. Specify the port for the Kubernetes in the sandbox.")
 	return cmdFlags
 }

--- a/flytectl/cmd/config/subcommand/sandbox/config_flags_test.go
+++ b/flytectl/cmd/config/subcommand/sandbox/config_flags_test.go
@@ -265,4 +265,18 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_port", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("port", testValue)
+			if vString, err := cmdFlags.GetString("port"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Port)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/flytectl/cmd/config/subcommand/sandbox/sandbox_config.go
+++ b/flytectl/cmd/config/subcommand/sandbox/sandbox_config.go
@@ -42,7 +42,7 @@ type Config struct {
 	Force bool `json:"force" pflag:",Optional. Forcefully delete existing sandbox cluster if it exists."`
 
 	// Allow user to specify the port for the sandbox
-	Port string `json:"port" pflag:",Optional. Specify the port for the sandbox."`
+	Port string `json:"port" pflag:",Optional. Specify the port for the Kubernetes in the sandbox."`
 }
 
 //go:generate pflags Config --default-var DefaultConfig --bind-default-var

--- a/flytectl/cmd/config/subcommand/sandbox/sandbox_config.go
+++ b/flytectl/cmd/config/subcommand/sandbox/sandbox_config.go
@@ -1,6 +1,10 @@
 package sandbox
 
-import "github.com/flyteorg/flyte/flytectl/pkg/docker"
+import (
+	"fmt"
+
+	"github.com/flyteorg/flyte/flytectl/pkg/docker"
+)
 
 // Config holds configuration flags for sandbox command.
 type Config struct {
@@ -36,9 +40,18 @@ type Config struct {
 	DryRun bool `json:"dryRun" pflag:",Optional. Only print the docker commands to bring up flyte sandbox/demo container.This will still call github api's to get the latest flyte release to use'"`
 
 	Force bool `json:"force" pflag:",Optional. Forcefully delete existing sandbox cluster if it exists."`
+
+	// Allow user to specify the port for the sandbox
+	Port string `json:"port" pflag:",Optional. Specify the port for the sandbox."`
 }
 
 //go:generate pflags Config --default-var DefaultConfig --bind-default-var
 var (
-	DefaultConfig = &Config{}
+	DefaultConfig = &Config{
+		Port: "6443", // Default port for the sandbox
+	}
 )
+
+func (c Config) GetK8sEndpoint() string {
+	return fmt.Sprintf("https://127.0.0.1:%s", c.Port)
+}

--- a/flytectl/cmd/demo/demo.go
+++ b/flytectl/cmd/demo/demo.go
@@ -6,11 +6,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	flyteNs     = "flyte"
-	K8sEndpoint = "https://127.0.0.1:6443"
-)
-
 // Long descriptions are whitespace sensitive when generating docs using sphinx.
 const (
 	demoShort = `Helps with demo interactions like start, teardown, status, and exec.`

--- a/flytectl/cmd/demo/reload.go
+++ b/flytectl/cmd/demo/reload.go
@@ -4,16 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	sandboxCmdConfig "github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/sandbox"
 	cmdCore "github.com/flyteorg/flyte/flytectl/cmd/core"
 	"github.com/flyteorg/flyte/flytectl/pkg/docker"
-	"github.com/flyteorg/flyte/flytectl/pkg/k8s"
-	"github.com/flyteorg/flyte/flytestdlib/logger"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/flyteorg/flyte/flytectl/pkg/sandbox"
 )
 
 const (
 	internalBootstrapAgent = "flyte-sandbox-bootstrap"
-	labelSelector          = "app.kubernetes.io/name=flyte-binary"
 )
 const (
 	reloadShort = "Power cycle the Flyte executable pod, effectively picking up an updated config."
@@ -73,7 +71,7 @@ func reloadDemoCluster(ctx context.Context, args []string, cmdCtx cmdCore.Comman
 		return err
 	}
 	if useLegacyMethod {
-		return legacyReloadDemoCluster(ctx)
+		return sandbox.LegacyReloadDemoCluster(ctx, sandboxCmdConfig.DefaultConfig)
 	}
 
 	// At this point we know that we are on a modern sandbox, and we can use the
@@ -83,35 +81,6 @@ func reloadDemoCluster(ctx context.Context, args []string, cmdCtx cmdCore.Comman
 		return err
 	}
 	if err = docker.InspectExecResp(ctx, cli, exec.ID); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// legacyReloadDemoCluster will kill the flyte binary pod so the new one can pick up a new config file
-func legacyReloadDemoCluster(ctx context.Context) error {
-	k8sClient, err := k8s.GetK8sClient(docker.Kubeconfig, K8sEndpoint)
-	if err != nil {
-		fmt.Println("Could not get K8s client")
-		return err
-	}
-	pi := k8sClient.CoreV1().Pods(flyteNs)
-	podList, err := pi.List(ctx, v1.ListOptions{LabelSelector: labelSelector})
-	if err != nil {
-		fmt.Println("could not list pods")
-		return err
-	}
-	if len(podList.Items) != 1 {
-		return fmt.Errorf("should only have one pod running, %d found, %v", len(podList.Items), podList.Items)
-	}
-	logger.Debugf(ctx, "Found %d pods\n", len(podList.Items))
-	var grace = int64(0)
-	err = pi.Delete(ctx, podList.Items[0].Name, v1.DeleteOptions{
-		GracePeriodSeconds: &grace,
-	})
-	if err != nil {
-		fmt.Printf("Could not delete Flyte pod, old configuration may still be in effect. Err: %s\n", err)
 		return err
 	}
 

--- a/flytectl/cmd/demo/start.go
+++ b/flytectl/cmd/demo/start.go
@@ -22,6 +22,7 @@ Starts the demo cluster without any source code:
 
 Starts the demo cluster with different port:
 ::
+
  flytectl demo start --port 6443
 
 Runs a dev cluster, which only has minio and postgres pod.

--- a/flytectl/cmd/demo/start.go
+++ b/flytectl/cmd/demo/start.go
@@ -20,6 +20,10 @@ Starts the demo cluster without any source code:
 
  flytectl demo start
 
+Starts the demo cluster with different port:
+::
+ flytectl demo start --port 6443
+
 Runs a dev cluster, which only has minio and postgres pod.
 ::
 

--- a/flytectl/pkg/docker/docker_util.go
+++ b/flytectl/pkg/docker/docker_util.go
@@ -134,14 +134,14 @@ func GetSandboxPorts() (map[nat.Port]struct{}, map[nat.Port][]nat.PortBinding, e
 }
 
 // GetDemoPorts will return demo ports
-func GetDemoPorts() (map[nat.Port]struct{}, map[nat.Port][]nat.PortBinding, error) {
+func GetDemoPorts(k8sPort string) (map[nat.Port]struct{}, map[nat.Port][]nat.PortBinding, error) {
 	return nat.ParsePortSpecs([]string{
-		"0.0.0.0:6443:6443",   // K3s API Port
-		"0.0.0.0:30080:30080", // HTTP Port
-		"0.0.0.0:30000:30000", // Registry Port
-		"0.0.0.0:30001:30001", // Postgres Port
-		"0.0.0.0:30002:30002", // Minio API Port (use HTTP port for minio console)
-		"0.0.0.0:30003:30003", // Buildkit Port
+		fmt.Sprintf("0.0.0.0:%s:6443", k8sPort), // K3s API Port
+		"0.0.0.0:30080:30080",                   // HTTP Port
+		"0.0.0.0:30000:30000",                   // Registry Port
+		"0.0.0.0:30001:30001",                   // Postgres Port
+		"0.0.0.0:30002:30002",                   // Minio API Port (use HTTP port for minio console)
+		"0.0.0.0:30003:30003",                   // Buildkit Port
 	})
 }
 

--- a/flytectl/pkg/docker/docker_util_test.go
+++ b/flytectl/pkg/docker/docker_util_test.go
@@ -435,7 +435,7 @@ func TestGetOrCreateVolume(t *testing.T) {
 }
 
 func TestDemoPorts(t *testing.T) {
-	_, ports, _ := GetDemoPorts()
+	_, ports, _ := GetDemoPorts("6443")
 	assert.Equal(t, 6, len(ports))
 }
 

--- a/flytectl/pkg/sandbox/reload.go
+++ b/flytectl/pkg/sandbox/reload.go
@@ -1,0 +1,47 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+
+	sandboxCmdConfig "github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/sandbox"
+	"github.com/flyteorg/flyte/flytectl/pkg/docker"
+	"github.com/flyteorg/flyte/flytectl/pkg/k8s"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	flyteNs       = "flyte"
+	labelSelector = "app.kubernetes.io/name=flyte-binary"
+)
+
+// LegacyReloadDemoCluster will kill the flyte binary pod so the new one can pick up a new config file
+func LegacyReloadDemoCluster(ctx context.Context, sandboxConfig *sandboxCmdConfig.Config) error {
+	k8sEndpoint := sandboxConfig.GetK8sEndpoint()
+	k8sClient, err := k8s.GetK8sClient(docker.Kubeconfig, k8sEndpoint)
+	if err != nil {
+		fmt.Println("Could not get K8s client")
+		return err
+	}
+	pi := k8sClient.CoreV1().Pods(flyteNs)
+	podList, err := pi.List(ctx, v1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		fmt.Println("could not list pods")
+		return err
+	}
+	if len(podList.Items) != 1 {
+		return fmt.Errorf("should only have one pod running, %d found, %v", len(podList.Items), podList.Items)
+	}
+	logger.Debugf(ctx, "Found %d pods\n", len(podList.Items))
+	var grace = int64(0)
+	err = pi.Delete(ctx, podList.Items[0].Name, v1.DeleteOptions{
+		GracePeriodSeconds: &grace,
+	})
+	if err != nil {
+		fmt.Printf("Could not delete Flyte pod, old configuration may still be in effect. Err: %s\n", err)
+		return err
+	}
+
+	return nil
+}

--- a/flytectl/pkg/sandbox/start.go
+++ b/flytectl/pkg/sandbox/start.go
@@ -36,7 +36,6 @@ const (
 	taintEffect          = "NoSchedule"
 	sandboxContextName   = "flyte-sandbox"
 	sandboxDockerContext = "default"
-	K8sEndpoint          = "https://127.0.0.1:6443"
 	sandboxK8sEndpoint   = "https://127.0.0.1:30086"
 	sandboxImageName     = "cr.flyte.org/flyteorg/flyte-sandbox"
 	demoImageName        = "cr.flyte.org/flyteorg/flyte-sandbox-bundled"
@@ -280,12 +279,13 @@ func StartCluster(ctx context.Context, args []string, sandboxConfig *sandboxCmdC
 		return err
 	}
 
+	k8sEndpoint := sandboxConfig.GetK8sEndpoint()
 	if reader != nil {
 		var k8sClient k8s.K8s
 		err = retry.Do(
 			func() error {
 				// This should wait for the kubeconfig file being there.
-				k8sClient, err = k8s.GetK8sClient(docker.Kubeconfig, K8sEndpoint)
+				k8sClient, err = k8s.GetK8sClient(docker.Kubeconfig, k8sEndpoint)
 				return err
 			},
 			retry.Attempts(10),
@@ -299,7 +299,7 @@ func StartCluster(ctx context.Context, args []string, sandboxConfig *sandboxCmdC
 		err = retry.Do(
 			func() error {
 				// Have to get a new client every time because you run into x509 errors if not
-				k8sClient, err = k8s.GetK8sClient(docker.Kubeconfig, K8sEndpoint)
+				k8sClient, err = k8s.GetK8sClient(docker.Kubeconfig, k8sEndpoint)
 				if err != nil {
 					logger.Debugf(ctx, "Error getting K8s client in liveness check %s", err)
 					return err
@@ -398,7 +398,7 @@ func StartClusterForSandbox(ctx context.Context, args []string, sandboxConfig *s
 
 func StartDemoCluster(ctx context.Context, args []string, sandboxConfig *sandboxCmdConfig.Config) error {
 	sandboxImagePrefix := "sha"
-	exposedPorts, portBindings, err := docker.GetDemoPorts()
+	exposedPorts, portBindings, err := docker.GetDemoPorts(sandboxConfig.Port)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->
Closes #3792 

## Why are the changes needed?
- As stated in #3792, when a developer uses Docker Desktop with Kubernetes running on port 6443, they must shut it down before running the demo cluster

- Allow users to configure the demo cluster port if needed

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
1. Add a new parameter `port`, e.g., `flytectl demo start --port 6443`
2. Dynamically retrieve k8sEndpoint from `sandbox_config.go` instead of using fixed ones
3. Refactor `reload.go` to retrieve sandbox config (follow other file structure under `flyte/flytectl/cmd/demo`)

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
4. If there is design documentation, please add the link.
-->

## How was this patch tested?
Tested that parameters were automatically generated with `make generate`

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
1. Run a k8s cluster that uses port 6443 (docker desktop k8s for testing)
2. Start the demo cluster without specifying port, which defaults to :6443 (expected to fail)
3. Start the demo cluster with port 6444
4. `kubectl --server=https://localhost:6444 get pods`
5. `export FLYTECTL_CONFIG= ~/<pathTo>/.flyte/config-sandbox.yaml`
6. Run the test with any `pyflyte run --remote`

### Screenshots
<img width="1913" alt="Screenshot 2024-11-07 at 10 58 51 AM" src="https://github.com/user-attachments/assets/32445953-bb22-4ea9-bd7a-93e2e6cc629b">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
