### PR TITLE
Print K8s Resolver Event for Agent Grpc request debugging

### DIFF
--- a/flytestdlib/resolver/k8s_resolver.go
+++ b/flytestdlib/resolver/k8s_resolver.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/resolver"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -157,6 +158,16 @@ func (k *kResolver) run() {
 	logger.Infof(k.ctx, "Starting k8s resolver for target: %s", k.target)
 	watcher, err := k.k8sClient.CoreV1().Endpoints(k.target.serviceNamespace).Watch(k.ctx, metav1.ListOptions{FieldSelector: "metadata.name=" + k.target.serviceName})
 	if err != nil {
+		logger.Errorf(
+			k.ctx,
+			"k8s resolver: failed to create watcher for target [%s]: namespace [%s], service [%s], error [%v]",
+			k.target, k.target.serviceNamespace, k.target.serviceName, err,
+		)
+		if statusErr, ok := err.(*errors.StatusError); ok {
+			logger.Errorf(k.ctx, "k8s resolver: status error details: %v", statusErr.ErrStatus)
+		}
+
+		logger.Infof(k.ctx, "k8s resolver: failed to create watcher: [%v]", err)
 		grpclog.Errorf("k8s resolver: failed to create watcher: %v", err)
 		return
 	}
@@ -166,6 +177,11 @@ func (k *kResolver) run() {
 		case <-k.ctx.Done():
 			return
 		case event, ok := <-watcher.ResultChan():
+			logger.Info(k.ctx, "k8s resolver watchet event response: [%v]", event)
+			logger.Info(k.ctx, "k8s resolver watchet event Object response: [%v]", event.Object)
+			if event.Object != nil {
+				logger.Info(k.ctx, "k8s resolver watchet event Object Kind: [%v]", event.Object.GetObjectKind())
+			}
 			if !ok {
 				logger.Debugf(k.ctx, "k8s resolver: watcher closed")
 				return


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
k8s resolver might fail if we set the wrong deployment endpoint for `agent service`, print what error happened will be super helpful.

## What changes were proposed in this pull request?
print service namespace, service name, and response event.

## How was this patch tested?
build a propeller image and tested in private cluster.

### Setup process
```zsh
alias dbxt="docker buildx build --platform linux/amd64 -t ";  # --platform linux/amd64
alias dp="docker push"
dbxt futureoutlier/flytepropeller:k8s-resolver-2025-0108-1147 -f Dockerfile.flytepropeller .
dp futureoutlier/flytepropeller:k8s-resolver-2025-0108-1147

use kubectl to edit the image
```
### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
Enhanced Kubernetes resolver logging in Flyte standard library by implementing detailed error logging for watcher creation failures and adding comprehensive logging for Kubernetes watcher events. Added service namespace and service name details to log messages, fixed typos, and removed redundant log statements for more concise and accurate debug information. The changes improve debugging capabilities by providing visibility into event responses, object details, and object kinds.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>