### PR TITLE
Support ArrayNode subNode timeouts

### DIFF
--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
@@ -290,6 +290,7 @@ type ExecutableArrayNodeStatus interface {
 	GetSubNodeTaskPhases() bitarray.CompactArray
 	GetSubNodeRetryAttempts() bitarray.CompactArray
 	GetSubNodeSystemFailures() bitarray.CompactArray
+	GetSubNodeDeltaTimestamps() bitarray.CompactArray
 	GetTaskPhaseVersion() uint32
 }
 
@@ -302,6 +303,7 @@ type MutableArrayNodeStatus interface {
 	SetSubNodeTaskPhases(subNodeTaskPhases bitarray.CompactArray)
 	SetSubNodeRetryAttempts(subNodeRetryAttempts bitarray.CompactArray)
 	SetSubNodeSystemFailures(subNodeSystemFailures bitarray.CompactArray)
+	SetSubNodeDeltaTimestamps(subNodeDeltaTimestamps bitarray.CompactArray)
 	SetTaskPhaseVersion(taskPhaseVersion uint32)
 }
 

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks/ExecutableArrayNodeStatus.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks/ExecutableArrayNodeStatus.go
@@ -82,6 +82,38 @@ func (_m *ExecutableArrayNodeStatus) GetExecutionError() *core.ExecutionError {
 	return r0
 }
 
+type ExecutableArrayNodeStatus_GetSubNodeDeltaTimestamps struct {
+	*mock.Call
+}
+
+func (_m ExecutableArrayNodeStatus_GetSubNodeDeltaTimestamps) Return(_a0 bitarray.CompactArray) *ExecutableArrayNodeStatus_GetSubNodeDeltaTimestamps {
+	return &ExecutableArrayNodeStatus_GetSubNodeDeltaTimestamps{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *ExecutableArrayNodeStatus) OnGetSubNodeDeltaTimestamps() *ExecutableArrayNodeStatus_GetSubNodeDeltaTimestamps {
+	c_call := _m.On("GetSubNodeDeltaTimestamps")
+	return &ExecutableArrayNodeStatus_GetSubNodeDeltaTimestamps{Call: c_call}
+}
+
+func (_m *ExecutableArrayNodeStatus) OnGetSubNodeDeltaTimestampsMatch(matchers ...interface{}) *ExecutableArrayNodeStatus_GetSubNodeDeltaTimestamps {
+	c_call := _m.On("GetSubNodeDeltaTimestamps", matchers...)
+	return &ExecutableArrayNodeStatus_GetSubNodeDeltaTimestamps{Call: c_call}
+}
+
+// GetSubNodeDeltaTimestamps provides a mock function with given fields:
+func (_m *ExecutableArrayNodeStatus) GetSubNodeDeltaTimestamps() bitarray.CompactArray {
+	ret := _m.Called()
+
+	var r0 bitarray.CompactArray
+	if rf, ok := ret.Get(0).(func() bitarray.CompactArray); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bitarray.CompactArray)
+	}
+
+	return r0
+}
+
 type ExecutableArrayNodeStatus_GetSubNodePhases struct {
 	*mock.Call
 }

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks/MutableArrayNodeStatus.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks/MutableArrayNodeStatus.go
@@ -82,6 +82,38 @@ func (_m *MutableArrayNodeStatus) GetExecutionError() *core.ExecutionError {
 	return r0
 }
 
+type MutableArrayNodeStatus_GetSubNodeDeltaTimestamps struct {
+	*mock.Call
+}
+
+func (_m MutableArrayNodeStatus_GetSubNodeDeltaTimestamps) Return(_a0 bitarray.CompactArray) *MutableArrayNodeStatus_GetSubNodeDeltaTimestamps {
+	return &MutableArrayNodeStatus_GetSubNodeDeltaTimestamps{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *MutableArrayNodeStatus) OnGetSubNodeDeltaTimestamps() *MutableArrayNodeStatus_GetSubNodeDeltaTimestamps {
+	c_call := _m.On("GetSubNodeDeltaTimestamps")
+	return &MutableArrayNodeStatus_GetSubNodeDeltaTimestamps{Call: c_call}
+}
+
+func (_m *MutableArrayNodeStatus) OnGetSubNodeDeltaTimestampsMatch(matchers ...interface{}) *MutableArrayNodeStatus_GetSubNodeDeltaTimestamps {
+	c_call := _m.On("GetSubNodeDeltaTimestamps", matchers...)
+	return &MutableArrayNodeStatus_GetSubNodeDeltaTimestamps{Call: c_call}
+}
+
+// GetSubNodeDeltaTimestamps provides a mock function with given fields:
+func (_m *MutableArrayNodeStatus) GetSubNodeDeltaTimestamps() bitarray.CompactArray {
+	ret := _m.Called()
+
+	var r0 bitarray.CompactArray
+	if rf, ok := ret.Get(0).(func() bitarray.CompactArray); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bitarray.CompactArray)
+	}
+
+	return r0
+}
+
 type MutableArrayNodeStatus_GetSubNodePhases struct {
 	*mock.Call
 }
