### PR TITLE
Add visibility control to dynamic log links

### DIFF
--- a/flyteplugins/go/tasks/logs/logging_utils.go
+++ b/flyteplugins/go/tasks/logs/logging_utils.go
@@ -129,6 +129,8 @@ func InitializeLogPlugins(cfg *LogConfig) (tasklog.Plugin, error) {
 				DisplayName:         dynamicLogLink.DisplayName,
 				DynamicTemplateURIs: dynamicLogLink.TemplateURIs,
 				MessageFormat:       core.TaskLog_JSON,
+				ShowWhilePending:    dynamicLogLink.ShowWhilePending,
+				HideOnceFinished:    dynamicLogLink.HideOnceFinished,
 			})
 	}
 

--- a/flyteplugins/go/tasks/pluginmachinery/tasklog/template.go
+++ b/flyteplugins/go/tasks/pluginmachinery/tasklog/template.go
@@ -219,9 +219,11 @@ func (p TemplateLogPlugin) GetTaskLogs(input Input) (Output, error) {
 					}
 				}
 				taskLogs = append(taskLogs, &core.TaskLog{
-					Uri:           replaceAll(dynamicTemplateURI, templateVars),
-					Name:          p.DisplayName + input.LogName,
-					MessageFormat: p.MessageFormat,
+					Uri:              replaceAll(dynamicTemplateURI, templateVars),
+					Name:             p.DisplayName + input.LogName,
+					MessageFormat:    p.MessageFormat,
+					ShowWhilePending: p.ShowWhilePending,
+					HideOnceFinished: p.HideOnceFinished,
 				})
 			}
 		}

--- a/flyteplugins/go/tasks/pluginmachinery/tasklog/template_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/tasklog/template_test.go
@@ -479,6 +479,37 @@ func TestTemplateLogPlugin(t *testing.T) {
 			},
 		},
 		{
+			"flyteinteractive",
+			TemplateLogPlugin{
+				Name:                "vscode",
+				DynamicTemplateURIs: []TemplateURI{"vscode://flyteinteractive:{{ .taskConfig.port }}/{{ .podName }}"},
+				MessageFormat:       core.TaskLog_JSON,
+				HideOnceFinished:    true,
+				ShowWhilePending:    true,
+			},
+			args{
+				input: Input{
+					PodName: "my-pod-name",
+					TaskTemplate: &core.TaskTemplate{
+						Config: map[string]string{
+							"link_type": "vscode",
+							"port":      "1234",
+						},
+					},
+				},
+			},
+			Output{
+				TaskLogs: []*core.TaskLog{
+					{
+						Uri:              "vscode://flyteinteractive:1234/my-pod-name",
+						MessageFormat:    core.TaskLog_JSON,
+						ShowWhilePending: true,
+						HideOnceFinished: true,
+					},
+				},
+			},
+		},
+		{
 			"flyteinteractive - no link_type in task template",
 			TemplateLogPlugin{
 				Name:                "vscode",


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
`HideOnceFinished` config doesn't work with dynamic log links

## What changes were proposed in this pull request?
Add `ShowWhilePending` and `HideOnceFinished` to the dynamic log links when creating the list of TaskLogs

## How was this patch tested?
flytepropeller config
```
plugins:
  logs:
    kubernetes-enabled: true
    kubernetes-template-uri: http://localhost:30080/kubernetes-dashboard/#/log/{{.namespace }}/{{ .podName }
}/pod?namespace={{ .namespace }}
    cloudwatch-enabled: false
    stackdriver-enabled: false
    templates:
    - displayName: ShowPending
      # showWhilePending: true
      hideOnceFinished: true
      templateUris: 456
    dynamic-log-links:
    - vscode:
        displayName: VSCode
        hideOnceFinished: true
        templateUris: 123
```

### Setup process

### Screenshots

<img width="1890" alt="Screenshot 2024-11-14 at 4 55 45 PM" src="https://github.com/user-attachments/assets/0f8e3b88-26b1-47c2-9c95-ac8e7df850fa">
<img width="1905" alt="Screenshot 2024-11-14 at 4 55 57 PM" src="https://github.com/user-attachments/assets/6f356c4c-a792-4476-a1cd-6098295fa669">



## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flyte/pull/4726

## Docs link
NA
