### PR TITLE
Fix flytestdlib's stowStore.List for google cloud storage

### DIFF
--- a/flytestdlib/storage/stow_store_test.go
+++ b/flytestdlib/storage/stow_store_test.go
@@ -97,8 +97,8 @@ func (m mockStowContainer) Items(prefix, cursor string, count int) ([]stow.Item,
 	numItems := endIndexExc - startIndex
 	results := make([]stow.Item, numItems)
 	for index, itemKey := range itemKeys[startIndex:endIndexExc] {
-		url := fmt.Sprintf("s3://%s/%s", m.id, m.items[itemKey].url)
-		results[index] = mockStowItem{url: url, size: m.items[itemKey].size}
+		url := fmt.Sprintf("s3://%s/%s", m.id, m.items[itemKey].name)
+		results[index] = mockStowItem{url: url, size: m.items[itemKey].size, name: m.items[itemKey].name}
 	}
 
 	if endIndexExc == len(m.items) {
@@ -123,7 +123,7 @@ func (m *mockStowContainer) Put(name string, r io.Reader, size int64, metadata m
 	if m.putCB != nil {
 		return m.putCB(name, r, size, metadata)
 	}
-	item := mockStowItem{url: name, size: size}
+	item := mockStowItem{url: name, name: name, size: size}
 	m.items[name] = item
 	return item, nil
 }
@@ -137,6 +137,7 @@ func newMockStowContainer(id string) *mockStowContainer {
 
 type mockStowItem struct {
 	url  string
+	name string
 	size int64
 }
 
@@ -145,7 +146,7 @@ func (m mockStowItem) ID() string {
 }
 
 func (m mockStowItem) Name() string {
-	return m.url
+	return m.name
 }
 
 func (m mockStowItem) URL() *url.URL {


### PR DESCRIPTION
## Why are the changes needed?

For RFC https://github.com/flyteorg/flyte/pull/5598, flytepropeller was given the ability to list error files in the so-called *raw output prefix* bucket of an execution with the goal of identifying which worker pod in a failed distributed task experienced the first error.

For this purpose, the `StowStore` in flytestdlib was given a `List` function.

For google cloud storage buckets, the listing and subsequent access of the error files currently does not work: When listing a bucket `gs://some-bucket/...`, one receives items in the form `google://storage.googleapis.com/download/storage/v1/b/some-bucket/...` which then cannot be found by the stow store for the `gs://` prefix.
This PR fixes this.

## What changes were proposed in this pull request?

Don't use `item.URL()` but construct the url from the protocol, the container name (bucket name), and the item name.

## How was this patch tested?

Tested in a GCP deployment and adapted unit test.

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

* https://github.com/flyteorg/flyte/pull/5741
* https://github.com/flyteorg/flyte/pull/5795