### PR TITLE
Fix: Make distributed error aggregation opt-in

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/config.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/config.go
@@ -218,6 +218,8 @@ type K8sPluginConfig struct {
 
 	// Extended resources that should be added to the tolerations automatically.
 	AddTolerationsForExtendedResources []string `json:"add-tolerations-for-extended-resources" pflag:",Name of the extended resources for which tolerations should be added."`
+
+	EnableDistributedErrorAggregation bool `json:"enable-distributed-error-aggregation" pflag:",If true, will aggregate errors of different worker pods for distributed tasks."`
 }
 
 // FlyteCoPilotConfig specifies configuration for the Flyte CoPilot system. FlyteCoPilot, allows running flytekit-less containers

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	pluginsK8s "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	flytek8sConfig "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
+	k8sConfig "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
 	pluginIOMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/k8s"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
@@ -724,8 +725,14 @@ func TestGetLogsElastic(t *testing.T) {
 }
 
 func TestGetProperties(t *testing.T) {
+	config := k8sConfig.GetK8sPluginConfig()
 	pytorchResourceHandler := pytorchOperatorResourceHandler{}
-	expected := k8s.PluginProperties{
+
+	expected := k8s.PluginProperties{}
+	assert.Equal(t, expected, pytorchResourceHandler.GetProperties())
+
+	config.EnableDistributedErrorAggregation = true
+	expected = k8s.PluginProperties{
 		ErrorAggregationStrategy: k8s.EarliestErrorAggregationStrategy,
 	}
 	assert.Equal(t, expected, pytorchResourceHandler.GetProperties())
@@ -861,6 +868,8 @@ func TestBuildResourcePytorchV1(t *testing.T) {
 			},
 		}
 
+		config := k8sConfig.GetK8sPluginConfig()
+		config.EnableDistributedErrorAggregation = true
 		pytorchResourceHandler := pytorchOperatorResourceHandler{}
 
 		taskTemplate := dummyPytorchTaskTemplate("job4", taskConfig)


### PR DESCRIPTION
## Why are the changes needed?

For RFC https://github.com/flyteorg/flyte/pull/5598, flytepropeller was given the ability to list error files in the so-called raw output prefix bucket of an execution with the goal of identifying which worker pod in a failed distributed task experienced the first error.

In GCP, listing the error files requires the `"storage.objects.list"` permission which so far wasn't given to propeller. I added this permission to the Flyte propeller custom role [here](https://github.com/unionai-oss/deploy-flyte/pull/40).

That being said, because this feature is therefore not backwards compatible, I propose to make it opt-in.

If you agree with this, I'll make another PR to document this feature and how to activate it [here](https://docs.flyte.org/en/latest/flytesnacks/examples/kfpytorch_plugin/pytorch_mnist.html) and/or [here](https://docs.flyte.org/en/latest/deployment/plugins/k8s/index.html#install-the-kubernetes-operator).

## What changes were proposed in this pull request?

Only search for multiple error files from the different workers of a distributed task as proposed in RFC https://github.com/flyteorg/flyte/pull/5598 if actively enabled in the flytepropeller config in order to not strictly require the addition of the `"storage.objects.list"` permission.

## How was this patch tested?

Ran flytepropeller with/without the flag enabled locally for a GKE based deployment and adapted unit tests.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

