### PR TITLE
stripping metadata from dataclass types (#626)

### DIFF
--- a/flytepropeller/pkg/compiler/transformers/k8s/utils.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/utils.go
@@ -97,9 +97,15 @@ func StripTypeMetadata(t *core.LiteralType) *core.LiteralType {
 		}
 	}
 
-	// Note that we cannot strip `Structure` from the type because the dynamic node output type is used to validate the
-	// interface of the dynamically compiled workflow. `Structure` is used to extend type checking information on
-	// different Flyte types and is therefore required to ensure correct type validation.
+	// strip metadata from dataclass types
+	if c.Structure != nil && len(c.Structure.DataclassType) > 0 {
+		dataclassTypes := make(map[string]*core.LiteralType, len(c.Structure.DataclassType))
+		for k, v := range c.Structure.DataclassType {
+			dataclassTypes[k] = StripTypeMetadata(v)
+		}
+
+		c.Structure.DataclassType = dataclassTypes
+	}
 
 	switch underlyingType := c.GetType().(type) {
 	case *core.LiteralType_UnionType:

--- a/flytepropeller/pkg/compiler/transformers/k8s/utils.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/utils.go
@@ -98,13 +98,13 @@ func StripTypeMetadata(t *core.LiteralType) *core.LiteralType {
 	}
 
 	// strip metadata from dataclass types
-	if c.Structure != nil && len(c.Structure.DataclassType) > 0 {
-		dataclassTypes := make(map[string]*core.LiteralType, len(c.Structure.DataclassType))
-		for k, v := range c.Structure.DataclassType {
+	if c.GetStructure() != nil && len(c.GetStructure().GetDataclassType()) > 0 {
+		dataclassTypes := make(map[string]*core.LiteralType, len(c.GetStructure().GetDataclassType()))
+		for k, v := range c.GetStructure().GetDataclassType() {
 			dataclassTypes[k] = StripTypeMetadata(v)
 		}
 
-		c.Structure.DataclassType = dataclassTypes
+		c.GetStructure().DataclassType = dataclassTypes
 	}
 
 	switch underlyingType := c.GetType().(type) {

--- a/flytepropeller/pkg/compiler/transformers/k8s/utils_test.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/utils_test.go
@@ -224,7 +224,25 @@ func TestStripTypeMetadata(t *testing.T) {
 											},
 										},
 									},
-									Structure: &core.TypeStructure{Tag: "str"},
+									Structure: &core.TypeStructure{
+										DataclassType: map[string]*core.LiteralType{
+											"foo": {
+												Type: &core.LiteralType_Simple{
+													Simple: core.SimpleType_STRING,
+												},
+												Metadata: &_struct.Struct{
+													Fields: map[string]*_struct.Value{
+														"foo": {
+															Kind: &_struct.Value_StringValue{
+																StringValue: "bar",
+															},
+														},
+													},
+												},
+											},
+										},
+										Tag: "str",
+									},
 								},
 							},
 						},
@@ -241,7 +259,16 @@ func TestStripTypeMetadata(t *testing.T) {
 									Type: &core.LiteralType_Simple{
 										Simple: core.SimpleType_STRING,
 									},
-									Structure: &core.TypeStructure{Tag: "str"},
+									Structure: &core.TypeStructure{
+										DataclassType: map[string]*core.LiteralType{
+											"foo": {
+												Type: &core.LiteralType_Simple{
+													Simple: core.SimpleType_STRING,
+												},
+											},
+										},
+										Tag: "str",
+									},
 								},
 							},
 						},


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
Metadata is stripped from all other places in the interface(s). It is unnecessary for type checking and only attributes to bloating the CRD.

## What changes were proposed in this pull request?
Stripping metadata from dataclass types.

## How was this patch tested?
Tested under a variety of workflows and 

### Labels
- **changed**: For changes in existing functionality.

### Setup process
N/A

### Screenshots
N/A

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
N/A

## Docs link
N/A 
 <div id='description'>
<h3>Summary by Bito</h3>
Implementation of metadata stripping functionality for dataclass types in Flyte compiler, modifying StripTypeMetadata function to handle dataclass types and replacing direct struct field access with getter methods. The changes focus on removing unnecessary metadata and reducing CRD bloat while maintaining type safety, with updates to test coverage to verify the functionality.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>