### PR TITLE
docs: update command for running the single binary

### DIFF
--- a/docs/community/contribute/contribute_code.rst
+++ b/docs/community/contribute/contribute_code.rst
@@ -293,7 +293,7 @@ that integrates all Flyte components into a single binary.
    # Step 4: Running the single binary.
    # The POD_NAMESPACE environment variable is necessary for the webhook to function correctly.
    # You may encounter an error due to `ERROR: duplicate key value violates unique constraint`. Running the command again will solve the problem.
-   POD_NAMESPACE=flyte ./flyte start --config flyte-single-binary-local.yaml
+   POD_NAMESPACE=flyte flyte start --config flyte-single-binary-local.yaml
    # All logs from flyteadmin, flyteplugins, flytepropeller, etc. will appear in the terminal.
 
 
@@ -327,7 +327,7 @@ The following instructions provide guidance on how to build single binary with y
    # Step 3: Now, you can build the single binary. Go back to Flyte directory.
    make go-tidy
    make compile
-   POD_NAMESPACE=flyte ./flyte start --config flyte-single-binary-local.yaml
+   POD_NAMESPACE=flyte flyte start --config flyte-single-binary-local.yaml
 
 **5. Test by running a hello world workflow.**
 


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

Following the instruction of [setting up environment](https://docs.flyte.org/en/latest/community/contribute/contribute_code.html#how-to-setup-dev-environment-for-flyteidl-flyteadmin-flyteplugins-flytepropeller-datacatalog-and-flytestdlib), the command `POD_NAMESPACE=flyte ./flyte start --config flyte-single-binary-local.yaml` gives error `no such file or directory: ./flyte`

![image](https://github.com/user-attachments/assets/2dfe21da-46ab-4da8-81e5-64c30fb444d9)

It turns out that `make compile` command move `./flyte` file to `$GOPATH/bin`. Hence, directly run `flyte` instead of `./flyte` works.

## What changes were proposed in this pull request?

change `./flyte` in command to `flyte`

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

![image](https://github.com/user-attachments/assets/377a5643-2e7f-49f5-b2a9-a16b1c8be6e6)


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
