### PR TITLE
Add securityContext for individual containers in flyte-binary Deployment

### DIFF
--- a/charts/flyte-binary/README.md
+++ b/charts/flyte-binary/README.md
@@ -91,6 +91,7 @@ Chart for basic single Flyte executable deployment
 | deployment.extraVolumes | list | `[]` |  |
 | deployment.genAdminAuthSecret.args | list | `[]` |  |
 | deployment.genAdminAuthSecret.command | list | `[]` |  |
+| deployment.genAdminAuthSecret.securityContext | object | `{}` |  |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.image.repository | string | `"cr.flyte.org/flyteorg/flyte-binary"` |  |
 | deployment.image.tag | string | `"latest"` |  |
@@ -105,6 +106,7 @@ Chart for basic single Flyte executable deployment
 | deployment.podSecurityContext.runAsGroup | int | `65534` |  |
 | deployment.podSecurityContext.runAsUser | int | `65534` |  |
 | deployment.readinessProbe | object | `{}` |  |
+| deployment.securityContext | object | `{}` |  |
 | deployment.sidecars | list | `[]` |  |
 | deployment.startupProbe | object | `{}` |  |
 | deployment.waitForDB.args | list | `[]` |  |
@@ -112,6 +114,7 @@ Chart for basic single Flyte executable deployment
 | deployment.waitForDB.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.waitForDB.image.repository | string | `"postgres"` |  |
 | deployment.waitForDB.image.tag | string | `"15-alpine"` |  |
