### PR TITLE
[Docs] Align fd code lines with Flytesnacks examples

### DIFF
--- a/docs/user_guide/data_types_and_io/flytedirectory.md
+++ b/docs/user_guide/data_types_and_io/flytedirectory.md
@@ -18,7 +18,7 @@ To begin, import the libraries:
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/folder.py
 :caption: data_types_and_io/folder.py
-:lines: 1-10
+:lines: 1-9
 ```
 
 Building upon the previous example demonstrated in the {std:ref}`file <file>` section,
@@ -100,7 +100,7 @@ Here is a simple example, you can accept a `FlyteDirectory` as an input, walk th
 
 ```{literalinclude} /examples/data_types_and_io/data_types_and_io/file_streaming.py
 :caption: data_types_and_io/file_streaming.py
-:lines: 23-33
+:lines: 24-34
 ```
 
 [flytesnacks]: https://github.com/flyteorg/flytesnacks/tree/master/examples/data_types_and_io/


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Due to the transition from `rli` to `literalinclude`, two code snippets on [FlyteDirectory page](https://flyte--6135.org.readthedocs.build/en/6135/user_guide/data_types_and_io/flytedirectory.html) are out of sync of the following two Flytesnacks examples, [folder.py](https://github.com/flyteorg/flytesnacks/blob/master/examples/data_types_and_io/data_types_and_io/folder.py) and [file_streaming.py](https://github.com/flyteorg/flytesnacks/blob/master/examples/data_types_and_io/data_types_and_io/file_streaming.py).

## What changes were proposed in this pull request?
Align code snippets on the doc page with two corresponding examples.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flyte/pull/6008

## Docs link
https://flyte--6149.org.readthedocs.build/en/6149/user_guide/data_types_and_io/flytedirectory.html
