### PR TITLE
set viper delimiter to :: to support . in config keys

### DIFF
--- a/flytestdlib/config/tests/accessor_test.go
+++ b/flytestdlib/config/tests/accessor_test.go
@@ -22,6 +22,7 @@ import (
 	k8sRand "k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/flyteorg/flyte/flytestdlib/config"
+	"github.com/flyteorg/flyte/flytestdlib/config/viper"
 	"github.com/flyteorg/flyte/flytestdlib/internal/utils"
 )
 
@@ -132,7 +133,7 @@ func TestAccessor_InitializePflags(t *testing.T) {
 
 			set := pflag.NewFlagSet("test", pflag.ContinueOnError)
 			v.InitializePflags(set)
-			key := "MY_COMPONENT.STR2"
+			key := fmt.Sprintf("MY_COMPONENT%sSTR2", viper.KeyDelim)
 			assert.NoError(t, os.Setenv(key, "123"))
 			defer func() { assert.NoError(t, os.Unsetenv(key)) }()
 			assert.NoError(t, v.UpdateConfig(context.TODO()))
@@ -179,10 +180,10 @@ func TestAccessor_InitializePflags(t *testing.T) {
 
 			set := pflag.NewFlagSet("test", pflag.ExitOnError)
 			v.InitializePflags(set)
-			assert.NoError(t, set.Parse([]string{"--my-component.nested.int-val=3"}))
+			assert.NoError(t, set.Parse([]string{fmt.Sprintf("--my-component%snested%sint-val=3", viper.KeyDelim, viper.KeyDelim)}))
 			assert.True(t, set.Parsed())
 
-			flagValue, err := set.GetInt("my-component.nested.int-val")
+			flagValue, err := set.GetInt(fmt.Sprintf("my-component%snested%sint-val", viper.KeyDelim, viper.KeyDelim))
 			assert.NoError(t, err)
 			assert.Equal(t, 3, flagValue)
 
@@ -414,7 +415,7 @@ func TestAccessor_UpdateConfig(t *testing.T) {
 				SearchPaths: []string{filepath.Join("testdata", "config.yaml")},
 				RootSection: reg,
 			})
-			key := strings.ToUpper("my-component.str")
+			key := strings.ToUpper(fmt.Sprintf("my-component%sstr", viper.KeyDelim))
 			assert.NoError(t, os.Setenv(key, "Set From Env"))
 			defer func() { assert.NoError(t, os.Unsetenv(key)) }()
 			assert.NoError(t, v.UpdateConfig(context.TODO()))
@@ -428,7 +429,7 @@ func TestAccessor_UpdateConfig(t *testing.T) {
 			assert.NoError(t, err)
 
 			v := provider(config.Options{RootSection: reg})
-			key := strings.ToUpper("my-component.str3")
+			key := strings.ToUpper(fmt.Sprintf("my-component%sstr3", viper.KeyDelim))
 			assert.NoError(t, os.Setenv(key, "Set From Env"))
 			defer func() { assert.NoError(t, os.Unsetenv(key)) }()
 			assert.NoError(t, v.UpdateConfig(context.TODO()))
@@ -521,7 +522,7 @@ func TestAccessor_UpdateConfig(t *testing.T) {
 				SearchPaths: []string{filepath.Join("testdata", "config.yaml")},
 				RootSection: reg,
 			})
-			key := strings.ToUpper("my-component.str")
+			key := strings.ToUpper(fmt.Sprintf("my-component%sstr", viper.KeyDelim))
 			assert.NoError(t, os.Setenv(key, "Set From Env"))
 			defer func() { assert.NoError(t, os.Unsetenv(key)) }()
 			assert.NoError(t, v.UpdateConfig(context.TODO()))

--- a/flytestdlib/config/viper/collection.go
+++ b/flytestdlib/config/viper/collection.go
@@ -114,7 +114,7 @@ func (c CollectionProxy) MergeConfig(in io.Reader) error {
 }
 
 func (c CollectionProxy) MergeAllConfigs() (all Viper, err error) {
-	combinedConfig := viperLib.New()
+	combinedConfig := viperLib.NewWithOptions(viperLib.KeyDelimiter(KeyDelim))
 	if c.envVars != nil {
 		for _, envConfig := range c.envVars {
 			err = combinedConfig.BindEnv(envConfig...)

--- a/flytestdlib/config/viper/viper.go
+++ b/flytestdlib/config/viper/viper.go
@@ -272,9 +272,6 @@ func (v viperAccessor) parseViperConfigRecursive(root config.Section, settings i
 	if asMap, casted := settings.(map[string]interface{}); casted {
 		myMap := map[string]interface{}{}
 		for childKey, childValue := range asMap {
-			if childKey == "default-annotations" {
-				logger.Debugf(context.Background(), "Found default-annotations in config. Skipping.")
-			}
 			if childSection, found := root.GetSections()[childKey]; found {
 				errs.Append(v.parseViperConfigRecursive(childSection, childValue))
 			} else {


### PR DESCRIPTION
## Tracking issue
closes: https://github.com/flyteorg/flyte/issues/6166

## Why are the changes needed?
parsing configs breaks when "." is part of a key

## What changes were proposed in this pull request?
Update key delimiter to "::" when parsing configs

Note both "." and "::" in keys are valid yaml, but "." seems more likely to be utilized than "::"

## How was this patch tested?
- updated unit test

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
