### PR TITLE
Adding support for downloading offloaded literal in copilot

### DIFF
--- a/flytecopilot/data/download.go
+++ b/flytecopilot/data/download.go
@@ -366,6 +366,10 @@ func (d Downloader) handleLiteral(ctx context.Context, lit *core.Literal, filePa
 			Collection: c2,
 		}}, nil
 	case *core.Literal_Map:
+		err := os.MkdirAll(filePath, os.ModePerm)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to create directory [%s]", filePath)
+		}
 		v, m, err := d.RecursiveDownload(ctx, lit.GetMap(), filePath, writeToFile)
 		if err != nil {
 			return nil, nil, err
@@ -387,6 +391,10 @@ func (d Downloader) handleCollection(ctx context.Context, c *core.LiteralCollect
 	litCollection := &core.LiteralCollection{}
 	for i, lit := range c.GetLiterals() {
 		filePath := path.Join(dir, strconv.Itoa(i))
+		err := os.MkdirAll(dir, os.ModePerm)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to create directory [%s]", dir)
+		}
 		v, lit, err := d.handleLiteral(ctx, lit, filePath, writePrimitiveToFile)
 		if err != nil {
 			return nil, nil, err
@@ -410,6 +418,16 @@ func (d Downloader) RecursiveDownload(ctx context.Context, inputs *core.LiteralM
 	}
 	f := make(FutureMap, len(inputs.GetLiterals()))
 	for variable, literal := range inputs.GetLiterals() {
+		if literal.GetOffloadedMetadata() != nil {
+			offloadedMetadataURI := literal.GetOffloadedMetadata().GetUri()
+			// literal will be overwritten with the contents of the offloaded data which contains the actual large literal.
+			if err := d.store.ReadProtobuf(ctx, storage.DataReference(offloadedMetadataURI), literal); err != nil {
+				errString := fmt.Sprintf("Failed to  read the object at location [%s] with error [%s]", offloadedMetadataURI, err)
+				logger.Error(ctx, errString)
+				return nil, nil, fmt.Errorf(errString)
+			}
+			logger.Infof(ctx, "read object at location [%s]", offloadedMetadataURI)
+		}
 		varPath := path.Join(dir, variable)
 		lit := literal
 		f[variable] = futures.NewAsyncFuture(childCtx, func(ctx2 context.Context) (interface{}, error) {


### PR DESCRIPTION
## Why are the changes needed?
Introduces reading offloaded literals in container tasks without which large literal cant be supported for this type of task.


## What changes were proposed in this pull request?
* Fixes the issue with reading collection and maps in container task which is currently broken.
* The reason its broken is because for collection and map there needs to exist directory with the literal name to dump the values. Added unit tests to cover this. They break before the changes
* Adds reading of the offloaded literal 

## How was this patch tested?

Tested using the following workflow which writes a large output and is read by  container task

```
from typing import List
from flytekit import ContainerTask, kwtypes, task, workflow, LaunchPlan, map_task
import logging

logging.basicConfig(level=logging.DEBUG)

# Generate individual 1MB-sized strings
@task(cache=True, cache_version="1.1")
def my_1mb_task(i: str) -> str:
    return f"Hello world {i}" * 100 * 1024

# Generate a list of strings
@task(cache=True, cache_version="1.1")
def generate_strs(count: int) -> List[str]:
    return ["a"] * count

# Workflow to generate large output
@workflow
def my_wf(mbs: int) -> List[str]:
    strs = generate_strs(count=mbs)
    return map_task(my_1mb_task)(i=strs)

# ContainerTask to process large output
process_large_output = ContainerTask(
    name="process_large_output",
    input_data_dir="/var/inputs",
    output_data_dir="/var/outputs",
    inputs=kwtypes(input=List[str]),
    outputs=kwtypes(result=str),
    #image="ghcr.io/flyteorg/rawcontainers-shell:v2",  # Replace with your preferred image
    image="localhost:30000/process-large-output:latest",  # Replace with your preferred image
    command=[
        "python",
        "process_large_output.py",
        "/var/inputs/input.json",
        #"{{.inputs.input}}",
        "/var/outputs/result.txt"
    ]
)

# Task to consume outputs
@task(cache=True, cache_version="1.1")
def noop(input: List[str]):
    pass

# New workflow for larger inputs
@workflow
def big_inputs_wf(input: List[str]):
    noop(input=input)

# New workflow with container task processing
@workflow
def big_inputs_with_container_wf(input: List[str]) -> str:
    return process_large_output(input=input)

# Reference workflows
@workflow
def ref_wf(mbs: int):
    big_inputs_wf(input=my_wf(mbs))

@workflow
def ref_wf_with_container(mbs: int) -> str:
    return big_inputs_with_container_wf(input=my_wf(mbs))
```


Generated image locally 
```
 docker build -t  localhost:30000/process-large-output:latest .
```

And also used the copilot image built locally
```
docker build -f Dockerfile.flytecopilot -t localhost:30000/my-flytecopilot-app:latest . 
```

Following is the code for container

```
import sys
import os
import time


def process_large_output(input_list):
    """
    Processes a list of large strings and generates a summary.
    
    Args:
        input_list (list): List of large strings to process.

    Returns:
        str: Summary of the processed input.
    """
    # Example processing: Calculate total characters and number of strings
    total_strings = len(input_list)
    total_chars = sum(len(s) for s in input_list)
    return f"Processed {total_strings} strings with a total of {total_chars} characters."


def read_folder(folder_path):
    """
    Reads files in a folder, each representing a string, and returns a list of their contents.
    
    Args:
        folder_path (str): Path to the folder containing the files.

    Returns:
        list: List of strings read from the files.
    """
    if not os.path.exists(folder_path):
        print(f"Error: Folder '{folder_path}' does not exist.")
        sys.exit(1)

    files = sorted(os.listdir(folder_path), key=lambda x: int(x) if x.isdigit() else float('inf'))
    input_list = []

    for file_name in files:
        file_path = os.path.join(folder_path, file_name)
        if os.path.isfile(file_path):
            with open(file_path, "r") as f:
                input_list.append(f.read().strip())
        else:
            print(f"Skipping non-file entry: {file_path}")

    return input_list


def main():
    # Check if the correct arguments are passed
    if len(sys.argv) < 3:
        print("Usage: python process_large_output.py <input_folder> <output_file>")
        sys.exit(1)

    input_folder = sys.argv[1]
    output_file = sys.argv[2]

    # Read the input folder
    input_data = read_folder(input_folder)

    # Process the input list
    summary = process_large_output(input_data)

    # Write the summary to the output file
    with open(output_file, "w") as f:
        f.write(summary)

    print(f"Processing complete. Summary written to '{output_file}'.")


if __name__ == "__main__":
    main()
```
<img width="1643" alt="Screenshot 2024-11-25 at 6 10 28 PM" src="https://github.com/user-attachments/assets/732f6f42-edfd-4715-8816-29003c736a34">


Local sandbox output


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