+| deployment.waitForDB.securityContext | object | `{}` |  |
 | enabled_plugins.tasks | object | `{"task-plugins":{"default-for-task-types":{"container":"container","container_array":"k8s-array","sidecar":"sidecar"},"enabled-plugins":["container","sidecar","k8s-array","agent-service","echo"]}}` | Tasks specific configuration [structure](https://pkg.go.dev/github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/config#GetConfig) |
 | enabled_plugins.tasks.task-plugins | object | `{"default-for-task-types":{"container":"container","container_array":"k8s-array","sidecar":"sidecar"},"enabled-plugins":["container","sidecar","k8s-array","agent-service","echo"]}` | Plugins configuration, [structure](https://pkg.go.dev/github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/config#TaskPluginConfig) |
 | enabled_plugins.tasks.task-plugins.enabled-plugins | list | `["container","sidecar","k8s-array","agent-service","echo"]` | [Enabled Plugins](https://pkg.go.dev/github.com/lyft/flyteplugins/go/tasks/config#Config). Enable sagemaker*, athena if you install the backend plugins |

--- a/charts/flyte-binary/templates/deployment.yaml
+++ b/charts/flyte-binary/templates/deployment.yaml
@@ -94,6 +94,9 @@ spec:
           {{- if .Values.deployment.resources }}
           resources: {{- toYaml .Values.deployment.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.deployment.waitForDB.securityContext }}
+          securityContext: {{- toYaml .Values.deployment.waitForDB.securityContext | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- if .Values.configuration.auth.enabled }}
         - name: gen-admin-auth-secret
@@ -130,6 +133,9 @@ spec:
               mountPath: /etc/flyte/config.d
           {{- if .Values.deployment.resources }}
           resources: {{- toYaml .Values.deployment.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.deployment.genAdminAuthSecret.securityContext }}
+          securityContext: {{- toYaml .Values.deployment.genAdminAuthSecret.securityContext | nindent 12 }}
           {{- end }}
         {{- end }}
         {{- if .Values.deployment.initContainers }}
@@ -224,6 +230,9 @@ spec:
             {{- if .Values.deployment.extraVolumeMounts }}
             {{- tpl ( .Values.deployment.extraVolumeMounts | toYaml ) . | nindent 12 }}
             {{- end }}
+          {{- if .Values.deployment.securityContext }}
+          securityContext: {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+          {{- end }}
         {{- if .Values.deployment.sidecars }}
         {{- tpl ( .Values.deployment.sidecars | toYaml ) . | nindent 8 }}
         {{- end }}

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -275,12 +275,16 @@ deployment:
     command: []
     # args Override default init container args
     args: []
+    # securityContext Specify security context for wait-for-db init container
+    securityContext: {}
   # genAdminAuthSecret Configure init container to generate secrets for internal use
   genAdminAuthSecret:
     # command Override default init container command
     command: []
     # args Override default init container args
     args: []
+    # securityContext Specify security context for gen-admin-auth-secret init container
+    securityContext: {}
   # labels Add labels to Flyte deployment
   labels: {}
   # annotations Add annotations to Flyte deployment
@@ -300,6 +304,8 @@ deployment:
   # extraPodSpec Specify additional configuration for Flyte pod
   # This can be used for adding affinity, tolerations, hostNetwork, etc.
   extraPodSpec: {}
+  # securityContext Specify security context for Flyte container
+  securityContext: {}
 
 # service Configure service for Flyte
 service:

--- a/docker/sandbox-bundled/manifests/complete-agent.yaml
+++ b/docker/sandbox-bundled/manifests/complete-agent.yaml
@@ -823,7 +823,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: VFRKYXBKM2xsTERQb1ZDaQ==
+  haSharedSecret: UnZJZHEzUExzbkJsOW1wYw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1420,7 +1420,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 4c7bc4fbd20227034bda9ead9cd941c94879028d6920b98113f9a08ef3c6f9d9
+        checksum/secret: ce172103045f4215e361b4c109776a78fe06660a4ade01c7351ea07212e7cfb9
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -805,7 +805,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: Zm4xWHVaRlNsb2EyVFFIVg==
+  haSharedSecret: dDFiem04NjFzb29ZWHFtNA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1369,7 +1369,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: fdbda8db15a09ca5943cc534a824402836c98722de81d1631c45099a8e04b043
+        checksum/secret: 529d34a9c4d3c82b9eec5028fcc30f26e923fa77a57eb29c4705d28c85355963
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: RjY3OEtOeFVDMjFabkI0SA==
+  haSharedSecret: Y1V1RU03eGVhUDFFc1pSdQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 6ab17d37fe9743709a5aa2a140c06a7a25fe33cfe4d6c0cbcb2ddf0a2dcf1675
+        checksum/secret: 66507f448be8010226a1ad2c741fb2866ef4372b68e61287c7500b47fae05572
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## Why are the changes needed?
Some k8s clusters (including the one I work with) have strict requirements when it comes to `securityContext` for pods and containers, enforced by tools like `Gatekeeper.sh`.

These changes introduce the ability to configure `securityContext` at container level (init containers and the main container) within `flyte-binary` Helm Chart.

 Specifying a `securityContext` is a Kubernetes best practice, as it allows you to configure various security-related settings (e.g., running as a non-root user, setting read-only file systems, etc.). This helps ensure that deployments adhere to stricter security guidelines and can comply with organizational or regulatory requirements.

## What changes were proposed in this pull request?


  - Added optional `securityContext` fields under:
    1. `deployment.waitForDB.securityContext` for the `wait-for-db` init container.  
    2. `deployment.genAdminAuthSecret.securityContext` for the `gen-admin-auth-secret` init container.  
    3. `deployment.securityContext` for the main Flyte container.  
  - Updated the Helm template (`deployment.yaml`) to conditionally render these `securityContext` blocks if they are defined in `values.yaml`.

These changes allow end users to specify privileged or non-privileged modes, user/group IDs, and other security settings in a flexible manner.

## How was this patch tested?

- **Helm Installation**:  
  - Deployed the chart in my own cluster with various `securityContext` configurations to ensure that the containers correctly applied the specified context (e.g., run as non-root, set read-only file system).
  - Verified that omitting the `securityContext` in `values.yaml` falls back to the existing default behavior, ensuring backward compatibility.

No automated tests were added specifically for this change because it primarily involves YAML configuration and conditional Helm templating. However, the local deployment tests validated that the feature works as expected and does not introduce regressions.

### Labels

- **added** (new functionality: new fields and optional configuration for `securityContext`)

### Setup process

No special setup is required. Users can opt in to the new functionality by defining the relevant `securityContext` fields in their `values.yaml`.

### Screenshots

N/A – the feature pertains to YAML/config changes and does not alter UI/visual output.

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

N/A

## Docs link

N/A 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances the security configuration capabilities of the flyte-binary Helm chart by introducing container-level securityContext settings. The implementation enables individual security context configuration for multiple containers including wait-for-db init container, gen-admin-auth-secret init container, and the main Flyte container. The changes include conditional rendering of securityContext blocks and updated manifest files with new haSharedSecret and checksum values.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>