### PR TITLE
Replace other instances of rli

### DIFF
--- a/docs/user_guide/advanced_composition/chaining_flyte_entities.md
+++ b/docs/user_guide/advanced_composition/chaining_flyte_entities.md
@@ -17,7 +17,7 @@ To clone and run the example code on this page, see the [Flytesnacks repo][flyte
 
 Let's establish a sequence where `t1()` occurs after `t0()`, and `t2()` follows `t1()`.
  
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/chain_entities.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/chain_entities.py
 :caption: advanced_composition/chain_entities.py
 :lines: 1-30
 ```
@@ -27,7 +27,7 @@ Let's establish a sequence where `t1()` occurs after `t0()`, and `t2()` follows 
 
 Just like tasks, you can chain {ref}`subworkflows <subworkflow>`.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/chain_entities.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/chain_entities.py
 :caption: advanced_composition/chain_entities.py
 :lines: 34-49
 ```

--- a/docs/user_guide/advanced_composition/conditionals.md
+++ b/docs/user_guide/advanced_composition/conditionals.md
@@ -18,7 +18,7 @@ To clone and run the example code on this page, see the [Flytesnacks repo][flyte
 
 To begin, import the necessary libraries.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :lines: 1-4
 ```
@@ -29,7 +29,7 @@ In this example, we introduce two tasks, `calculate_circle_circumference` and
 `calculate_circle_area`. The workflow dynamically chooses between these tasks based on whether the input
 falls within the fraction range (0-1) or not.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :lines: 12-38
 ```
@@ -40,7 +40,7 @@ We establish an `if` condition with multiple branches, which will result in a fa
 It's important to note that any `conditional` statement in Flyte is expected to be complete,
 meaning that all possible branches must be accounted for.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :pyobject: shape_properties_with_multiple_branches
 ```
@@ -55,7 +55,7 @@ a convention also observed in other libraries.
 ## Consuming the output of a conditional
 Here, we write a task that consumes the output returned by a `conditional`.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :lines: 67-85
 ```
@@ -66,7 +66,7 @@ You can check if a boolean returned from the previous task is `True`,
 but unary operations are not supported directly. Instead, use the `is_true`,
 `is_false` and `is_none` methods on the result.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :lines: 93-123
 ```
@@ -79,7 +79,7 @@ Inputs and outputs are automatically encapsulated in a special object known as {
 ## Using boolean workflow inputs in a conditional
 You can directly pass a boolean to a workflow.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :pyobject: boolean_input_wf
 ```
@@ -92,7 +92,7 @@ This special object enables it to exhibit additional behavior.
 
 You can run the workflows locally as follows:
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :lines: 133-139
 ```
@@ -102,7 +102,7 @@ You can run the workflows locally as follows:
 You can nest conditional sections arbitrarily inside other conditional sections.
 However, these nested sections can only be in the `then` part of a `conditional` block.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :lines: 146-168
 ```
@@ -112,14 +112,14 @@ However, these nested sections can only be in the `then` part of a `conditional`
 Let's write a fun workflow that triggers the `calculate_circle_circumference` task in the event of a "heads" outcome,
 and alternatively, runs the `calculate_circle_area` task in the event of a "tail" outcome.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :pyobject: consume_task_output
 ```
 
 You can run the workflow locally as follows:
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :lines: 216-225
 ```
@@ -138,7 +138,7 @@ task-plugins:
 ```
 :::
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/656e63d1c8dded3e9e7161c7af6425e9fcd43f56/examples/advanced_composition/advanced_composition/conditional.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/conditional.py
 :caption: advanced_composition/conditional.py
 :lines: 200-212
 ```

--- a/docs/user_guide/advanced_composition/decorating_tasks.md
+++ b/docs/user_guide/advanced_composition/decorating_tasks.md
@@ -17,14 +17,14 @@ To clone and run the example code on this page, see the [Flytesnacks repo][flyte
 
 To begin, import the required dependencies.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/decorating_tasks.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/decorating_tasks.py
 :caption: advanced_composition/decorating_tasks.py
 :lines: 1-4
 ```
 
 Create a logger to monitor the execution's progress.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/decorating_tasks.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/decorating_tasks.py
 :caption: advanced_composition/decorating_tasks.py
 :lines: 7
 ```
@@ -33,7 +33,7 @@ Create a logger to monitor the execution's progress.
 
 We define a decorator that logs the input and output details for a decorated task.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/decorating_tasks.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/decorating_tasks.py
 :caption: advanced_composition/decorating_tasks.py
 :pyobject: log_io
 ```
@@ -44,7 +44,7 @@ We create a task named `t1` that is decorated with `log_io`.
 The order of invoking the decorators is important. `@task` should always be the outer-most decorator.
 :::
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/decorating_tasks.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/decorating_tasks.py
 :caption: advanced_composition/decorating_tasks.py
 :pyobject: t1
 ```
@@ -58,7 +58,7 @@ You can also stack multiple decorators on top of each other as long as `@task` i
 We define a decorator that verifies if the output from the decorated function is a positive number before it's returned.
 If this assumption is violated, it raises a `ValueError` exception.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/decorating_tasks.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/decorating_tasks.py
 :caption: advanced_composition/decorating_tasks.py
 :pyobject: validate_output
 ```
@@ -69,14 +69,14 @@ The output of the `validate_output` task uses {py:func}`~functools.partial` to i
 
 We define a function that uses both the logging and validator decorators.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/decorating_tasks.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/decorating_tasks.py
 :caption: advanced_composition/decorating_tasks.py
 :pyobject: t2
 ```
 
 Finally, we compose a workflow that calls `t1` and `t2`.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/decorating_tasks.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/decorating_tasks.py
 :caption: advanced_composition/decorating_tasks.py
 :lines: 53-59
 ```

--- a/docs/user_guide/advanced_composition/dynamic_workflows.md
+++ b/docs/user_guide/advanced_composition/dynamic_workflows.md
@@ -40,28 +40,28 @@ To clone and run the example code on this page, see the [Flytesnacks repo][flyte
 
 To begin, we import the required libraries.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/dynamic_workflow.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/dynamic_workflow.py
 :caption: advanced_composition/dynamic_workflow.py
 :lines: 1
 ```
 
 We define a task that returns the index of a character, where A-Z/a-z is equivalent to 0-25.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/dynamic_workflow.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/dynamic_workflow.py
 :caption: advanced_composition/dynamic_workflow.py
 :pyobject: return_index
 ```
 
 We also create a task that prepares a list of 26 characters by populating the frequency of each character.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/dynamic_workflow.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/dynamic_workflow.py
 :caption: advanced_composition/dynamic_workflow.py
 :pyobject: update_list
 ```
 
 We define a task to calculate the number of common characters between the two strings.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/dynamic_workflow.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/dynamic_workflow.py
 :caption: advanced_composition/dynamic_workflow.py
 :pyobject: derive_count
 ```
@@ -75,7 +75,7 @@ We define a dynamic workflow to accomplish the following:
 
 The looping process is contingent on the number of characters in both strings, which is unknown until runtime.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/dynamic_workflow.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/dynamic_workflow.py
 :caption: advanced_composition/dynamic_workflow.py
 :pyobject: count_characters
 ```
@@ -97,14 +97,14 @@ Local execution works when a `@dynamic` decorator is used because Flytekit treat
 
 Define a workflow that triggers the dynamic workflow.
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/dynamic_workflow.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/dynamic_workflow.py
 :caption: advanced_composition/dynamic_workflow.py
 :pyobject: dynamic_wf
 ```
 
 You can run the workflow locally as follows:
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/dynamic_workflow.py
+```{literalinclude} /examples/advanced_composition/advanced_composition/dynamic_workflow.py
 :caption: advanced_composition/dynamic_workflow.py
 :lines: 78-79
 ```

--- a/docs/user_guide/getting_started_with_workflow_development/flyte_project_components.md
+++ b/docs/user_guide/getting_started_with_workflow_development/flyte_project_components.md
@@ -33,8 +33,8 @@ manage your project's Python requirements.
 
 ````{dropdown} See requirements.txt
 
-```{rli} https://raw.githubusercontent.com/flyteorg/flytekit-python-template/main/basic-template-imagespec/%7B%7Bcookiecutter.project_name%7D%7D/requirements.txt
-:caption: requirements.txt
+```{code-block} bash
+flytekit>=1.5.0
 ```
 
 ````


### PR DESCRIPTION
## Why are the changes needed?
Similar to https://github.com/flyteorg/flyte/pull/6008, this PR deletes the remaining instances of `{rli}`.

Note that in one case I replaced the `rli` with a code-block, since that's supposed to be a file. I'm not sure if that's the appropriate way of displaying these simple files.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
