### PR TITLE
Use an empty config file to produce docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ docs/examples
 docs/_src
 docs/_projects
 docs/tests
+empty-config.yaml

--- a/script/generate_config_docs.sh
+++ b/script/generate_config_docs.sh
@@ -18,7 +18,7 @@ make -C flytepropeller compile_flytepropeller
 mv flytepropeller/bin/flytepropeller ${GOBIN}/flytepropeller
 
 # Config files are needed to generate docs, so we generate an empty
-# file and re-use it to invoke the docs command in all components.
+# file and reuse it to invoke the docs command in all components.
 EMPTY_CONFIG_FILE=empty-config.yaml
 touch empty-config.yaml
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
After https://github.com/flyteorg/flyte/pull/5972/ we require a config file in order to run the `docs` subcommand in all components. 

We use the `docs` subcommand to produce the rst files under the `docs` directory, e.g. https://github.com/flyteorg/flyte/blob/master/docs/deployment/configuration/generated/flyteadmin_config.rst.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
This PR introduces an empty config file to be passed to each of the invocations of the components `docs` subcommands in https://github.com/flyteorg/flyte/blob/master/script/generate_config_docs.sh#L46-L49.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Ran `make release_automation` locally and confirmed that the command succeeds and docs are generated.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
