### PR TITLE
Revert "[COR-2297/] Fix nested offloaded type validation (#552) (#5996)"

### DIFF
--- a/flytepropeller/pkg/compiler/validators/utils.go
+++ b/flytepropeller/pkg/compiler/validators/utils.go
@@ -276,13 +276,13 @@ func LiteralTypeForLiteral(l *core.Literal) *core.LiteralType {
 	case *core.Literal_Collection:
 		return &core.LiteralType{
 			Type: &core.LiteralType_CollectionType{
-				CollectionType: literalTypeForLiterals(l.GetCollection().Literals),
+				CollectionType: literalTypeForLiterals(l.GetCollection().GetLiterals()),
 			},
 		}
 	case *core.Literal_Map:
 		return &core.LiteralType{
 			Type: &core.LiteralType_MapValueType{
-				MapValueType: literalTypeForLiterals(maps.Values(l.GetMap().Literals)),
+				MapValueType: literalTypeForLiterals(maps.Values(l.GetMap().GetLiterals())),
 			},
 		}
 	case *core.Literal_OffloadedMetadata:

--- a/flytepropeller/pkg/compiler/validators/utils_test.go
+++ b/flytepropeller/pkg/compiler/validators/utils_test.go
@@ -13,9 +13,8 @@ import (
 
 func TestLiteralTypeForLiterals(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		lt, isOffloaded := literalTypeForLiterals(nil)
+		lt := literalTypeForLiterals(nil)
 		assert.Equal(t, core.SimpleType_NONE.String(), lt.GetSimple().String())
-		assert.False(t, isOffloaded)
 	})
 
 	t.Run("binary idl with raw binary data and no tag", func(t *testing.T) {
@@ -95,18 +94,17 @@ func TestLiteralTypeForLiterals(t *testing.T) {
 	})
 
 	t.Run("homogeneous", func(t *testing.T) {
-		lt, isOffloaded := literalTypeForLiterals([]*core.Literal{
+		lt := literalTypeForLiterals([]*core.Literal{
 			coreutils.MustMakeLiteral(5),
 			coreutils.MustMakeLiteral(0),
 			coreutils.MustMakeLiteral(5),
 		})
 
 		assert.Equal(t, core.SimpleType_INTEGER.String(), lt.GetSimple().String())
-		assert.False(t, isOffloaded)
 	})
 
 	t.Run("non-homogenous", func(t *testing.T) {
-		lt, isOffloaded := literalTypeForLiterals([]*core.Literal{
+		lt := literalTypeForLiterals([]*core.Literal{
 			coreutils.MustMakeLiteral("hello"),
 			coreutils.MustMakeLiteral(5),
 			coreutils.MustMakeLiteral("world"),
@@ -114,24 +112,22 @@ func TestLiteralTypeForLiterals(t *testing.T) {
 			coreutils.MustMakeLiteral(2),
 		})
 
-		assert.Len(t, lt.GetUnionType().GetVariants(), 2)
-		assert.Equal(t, core.SimpleType_INTEGER.String(), lt.GetUnionType().GetVariants()[0].GetSimple().String())
-		assert.Equal(t, core.SimpleType_STRING.String(), lt.GetUnionType().GetVariants()[1].GetSimple().String())
-		assert.False(t, isOffloaded)
+		assert.Len(t, lt.GetUnionType().Variants, 2)
+		assert.Equal(t, core.SimpleType_INTEGER.String(), lt.GetUnionType().Variants[0].GetSimple().String())
+		assert.Equal(t, core.SimpleType_STRING.String(), lt.GetUnionType().Variants[1].GetSimple().String())
 	})
 
 	t.Run("non-homogenous ensure ordering", func(t *testing.T) {
-		lt, isOffloaded := literalTypeForLiterals([]*core.Literal{
+		lt := literalTypeForLiterals([]*core.Literal{
 			coreutils.MustMakeLiteral(5),
 			coreutils.MustMakeLiteral("world"),
 			coreutils.MustMakeLiteral(0),
 			coreutils.MustMakeLiteral(2),
 		})
 
-		assert.Len(t, lt.GetUnionType().GetVariants(), 2)
-		assert.Equal(t, core.SimpleType_INTEGER.String(), lt.GetUnionType().GetVariants()[0].GetSimple().String())
-		assert.Equal(t, core.SimpleType_STRING.String(), lt.GetUnionType().GetVariants()[1].GetSimple().String())
-		assert.False(t, isOffloaded)
+		assert.Len(t, lt.GetUnionType().Variants, 2)
+		assert.Equal(t, core.SimpleType_INTEGER.String(), lt.GetUnionType().Variants[0].GetSimple().String())
+		assert.Equal(t, core.SimpleType_STRING.String(), lt.GetUnionType().Variants[1].GetSimple().String())
 	})
 
 	t.Run("list with mixed types", func(t *testing.T) {
@@ -453,89 +449,6 @@ func TestLiteralTypeForLiterals(t *testing.T) {
 				},
 			},
 		}
-		expectedLt := inferredType
-		lt := LiteralTypeForLiteral(literals)
-		assert.True(t, proto.Equal(expectedLt, lt))
-	})
-
-	t.Run("nested Lists of offloaded List of string types", func(t *testing.T) {
-		inferredType := &core.LiteralType{
-			Type: &core.LiteralType_CollectionType{
-				CollectionType: &core.LiteralType{
-					Type: &core.LiteralType_Simple{
-						Simple: core.SimpleType_STRING,
-					},
-				},
-			},
-		}
-		literals := &core.Literal{
-			Value: &core.Literal_Collection{
-				Collection: &core.LiteralCollection{
-					Literals: []*core.Literal{
-						{
-							Value: &core.Literal_OffloadedMetadata{
-								OffloadedMetadata: &core.LiteralOffloadedMetadata{
-									Uri:          "dummy/uri-1",
-									SizeBytes:    1000,
-									InferredType: inferredType,
-								},
-							},
-						},
-						{
-							Value: &core.Literal_OffloadedMetadata{
-								OffloadedMetadata: &core.LiteralOffloadedMetadata{
-									Uri:          "dummy/uri-2",
-									SizeBytes:    1000,
-									InferredType: inferredType,
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-		expectedLt := inferredType
-		lt := LiteralTypeForLiteral(literals)
-		assert.True(t, proto.Equal(expectedLt, lt))
-	})
-	t.Run("nested map of offloaded map of string types", func(t *testing.T) {
-		inferredType := &core.LiteralType{
-			Type: &core.LiteralType_MapValueType{
-				MapValueType: &core.LiteralType{
-					Type: &core.LiteralType_Simple{
-						Simple: core.SimpleType_STRING,
-					},
-				},
-			},
-		}
-		literals := &core.Literal{
-			Value: &core.Literal_Map{
-				Map: &core.LiteralMap{
-					Literals: map[string]*core.Literal{
-
-						"key1": {
-							Value: &core.Literal_OffloadedMetadata{
-								OffloadedMetadata: &core.LiteralOffloadedMetadata{
-									Uri:          "dummy/uri-1",
-									SizeBytes:    1000,
-									InferredType: inferredType,
-								},
-							},
-						},
-						"key2": {
-							Value: &core.Literal_OffloadedMetadata{
-								OffloadedMetadata: &core.LiteralOffloadedMetadata{
-									Uri:          "dummy/uri-2",
-									SizeBytes:    1000,
-									InferredType: inferredType,
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-
 		expectedLt := inferredType
 		lt := LiteralTypeForLiteral(literals)
 		assert.True(t, proto.Equal(expectedLt, lt))

--- a/flytepropeller/pkg/compiler/validators/utils_test.go
+++ b/flytepropeller/pkg/compiler/validators/utils_test.go
@@ -112,9 +112,9 @@ func TestLiteralTypeForLiterals(t *testing.T) {
 			coreutils.MustMakeLiteral(2),
 		})
 
-		assert.Len(t, lt.GetUnionType().Variants, 2)
-		assert.Equal(t, core.SimpleType_INTEGER.String(), lt.GetUnionType().Variants[0].GetSimple().String())
-		assert.Equal(t, core.SimpleType_STRING.String(), lt.GetUnionType().Variants[1].GetSimple().String())
+		assert.Len(t, lt.GetUnionType().GetVariants(), 2)
+		assert.Equal(t, core.SimpleType_INTEGER.String(), lt.GetUnionType().GetVariants()[0].GetSimple().String())
+		assert.Equal(t, core.SimpleType_STRING.String(), lt.GetUnionType().GetVariants()[1].GetSimple().String())
 	})
 
 	t.Run("non-homogenous ensure ordering", func(t *testing.T) {
@@ -125,9 +125,9 @@ func TestLiteralTypeForLiterals(t *testing.T) {
 			coreutils.MustMakeLiteral(2),
 		})
 
-		assert.Len(t, lt.GetUnionType().Variants, 2)
-		assert.Equal(t, core.SimpleType_INTEGER.String(), lt.GetUnionType().Variants[0].GetSimple().String())
-		assert.Equal(t, core.SimpleType_STRING.String(), lt.GetUnionType().Variants[1].GetSimple().String())
+		assert.Len(t, lt.GetUnionType().GetVariants(), 2)
+		assert.Equal(t, core.SimpleType_INTEGER.String(), lt.GetUnionType().GetVariants()[0].GetSimple().String())
+		assert.Equal(t, core.SimpleType_STRING.String(), lt.GetUnionType().GetVariants()[1].GetSimple().String())
 	})
 
 	t.Run("list with mixed types", func(t *testing.T) {


### PR DESCRIPTION
This reverts commit f20b8aa082820c56c0c721670b54148afa7d36a4.

## Tracking issue
Related to https://github.com/flyteorg/flyte/pull/5103

## Why are the changes needed?
In https://github.com/flyteorg/flytekit/pull/2872 we're handling the case of offloading literals in map tasks single executions explicitly. The impact of this is that we can simplify the handling of this case in the backend, invalidating https://github.com/flyteorg/flyte/pull/5996.

## What changes were proposed in this pull request?
Revert https://github.com/flyteorg/flyte/pull/5996.

## How was this patch tested?
Confirmed that the original test workflow works:
```
import logging
from typing import List
from flytekit import map_task, task, workflow,LaunchPlan

logging.basicConfig(level=logging.DEBUG)
logger = logging.getLogger("flytekit")
logger.setLevel(logging.DEBUG)

@task(cache=True, cache_version="1.1")
def my_30mb_task(i: str) -> str:
    return f"Hello world {i}" * 30 * 100 * 1024

@task(cache=True, cache_version="1.1")
def generate_strs(count: int) -> List[str]:
    return ["a"] * count

@workflow
def my_30mb_wf(mbs: int) -> List[str]:
  strs = generate_strs(count=mbs)
  return map_task(my_30mb_task)(i=strs)

@workflow
def big_inputs_wf(input: List[str]):
   noop()

@task(cache=True, cache_version="1.1")
def noop():
    ...

big_inputs_wf_lp = LaunchPlan.get_or_create(name="big_inputs_wf_lp", workflow=big_inputs_wf)

@workflow
def ref_wf(mbs: int):
  big_inputs_wf_lp(input=my_30mb_wf(mbs))
```


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
