### PR TITLE
[flytectl][MSGPACK IDL] Gate feature by setting ENV

### DIFF
--- a/flytecopilot/go.mod
+++ b/flytecopilot/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/shamaton/msgpack/v2 v2.2.2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.4.1 // indirect

--- a/flytecopilot/go.sum
+++ b/flytecopilot/go.sum
@@ -309,6 +309,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shamaton/msgpack/v2 v2.2.2 h1:GOIg0c9LV04VwzOOqZSrmsv/JzjNOOMxnS/HvOHGdgs=
+github.com/shamaton/msgpack/v2 v2.2.2/go.mod h1:6khjYnkx73f7VQU7wjcFS9DFjs+59naVWJv1TB7qdOI=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=

--- a/flyteidl/clients/go/coreutils/extract_literal_test.go
+++ b/flyteidl/clients/go/coreutils/extract_literal_test.go
@@ -4,6 +4,7 @@
 package coreutils
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -125,6 +126,7 @@ func TestFetchLiteral(t *testing.T) {
 	})
 
 	t.Run("Generic", func(t *testing.T) {
+		os.Setenv("FLYTE_USE_OLD_DC_FORMAT", "true")
 		literalVal := map[string]interface{}{
 			"x": 1,
 			"y": "ystringvalue",
@@ -150,6 +152,7 @@ func TestFetchLiteral(t *testing.T) {
 		for key, val := range expectedStructVal.Fields {
 			assert.Equal(t, val.Kind, extractedStructValue.Fields[key].Kind)
 		}
+		os.Unsetenv("FLYTE_USE_OLD_DC_FORMAT")
 	})
 
 	t.Run("Generic Passed As String", func(t *testing.T) {

--- a/flyteidl/clients/go/coreutils/extract_literal_test.go
+++ b/flyteidl/clients/go/coreutils/extract_literal_test.go
@@ -126,7 +126,7 @@ func TestFetchLiteral(t *testing.T) {
 	})
 
 	t.Run("Generic", func(t *testing.T) {
-		os.Setenv("FLYTE_USE_OLD_DC_FORMAT", "true")
+		os.Setenv(FlyteUseOldDcFormat, "true")
 		literalVal := map[string]interface{}{
 			"x": 1,
 			"y": "ystringvalue",
@@ -152,7 +152,7 @@ func TestFetchLiteral(t *testing.T) {
 		for key, val := range expectedStructVal.Fields {
 			assert.Equal(t, val.Kind, extractedStructValue.Fields[key].Kind)
 		}
-		os.Unsetenv("FLYTE_USE_OLD_DC_FORMAT")
+		os.Unsetenv(FlyteUseOldDcFormat)
 	})
 
 	t.Run("Generic Passed As String", func(t *testing.T) {

--- a/flyteidl/clients/go/coreutils/literals.go
+++ b/flyteidl/clients/go/coreutils/literals.go
@@ -22,7 +22,7 @@ import (
 )
 
 const MESSAGEPACK = "msgpack"
-const FLYTE_USE_OLD_DC_FORMAT = "FLYTE_USE_OLD_DC_FORMAT"
+const FlyteUseOldDcFormat = "FLYTE_USE_OLD_DC_FORMAT"
 
 func MakePrimitive(v interface{}) (*core.Primitive, error) {
 	switch p := v.(type) {
@@ -565,7 +565,7 @@ func MakeLiteralForType(t *core.LiteralType, v interface{}) (*core.Literal, erro
 			strValue = fmt.Sprintf("%.0f", math.Trunc(f))
 		}
 		if newT.Simple == core.SimpleType_STRUCT {
-			useOldFormat := strings.ToLower(os.Getenv(FLYTE_USE_OLD_DC_FORMAT))
+			useOldFormat := strings.ToLower(os.Getenv(FlyteUseOldDcFormat))
 			if _, isValueStringType := v.(string); !isValueStringType {
 				if useOldFormat == "1" || useOldFormat == "t" || useOldFormat == "true" {
 					byteValue, err := json.Marshal(v)

--- a/flyteidl/clients/go/coreutils/literals.go
+++ b/flyteidl/clients/go/coreutils/literals.go
@@ -5,20 +5,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyte/flytestdlib/storage"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/pkg/errors"
+	"github.com/shamaton/msgpack/v2"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
 const MESSAGEPACK = "msgpack"
+const FLYTE_USE_OLD_DC_FORMAT = "FLYTE_USE_OLD_DC_FORMAT"
 
 func MakePrimitive(v interface{}) (*core.Primitive, error) {
 	switch p := v.(type) {
@@ -561,12 +565,32 @@ func MakeLiteralForType(t *core.LiteralType, v interface{}) (*core.Literal, erro
 			strValue = fmt.Sprintf("%.0f", math.Trunc(f))
 		}
 		if newT.Simple == core.SimpleType_STRUCT {
+			useOldFormat := strings.ToLower(os.Getenv(FLYTE_USE_OLD_DC_FORMAT))
 			if _, isValueStringType := v.(string); !isValueStringType {
-				byteValue, err := json.Marshal(v)
-				if err != nil {
-					return nil, fmt.Errorf("unable to marshal to json string for struct value %v", v)
+				if useOldFormat == "1" || useOldFormat == "t" || useOldFormat == "true" {
+					byteValue, err := json.Marshal(v)
+					if err != nil {
+						return nil, fmt.Errorf("unable to marshal to json string for struct value %v", v)
+					}
+					strValue = string(byteValue)
+				} else {
+					byteValue, err := msgpack.Marshal(v)
+					if err != nil {
+						return nil, fmt.Errorf("unable to marshal to msgpack bytes for struct value %v", v)
+					}
+					return &core.Literal{
+						Value: &core.Literal_Scalar{
+							Scalar: &core.Scalar{
+								Value: &core.Scalar_Binary{
+									Binary: &core.Binary{
+										Value: byteValue,
+										Tag:   MESSAGEPACK,
+									},
+								},
+							},
+						},
+					}, nil
 				}
-				strValue = string(byteValue)
 			}
 		}
 		lv, err := MakeLiteralForSimpleType(newT.Simple, strValue)

--- a/flyteidl/clients/go/coreutils/literals_test.go
+++ b/flyteidl/clients/go/coreutils/literals_test.go
@@ -5,6 +5,8 @@ package coreutils
 
 import (
 	"fmt"
+	"github.com/shamaton/msgpack/v2"
+	"os"
 	"reflect"
 	"strconv"
 	"testing"
@@ -455,6 +457,7 @@ func TestMakeLiteralForType(t *testing.T) {
 	})
 
 	t.Run("Generic", func(t *testing.T) {
+		os.Setenv("FLYTE_USE_OLD_DC_FORMAT", "true")
 		literalVal := map[string]interface{}{
 			"x": 1,
 			"y": "ystringvalue",
@@ -480,6 +483,69 @@ func TestMakeLiteralForType(t *testing.T) {
 		for key, val := range expectedStructVal.Fields {
 			assert.Equal(t, val.Kind, extractedStructValue.Fields[key].Kind)
 		}
+		os.Unsetenv("FLYTE_USE_OLD_DC_FORMAT")
+	})
+
+	t.Run("SimpleBinary", func(t *testing.T) {
+		// We compare the deserialized values instead of the raw msgpack bytes because Go does not guarantee the order
+		// of map keys during serialization. This means that while the serialized bytes may differ, the deserialized
+		// values should be logically equivalent.
+
+		var literalType = &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRUCT}}
+		v := map[string]interface{}{
+			"a": int64(1),
+			"b": 3.14,
+			"c": "example_string",
+			"d": map[string]interface{}{
+				"1": int64(100),
+				"2": int64(200),
+			},
+			"e": map[string]interface{}{
+				"a": int64(1),
+				"b": 3.14,
+			},
+			"f": []string{"a", "b", "c"},
+		}
+
+		val, err := MakeLiteralForType(literalType, v)
+		assert.NoError(t, err)
+
+		msgpackBytes, err := msgpack.Marshal(v)
+		assert.NoError(t, err)
+
+		literalVal := &core.Literal{
+			Value: &core.Literal_Scalar{
+				Scalar: &core.Scalar{
+					Value: &core.Scalar_Binary{
+						Binary: &core.Binary{
+							Value: msgpackBytes,
+							Tag:   MESSAGEPACK,
+						},
+					},
+				},
+			},
+		}
+
+		expectedLiteralVal, err := ExtractFromLiteral(literalVal)
+		assert.NoError(t, err)
+		actualLiteralVal, err := ExtractFromLiteral(val)
+		assert.NoError(t, err)
+
+		// Check if the extracted value is of type *core.Binary (not []byte)
+		expectedBinary, ok := expectedLiteralVal.(*core.Binary)
+		assert.True(t, ok, "expectedLiteralVal is not of type *core.Binary")
+		actualBinary, ok := actualLiteralVal.(*core.Binary)
+		assert.True(t, ok, "actualLiteralVal is not of type *core.Binary")
+
+		// Now check if the Binary values match
+		var expectedVal, actualVal map[string]interface{}
+		err = msgpack.Unmarshal(expectedBinary.Value, &expectedVal)
+		assert.NoError(t, err)
+		err = msgpack.Unmarshal(actualBinary.Value, &actualVal)
+		assert.NoError(t, err)
+
+		// Finally, assert that the deserialized values are equal
+		assert.Equal(t, expectedVal, actualVal)
 	})
 
 	t.Run("ArrayStrings", func(t *testing.T) {

--- a/flyteidl/clients/go/coreutils/literals_test.go
+++ b/flyteidl/clients/go/coreutils/literals_test.go
@@ -5,7 +5,6 @@ package coreutils
 
 import (
 	"fmt"
-	"github.com/shamaton/msgpack/v2"
 	"os"
 	"reflect"
 	"strconv"
@@ -16,6 +15,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/pkg/errors"
+	"github.com/shamaton/msgpack/v2"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
@@ -457,7 +457,7 @@ func TestMakeLiteralForType(t *testing.T) {
 	})
 
 	t.Run("Generic", func(t *testing.T) {
-		os.Setenv("FLYTE_USE_OLD_DC_FORMAT", "true")
+		os.Setenv(FlyteUseOldDcFormat, "true")
 		literalVal := map[string]interface{}{
 			"x": 1,
 			"y": "ystringvalue",
@@ -483,7 +483,7 @@ func TestMakeLiteralForType(t *testing.T) {
 		for key, val := range expectedStructVal.Fields {
 			assert.Equal(t, val.Kind, extractedStructValue.Fields[key].Kind)
 		}
-		os.Unsetenv("FLYTE_USE_OLD_DC_FORMAT")
+		os.Unsetenv(FlyteUseOldDcFormat)
 	})
 
 	t.Run("SimpleBinary", func(t *testing.T) {

--- a/flyteidl/go.mod
+++ b/flyteidl/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/shamaton/msgpack/v2 v2.2.2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/flyteidl/go.mod
+++ b/flyteidl/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
+	github.com/shamaton/msgpack/v2 v2.2.2
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/net v0.27.0
@@ -80,7 +81,6 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/shamaton/msgpack/v2 v2.2.2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/flyteidl/go.sum
+++ b/flyteidl/go.sum
@@ -215,6 +215,8 @@ github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoG
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shamaton/msgpack/v2 v2.2.2 h1:GOIg0c9LV04VwzOOqZSrmsv/JzjNOOMxnS/HvOHGdgs=
+github.com/shamaton/msgpack/v2 v2.2.2/go.mod h1:6khjYnkx73f7VQU7wjcFS9DFjs+59naVWJv1TB7qdOI=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5318

## Why are the changes needed?
We want to ease the pain of generic IDL -> msgpack IDL when the user upgrades to flyte 1.14.

## What changes were proposed in this pull request?
1. if `os.environ["FLYTE_USE_OLD_DC_FORMAT"] = "true"`, then use old behavior to generate protobuf struct in the generic IDL.
else generate msgpack IDL.
2. add back unit tests deleted in this PR:
https://github.com/flyteorg/flyte/pull/5840

note: use `envs` is passed to flyteadmin to inform that the first task pod need to inject `envs` in this file, but not be used to command line create `protobuf struct`.

```yaml
iamRoleARN: ""
inputs:
    dc:
        a: 1
        b: 3.14
        c: example_string
envs:
    FLYTE_USE_OLD_DC_FORMAT: true  # Here doesn't work to produce protobuf struct
kubeServiceAcct: ""
targetDomain: ""
targetProject: ""
task: build.current_PR.priority_msgpack.backend_version.dataclass_all.t_dc
version: MO9p1YLmOU041912EgsVUg
```

## How was this patch tested?
use `flytectl create execution` and unit test.

### Setup process
1. pyflyte run --remote a worfklow
2. (msgpack idl) use flytectl to create an execution

3. (protobuf struct) use flytectl to create an execution

```yaml
iamRoleARN: ""
inputs:
    dc:
        a: 1
        b: 3.14
        c: example_string

kubeServiceAcct: ""
targetDomain: ""
targetProject: ""
task: build.current_PR.priority_msgpack.backend_version.dataclass_all.t_dc
version: MO9p1YLmOU041912EgsVUg
```

### Screenshots
#### msgpack idl
```zsh
flytectl create execution --execFile /Users/future-outlier/code/dev/flytekit/build/current_PR/priority_msgpack/flytectl_env/flytectl/create_json_dataclass.yaml -p flytesnacks -d development
execution identifier project:"flytesnacks" domain:"development" name:"a7q4ppv6szk8tqp7972m"
```
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/7f096d60-516b-4d8a-9fef-0a228f20c134">

#### protobuf struct
```zsh
FLYTE_USE_OLD_DC_FORMAT=true flytectl create execution --execFile /Users/future-outlier/code/dev/flytekit/build/current_PR/priority_msgpack/flytectl_env/flytectl/create_json_dataclass.yaml -p flytesnacks -d development
execution identifier project:"flytesnacks" domain:"development" name:"a8vxtjr4r6z2kgbk46jv"
```
<img width="1273" alt="image" src="https://github.com/user-attachments/assets/74e7f073-1c44-48de-b79e-88a3c7635157">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

