### PR TITLE
Revert "fix: return the config file not found error"

### DIFF
--- a/.github/workflows/single-binary.yml
+++ b/.github/workflows/single-binary.yml
@@ -159,6 +159,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: unionai/flytectl-setup-action@v0.0.3
+        with:
+          version: '0.9.2'
       - name: Setup sandbox
         run: |
           mkdir -p ~/.flyte/sandbox

--- a/flytestdlib/config/tests/accessor_test.go
+++ b/flytestdlib/config/tests/accessor_test.go
@@ -431,11 +431,9 @@ func TestAccessor_UpdateConfig(t *testing.T) {
 			key := strings.ToUpper("my-component.str3")
 			assert.NoError(t, os.Setenv(key, "Set From Env"))
 			defer func() { assert.NoError(t, os.Unsetenv(key)) }()
-			err = v.UpdateConfig(context.TODO())
-			assert.Error(t, err)
-			assert.EqualError(t, err, "Config File \"config\" Not Found in \"[]\"")
+			assert.NoError(t, v.UpdateConfig(context.TODO()))
 			r := reg.GetSection(MyComponentSectionKey).GetConfig().(*MyComponentConfig)
-			assert.Equal(t, "", r.StringValue3)
+			assert.Equal(t, "Set From Env", r.StringValue3)
 		})
 
 		t.Run(fmt.Sprintf("[%v] Change handler", provider(config.Options{}).ID()), func(t *testing.T) {

--- a/flytestdlib/config/tests/config_cmd_test.go
+++ b/flytestdlib/config/tests/config_cmd_test.go
@@ -32,7 +32,7 @@ func TestDiscoverCommand(t *testing.T) {
 		t.Run(fmt.Sprintf(testNameFormatter, provider(config.Options{}).ID(), "No config file"), func(t *testing.T) {
 			cmd := config.NewConfigCommand(provider)
 			output, err := executeCommand(cmd, config.CommandDiscover)
-			assert.Error(t, err)
+			assert.NoError(t, err)
 			assert.Contains(t, output, "Couldn't find a config file.")
 		})
 
@@ -57,7 +57,7 @@ func TestValidateCommand(t *testing.T) {
 		t.Run(fmt.Sprintf(testNameFormatter, provider(config.Options{}).ID(), "No config file"), func(t *testing.T) {
 			cmd := config.NewConfigCommand(provider)
 			output, err := executeCommand(cmd, config.CommandValidate)
-			assert.Error(t, err)
+			assert.NoError(t, err)
 			assert.Contains(t, output, "Couldn't find a config file.")
 		})
 

--- a/flytestdlib/config/viper/testdata/viper_test_config.yaml
+++ b/flytestdlib/config/viper/testdata/viper_test_config.yaml
@@ -1,2 +1,0 @@
-test:
-  field: 1

--- a/flytestdlib/config/viper/viper.go
+++ b/flytestdlib/config/viper/viper.go
@@ -128,34 +128,38 @@ func (v viperAccessor) updateConfig(ctx context.Context, r config.Section) error
 
 	v.viper.AutomaticEnv() // read in environment variables that match
 
+	shouldWatchChanges := true
 	// If a config file is found, read it in.
 	if err = v.viper.ReadInConfig(); err == nil {
 		logger.Debugf(ctx, "Using config file: %+v", v.viper.ConfigFilesUsed())
 	} else if asErrorCollection, ok := err.(stdLibErrs.ErrorCollection); ok {
+		shouldWatchChanges = false
 		for i, e := range asErrorCollection {
 			if _, isNotFound := errors.Cause(e).(viperLib.ConfigFileNotFoundError); isNotFound {
-				logger.Errorf(ctx, "[%v] Couldn't find a config file [%v]. Relying on env vars and pflags.",
+				logger.Infof(ctx, "[%v] Couldn't find a config file [%v]. Relying on env vars and pflags.",
 					i, v.viper.underlying[i].ConfigFileUsed())
-				return e
+			} else {
+				return err
 			}
 		}
-		return err
 	} else if reflect.TypeOf(err) == reflect.TypeOf(viperLib.ConfigFileNotFoundError{}) {
-		logger.Errorf(ctx, "Couldn't find a config file. Relying on env vars and pflags.")
-		return err
+		shouldWatchChanges = false
+		logger.Info(ctx, "Couldn't find a config file. Relying on env vars and pflags.")
 	} else {
 		return err
 	}
 
-	v.watcherInitializer.Do(func() {
-		// Watch config files to pick up on file changes without requiring a full application restart.
-		// This call must occur after *all* config paths have been added.
-		v.viper.OnConfigChange(func(e fsnotify.Event) {
-			logger.Debugf(ctx, "Got a notification change for file [%v] \n", e.Name)
-			v.configChangeHandler()
+	if shouldWatchChanges {
+		v.watcherInitializer.Do(func() {
+			// Watch config files to pick up on file changes without requiring a full application restart.
+			// This call must occur after *all* config paths have been added.
+			v.viper.OnConfigChange(func(e fsnotify.Event) {
+				logger.Debugf(ctx, "Got a notification change for file [%v] \n", e.Name)
+				v.configChangeHandler()
+			})
+			v.viper.WatchConfig()
 		})
-		v.viper.WatchConfig()
-	})
+	}
 
 	return v.RefreshFromConfig(ctx, r, true)
 }

--- a/flytestdlib/config/viper/viper_test.go
+++ b/flytestdlib/config/viper/viper_test.go
@@ -1,14 +1,11 @@
 package viper
 
 import (
-	"context"
 	"encoding/base64"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/flyteorg/flyte/flytestdlib/config"
 )
 
 func Test_stringToByteArray(t *testing.T) {
@@ -53,32 +50,5 @@ func Test_stringToByteArray(t *testing.T) {
 		res, err := stringToByteArray(reflect.TypeOf(input), reflect.TypeOf(""), input)
 		assert.NoError(t, err)
 		assert.NotEqual(t, []byte("hello"), res)
-	})
-}
-
-func TestViperAccessor_UpdateConfig(t *testing.T) {
-	ctx := context.Background()
-	t.Run("unable to find the config file", func(t *testing.T) {
-		// Create accessor
-		accessor := newAccessor(config.Options{
-			SearchPaths: []string{".", "/etc/flyte/config", "$GOPATH/src/github.com/flyteorg/flyte"},
-			StrictMode:  false,
-		})
-
-		// Update config
-		err := accessor.updateConfig(ctx, accessor.rootConfig)
-		assert.EqualError(t, err, "Config File \"config\" Not Found in \"[]\"")
-	})
-
-	t.Run("find the config file", func(t *testing.T) {
-		// Create accessor
-		accessor := newAccessor(config.Options{
-			SearchPaths: []string{"./testdata/viper_test_config.yaml"},
-			StrictMode:  false,
-		})
-
-		// Update config
-		err := accessor.updateConfig(ctx, accessor.rootConfig)
-		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Reverts flyteorg/flyte#5972

This change forced a config file to be defined for all invocations of the flyte binaries (flytectl, flyteadmin, flytepropeller, etc). The blast radius of missing a config file is a lot bigger than simply flytectl, so reverting this change for now while we consider other options for the original issue.
