### PR TITLE
[Docs] Align code lines of TensorFlow types with flytesnacks

### DIFF
--- a/docs/user_guide/data_types_and_io/tensorflow_type.md
+++ b/docs/user_guide/data_types_and_io/tensorflow_type.md
@@ -9,7 +9,7 @@
 This document outlines the TensorFlow types available in Flyte, which facilitate the integration of TensorFlow models and datasets in Flyte workflows.
 
 ### Import necessary libraries and modules
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/refs/heads/master/examples/data_types_and_io/data_types_and_io/tensorflow_type.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/9aadec205a6e208c62e29f52873fb3d675965a51/examples/data_types_and_io/data_types_and_io/tensorflow_type.py
 :caption: data_types_and_io/tensorflow_type.py
 :lines: 3-12
 ```
@@ -30,7 +30,7 @@ The `TensorFlowModelTransformer` allows you to save a TensorFlow model to a remo
 ```{note}
 To clone and run the example code on this page, see the [Flytesnacks repo][flytesnacks].
 ```
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/refs/heads/master/examples/data_types_and_io/data_types_and_io/tensorflow_type.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/9aadec205a6e208c62e29f52873fb3d675965a51/examples/data_types_and_io/data_types_and_io/tensorflow_type.py
 :caption: data_types_and_io/tensorflow_type.py
 :lines: 16-34
 ```
@@ -47,7 +47,7 @@ Flyte supports TFRecord files through the TFRecordFile type, which can handle se
 ### Usage
 The `TensorFlowRecordFileTransformer` enables you to work with single TFRecord files, making it easy to read and write data in TensorFlow's TFRecord format.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/refs/heads/master/examples/data_types_and_io/data_types_and_io/tensorflow_type.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/9aadec205a6e208c62e29f52873fb3d675965a51/examples/data_types_and_io/data_types_and_io/tensorflow_type.py
 :caption: data_types_and_io/tensorflow_type.py
 :lines: 38-48
 ```
@@ -66,7 +66,7 @@ Flyte supports directories containing multiple TFRecord files through the `TFRec
 The `TensorFlowRecordsDirTransformer` allows you to work with directories of TFRecord files, which is useful for handling large datasets that are split across multiple files.
 
 #### Example
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/refs/heads/master/examples/data_types_and_io/data_types_and_io/tensorflow_type.py
+```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/9aadec205a6e208c62e29f52873fb3d675965a51/examples/data_types_and_io/data_types_and_io/tensorflow_type.py
 :caption: data_types_and_io/tensorflow_type.py
 :lines: 52-62
 ```

--- a/docs/user_guide/data_types_and_io/tensorflow_type.md
+++ b/docs/user_guide/data_types_and_io/tensorflow_type.md
@@ -11,7 +11,7 @@ This document outlines the TensorFlow types available in Flyte, which facilitate
 ### Import necessary libraries and modules
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/refs/heads/master/examples/data_types_and_io/data_types_and_io/tensorflow_type.py
 :caption: data_types_and_io/tensorflow_type.py
-:lines: 2-14
+:lines: 3-12
 ```
 
 ## Tensorflow model
@@ -32,7 +32,7 @@ To clone and run the example code on this page, see the [Flytesnacks repo][flyte
 ```
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/refs/heads/master/examples/data_types_and_io/data_types_and_io/tensorflow_type.py
 :caption: data_types_and_io/tensorflow_type.py
-:lines: 16-33
+:lines: 16-34
 ```
 
 ## TFRecord files
@@ -49,7 +49,7 @@ The `TensorFlowRecordFileTransformer` enables you to work with single TFRecord f
 
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/refs/heads/master/examples/data_types_and_io/data_types_and_io/tensorflow_type.py
 :caption: data_types_and_io/tensorflow_type.py
-:lines: 35-45
+:lines: 38-48
 ```
 
 ## TFRecord directories
@@ -68,7 +68,7 @@ The `TensorFlowRecordsDirTransformer` allows you to work with directories of TFR
 #### Example
 ```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/refs/heads/master/examples/data_types_and_io/data_types_and_io/tensorflow_type.py
 :caption: data_types_and_io/tensorflow_type.py
-:lines: 47-56
+:lines: 52-62
 ```
 
 ## Configuration class: `TFRecordDatasetConfig`


### PR DESCRIPTION
## Why are the changes needed?
The code lines of [Tensorflow types](https://docs.flyte.org/en/latest/user_guide/data_types_and_io/tensorflow_type.html) are out of sync of the [Flytesnacks example](https://raw.githubusercontent.com/flyteorg/flytesnacks/9aadec205a6e208c62e29f52873fb3d675965a51/examples/data_types_and_io/data_types_and_io/tensorflow_type.py).

## What changes were proposed in this pull request?
Fix code lines to align with the code example in flytesnacks.

## Docs link
https://flyte--5983.org.readthedocs.build/en/5983/user_guide/data_types_and_io/tensorflow_type.html
