### PR TITLE
Flyteadmin digest comparison should rely on database semantics

### DIFF
--- a/flyteadmin/pkg/manager/impl/task_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/task_manager_test.go
@@ -105,10 +105,10 @@ func TestCreateTask_DuplicateTaskRegistration(t *testing.T) {
 		func(input interfaces.Identifier) (models.Task, error) {
 			return models.Task{
 				TaskKey: models.TaskKey{
-					Project: taskIdentifier.Project,
-					Domain:  taskIdentifier.Domain,
-					Name:    taskIdentifier.Name,
-					Version: taskIdentifier.Version,
+					Project: taskIdentifier.GetProject(),
+					Domain:  taskIdentifier.GetDomain(),
+					Name:    taskIdentifier.GetName(),
+					Version: taskIdentifier.GetVersion(),
 				},
 				Digest: []byte{
 					0xbf, 0x79, 0x61, 0x1c, 0xf5, 0xc1, 0xfb, 0x4c, 0xf8, 0xf4, 0xc4, 0x53, 0x5f, 0x8f, 0x73, 0xe2, 0x26, 0x5a,

--- a/flyteadmin/pkg/repositories/gormimpl/task_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/task_repo.go
@@ -30,12 +30,12 @@ func (r *TaskRepo) Create(ctx context.Context, input models.Task, descriptionEnt
 			}
 			return nil
 		}
-		tx := r.db.WithContext(ctx).Omit("id").Create(descriptionEntity)
+		tx := r.db.WithContext(ctx).Omit("id").Create(&input)
 		if tx.Error != nil {
 			return r.errorTransformer.ToFlyteAdminError(tx.Error)
 		}
 
-		tx = r.db.WithContext(ctx).Omit("id").Create(&input)
+		tx = r.db.WithContext(ctx).Omit("id").Create(descriptionEntity)
 		if tx.Error != nil {
 			return r.errorTransformer.ToFlyteAdminError(tx.Error)
 		}


### PR DESCRIPTION
## Tracking issue
Closes #4780 
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?
In current TaskManager CreateTask [code](https://github.com/flyteorg/flyte/blob/8f516e839074d0c1013ab58650a1a0fec575d990/flyteadmin/pkg/manager/impl/task_manager.go#L91-L120), FlyteAdmin checks if a task with the same ID already exists in the database. If it does, FlyteAdmin verifies whether the registered task has a different digest compared to the existing task. If no task with the same ID is found in the database, FlyteAdmin proceeds to create the task in the database.

However, the current approach may lead to a race condition that prevents the digest comparison for two identical tasks from occurring. For example, consider two identical tasks (tasks with the same ID and digest), A and B, being registered to FlyteAdmin simultaneously. It is likely that the digest check will be skipped because the existing task is not yet present in the database. Consequently, one task will be created in the database, and the other will fail due to a primary key conflict. (Refer to the diagram below for a better understanding.)
 
![截圖 2024-11-29 下午2 36 48](https://github.com/user-attachments/assets/626bab6a-b494-4219-96ab-af92059c5daa)


<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

1.Do digest check in a transactional way:

The procedure of creating task should be 1. create task -> 2. if task id exists already(pramary key conflict) -> 3. do digest check. The pseudocode could look like
```
in the transaction:
try:
  create a task with given primary key
except:
  primary key already exists
  get existing entry with identical primary key
    if digest of existing == new entry's digest -> return `NewTaskExistsIdenticalStructureError`
    else -> return `NewTaskExistsDifferentStructureError`
```
In this way we can make sure that task digest will be checked even though 2 identical task registered at the same time frame. Refer to the diagram below for a better understanding.

![截圖 2024-11-22 下午5 28 50](https://github.com/user-attachments/assets/4fcd5856-0180-464f-9cdd-a589d612483d)

2.Write Task to DB before write Description in TaskRepo Create method:

In current TaskRepo [Create method](https://github.com/flyteorg/flyte/blob/8f516e839074d0c1013ab58650a1a0fec575d990/flyteadmin/pkg/repositories/gormimpl/task_repo.go#L23-L47), task description is created before task. However, if TaskManger catches primary key conflict error from task description creation and try to get existing task in DB for digest check, a task not found error could possibly occurred as task is not yet created in DB, which does not make sense for user. In this PR it is proposed to write Task to DB before write Description in TaskRepo Create method.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
3. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Set up a simple workflow with 2 tasks

<img width="833" alt="截圖 2024-11-29 下午3 23 27" src="https://github.com/user-attachments/assets/b36a4474-0927-4534-9322-5016e5289df8">

Write a shell script to request task registration 10 times at the same time to simulate hi concurrency situation. It is expected that each task will be registered successfully once only, otherwise the response message should shown AlreadyExists.

<img width="325" alt="截圖 2024-11-29 下午3 31 06" src="https://github.com/user-attachments/assets/7cc430e6-43ba-4c4f-bf28-e481ca8329d9">

The result show each task only registered once as we expected

<img width="865" alt="截圖 2024-11-28 上午11 55 20" src="https://github.com/user-attachments/assets/6b28da59-3823-4952-9510-d57ee5dba8d9">
<img width="865" alt="截圖 2024-11-28 上午11 55 46" src="https://github.com/user-attachments/assets/5f9c7614-5876-4922-9940-71650a6ca772">

Then, we make a shell script to register 2 groups of tasks with same ID but different digest at the same time. It is expected that TaskExistsDifferentStructureError will shown in the response

<img width="325" alt="截圖 2024-11-29 下午3 40 48" src="https://github.com/user-attachments/assets/bb91f172-0ab3-4f62-af94-999352816e22" />

The error shown as expected

<img width="1686" alt="截圖 2024-11-29 上午11 51 21" src="https://github.com/user-attachments/assets/1d950579-3367-4e42-afa4-a2a5800dbcfb">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements a transactional approach to resolve race conditions in FlyteAdmin's task registration process. The changes modify task creation workflow by handling primary key conflicts and performing digest checks. The implementation reorders task and description creation sequence in the database for consistent error handling.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>