### PR TITLE
[Docs] MessagePack IDL, Pydantic Support, and Attribute Access

### DIFF
--- a/docs/user_guide/data_types_and_io/accessing_attributes.md
+++ b/docs/user_guide/data_types_and_io/accessing_attributes.md
@@ -11,7 +11,7 @@ Note that while this functionality may appear to be the normal behavior of Pytho
 Consequently, accessing attributes in this manner is, in fact, a specially implemented feature.
 This functionality facilitates the direct passing of output attributes within workflows, enhancing the convenience of working with complex data structures.
 
-```{note}
+```{important}
 Flytekit version >= v1.14.0 supports Pydantic BaseModel V2, you can do attribute access on Pydantic BaseModel V2 as well.
 ```
 

--- a/docs/user_guide/data_types_and_io/accessing_attributes.md
+++ b/docs/user_guide/data_types_and_io/accessing_attributes.md
@@ -12,6 +12,10 @@ Consequently, accessing attributes in this manner is, in fact, a specially imple
 This functionality facilitates the direct passing of output attributes within workflows, enhancing the convenience of working with complex data structures.
 
 ```{note}
+Flytekit version >= v1.14.0 supports Pydantic BaseModel V2, you can do attribute access on Pydantic BaseModel V2 as well.
+```
+
+```{note}
 To clone and run the example code on this page, see the [Flytesnacks repo][flytesnacks].
 ```
 

--- a/docs/user_guide/data_types_and_io/accessing_attributes.md
+++ b/docs/user_guide/data_types_and_io/accessing_attributes.md
@@ -23,7 +23,7 @@ To begin, import the required dependencies and define a common task for subseque
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/attribute_access.py
 :caption: data_types_and_io/attribute_access.py
-:lines: 1-10
+:lines: 1-9
 ```
 
 ## List
@@ -35,7 +35,7 @@ Flyte currently does not support output promise access through list slicing.
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/attribute_access.py
 :caption: data_types_and_io/attribute_access.py
-:lines: 14-23
+:lines: 13-22
 ```
 
 ## Dictionary
@@ -43,7 +43,7 @@ Access the output dictionary by specifying the key.
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/attribute_access.py
 :caption: data_types_and_io/attribute_access.py
-:lines: 27-35
+:lines: 26-34
 ```
 
 ## Data class
@@ -51,7 +51,7 @@ Directly access an attribute of a dataclass.
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/attribute_access.py
 :caption: data_types_and_io/attribute_access.py
-:lines: 39-53
+:lines: 38-51
 ```
 
 ## Complex type
@@ -59,14 +59,14 @@ Combinations of list, dict and dataclass also work effectively.
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/attribute_access.py
 :caption: data_types_and_io/attribute_access.py
-:lines: 57-80
+:lines: 55-78
 ```
 
 You can run all the workflows locally as follows:
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/attribute_access.py
 :caption: data_types_and_io/attribute_access.py
-:lines: 84-88
+:lines: 82-86
 ```
 
 ## Failure scenario

--- a/docs/user_guide/data_types_and_io/dataclass.md
+++ b/docs/user_guide/data_types_and_io/dataclass.md
@@ -26,7 +26,6 @@ literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to 
 If you're using Flytekit version < v1.11.1, you will need to add `from dataclasses_json import dataclass_json` to your imports and decorate your dataclass with `@dataclass_json`.
 :::
 
-:::{important}
 Flytekit version < v1.14.0 will produce protobuf struct literal for dataclasses.
 
 Flytekit version >= v1.14.0 will produce msgpack bytes literal for dataclasses.

--- a/docs/user_guide/data_types_and_io/dataclass.md
+++ b/docs/user_guide/data_types_and_io/dataclass.md
@@ -9,11 +9,13 @@
 When you've multiple values that you want to send across Flyte entities, you can use a `dataclass`.
 
 Flytekit uses the [Mashumaro library](https://github.com/Fatal1ty/mashumaro)
-to serialize and deserialize dataclasses. With the 1.14 release, `flytekit` adopted `MessagePack` as the serialization format for dataclasses, overcoming  a major limitation of serialization into a JSON string within a Protobuf `struct` datatype, like the previous versions do: to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to workaround this issue. By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses.
+to serialize and deserialize dataclasses. With the 1.14 release, `flytekit` adopted `MessagePack` as the 
+serialization format for dataclasses, overcoming  a major limitation of serialization into a JSON string within a Protobuf `struct` datatype, like the previous versions do: to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to work around this issue. By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses.
 
 :::{important}
 
-If you're serializing dataclasses using `flytekit` version >= v1.14.0 and you want to produce Protobuf `struct literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
+If you're serializing dataclasses using `flytekit` version >= v1.14.0, and you want to produce Protobuf `struct 
+literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 
 :::{important}
 If you're using Flytekit version < v1.11.1, you will need to add `from dataclasses_json import dataclass_json` to your imports and decorate your dataclass with `@dataclass_json`.

