### PR TITLE
[demo sandbox] Add env vars to plugin config

### DIFF
--- a/charts/flyte-sandbox/README.md
+++ b/charts/flyte-sandbox/README.md
@@ -30,6 +30,8 @@ A Helm chart for the Flyte local sandbox
 | flyte-binary.configuration.inline.plugins.k8s.default-env-vars[0].FLYTE_AWS_ENDPOINT | string | `"http://{{ printf \"%s-minio\" .Release.Name | trunc 63 | trimSuffix \"-\" }}.{{ .Release.Namespace }}:9000"` |  |
 | flyte-binary.configuration.inline.plugins.k8s.default-env-vars[1].FLYTE_AWS_ACCESS_KEY_ID | string | `"minio"` |  |
 | flyte-binary.configuration.inline.plugins.k8s.default-env-vars[2].FLYTE_AWS_SECRET_ACCESS_KEY | string | `"miniostorage"` |  |
+| flyte-binary.configuration.inline.plugins.k8s.default-env-vars[3].FLYTE_PLATFORM_URL | string | `"{{ printf \"%s-grpc\" .Release.Name }}.{{ .Release.Namespace }}:8089"` |  |
+| flyte-binary.configuration.inline.plugins.k8s.default-env-vars[4].FLYTE_PLATFORM_INSECURE | bool | `true` |  |
 | flyte-binary.configuration.inline.storage.signedURL.stowConfigOverride.endpoint | string | `"http://localhost:30002"` |  |
 | flyte-binary.configuration.inline.task_resources.defaults.cpu | string | `"500m"` |  |
 | flyte-binary.configuration.inline.task_resources.defaults.ephemeralStorage | int | `0` |  |

--- a/charts/flyte-sandbox/values.yaml
+++ b/charts/flyte-sandbox/values.yaml
@@ -57,6 +57,8 @@ flyte-binary:
             - FLYTE_AWS_ENDPOINT: http://{{ printf "%s-minio" .Release.Name | trunc 63 | trimSuffix "-" }}.{{ .Release.Namespace }}:9000
             - FLYTE_AWS_ACCESS_KEY_ID: minio
             - FLYTE_AWS_SECRET_ACCESS_KEY: miniostorage
+            - FLYTE_PLATFORM_URL: '{{ printf "%s-grpc" .Release.Name }}.{{ .Release.Namespace }}:8089'
+            - FLYTE_PLATFORM_INSECURE: True
     inlineConfigMap: '{{ include "flyte-sandbox.configuration.inlineConfigMap" . }}'
   clusterResourceTemplates:
     inlineConfigMap: '{{ include "flyte-sandbox.clusterResourceTemplates.inlineConfigMap" . }}'

--- a/docker/sandbox-bundled/manifests/complete-agent.yaml
+++ b/docker/sandbox-bundled/manifests/complete-agent.yaml
@@ -517,6 +517,8 @@ data:
         - FLYTE_AWS_ENDPOINT: http://flyte-sandbox-minio.flyte:9000
         - FLYTE_AWS_ACCESS_KEY_ID: minio
         - FLYTE_AWS_SECRET_ACCESS_KEY: miniostorage
+        - FLYTE_PLATFORM_URL: 'flyte-sandbox-grpc.flyte:8089'
+        - FLYTE_PLATFORM_INSECURE: true
     storage:
       signedURL:
         stowConfigOverride:
@@ -819,7 +821,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: UE1mU01ZdUU3Mm1EU0M0dg==
+  haSharedSecret: azZKdDN4dWhpMDI0RVdnOQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1250,7 +1252,7 @@ spec:
     metadata:
       annotations:
         checksum/cluster-resource-templates: 6fd9b172465e3089fcc59f738b92b8dc4d8939360c19de8ee65f68b0e7422035
-        checksum/configuration: a823eaadac5f3a4358c8acf628ebeb3719f88312af520d2c253de2579dff262d
+        checksum/configuration: 73e77e790b0ce72a7f3f7a81e4ca3f279f33c1aaea5e5172f61959f3960b0d7b
         checksum/configuration-secret: 09216ffaa3d29e14f88b1f30af580d02a2a5e014de4d750b7f275cc07ed4e914
       labels:
         app.kubernetes.io/component: flyte-binary
