### PR TITLE
Pass CustomInfo metadata through ArrayNode ExternalResourceInfo (#591)

### DIFF
--- a/flytepropeller/pkg/controller/nodes/array/event_recorder.go
+++ b/flytepropeller/pkg/controller/nodes/array/event_recorder.go
@@ -136,7 +136,7 @@ func (e *externalResourcesEventRecorder) process(ctx context.Context, nCtx inter
 			log.Name = fmt.Sprintf("%s-%d", log.GetName(), index)
 		}
 
-		externalResourceInfo := events.ExternalResourceInfo{
+		externalResourceInfo := event.ExternalResourceInfo{
 			ExternalId:   externalResourceID,
 			Index:        uint32(index), // #nosec G115
 			Logs:         taskExecutionEvent.GetLogs(),

--- a/flytepropeller/pkg/controller/nodes/array/event_recorder.go
+++ b/flytepropeller/pkg/controller/nodes/array/event_recorder.go
@@ -143,11 +143,11 @@ func (e *externalResourcesEventRecorder) process(ctx context.Context, nCtx inter
 			RetryAttempt: retryAttempt,
 			Phase:        taskExecutionEvent.GetPhase(),
 			CacheStatus:  cacheStatus,
-			CustomInfo:   taskExecutionEvent.CustomInfo,
+			CustomInfo:   taskExecutionEvent.GetCustomInfo(),
 		}
 
-		if taskExecutionEvent.GetMetadata() != nil && len(taskExecutionEvent.GetMetadata().ExternalResources) == 1 {
-			externalResourceInfo.CustomInfo = taskExecutionEvent.GetMetadata().ExternalResources[0].CustomInfo
+		if taskExecutionEvent.GetMetadata() != nil && len(taskExecutionEvent.GetMetadata().GetExternalResources()) == 1 {
+			externalResourceInfo.CustomInfo = taskExecutionEvent.GetMetadata().GetExternalResources()[0].GetCustomInfo()
 		}
 
 		e.externalResources = append(e.externalResources, &externalResourceInfo)

--- a/flytepropeller/pkg/controller/nodes/array/event_recorder.go
+++ b/flytepropeller/pkg/controller/nodes/array/event_recorder.go
@@ -136,14 +136,21 @@ func (e *externalResourcesEventRecorder) process(ctx context.Context, nCtx inter
 			log.Name = fmt.Sprintf("%s-%d", log.GetName(), index)
 		}
 
-		e.externalResources = append(e.externalResources, &event.ExternalResourceInfo{
+		externalResourceInfo := events.ExternalResourceInfo{
 			ExternalId:   externalResourceID,
 			Index:        uint32(index), // #nosec G115
 			Logs:         taskExecutionEvent.GetLogs(),
 			RetryAttempt: retryAttempt,
 			Phase:        taskExecutionEvent.GetPhase(),
 			CacheStatus:  cacheStatus,
-		})
+			CustomInfo:   taskExecutionEvent.CustomInfo,
+		}
+
+		if taskExecutionEvent.GetMetadata() != nil && len(taskExecutionEvent.GetMetadata().ExternalResources) == 1 {
+			externalResourceInfo.CustomInfo = taskExecutionEvent.GetMetadata().ExternalResources[0].CustomInfo
+		}
+
+		e.externalResources = append(e.externalResources, &externalResourceInfo)
 	}
 
 	// clear nodeEvents and taskEvents


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
Passes `CustomInfo` from `ExternalResourceInfo` through ArrayNode subNode executions.

## What changes were proposed in this pull request?
^^^

## How was this patch tested?
Tested locally.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs
N/A

## Docs link
N/A
