### PR TITLE
Special-case type annotations to force cache invalidations for msgpack-binary literals

### DIFF
--- a/flytepropeller/pkg/compiler/transformers/k8s/utils.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/utils.go
@@ -86,7 +86,17 @@ func StripTypeMetadata(t *core.LiteralType) *core.LiteralType {
 
 	c := *t
 	c.Metadata = nil
-	c.Annotation = nil
+
+	// Special-case the presence of cache-key-metadata. This is a special field that is used to store metadata about
+	// used in the cache key generation. This does not affect compatibility and it is purely used for cache key calculations.
+	if c.GetAnnotation() != nil {
+		annotations := c.GetAnnotation().GetAnnotations().GetFields()
+		// The presence of the key `cache-key-metadata` indicates that we should leave the metadata intact.
+		if _, ok := annotations["cache-key-metadata"]; !ok {
+			c.Annotation = nil
+		}
+	}
+
 	// Note that we cannot strip `Structure` from the type because the dynamic node output type is used to validate the
 	// interface of the dynamically compiled workflow. `Structure` is used to extend type checking information on
 	// different Flyte types and is therefore required to ensure correct type validation.

--- a/flytepropeller/pkg/compiler/transformers/k8s/utils_test.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-test/deep"
 	_struct "github.com/golang/protobuf/ptypes/struct"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
@@ -245,6 +246,99 @@ func TestStripTypeMetadata(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+		},
+		{
+			name: "cache-key-metadata set",
+			args: &core.LiteralType{
+				Type: &core.LiteralType_Simple{
+					Simple: core.SimpleType_INTEGER,
+				},
+				Annotation: &core.TypeAnnotation{
+					Annotations: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"cache-key-metadata": {
+								Kind: &_struct.Value_StructValue{
+									StructValue: &structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"foo": {
+												Kind: &_struct.Value_StringValue{
+													StringValue: "bar",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Metadata: &_struct.Struct{
+					Fields: map[string]*_struct.Value{
+						"foo": {
+							Kind: &_struct.Value_StringValue{
+								StringValue: "bar",
+							},
+						},
+					},
+				},
+			},
+			want: &core.LiteralType{
+				Type: &core.LiteralType_Simple{
+					Simple: core.SimpleType_INTEGER,
+				},
+				Annotation: &core.TypeAnnotation{
+					Annotations: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"cache-key-metadata": {
+								Kind: &_struct.Value_StructValue{
+									StructValue: &structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"foo": {
+												Kind: &_struct.Value_StringValue{
+													StringValue: "bar",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "cache-key-metadata not present in annotation",
+			args: &core.LiteralType{
+				Type: &core.LiteralType_Simple{
+					Simple: core.SimpleType_INTEGER,
+				},
+				Annotation: &core.TypeAnnotation{
+					Annotations: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"some-key": {
+								Kind: &_struct.Value_StringValue{
+									StringValue: "some-value",
+								},
+							},
+						},
+					},
+				},
+				Metadata: &_struct.Struct{
+					Fields: map[string]*_struct.Value{
+						"foo": {
+							Kind: &_struct.Value_StringValue{
+								StringValue: "bar",
+							},
+						},
+					},
+				},
+			},
+			want: &core.LiteralType{
+				Type: &core.LiteralType_Simple{
+					Simple: core.SimpleType_INTEGER,
 				},
 			},
 		},


### PR DESCRIPTION
## Tracking issue
https://linear.app/unionai/issue/DX-1202/add-cacke-key-attributes-to-typeannotation

## Why are the changes needed?
In order to  help the transition to the new version of flytekit, we special-case type annotations that contain a certain key, namely `cache-key-metadata`. The presence of this key will indicate that we should *not* nil out the type annotation field in the CRD.

A change in flytekit will accompany this.

## What changes were proposed in this pull request?
Special-case `TypeAnnotation` objects that contain a key called `cache-key-metadata`, which, as the name suggests, will contain information used to generate unique cache keys.

## How was this patch tested?
Unit tests and sandbox.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