@@ -1416,7 +1418,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: f41ce2d3d3713b025ef28e36a69f78f91ed84b132cc9cb337dd7d23ad9783615
+        checksum/secret: c5177d5f2bbef90436b961a14dee53c296aa7f1fb78630cda5548db5b4cd41ab
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete-agent.yaml
+++ b/docker/sandbox-bundled/manifests/complete-agent.yaml
@@ -821,7 +821,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: azZKdDN4dWhpMDI0RVdnOQ==
+  haSharedSecret: ZncyUmNBaWdYWlJmTUVMVA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1418,7 +1418,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: c5177d5f2bbef90436b961a14dee53c296aa7f1fb78630cda5548db5b4cd41ab
+        checksum/secret: f2f7afffa66c57f22b3c423e1ec672e533bededf3848df42ae23e805da175146
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: WW43U29MYlh0VGVqVHpGaw==
+  haSharedSecret: VWxGQXNKU1RyMk5haUpZWA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 8b74202a1f99092905c748a87eda41b493d88a2c7bd7a0ab63e711f3a8e19bde
+        checksum/secret: 421896ac3426efc3fb1d427ce98c9c6d631de7dcc4599a53726fb37eb59e6aad
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -499,6 +499,8 @@ data:
         - FLYTE_AWS_ENDPOINT: http://flyte-sandbox-minio.flyte:9000
         - FLYTE_AWS_ACCESS_KEY_ID: minio
         - FLYTE_AWS_SECRET_ACCESS_KEY: miniostorage
+        - FLYTE_PLATFORM_URL: 'flyte-sandbox-grpc.flyte:8089'
+        - FLYTE_PLATFORM_INSECURE: true
     storage:
       signedURL:
         stowConfigOverride:
@@ -801,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: UzlMUFQ4QmRVb05pbHZNUw==
+  haSharedSecret: WW43U29MYlh0VGVqVHpGaw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1199,7 +1201,7 @@ spec:
     metadata:
       annotations:
         checksum/cluster-resource-templates: 6fd9b172465e3089fcc59f738b92b8dc4d8939360c19de8ee65f68b0e7422035
-        checksum/configuration: c2649df6bcb523f120c73b0fdeec5d9516f555eab12e4eae78b04dea2cf2abae
+        checksum/configuration: 956d7a4502a3f977583a7b1bf4da2e985d64c09c94f357798ce289efa25facd7
         checksum/configuration-secret: 09216ffaa3d29e14f88b1f30af580d02a2a5e014de4d750b7f275cc07ed4e914
       labels:
         app.kubernetes.io/component: flyte-binary
@@ -1365,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: ed16cace6787759cf9bbaa202aa5d2942f803ca84fca4a54c2c4128ea9a42d94
+        checksum/secret: 8b74202a1f99092905c748a87eda41b493d88a2c7bd7a0ab63e711f3a8e19bde
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: SnZMbUdvd29EbDF1ckJlVA==
+  haSharedSecret: VUNmcHFIMVlxNlE2NnBOdg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: d28e9a7527a41cb3e2b70a28d1bd8aced26f0577ce1b5eea807968f112328499
+        checksum/secret: 66d87c34561c5c117f483533ba5af79dff002a0c2e43253eec6809036c852f7e
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: VUNmcHFIMVlxNlE2NnBOdg==
+  haSharedSecret: QXRvTWlFM1NYcE5NRWlidg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 66d87c34561c5c117f483533ba5af79dff002a0c2e43253eec6809036c852f7e
+        checksum/secret: ba6d3d6226ec4daefb7d441c51c19ea2363808c06739832a58c342a92df951e8
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## What changes were proposed in this pull request?
This adds two environment variables to the sandbox config `FLYTE_PLATFORM_URL` and `FLYTE_PLATFORM_INSECURE` so that these are injected into pods launched by propeller.  These env vars indicate to flytekit that the system is running internally within a sandbox, and how to reach out to the demo sandbox control plane.


## How was this patch tested?
Locally by building a sandbox, and registering/running eager tasks against it.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
