### PR TITLE
Fix inconsistent code examples in caching.md documentation

### DIFF
--- a/docs/user_guide/development_lifecycle/caching.md
+++ b/docs/user_guide/development_lifecycle/caching.md
@@ -152,7 +152,7 @@ The default behavior displayed by Flyte's memoization feature might not match th
 
 ```{literalinclude} /examples/development_lifecycle/development_lifecycle/task_cache.py
 :caption: development_lifecycle/task_cache.py
-:lines: 39-54
+:lines: 44-59
 ```
 
 If run twice with the same inputs, one would expect that `bar` would trigger a cache hit, but it turns out that's not the case because of how dataframes are represented in Flyte.
@@ -161,7 +161,7 @@ For example, in order to cache the result of calls to `bar`, you can rewrite the
 
 ```{literalinclude} /examples/development_lifecycle/development_lifecycle/task_cache.py
 :caption: development_lifecycle/task_cache.py
-:lines: 64-85
+:lines: 69-91
 ```
 
 Note how the output of task `foo` is annotated with an object of type `HashMethod`. Essentially, it represents a function that produces a hash that is used as part of the cache key calculation in calling the task `bar`.
@@ -177,7 +177,7 @@ Here's a complete example of the feature:
 
 ```{literalinclude} /examples/development_lifecycle/development_lifecycle/task_cache.py
 :caption: development_lifecycle/task_cache.py
-:lines: 97-134
+:lines: 103-140
 ```
 
 [flytesnacks]: https://github.com/flyteorg/flytesnacks/tree/master/examples/development_lifecycle/


### PR DESCRIPTION

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
The code block examples in the [Caching documentation](https://docs.flyte.org/en/latest/user_guide/development_lifecycle/caching.html#) look misaligned. This might be due to new code being added to the original file in flytesnacks, which would shift the line numbers. I'm adjusting the line references to match the current code.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
Please refer to the changed file down below.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Screenshots
![Screenshot 2024-12-03 at 17 09 58](https://github.com/user-attachments/assets/e57412e5-f232-4896-841a-d7ab707e1616)
![Screenshot 2024-12-03 at 17 10 09](https://github.com/user-attachments/assets/812bd53b-75be-49f9-9376-7a402c345dba)
![Screenshot 2024-12-03 at 17 10 21](https://github.com/user-attachments/assets/d4b465fe-1026-4f9d-b582-f20ad4d9af8a)



## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
[First code block](https://github.com/flyteorg/flytesnacks/blob/3e92ef9af7245254fbccb9d7b63c6a542b71cef1/examples/development_lifecycle/development_lifecycle/task_cache.py#L44C1-L59C33)
[Second code block](https://github.com/flyteorg/flytesnacks/blob/3e92ef9af7245254fbccb9d7b63c6a542b71cef1/examples/development_lifecycle/development_lifecycle/task_cache.py#L69C1-L91C33)
[Third code block](https://github.com/flyteorg/flytesnacks/blob/3e92ef9af7245254fbccb9d7b63c6a542b71cef1/examples/development_lifecycle/development_lifecycle/task_cache.py#L103C1-L140C55)