### PR TITLE
docs: Update datatype mapping for polars Dataframe and LazyFrame

### DIFF
--- a/docs/user_guide/data_types_and_io/index.md
+++ b/docs/user_guide/data_types_and_io/index.md
@@ -108,6 +108,14 @@ Here's a breakdown of these mappings:
       - Structured Dataset
       - Automatic
       - Use ``pandas.DataFrame`` as a type hint. Pandas column types aren't preserved.
+    * - ``polars.DataFrame``
+      - Structured Dataset
+      - Automatic
+      - Use ``polars.DataFrame`` as a type hint. Polars column types aren't preserved.
+    * - ``polars.LazyFrame``
+      - Structured Dataset
+      - Automatic
+      - Use ``polars.LazyFrame`` as a type hint. Polars column types aren't preserved.
     * - ``pyspark.DataFrame``
       - Structured Dataset
       - To utilize the type, install the ``flytekitplugins-spark`` plugin.


### PR DESCRIPTION
## Why are the changes needed?
People using polars instead of pandas are afraid that their workflow will not work with Flyte when the documentation does not mention Polars at all.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Adding polars.DataFrame and polars.LazyFrame to the data type mapping documentation to show that these are supported.
https://docs.flyte.org/en/latest/user_guide/data_types_and_io/index.html
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytekit/pull/2695#issuecomment-2546013449
<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
