### PR TITLE
[Docs] Align sd code lines with Flytesnacks example 

### DIFF
--- a/docs/user_guide/data_types_and_io/structureddataset.md
+++ b/docs/user_guide/data_types_and_io/structureddataset.md
@@ -68,7 +68,7 @@ First, initialize column types you want to extract from the `StructuredDataset`.
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
-:lines: 31-32
+:lines: 36-37
 ```
 
 Define a task that opens a structured dataset by calling `all()`.
@@ -78,7 +78,7 @@ For instance, you can use ``pa.Table`` to convert the Pandas DataFrame to a PyAr
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
-:lines: 42-52
+:lines: 47-57
 ```
 
 The code may result in runtime failures if the columns do not match.
@@ -91,7 +91,7 @@ and enable the CSV serialization by annotating the structured dataset with the C
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
-:lines: 58-72
+:lines: 63-77
 ```
 
 ## Storage driver and location
@@ -230,14 +230,14 @@ and the byte format, which in this case is `PARQUET`.
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
-:lines: 128-130
+:lines: 133-135
 ```
 
 You can now use `numpy.ndarray` to deserialize the parquet file to NumPy and serialize a task's output (NumPy array) to a parquet file.
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
-:lines: 135-148
+:lines: 140-153
 ```
 
 :::{note}
@@ -248,7 +248,7 @@ You can run the code locally as follows:
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
-:lines: 152-156
+:lines: 157-161
 ```
 
 ### The nested typed columns
@@ -261,7 +261,7 @@ Nested field StructuredDataset should be run when flytekit version > 1.11.0.
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/structured_dataset.py
 :caption: data_types_and_io/structured_dataset.py
-:lines: 158-285
+:lines: 163-290
 ```
 
 [flytesnacks]: https://github.com/flyteorg/flytesnacks/tree/master/examples/data_types_and_io/


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?
Code snippets on this [page](https://docs.flyte.org/en/latest/user_guide/data_types_and_io/structureddataset.html#structureddataset) are out of sync of this [Flytesnacks example](https://github.com/flyteorg/flytesnacks/blob/783a180903c22d61c4b93700866f9921353db800/examples/data_types_and_io/data_types_and_io/structured_dataset.py) after recent transition from `rli` to `literalinclude`.

## What changes were proposed in this pull request?
Align code snippets on the doc page with the corresponding example.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flyte/pull/6008

## Docs link
https://flyte--6063.org.readthedocs.build/en/6063/user_guide/data_types_and_io/structureddataset.html
