### PR TITLE
[WIP][flyteadmin] Make New DC and Old DC Default Inputs Compatible

### DIFF
--- a/flyteadmin/pkg/errors/errors.go
+++ b/flyteadmin/pkg/errors/errors.go
@@ -211,6 +211,7 @@ func IsSameDCFormat(oldSpec *admin.LaunchPlanSpec, newSpec *admin.LaunchPlanSpec
 	return true
 }
 
+// todo: if collection type or map type, we should handle it
 func parametersAreEqual(oldParam, newParam *core.Parameter) bool {
 	oldDefault := oldParam.GetDefault()
 	newDefault := newParam.GetDefault()

--- a/flyteadmin/pkg/errors/errors.go
+++ b/flyteadmin/pkg/errors/errors.go
@@ -5,18 +5,19 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/flyteorg/flyte/flytestdlib/pbhash"
+	"reflect"
+	"strings"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/shamaton/msgpack/v2"
 	"github.com/wI2L/jsondiff"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"reflect"
-	"strings"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"github.com/flyteorg/flyte/flytestdlib/pbhash"
 )
 
 type FlyteAdminError interface {


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5318

## Why are the changes needed?
**Context:**

When users use data classes (`dataclass`), lists of data classes (`list[dataclass]`), or maps of data classes (`map[key]dataclass`) as `workflow default input`, they might encounter issues when upgrading or downgrading between `flytekit` versions 1.13.0 and 1.14.0, especially when running workflows remotely using `pyflyte run --remote`.

**Use Cases:**

~~1. **Upgrade Scenario:**
   - A user registers a workflow with default inputs using `flytekit` **1.13.0**.
   - They upgrade to `flytekit` **1.14.0**.
   - They execute `pyflyte run --remote file.py`.~~

2. **Downgrade Scenario:**
   - A user registers a workflow with default inputs using `flytekit` **1.14.0**.
   - They downgrade to `flytekit` **1.13.0**.
   - They execute `pyflyte run --remote file.py`.

**Problem:**

- In the **first scenario**, the default input is stored as a **protobuf struct**, but when running `pyflyte run --remote`, it uses **msgpack IDL** to construct the default input.
- In the **second scenario**, the default input is stored as **msgpack IDL**, but `pyflyte run --remote` uses a **protobuf struct** to construct the default input.
- This mismatch leads to the following error:

  ```
  Launch plan with different structure already exists. (Please register a new version of the launch plan).
  ```

## What changes were proposed in this pull request?
**Root Cause:**

- The `LaunchPlanSpec` is hashed to determine if the remotely run workflow matches the registered one.
- `LaunchPlanSpec.DefaultInputs.ParameterMap` contains either a **msgpack IDL** or a **protobuf struct**, depending on the `flytekit` version used.
- The difference in serialization formats causes the hash comparison to fail, even if the underlying data is the same.

**Solution:**

- Convert both the **msgpack IDL** and the **protobuf struct** representations to a common `map[string]interface{}` in Go, and use `reflect.deepEqual` to compare them.
- With this change, the system recognizes that the workflows are the same, preventing the error and allowing users to upgrade or downgrade `flytekit` versions seamlessly.


**Follow-Up**

This Pull Request (PR) does not address cases where we use `list[DC]` or `dict[str, DC]` as default inputs.
 There's a known bug in Flytekit related to these cases, which is documented in [Flyte issue #5318](https://github.com/flyteorg/flyte/issues/5318).

We need to resolve this Flytekit issue first before we can handle `list[DC]` or `dict[str, DC]` default inputs in this PR.


## How was this patch tested?

| Step                                 | Command                                                                                                                                                                                                                               | Screenshot                                                                                                               |
|--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
| **1. Register a workflow**           | ```pyflyte register /Users/future-outlier/code/dev/flytekit/build/current_PR/priority_msgpack/flytefile_upload/default_input_upload_2.py ```                                             | <img width="300" alt="image" src="https://github.com/user-attachments/assets/343a53f5-0336-4796-a2fd-f9a6a9f62d03">     |
| **2. Use the new dc format remotely** | ```pyflyte run --remote /Users/future-outlier/code/dev/flytekit/build/current_PR/priority_msgpack/flytefile_upload/default_input_upload_2.py wf ```                                      | <img src="https://github.com/user-attachments/assets/001be466-cd59-4bf9-9080-17ad5da5dc86" alt="image" width="300">     |
| **3. Use the old dc format remotely** | ```FLYTE_USE_OLD_DC_FORMAT=true pyflyte run --remote /Users/future-outlier/code/dev/flytekit/build/current_PR/priority_msgpack/flytefile_upload/default_input_upload_2.py wf ```         | <img src="https://github.com/user-attachments/assets/2607f023-349c-4d91-bc10-2ff6fdbedf6d" alt="image" width="300">     |

---

### Example code

```python
import os
from dataclasses import dataclass
from flytekit.types.file import FlyteFile
from flytekit.types.structured import StructuredDataset
from flytekit.types.directory import FlyteDirectory
from flytekit import task, workflow, ImageSpec
import pandas as pd

flytekit_hash = "bfe32b52a6fa4b80ab6876b60edd8cbda1636c07"
flytekit = f"git+https://github.com/flyteorg/flytekit.git@{flytekit_hash}"
image = ImageSpec(
    packages=[flytekit, "pandas", "pyarrow"],
    apt_packages=["git"],
    registry="localhost:30000",
)

image = "localhost:30000/flytekit:dev"

@dataclass
class DC:
    ff: FlyteFile
    sd: StructuredDataset
    fd: FlyteDirectory

@task(container_image=image)
def t1(dc: DC = DC(ff=FlyteFile(os.path.realpath(__file__)),
                   sd=StructuredDataset(uri="/Users/future-outlier/code/dev/flytekit/build/debugyt/user/FE/src/data/df.parquet",
                                        file_format="parquet"),
                   fd=FlyteDirectory("/Users/future-outlier/code/dev/flytekit/build/debugyt/user/FE/src/data/"),
                  )) -> DC:
    with open(dc.ff, "r") as f:
        print("File Content: ", f.read())

    print("sd:", dc.sd.open(pd.DataFrame).all())

    df_path = os.path.join(dc.fd.path, "df.parquet")
    print("fd: ", os.path.isdir(df_path))

    return dc

@workflow
def wf(dc: DC = DC(ff=FlyteFile(os.path.realpath(__file__)),
                   sd=StructuredDataset(uri="/Users/future-outlier/code/dev/flytekit/build/debugyt/user/FE/src/data/df.parquet",
                                        file_format="parquet"),
                   fd=FlyteDirectory("/Users/future-outlier/code/dev/flytekit/build/debugyt/user/FE/src/data/"),
                  )):
    t1(dc=dc)
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytekit/pull/2907

## Docs link