@@ -282,6 +314,11 @@ func (_m *MutableArrayNodeStatus) SetArrayNodePhase(phase v1alpha1.ArrayNodePhas
 // SetExecutionError provides a mock function with given fields: executionError
 func (_m *MutableArrayNodeStatus) SetExecutionError(executionError *core.ExecutionError) {
 	_m.Called(executionError)
+}
+
+// SetSubNodeDeltaTimestamps provides a mock function with given fields: subNodeDeltaTimestamps
+func (_m *MutableArrayNodeStatus) SetSubNodeDeltaTimestamps(subNodeDeltaTimestamps bitarray.CompactArray) {
+	_m.Called(subNodeDeltaTimestamps)
 }
 
 // SetSubNodePhases provides a mock function with given fields: subNodePhases

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status.go
@@ -230,13 +230,14 @@ const (
 
 type ArrayNodeStatus struct {
 	MutableStruct
-	Phase                 ArrayNodePhase        `json:"phase,omitempty"`
-	ExecutionError        *core.ExecutionError  `json:"executionError,omitempty"`
-	SubNodePhases         bitarray.CompactArray `json:"subphase,omitempty"`
-	SubNodeTaskPhases     bitarray.CompactArray `json:"subtphase,omitempty"`
-	SubNodeRetryAttempts  bitarray.CompactArray `json:"subattempts,omitempty"`
-	SubNodeSystemFailures bitarray.CompactArray `json:"subsysfailures,omitempty"`
-	TaskPhaseVersion      uint32                `json:"taskPhaseVersion,omitempty"`
+	Phase                  ArrayNodePhase        `json:"phase,omitempty"`
+	ExecutionError         *core.ExecutionError  `json:"executionError,omitempty"`
+	SubNodePhases          bitarray.CompactArray `json:"subphase,omitempty"`
+	SubNodeTaskPhases      bitarray.CompactArray `json:"subtphase,omitempty"`
+	SubNodeRetryAttempts   bitarray.CompactArray `json:"subattempts,omitempty"`
+	SubNodeSystemFailures  bitarray.CompactArray `json:"subsysfailures,omitempty"`
+	SubNodeDeltaTimestamps bitarray.CompactArray `json: "subtimestamps",omitempty"`
+	TaskPhaseVersion       uint32                `json:"taskPhaseVersion,omitempty"`
 }
 
 func (in *ArrayNodeStatus) GetArrayNodePhase() ArrayNodePhase {
@@ -302,6 +303,17 @@ func (in *ArrayNodeStatus) SetSubNodeSystemFailures(subNodeSystemFailures bitarr
 	if in.SubNodeSystemFailures != subNodeSystemFailures {
 		in.SetDirty()
 		in.SubNodeSystemFailures = subNodeSystemFailures
+	}
+}
+
+func (in *ArrayNodeStatus) GetSubNodeDeltaTimestamps() bitarray.CompactArray {
+	return in.SubNodeDeltaTimestamps
+}
+
+func (in *ArrayNodeStatus) SetSubNodeDeltaTimestamps(subNodeDeltaTimestamps bitarray.CompactArray) {
+ 	if in.SubNodeDeltaTimestamps != subNodeDeltaTimestamps {
+		in.SetDirty()
+		in.SubNodeDeltaTimestamps = subNodeDeltaTimestamps
 	}
 }
 

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status.go
@@ -236,7 +236,7 @@ type ArrayNodeStatus struct {
 	SubNodeTaskPhases      bitarray.CompactArray `json:"subtphase,omitempty"`
 	SubNodeRetryAttempts   bitarray.CompactArray `json:"subattempts,omitempty"`
 	SubNodeSystemFailures  bitarray.CompactArray `json:"subsysfailures,omitempty"`
-	SubNodeDeltaTimestamps bitarray.CompactArray `json: "subtimestamps",omitempty"`
+	SubNodeDeltaTimestamps bitarray.CompactArray `json:"subtimestamps,omitempty"`
 	TaskPhaseVersion       uint32                `json:"taskPhaseVersion,omitempty"`
 }
 
@@ -311,7 +311,7 @@ func (in *ArrayNodeStatus) GetSubNodeDeltaTimestamps() bitarray.CompactArray {
 }
 
 func (in *ArrayNodeStatus) SetSubNodeDeltaTimestamps(subNodeDeltaTimestamps bitarray.CompactArray) {
- 	if in.SubNodeDeltaTimestamps != subNodeDeltaTimestamps {
+	if in.SubNodeDeltaTimestamps != subNodeDeltaTimestamps {
 		in.SetDirty()
 		in.SubNodeDeltaTimestamps = subNodeDeltaTimestamps
 	}

--- a/flytepropeller/pkg/compiler/transformers/k8s/node.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/node.go
@@ -197,6 +197,11 @@ func buildNodeSpec(n *core.Node, tasks []*core.CompiledTask, errs errors.Compile
 		case *core.ArrayNode_MinSuccessRatio:
 			nodeSpec.ArrayNode.MinSuccessRatio = &successCriteria.MinSuccessRatio
 		}
+
+		// TODO @hamersaw - tmp
+		nodeSpec.ActiveDeadline = nil
+		nodeSpec.ExecutionDeadline = nil
+		nodeSpec.RetryStrategy = nil
 	default:
 		if n.GetId() == v1alpha1.StartNodeID {
 			nodeSpec.Kind = v1alpha1.NodeKindStart

--- a/flytepropeller/pkg/compiler/transformers/k8s/node.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/node.go
@@ -197,11 +197,6 @@ func buildNodeSpec(n *core.Node, tasks []*core.CompiledTask, errs errors.Compile
 		case *core.ArrayNode_MinSuccessRatio:
 			nodeSpec.ArrayNode.MinSuccessRatio = &successCriteria.MinSuccessRatio
 		}
-
-		// TODO @hamersaw - tmp
-		nodeSpec.ActiveDeadline = nil
-		nodeSpec.ExecutionDeadline = nil
-		nodeSpec.RetryStrategy = nil
 	default:
 		if n.GetId() == v1alpha1.StartNodeID {
 			nodeSpec.Kind = v1alpha1.NodeKindStart

--- a/flytepropeller/pkg/controller/nodes/array/handler.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler.go
@@ -785,7 +785,6 @@ func (a *arrayNodeHandler) buildArrayNodeContext(ctx context.Context, nCtx inter
 
 	// compute start time for subNode using delta timestamp from ArrayNode NodeStatus
 	var startedAt *v1.Time
-	fmt.Printf("HAMERSAW - retrieving subNodeIndex %d/%d\n", subNodeIndex, arrayNodeState.SubNodeDeltaTimestamps.ItemsCount)
 	if deltaSeconds := arrayNodeState.SubNodeDeltaTimestamps.GetItem(subNodeIndex); deltaSeconds != 0 {
 		startedAt = &v1.Time{Time: nCtx.NodeStatus().GetLastAttemptStartedAt().Add(time.Duration(deltaSeconds) * time.Second)}
 	}

--- a/flytepropeller/pkg/controller/nodes/array/handler.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler.go
@@ -31,6 +31,11 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
+const (
+	// value is 3 days of seconds which is covered by 18 bits (262144)
+	MAX_DELTA_TIMESTAMP = 259200
+)
+
 var (
 	nilLiteral = &idlcore.Literal{
 		Value: &idlcore.Literal_Scalar{
@@ -257,7 +262,7 @@ func (a *arrayNodeHandler) Handle(ctx context.Context, nCtx interfaces.NodeExecu
 			{arrayReference: &arrayNodeState.SubNodeTaskPhases, maxValue: len(core.Phases) - 1},
 			{arrayReference: &arrayNodeState.SubNodeRetryAttempts, maxValue: maxAttemptsValue},
 			{arrayReference: &arrayNodeState.SubNodeSystemFailures, maxValue: maxSystemFailuresValue},
-			{arrayReference: &arrayNodeState.SubNodeDeltaTimestamps, maxValue: 259200}, // max value is 3 days of seconds which is coverd by 18 bits (262144)
+			{arrayReference: &arrayNodeState.SubNodeDeltaTimestamps, maxValue: MAX_DELTA_TIMESTAMP},
 		} {
 
 			*item.arrayReference, err = bitarray.NewCompactArray(uint(size), bitarray.Item(item.maxValue)) // #nosec G115

--- a/flytepropeller/pkg/controller/nodes/array/handler.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler.go
@@ -389,8 +389,7 @@ func (a *arrayNodeHandler) Handle(ctx context.Context, nCtx interfaces.NodeExecu
 			arrayNodeState.SubNodeRetryAttempts.SetItem(index, uint64(subNodeStatus.GetAttempts()))
 			arrayNodeState.SubNodeSystemFailures.SetItem(index, uint64(subNodeStatus.GetSystemFailures()))
 
-			indexUint := uint(index) // #nosec G115
-			if arrayNodeState.SubNodeDeltaTimestamps.ItemsCount > indexUint {
+			if arrayNodeState.SubNodeDeltaTimestamps.BitSet != nil {
 				startedAt := nCtx.NodeStatus().GetLastAttemptStartedAt()
 				subNodeStartedAt := subNodeStatus.GetLastAttemptStartedAt()
 				if subNodeStartedAt == nil {
@@ -793,8 +792,7 @@ func (a *arrayNodeHandler) buildArrayNodeContext(ctx context.Context, nCtx inter
 
 	// compute start time for subNode using delta timestamp from ArrayNode NodeStatus
 	var startedAt *metav1.Time
-	subNodeIndexUint := uint(subNodeIndex) // #nosec G115
-	if arrayNodeState.SubNodeDeltaTimestamps.ItemsCount > subNodeIndexUint {
+	if nCtx.NodeStatus().GetLastAttemptStartedAt() != nil && arrayNodeState.SubNodeDeltaTimestamps.BitSet != nil {
 		if deltaSeconds := arrayNodeState.SubNodeDeltaTimestamps.GetItem(subNodeIndex); deltaSeconds != 0 {
 			startedAt = &metav1.Time{Time: nCtx.NodeStatus().GetLastAttemptStartedAt().Add(time.Duration(deltaSeconds) * time.Second)} // #nosec G115
 		}

--- a/flytepropeller/pkg/controller/nodes/array/handler.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler.go
@@ -390,7 +390,7 @@ func (a *arrayNodeHandler) Handle(ctx context.Context, nCtx interfaces.NodeExecu
 			arrayNodeState.SubNodeSystemFailures.SetItem(index, uint64(subNodeStatus.GetSystemFailures()))
 
 			indexUint := uint(index) // #nosec G115
-			if arrayNodeState.SubNodeDeltaTimestamps.ItemsCount >= indexUint {
+			if arrayNodeState.SubNodeDeltaTimestamps.ItemsCount > indexUint {
 				startedAt := nCtx.NodeStatus().GetLastAttemptStartedAt()
 				subNodeStartedAt := subNodeStatus.GetLastAttemptStartedAt()
 				if subNodeStartedAt == nil {
@@ -794,7 +794,7 @@ func (a *arrayNodeHandler) buildArrayNodeContext(ctx context.Context, nCtx inter
 	// compute start time for subNode using delta timestamp from ArrayNode NodeStatus
 	var startedAt *metav1.Time
 	subNodeIndexUint := uint(subNodeIndex) // #nosec G115
-	if arrayNodeState.SubNodeDeltaTimestamps.ItemsCount >= subNodeIndexUint {
+	if arrayNodeState.SubNodeDeltaTimestamps.ItemsCount > subNodeIndexUint {
 		if deltaSeconds := arrayNodeState.SubNodeDeltaTimestamps.GetItem(subNodeIndex); deltaSeconds != 0 {
 			startedAt = &metav1.Time{Time: nCtx.NodeStatus().GetLastAttemptStartedAt().Add(time.Duration(deltaSeconds) * time.Second)} // #nosec G115
 		}

--- a/flytepropeller/pkg/controller/nodes/array/handler.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	idlcore "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
@@ -789,9 +789,12 @@ func (a *arrayNodeHandler) buildArrayNodeContext(ctx context.Context, nCtx inter
 	}
 
 	// compute start time for subNode using delta timestamp from ArrayNode NodeStatus
-	var startedAt *v1.Time
-	if deltaSeconds := arrayNodeState.SubNodeDeltaTimestamps.GetItem(subNodeIndex); deltaSeconds != 0 {
-		startedAt = &v1.Time{Time: nCtx.NodeStatus().GetLastAttemptStartedAt().Add(time.Duration(deltaSeconds) * time.Second)}
+	var startedAt *metav1.Time
+	subNodeIndexUint := uint(subNodeIndex) // #nosec G115
+	if arrayNodeState.SubNodeDeltaTimestamps.ItemsCount >= subNodeIndexUint {
+		if deltaSeconds := arrayNodeState.SubNodeDeltaTimestamps.GetItem(subNodeIndex); deltaSeconds != 0 {
+			startedAt = &metav1.Time{Time: nCtx.NodeStatus().GetLastAttemptStartedAt().Add(time.Duration(deltaSeconds) * time.Second)} // #nosec G115
+		}
 	}
 
 	subNodeStatus := &v1alpha1.NodeStatus{

--- a/flytepropeller/pkg/controller/nodes/array/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler_test.go
@@ -191,10 +191,10 @@ func createNodeExecutionContext(dataStore *storage.DataStore, eventRecorder inte
 		Time: nowMinus,
 	}
 	nCtx.OnNodeStatus().Return(&v1alpha1.NodeStatus{
-		DataDir:   storage.DataReference("s3://bucket/data"),
-		OutputDir: storage.DataReference("s3://bucket/output"),
+		DataDir:              storage.DataReference("s3://bucket/data"),
+		OutputDir:            storage.DataReference("s3://bucket/output"),
 		LastAttemptStartedAt: &metav1NowMinus,
-		StartedAt: &metav1NowMinus,
+		StartedAt:            &metav1NowMinus,
 	})
 
 	return nCtx
@@ -516,27 +516,27 @@ func TestHandleArrayNodePhaseExecuting(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                                string
-		parallelism                         *uint32
-		minSuccessRatio                     *float32
-		subNodePhases                       []v1alpha1.NodePhase
-		subNodeTaskPhases                   []core.Phase
-		subNodeDeltaTimestamps              []uint64
-		subNodeTransitions                  []handler.Transition
-		expectedArrayNodePhase              v1alpha1.ArrayNodePhase
-		expectedArrayNodeSubPhases          []v1alpha1.NodePhase
+		name                                    string
+		parallelism                             *uint32
+		minSuccessRatio                         *float32
+		subNodePhases                           []v1alpha1.NodePhase
+		subNodeTaskPhases                       []core.Phase
+		subNodeDeltaTimestamps                  []uint64
+		subNodeTransitions                      []handler.Transition
+		expectedArrayNodePhase                  v1alpha1.ArrayNodePhase
+		expectedArrayNodeSubPhases              []v1alpha1.NodePhase
 		expectedDiffArrayNodeSubDeltaTimestamps []bool
-		expectedTransitionPhase             handler.EPhase
-		expectedExternalResourcePhases      []idlcore.TaskExecution_Phase
-		currentWfParallelism                uint32
-		maxWfParallelism                    uint32
-		incrementParallelismCount           uint32
-		useFakeEventRecorder                bool
-		eventRecorderFailures               uint32
-		eventRecorderError                  error
-		expectedTaskPhaseVersion            uint32
-		expectHandleError                   bool
-		expectedEventingCalls               int
+		expectedTransitionPhase                 handler.EPhase
+		expectedExternalResourcePhases          []idlcore.TaskExecution_Phase
+		currentWfParallelism                    uint32
+		maxWfParallelism                        uint32
+		incrementParallelismCount               uint32
+		useFakeEventRecorder                    bool
+		eventRecorderFailures                   uint32
+		eventRecorderError                      error
+		expectedTaskPhaseVersion                uint32
+		expectHandleError                       bool
+		expectedEventingCalls                   int
 	}{
 		{
 			name:        "StartAllSubNodes",
@@ -906,7 +906,7 @@ func TestHandleArrayNodePhaseExecuting(t *testing.T) {
 			}
 
 			for i, deltaTimestmap := range test.subNodeDeltaTimestamps {
-				arrayNodeState.SubNodeDeltaTimestamps.SetItem(i, bitarray.Item(deltaTimestmap)) // #nosec G115
+				arrayNodeState.SubNodeDeltaTimestamps.SetItem(i, deltaTimestmap) // #nosec G115
 			}
 
 			nodeSpec := arrayNodeSpec

--- a/flytepropeller/pkg/controller/nodes/array/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	idlcore "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
@@ -184,9 +186,15 @@ func createNodeExecutionContext(dataStore *storage.DataStore, eventRecorder inte
 	nCtx.OnNodeStateWriter().Return(nodeStateWriter)
 
 	// NodeStatus
+	nowMinus := time.Now().Add(time.Duration(-5) * time.Second)
+	metav1NowMinus := metav1.Time{
+		Time: nowMinus,
+	}
 	nCtx.OnNodeStatus().Return(&v1alpha1.NodeStatus{
 		DataDir:   storage.DataReference("s3://bucket/data"),
 		OutputDir: storage.DataReference("s3://bucket/output"),
+		LastAttemptStartedAt: &metav1NowMinus,
+		StartedAt: &metav1NowMinus,
 	})
 
 	return nCtx
@@ -508,25 +516,27 @@ func TestHandleArrayNodePhaseExecuting(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                           string
-		parallelism                    *uint32
-		minSuccessRatio                *float32
-		subNodePhases                  []v1alpha1.NodePhase
-		subNodeTaskPhases              []core.Phase
-		subNodeTransitions             []handler.Transition
-		expectedArrayNodePhase         v1alpha1.ArrayNodePhase
-		expectedArrayNodeSubPhases     []v1alpha1.NodePhase
-		expectedTransitionPhase        handler.EPhase
-		expectedExternalResourcePhases []idlcore.TaskExecution_Phase
-		currentWfParallelism           uint32
-		maxWfParallelism               uint32
-		incrementParallelismCount      uint32
-		useFakeEventRecorder           bool
-		eventRecorderFailures          uint32
-		eventRecorderError             error
-		expectedTaskPhaseVersion       uint32
-		expectHandleError              bool
-		expectedEventingCalls          int
+		name                                string
+		parallelism                         *uint32
+		minSuccessRatio                     *float32
+		subNodePhases                       []v1alpha1.NodePhase
+		subNodeTaskPhases                   []core.Phase
+		subNodeDeltaTimestamps              []uint64
+		subNodeTransitions                  []handler.Transition
+		expectedArrayNodePhase              v1alpha1.ArrayNodePhase
+		expectedArrayNodeSubPhases          []v1alpha1.NodePhase
+		expectedDiffArrayNodeSubDeltaTimestamps []bool
+		expectedTransitionPhase             handler.EPhase
+		expectedExternalResourcePhases      []idlcore.TaskExecution_Phase
+		currentWfParallelism                uint32
+		maxWfParallelism                    uint32
+		incrementParallelismCount           uint32
+		useFakeEventRecorder                bool
+		eventRecorderFailures               uint32
+		eventRecorderError                  error
+		expectedTaskPhaseVersion            uint32
+		expectHandleError                   bool
+		expectedEventingCalls               int
 	}{
 		{
 			name:        "StartAllSubNodes",
@@ -829,6 +839,31 @@ func TestHandleArrayNodePhaseExecuting(t *testing.T) {
 			expectHandleError:              true,
 			expectedEventingCalls:          1,
 		},
+		{
+			name:        "DeltaTimestampUpdates",
+			parallelism: uint32Ptr(0),
+			subNodePhases: []v1alpha1.NodePhase{
+				v1alpha1.NodePhaseQueued,
+				v1alpha1.NodePhaseRunning,
+			},
+			subNodeTaskPhases: []core.Phase{
+				core.PhaseUndefined,
+				core.PhaseUndefined,
+			},
+			subNodeTransitions: []handler.Transition{
+				handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRunning(&handler.ExecutionInfo{})),
+				handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRetryableFailure(idlcore.ExecutionError_SYSTEM, "", "", &handler.ExecutionInfo{})),
+			},
+			expectedArrayNodePhase: v1alpha1.ArrayNodePhaseExecuting,
+			expectedArrayNodeSubPhases: []v1alpha1.NodePhase{
+				v1alpha1.NodePhaseRunning,
+				v1alpha1.NodePhaseRetryableFailure,
+			},
+			expectedTaskPhaseVersion:       1,
+			expectedTransitionPhase:        handler.EPhaseRunning,
+			expectedExternalResourcePhases: []idlcore.TaskExecution_Phase{idlcore.TaskExecution_RUNNING, idlcore.TaskExecution_FAILED},
+			incrementParallelismCount:      1,
+		},
 	}
 
 	for _, test := range tests {
@@ -868,6 +903,10 @@ func TestHandleArrayNodePhaseExecuting(t *testing.T) {
 
 			for i, nodePhase := range test.subNodePhases {
 				arrayNodeState.SubNodePhases.SetItem(i, bitarray.Item(nodePhase)) // #nosec G115
+			}
+
+			for i, deltaTimestmap := range test.subNodeDeltaTimestamps {
+				arrayNodeState.SubNodeDeltaTimestamps.SetItem(i, bitarray.Item(deltaTimestmap)) // #nosec G115
 			}
 
 			nodeSpec := arrayNodeSpec
@@ -923,6 +962,14 @@ func TestHandleArrayNodePhaseExecuting(t *testing.T) {
 
 			for i, expectedPhase := range test.expectedArrayNodeSubPhases {
 				assert.Equal(t, expectedPhase, v1alpha1.NodePhase(arrayNodeState.SubNodePhases.GetItem(i))) // #nosec G115
+			}
+
+			for i, expectedDiffDeltaTimestamps := range test.expectedDiffArrayNodeSubDeltaTimestamps {
+				if expectedDiffDeltaTimestamps {
+					assert.NotEqual(t, arrayNodeState.SubNodeDeltaTimestamps.GetItem(i), test.subNodeDeltaTimestamps[i])
+				} else {
+					assert.Equal(t, arrayNodeState.SubNodeDeltaTimestamps.GetItem(i), test.subNodeDeltaTimestamps[i])
+				}
 			}
 
 			bufferedEventRecorder, ok := eventRecorder.(*bufferedEventRecorder)

--- a/flytepropeller/pkg/controller/nodes/array/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler_test.go
@@ -252,6 +252,7 @@ func TestAbort(t *testing.T) {
 				{arrayReference: &arrayNodeState.SubNodeTaskPhases, maxValue: len(core.Phases) - 1},
 				{arrayReference: &arrayNodeState.SubNodeRetryAttempts, maxValue: 1},
 				{arrayReference: &arrayNodeState.SubNodeSystemFailures, maxValue: 1},
+				{arrayReference: &arrayNodeState.SubNodeDeltaTimestamps, maxValue: 1024},
 			} {
 
 				*item.arrayReference, err = bitarray.NewCompactArray(uint(size), bitarray.Item(item.maxValue)) // #nosec G115
@@ -348,6 +349,7 @@ func TestFinalize(t *testing.T) {
 				{arrayReference: &arrayNodeState.SubNodeTaskPhases, maxValue: len(core.Phases) - 1},
 				{arrayReference: &arrayNodeState.SubNodeRetryAttempts, maxValue: 1},
 				{arrayReference: &arrayNodeState.SubNodeSystemFailures, maxValue: 1},
+				{arrayReference: &arrayNodeState.SubNodeDeltaTimestamps, maxValue: 1024},
 			} {
 				*item.arrayReference, err = bitarray.NewCompactArray(uint(size), bitarray.Item(item.maxValue)) // #nosec G115
 				assert.NoError(t, err)
@@ -858,6 +860,7 @@ func TestHandleArrayNodePhaseExecuting(t *testing.T) {
 				{arrayReference: &arrayNodeState.SubNodeTaskPhases, maxValue: len(core.Phases) - 1},
 				{arrayReference: &arrayNodeState.SubNodeRetryAttempts, maxValue: 1},
 				{arrayReference: &arrayNodeState.SubNodeSystemFailures, maxValue: 1},
+				{arrayReference: &arrayNodeState.SubNodeDeltaTimestamps, maxValue: 1024},
 			} {
 				*item.arrayReference, err = bitarray.NewCompactArray(uint(size), bitarray.Item(item.maxValue)) // #nosec G115
 				assert.NoError(t, err)
@@ -1301,6 +1304,7 @@ func TestHandleArrayNodePhaseFailing(t *testing.T) {
 				{arrayReference: &arrayNodeState.SubNodeTaskPhases, maxValue: len(core.Phases) - 1},
 				{arrayReference: &arrayNodeState.SubNodeRetryAttempts, maxValue: 1},
 				{arrayReference: &arrayNodeState.SubNodeSystemFailures, maxValue: 1},
+				{arrayReference: &arrayNodeState.SubNodeDeltaTimestamps, maxValue: 1024},
 			} {
 				*item.arrayReference, err = bitarray.NewCompactArray(uint(len(test.subNodePhases)), bitarray.Item(item.maxValue)) // #nosec G115
 				assert.NoError(t, err)

--- a/flytepropeller/pkg/controller/nodes/handler/state.go
+++ b/flytepropeller/pkg/controller/nodes/handler/state.go
@@ -48,11 +48,12 @@ type GateNodeState struct {
 }
 
 type ArrayNodeState struct {
-	Phase                 v1alpha1.ArrayNodePhase
-	TaskPhaseVersion      uint32
-	Error                 *core.ExecutionError
-	SubNodePhases         bitarray.CompactArray
-	SubNodeTaskPhases     bitarray.CompactArray
-	SubNodeRetryAttempts  bitarray.CompactArray
-	SubNodeSystemFailures bitarray.CompactArray
+	Phase                  v1alpha1.ArrayNodePhase
+	TaskPhaseVersion       uint32
+	Error                  *core.ExecutionError
+	SubNodePhases          bitarray.CompactArray
+	SubNodeTaskPhases      bitarray.CompactArray
+	SubNodeRetryAttempts   bitarray.CompactArray
+	SubNodeSystemFailures  bitarray.CompactArray
+	SubNodeDeltaTimestamps bitarray.CompactArray
 }

--- a/flytepropeller/pkg/controller/nodes/node_state_manager.go
+++ b/flytepropeller/pkg/controller/nodes/node_state_manager.go
@@ -65,7 +65,7 @@ func (n *nodeStateManager) HasWorkflowNodeState() bool {
 }
 
 func (n *nodeStateManager) HasGateNodeState() bool {
-	return n.g != nil
+return n.g != nil
 }
 
 func (n *nodeStateManager) HasArrayNodeState() bool {
@@ -180,6 +180,11 @@ func (n nodeStateManager) GetArrayNodeState() handler.ArrayNodeState {
 		subNodeSystemFailures := an.GetSubNodeSystemFailures()
 		if subNodeSystemFailuresCopy := subNodeSystemFailures.DeepCopy(); subNodeSystemFailuresCopy != nil {
 			as.SubNodeSystemFailures = *subNodeSystemFailuresCopy
+		}
+
+		subNodeDeltaTimestamps := an.GetSubNodeDeltaTimestamps()
+		if subNodeDeltaTimestampsCopy := subNodeDeltaTimestamps.DeepCopy(); subNodeDeltaTimestampsCopy != nil {
+			as.SubNodeDeltaTimestamps = *subNodeDeltaTimestampsCopy
 		}
 	}
 	return as

--- a/flytepropeller/pkg/controller/nodes/node_state_manager.go
+++ b/flytepropeller/pkg/controller/nodes/node_state_manager.go
@@ -65,7 +65,7 @@ func (n *nodeStateManager) HasWorkflowNodeState() bool {
 }
 
 func (n *nodeStateManager) HasGateNodeState() bool {
-return n.g != nil
+	return n.g != nil
 }
 
 func (n *nodeStateManager) HasArrayNodeState() bool {

--- a/flytepropeller/pkg/controller/nodes/transformers.go
+++ b/flytepropeller/pkg/controller/nodes/transformers.go
@@ -314,6 +314,7 @@ func UpdateNodeStatus(np v1alpha1.NodePhase, p handler.PhaseInfo, n interfaces.N
 		t.SetSubNodeTaskPhases(na.SubNodeTaskPhases)
 		t.SetSubNodeRetryAttempts(na.SubNodeRetryAttempts)
 		t.SetSubNodeSystemFailures(na.SubNodeSystemFailures)
+		t.SetSubNodeDeltaTimestamps(na.SubNodeDeltaTimestamps)
 		t.SetTaskPhaseVersion(na.TaskPhaseVersion)
 	}
 }


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
Currently, timeouts are not supported on ArryaNode subNodes. If there is a timeout set in the task decorator, that is applied only to the overall ArrayNode and not individual subNodes. This change ensures subNodes are executed with timeouts as a standalone execution would be.

## What changes were proposed in this pull request?
We store a `deltaTimestamp` to track `startedAt` for subNode executions. This delta is computed from the overall ArrayNode start time. This is stored using a `bitarray` (just like other ArrayNode subNode metadata), with a preset 18 bits of precision. This means for 5k subNodes there will be approximately 90kb added to the FlyteWorkflow CR - reducing scalability by a small amount. The 18 bits gives us around 3 days of delta time, meaning subNodes start times can be tracked up to 3 days after the overall ArrayNode starts. If this proves to be too imprecise, we can increase this value and incur further reductions to scale.

It is important to note **that we do not have a task phase for `TIMED_OUT`**. So in the UI this will display as `FAILED`. This is a restriction of the current eventing scheme for map tasks.

## How was this patch tested?
This was tested locally under a variety of failure scenarios (ex. retryable failures).

### Setup process
```
from datetime import timedelta
from flytekit import map_task, task, workflow
from typing import List

import time
from flytekit.exceptions.user import FlyteRecoverableException


@task(retries=3, timeout=timedelta(minutes=1))
def say_hello(name: str) -> str:
    #time.sleep(120)

    time.sleep(10)
    raise FlyteRecoverableException(f"testing failure for {name}")

    return f"hello {name}"


@workflow
def say_hello_wf(name: List[str]) -> List[str]:
    return map_task(say_hello)(name=name)
```

### Screenshots
N/A

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
N/A

## Docs link
N/A