--- a/docs/user_guide/data_types_and_io/dataclass.md
+++ b/docs/user_guide/data_types_and_io/dataclass.md
@@ -12,7 +12,16 @@ Flytekit uses the [Mashumaro library](https://github.com/Fatal1ty/mashumaro)
 to serialize and deserialize dataclasses.
 
 :::{important}
-If you're using Flytekit version below v1.11.1, you will need to add `from dataclasses_json import dataclass_json` to your imports and decorate your dataclass with `@dataclass_json`.
+If you're using Flytekit version < v1.11.1, you will need to add `from dataclasses_json import dataclass_json` to your imports and decorate your dataclass with `@dataclass_json`.
+:::
+
+:::{important}
+Flytekit version < v1.14.0 will produce protobuf struct literal for dataclasses.
+
+Flytekit version >= v1.14.0 will produce msgpack bytes literal for dataclasses.
+
+If you're using Flytekit version >= v1.14.0 and you want to produce protobuf struct literal for dataclasses, you can 
+set environment variable  `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 :::
 
 ```{note}

--- a/docs/user_guide/data_types_and_io/dataclass.md
+++ b/docs/user_guide/data_types_and_io/dataclass.md
@@ -9,7 +9,11 @@
 When you've multiple values that you want to send across Flyte entities, you can use a `dataclass`.
 
 Flytekit uses the [Mashumaro library](https://github.com/Fatal1ty/mashumaro)
-to serialize and deserialize dataclasses.
+to serialize and deserialize dataclasses. With the 1.14 release, `flytekit` adopted `MessagePack` as the serialization format for dataclasses, overcoming  a major limitation of serialization into a JSON string within a Protobuf `struct` datatype, like the previous versions do: to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to workaround this issue. By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses.
+
+:::{important}
+
+If you're serializing dataclasses using `flytekit` version >= v1.14.0 and you want to produce Protobuf `struct literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 
 :::{important}
 If you're using Flytekit version < v1.11.1, you will need to add `from dataclasses_json import dataclass_json` to your imports and decorate your dataclass with `@dataclass_json`.

--- a/docs/user_guide/data_types_and_io/dataclass.md
+++ b/docs/user_guide/data_types_and_io/dataclass.md
@@ -16,7 +16,6 @@ serialization format for dataclasses, overcoming  a major limitation of serializ
 
 to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to work around this issue.
 
-By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses.
 
 :::{important}
 

--- a/docs/user_guide/data_types_and_io/dataclass.md
+++ b/docs/user_guide/data_types_and_io/dataclass.md
@@ -12,20 +12,22 @@ Flytekit uses the [Mashumaro library](https://github.com/Fatal1ty/mashumaro)
 to serialize and deserialize dataclasses.
 
 With the 1.14 release, `flytekit` adopted `MessagePack` as the 
-serialization format for dataclasses, overcoming  a major limitation of serialization into a JSON string within a Protobuf `struct` datatype, like the previous versions do:
+serialization format for dataclasses, overcoming a major limitation of serialization into a JSON string within a Protobuf `struct` datatype, like the previous versions do:
 
 to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to work around this issue.
 
 
 :::{important}
-
 If you're serializing dataclasses using `flytekit` version >= v1.14.0, and you want to produce Protobuf `struct 
 literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
+:::
+
 
 :::{important}
 If you're using Flytekit version < v1.11.1, you will need to add `from dataclasses_json import dataclass_json` to your imports and decorate your dataclass with `@dataclass_json`.
 :::
 
+:::{important}
 Flytekit version < v1.14.0 will produce protobuf struct literal for dataclasses.
 
 Flytekit version >= v1.14.0 will produce msgpack bytes literal for dataclasses.

--- a/docs/user_guide/data_types_and_io/dataclass.md
+++ b/docs/user_guide/data_types_and_io/dataclass.md
@@ -9,8 +9,14 @@
 When you've multiple values that you want to send across Flyte entities, you can use a `dataclass`.
 
 Flytekit uses the [Mashumaro library](https://github.com/Fatal1ty/mashumaro)
-to serialize and deserialize dataclasses. With the 1.14 release, `flytekit` adopted `MessagePack` as the 
-serialization format for dataclasses, overcoming  a major limitation of serialization into a JSON string within a Protobuf `struct` datatype, like the previous versions do: to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to work around this issue. By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses.
+to serialize and deserialize dataclasses.
+
+With the 1.14 release, `flytekit` adopted `MessagePack` as the 
+serialization format for dataclasses, overcoming  a major limitation of serialization into a JSON string within a Protobuf `struct` datatype, like the previous versions do:
+
+to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to work around this issue.
+
+By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses.
 
 :::{important}
 

--- a/docs/user_guide/data_types_and_io/dataclass.md
+++ b/docs/user_guide/data_types_and_io/dataclass.md
@@ -16,23 +16,16 @@ serialization format for dataclasses, overcoming a major limitation of serializa
 
 to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to work around this issue.
 
-
-:::{important}
-If you're serializing dataclasses using `flytekit` version >= v1.14.0, and you want to produce Protobuf `struct 
-literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
-:::
-
-
 :::{important}
 If you're using Flytekit version < v1.11.1, you will need to add `from dataclasses_json import dataclass_json` to your imports and decorate your dataclass with `@dataclass_json`.
 :::
 
 :::{important}
-Flytekit version < v1.14.0 will produce protobuf struct literal for dataclasses.
+Flytekit version < v1.14.0 will produce protobuf `struct` literal for dataclasses.
 
 Flytekit version >= v1.14.0 will produce msgpack bytes literal for dataclasses.
 
-If you're using Flytekit version >= v1.14.0 and you want to produce protobuf struct literal for dataclasses, you can 
+If you're using Flytekit version >= v1.14.0 and you want to produce protobuf `struct` literal for dataclasses, you can 
 set environment variable  `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 
 For more details, you can refer the MSGPACK IDL RFC: https://github.com/flyteorg/flyte/blob/master/rfc/system/5741-binary-idl-with-message-pack.md

--- a/docs/user_guide/data_types_and_io/dataclass.md
+++ b/docs/user_guide/data_types_and_io/dataclass.md
@@ -22,6 +22,8 @@ Flytekit version >= v1.14.0 will produce msgpack bytes literal for dataclasses.
 
 If you're using Flytekit version >= v1.14.0 and you want to produce protobuf struct literal for dataclasses, you can 
 set environment variable  `FLYTE_USE_OLD_DC_FORMAT` to `true`.
+
+For more details, you can refer the MSGPACK IDL RFC: https://github.com/flyteorg/flyte/blob/master/rfc/system/5741-binary-idl-with-message-pack.md
 :::
 
 ```{note}

--- a/docs/user_guide/data_types_and_io/index.md
+++ b/docs/user_guide/data_types_and_io/index.md
@@ -114,7 +114,7 @@ Here's a breakdown of these mappings:
       - Use ``pyspark.DataFrame`` as a type hint.
     * - ``pydantic.BaseModel``
       - ``Map``
-      - To utilize the type, install the ``flytekitplugins-pydantic`` plugin.
+      - To utilize the type, install the ``pydantic>2`` module.
       - Use ``pydantic.BaseModel`` as a type hint.
     * - ``torch.Tensor`` / ``torch.nn.Module``
       - File
@@ -144,7 +144,7 @@ flytefile
 flytedirectory
 structureddataset
 dataclass
-pydantic
+pydantic_basemodel
 accessing_attributes
 pytorch_type
 enum_type

--- a/docs/user_guide/data_types_and_io/index.md
+++ b/docs/user_guide/data_types_and_io/index.md
@@ -144,6 +144,7 @@ flytefile
 flytedirectory
 structureddataset
 dataclass
+pydantic
 accessing_attributes
 pytorch_type
 enum_type

--- a/docs/user_guide/data_types_and_io/pydantic.md
+++ b/docs/user_guide/data_types_and_io/pydantic.md
@@ -19,3 +19,76 @@ If you're using Flytekit version >= v1.14.0 and you want to produce protobuf str
 you can set environment variable  `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 :::
 
+
+```{note}
+To clone and run the example code on this page, see the [Flytesnacks repo][flytesnacks].
+```
+
+To begin, import the necessary dependencies:
+
+```{literalinclude} /examples/data_types_and_io/data_types_and_io/pydantic_basemodel.py
+:caption: data_types_and_io/pydantic_basemodel.py
+:lines: 1-9
+```
+
+Build your custom image with ImageSpec:
+```{literalinclude} /examples/data_types_and_io/data_types_and_io/pydantic_basemodel.py
+:caption: data_types_and_io/pydantic_basemodel.py
+:lines: 11-14
+```
+
+## Python types
+We define a `dataclass` with `int`, `str` and `dict` as the data types.
+
+```{literalinclude} /examples/data_types_and_io/data_types_and_io/pydantic_basemodel.py
+:caption: data_types_and_io/pydantic_basemodel.py
+:pyobject: Datum
+```
+
+You can send a `dataclass` between different tasks written in various languages, and input it through the Flyte console as raw JSON.
+
+:::{note}
+All variables in a data class should be **annotated with their type**. Failure to do should will result in an error.
+:::
+
+Once declared, a dataclass can be returned as an output or accepted as an input.
+
+```{literalinclude} /examples/data_types_and_io/data_types_and_io/pydantic_basemodel.py
+:caption: data_types_and_io/pydantic_basemodel.py
+:lines: 26-41
+```
+
+## Flyte types
+We also define a data class that accepts {std:ref}`StructuredDataset <structured_dataset>`,
+{std:ref}`FlyteFile <files>` and {std:ref}`FlyteDirectory <folder>`.
+
+```{literalinclude} /examples/data_types_and_io/data_types_and_io/pydantic_basemodel.py
+:caption: data_types_and_io/pydantic_basemodel.py
+:lines: 45-86
+```
+
+A data class supports the usage of data associated with Python types, data classes,
+flyte file, flyte directory and structured dataset.
+
+We define a workflow that calls the tasks created above.
+
+```{literalinclude} /examples/data_types_and_io/data_types_and_io/pydantic_basemodel.py
+:caption: data_types_and_io/pydantic_basemodel.py
+:pyobject: basemodel_wf
+```
+
+You can run the workflow locally as follows:
+
+```{literalinclude} /examples/data_types_and_io/data_types_and_io/pydantic_basemodel.py
+:caption: data_types_and_io/pydantic_basemodel.py
+:lines: 99-100
+```
+
+To trigger a task that accepts a dataclass as an input with `pyflyte run`, you can provide a JSON file as an input:
+```
+pyflyte run \
+  https://raw.githubusercontent.com/flyteorg/flytesnacks/b71e01d45037cea883883f33d8d93f258b9a5023/examples/data_types_and_io/data_types_and_io/pydantic_basemodel.py \
+  basemodel_wf --x 1 --y 2
+```
+
+[flytesnacks]: https://github.com/flyteorg/flytesnacks/tree/master/examples/data_types_and_io/

--- a/docs/user_guide/data_types_and_io/pydantic.md
+++ b/docs/user_guide/data_types_and_io/pydantic.md
@@ -1,0 +1,18 @@
+(pydantic)=
+
+# Pydantic BaseModel
+
+```{eval-rst}
+.. tags:: Basic
+```
+
+When you've multiple values that you want to send across Flyte entities, and you want them to have, you can use a `pydantic.BaseModel`.
+Note:
+You can put Dataclass and FlyteTypes (FlyteFile, FlyteDirectory, FlyteSchema, and StructuredDataset) in a pydantic BaseModel.
+
+:::{important}
+Pydantic BaseModle V2 only works when you are using flytekit version >= v1.14.0.
+
+If you're using Flytekit version >= v1.14.0 and you want to produce protobuf struct literal for pydantic basemodels, 
+you can set environment variable  `FLYTE_USE_OLD_DC_FORMAT` to `true`.
+:::

--- a/docs/user_guide/data_types_and_io/pydantic.md
+++ b/docs/user_guide/data_types_and_io/pydantic.md
@@ -17,6 +17,8 @@ Pydantic BaseModel V2 only works when you are using flytekit version >= v1.14.0.
 :::{important}
 If you're using Flytekit version >= v1.14.0 and you want to produce protobuf struct literal for pydantic basemodels,
 you can set environment variable  `FLYTE_USE_OLD_DC_FORMAT` to `true`.
+
+For more details, you can refer the MSGPACK IDL RFC: https://github.com/flyteorg/flyte/blob/master/rfc/system/5741-binary-idl-with-message-pack.md
 :::
 
 

--- a/docs/user_guide/data_types_and_io/pydantic.md
+++ b/docs/user_guide/data_types_and_io/pydantic.md
@@ -11,8 +11,11 @@ Note:
 You can put Dataclass and FlyteTypes (FlyteFile, FlyteDirectory, FlyteSchema, and StructuredDataset) in a pydantic BaseModel.
 
 :::{important}
-Pydantic BaseModle V2 only works when you are using flytekit version >= v1.14.0.
+Pydantic BaseModel V2 only works when you are using flytekit version >= v1.14.0.
+:::
 
-If you're using Flytekit version >= v1.14.0 and you want to produce protobuf struct literal for pydantic basemodels, 
+:::{important}
+If you're using Flytekit version >= v1.14.0 and you want to produce protobuf struct literal for pydantic basemodels,
 you can set environment variable  `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 :::
+

--- a/docs/user_guide/data_types_and_io/pydantic_basemodel.md
+++ b/docs/user_guide/data_types_and_io/pydantic_basemodel.md
@@ -20,7 +20,8 @@ to store `int` types, Protobuf's `struct` converts them to `float`, forcing user
 
 
 :::{important}
-If you're serializing dataclasses using `flytekit` version >= v1.14.0 and you want to produce Protobuf `struct literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
+By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing, preserving the types defined in your `BaseModel` class.
+If you're serializing `BaseModel` using `flytekit` version >= v1.14.0 and you want to produce Protobuf `struct literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 
 For more details, you can refer the MESSAGEPACK IDL RFC: https://github.com/flyteorg/flyte/blob/master/rfc/system/5741-binary-idl-with-message-pack.md
 :::

--- a/docs/user_guide/data_types_and_io/pydantic_basemodel.md
+++ b/docs/user_guide/data_types_and_io/pydantic_basemodel.md
@@ -6,7 +6,7 @@
 .. tags:: Basic
 ```
 
-When you have multiple values that you want to send across Flyte entities, and you want them to have, you can use a `pydantic.BaseModel`.
+`flytekit` version >=1.14 supports natively the `JSON` format that Pydantic `BaseModel` produces,  enhancing the interoperability of Pydantic schemas with the Flyte type system.
 
 :::{important}
 Pydantic BaseModel V2 only works when you are using flytekit version >= v1.14.0.

--- a/docs/user_guide/data_types_and_io/pydantic_basemodel.md
+++ b/docs/user_guide/data_types_and_io/pydantic_basemodel.md
@@ -12,7 +12,9 @@
 Pydantic BaseModel V2 only works when you are using flytekit version >= v1.14.0.
 :::
 
+With the 1.14 release, `flytekit` adopted `MessagePack` as the serialization format for Pydantic `BaseModel`, overcoming a major limitation of serialization into a JSON string within a Protobuf `struct` datatype like the previous versions do: to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to workaround this issue. By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses, preserving the types defined in your `BaseModel` class.
 :::{important}
+If you're serializing dataclasses using `flytekit` version >= v1.14.0 and you want to produce Protobuf `struct literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 If you're using Flytekit version >= v1.14.0 and you want to produce protobuf struct literal for Pydantic BaseModels,
 you can set environment variable  `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 

--- a/docs/user_guide/data_types_and_io/pydantic_basemodel.md
+++ b/docs/user_guide/data_types_and_io/pydantic_basemodel.md
@@ -14,7 +14,11 @@ Pydantic BaseModel V2 only works when you are using flytekit version >= v1.14.0.
 :::
 
 With the 1.14 release, `flytekit` adopted `MessagePack` as the serialization format for Pydantic `BaseModel`, 
-overcoming a major limitation of serialization into a JSON string within a Protobuf `struct` datatype like the previous versions do: to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to work around this issue. By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses, preserving the types defined in your `BaseModel` class.
+overcoming a major limitation of serialization into a JSON string within a Protobuf `struct` datatype like the previous versions do:
+
+to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to work around this issue.
+
+By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses, preserving the types defined in your `BaseModel` class.
 
 :::{important}
 If you're serializing dataclasses using `flytekit` version >= v1.14.0 and you want to produce Protobuf `struct literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.

--- a/docs/user_guide/data_types_and_io/pydantic_basemodel.md
+++ b/docs/user_guide/data_types_and_io/pydantic_basemodel.md
@@ -18,7 +18,6 @@ overcoming a major limitation of serialization into a JSON string within a Proto
 
 to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to work around this issue.
 
-By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses, preserving the types defined in your `BaseModel` class.
 
 :::{important}
 If you're serializing dataclasses using `flytekit` version >= v1.14.0 and you want to produce Protobuf `struct literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.

--- a/docs/user_guide/data_types_and_io/pydantic_basemodel.md
+++ b/docs/user_guide/data_types_and_io/pydantic_basemodel.md
@@ -16,7 +16,6 @@ With the 1.14 release, `flytekit` adopted `MessagePack` as the serialization for
 :::{important}
 If you're serializing dataclasses using `flytekit` version >= v1.14.0 and you want to produce Protobuf `struct literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 If you're using Flytekit version >= v1.14.0 and you want to produce protobuf struct literal for Pydantic BaseModels,
-you can set environment variable  `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 
 For more details, you can refer the MESSAGEPACK IDL RFC: https://github.com/flyteorg/flyte/blob/master/rfc/system/5741-binary-idl-with-message-pack.md
 :::

--- a/docs/user_guide/data_types_and_io/pydantic_basemodel.md
+++ b/docs/user_guide/data_types_and_io/pydantic_basemodel.md
@@ -6,13 +6,16 @@
 .. tags:: Basic
 ```
 
-`flytekit` version >=1.14 supports natively the `JSON` format that Pydantic `BaseModel` produces,  enhancing the interoperability of Pydantic schemas with the Flyte type system.
+`flytekit` version >=1.14 supports natively the `JSON` format that Pydantic `BaseModel` produces,  enhancing the 
+interoperability of Pydantic BaseModels with the Flyte type system.
 
 :::{important}
 Pydantic BaseModel V2 only works when you are using flytekit version >= v1.14.0.
 :::
 
-With the 1.14 release, `flytekit` adopted `MessagePack` as the serialization format for Pydantic `BaseModel`, overcoming a major limitation of serialization into a JSON string within a Protobuf `struct` datatype like the previous versions do: to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to workaround this issue. By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses, preserving the types defined in your `BaseModel` class.
+With the 1.14 release, `flytekit` adopted `MessagePack` as the serialization format for Pydantic `BaseModel`, 
+overcoming a major limitation of serialization into a JSON string within a Protobuf `struct` datatype like the previous versions do: to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to work around this issue. By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses, preserving the types defined in your `BaseModel` class.
+
 :::{important}
 If you're serializing dataclasses using `flytekit` version >= v1.14.0 and you want to produce Protobuf `struct literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 

--- a/docs/user_guide/data_types_and_io/pydantic_basemodel.md
+++ b/docs/user_guide/data_types_and_io/pydantic_basemodel.md
@@ -15,7 +15,6 @@ Pydantic BaseModel V2 only works when you are using flytekit version >= v1.14.0.
 With the 1.14 release, `flytekit` adopted `MessagePack` as the serialization format for Pydantic `BaseModel`, overcoming a major limitation of serialization into a JSON string within a Protobuf `struct` datatype like the previous versions do: to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to workaround this issue. By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing dataclasses, preserving the types defined in your `BaseModel` class.
 :::{important}
 If you're serializing dataclasses using `flytekit` version >= v1.14.0 and you want to produce Protobuf `struct literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
-If you're using Flytekit version >= v1.14.0 and you want to produce protobuf struct literal for Pydantic BaseModels,
 
 For more details, you can refer the MESSAGEPACK IDL RFC: https://github.com/flyteorg/flyte/blob/master/rfc/system/5741-binary-idl-with-message-pack.md
 :::

--- a/docs/user_guide/data_types_and_io/pydantic_basemodel.md
+++ b/docs/user_guide/data_types_and_io/pydantic_basemodel.md
@@ -18,10 +18,9 @@ overcoming a major limitation of serialization into a JSON string within a Proto
 
 to store `int` types, Protobuf's `struct` converts them to `float`, forcing users to write boilerplate code to work around this issue.
 
-
 :::{important}
 By default, `flytekit >= 1.14` will produce `msgpack` bytes literals when serializing, preserving the types defined in your `BaseModel` class.
-If you're serializing `BaseModel` using `flytekit` version >= v1.14.0 and you want to produce Protobuf `struct literal` instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
+If you're serializing `BaseModel` using `flytekit` version >= v1.14.0 and you want to produce Protobuf `struct` literal instead, you can set environment variable `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 
 For more details, you can refer the MESSAGEPACK IDL RFC: https://github.com/flyteorg/flyte/blob/master/rfc/system/5741-binary-idl-with-message-pack.md
 :::

--- a/docs/user_guide/data_types_and_io/pydantic_basemodel.md
+++ b/docs/user_guide/data_types_and_io/pydantic_basemodel.md
@@ -1,4 +1,4 @@
-(pydantic)=
+(pydantic_basemodel)=
 
 # Pydantic BaseModel
 
@@ -6,21 +6,22 @@
 .. tags:: Basic
 ```
 
-When you've multiple values that you want to send across Flyte entities, and you want them to have, you can use a `pydantic.BaseModel`.
-Note:
-You can put Dataclass and FlyteTypes (FlyteFile, FlyteDirectory, FlyteSchema, and StructuredDataset) in a pydantic BaseModel.
+When you have multiple values that you want to send across Flyte entities, and you want them to have, you can use a `pydantic.BaseModel`.
 
 :::{important}
 Pydantic BaseModel V2 only works when you are using flytekit version >= v1.14.0.
 :::
 
 :::{important}
-If you're using Flytekit version >= v1.14.0 and you want to produce protobuf struct literal for pydantic basemodels,
+If you're using Flytekit version >= v1.14.0 and you want to produce protobuf struct literal for Pydantic BaseModels,
 you can set environment variable  `FLYTE_USE_OLD_DC_FORMAT` to `true`.
 
-For more details, you can refer the MSGPACK IDL RFC: https://github.com/flyteorg/flyte/blob/master/rfc/system/5741-binary-idl-with-message-pack.md
+For more details, you can refer the MESSAGEPACK IDL RFC: https://github.com/flyteorg/flyte/blob/master/rfc/system/5741-binary-idl-with-message-pack.md
 :::
 
+```{note}
+You can put Dataclass and FlyteTypes (FlyteFile, FlyteDirectory, FlyteSchema, and StructuredDataset) in a pydantic BaseModel.
+```
 
 ```{note}
 To clone and run the example code on this page, see the [Flytesnacks repo][flytesnacks].
@@ -40,14 +41,14 @@ Build your custom image with ImageSpec:
 ```
 
 ## Python types
-We define a `dataclass` with `int`, `str` and `dict` as the data types.
+We define a `pydantic basemodel` with `int`, `str` and `dict` as the data types.
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/pydantic_basemodel.py
 :caption: data_types_and_io/pydantic_basemodel.py
 :pyobject: Datum
 ```
 
-You can send a `dataclass` between different tasks written in various languages, and input it through the Flyte console as raw JSON.
+You can send a `pydantic basemodel` between different tasks written in various languages, and input it through the Flyte console as raw JSON.
 
 :::{note}
 All variables in a data class should be **annotated with their type**. Failure to do should will result in an error.


### PR DESCRIPTION
## Docs link
- dataclass: https://flyte--6022.org.readthedocs.build/en/6022/user_guide/data_types_and_io/dataclass.html
- pydantic basemodel: https://flyte--6022.org.readthedocs.build/en/6022/user_guide/data_types_and_io/pydantic_basemodel.html
- attribute access: https://flyte--6022.org.readthedocs.build/en/6022/user_guide/data_types_and_io/accessing_attributes.html

## Tracking issue
https://github.com/flyteorg/flyte/issues/5318
