### PR TITLE
Fix: Remove the default search dialog if it exists (on CMD + K)

### DIFF
--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -1,10 +1,17 @@
-window.addEventListener("DOMContentLoaded", function() {
-    // Select all <a> elements with class "external"
-    var externalLinks = document.querySelectorAll("a.external");
+window.addEventListener("DOMContentLoaded", function () {
+  // Select all <a> elements with class "external"
+  var externalLinks = document.querySelectorAll("a.external");
 
-    // Loop through each <a> element with class "external"
-    externalLinks.forEach(function(link) {
-        // Set the target attribute to "_blank"
-        link.setAttribute("target", "_blank");
-    });
+  // Loop through each <a> element with class "external"
+  externalLinks.forEach(function (link) {
+    // Set the target attribute to "_blank"
+    link.setAttribute("target", "_blank");
+  });
+
+  // Remove the default search dialog if it exists (on CMD + K)
+  // This collides with Algolia's search dialog
+  const searchDialog = document.getElementById("pst-search-dialog");
+  if (searchDialog) {
+    searchDialog.remove();
+  }
 });


### PR DESCRIPTION
## Why are the changes needed?
- Hitting CMD + K pops up two search dialogs (the `docsearch` and the default one)

## What changes were proposed in this pull request?
This PR adds a script block that gracefully removes the default search dialog from the tree.

## How was this patch tested?
1. Build
2. Serve
3. Hit CMD + K


### Screenshots
<img width="1337" alt="Screenshot 2024-12-13 at 09 49 49" src="https://github.com/user-attachments/assets/711728b0-f5d3-4862-a2ee-6a6118ca34ed" />

## Check all the applicable boxes 

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.