### PR TITLE
Add missing execution-keyed entities for custom filters

### DIFF
--- a/flyteadmin/pkg/common/filters.go
+++ b/flyteadmin/pkg/common/filters.go
@@ -103,9 +103,11 @@ var executionIdentifierFields = map[string]bool{
 
 // Entities that have special case handling for execution identifier fields.
 var executionIdentifierEntities = map[Entity]bool{
-	Execution:     true,
-	NodeExecution: true,
-	TaskExecution: true,
+	Execution:          true,
+	NodeExecution:      true,
+	NodeExecutionEvent: true,
+	TaskExecution:      true,
+	Signal:             true,
 }
 
 var entityMetadataFields = map[string]bool{

--- a/flyteadmin/pkg/repositories/gormimpl/signal_repo_test.go
+++ b/flyteadmin/pkg/repositories/gormimpl/signal_repo_test.go
@@ -138,7 +138,7 @@ func TestListSignals(t *testing.T) {
 	signalModels := []map[string]interface{}{toSignalMap(*signalModel)}
 	mockSelectQuery := GlobalMock.NewMock()
 	mockSelectQuery.WithQuery(
-		`SELECT * FROM "signals" WHERE project = $1 AND domain = $2 AND name = $3 LIMIT 20`).WithReply(signalModels)
+		`SELECT * FROM "signals" WHERE execution_project = $1 AND execution_domain = $2 AND execution_name = $3 LIMIT 20`).WithReply(signalModels)
 
 	signals, err := signalRepo.List(ctx, interfaces.ListResourceInput{
 		InlineFilters: []common.InlineFilter{


### PR DESCRIPTION
## Why are the changes needed?
Bug introduced in https://github.com/flyteorg/flyte/pull/5935

Entities in this list have execution-key as part of their primary key. Execution key columns are all prefixed with "execution_" under the hood, so we need to prepend the column values with this for DB queries to work.

## What changes were proposed in this pull request?
See PR title

## How was this patch tested?

Deployed to my sandbox and ran the `waiting_for_external_inputs` workflow on sandbox.
```
 pyflyte run --remote examples/advanced_composition/advanced_composition/waiting_for_external_inputs.py reporting_with_approval_wf --data '[1.0,2.0,3.0]'
/Users/katrina/.venv/union/lib/python3.12/site-packages/airflow/configuration.py:859 FutureWarning: section/key [core/sql_alchemy_conn] has been deprecated, you should use[database/sql_alchemy_conn] instead. Please update your `conf.get*` call to use the new name
Running Execution on Remote.
0:00:00 Running execution on remote.
[✔] Go to http://localhost:30080/console/projects/flytesnacks/domains/development/executions/ap8fz45qg24mcqnmcjjv to see execution in the console.
```

Then ran this script
```
from flytekit.remote import FlyteRemote
from flytekit.configuration import Config, PlatformConfig


def list_signals():
    # Step 1: Configure FlyteRemote

    remote = FlyteRemote(
        config=Config.for_sandbox(),
        default_project="flytesnacks",
        default_domain="development",
    )


    signals = remote.list_signals(execution_name="ap8fz45qg24mcqnmcjjv", project="flytesnacks", domain="development")
    print(f"signals fetched :: {signals}")

if __name__ == "__main__":
    list_signals()
```

and ensured it succeeded:

```
signals fetched :: [id {
  signal_id: "title"
  execution_id {
    project: "flytesnacks"
    domain: "development"
    name: "ap8fz45qg24mcqnmcjjv"
  }
}
type {
  simple: STRING
}
]

Process finished with exit code 0
```

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
