### PR TITLE
[flyteagent] Default Service Config Using Round Robin Mechanism

### DIFF
--- a/charts/flyte-binary/README.md
+++ b/charts/flyte-binary/README.md
@@ -22,7 +22,7 @@ Chart for basic single Flyte executable deployment
 | commonAnnotations | object | `{}` |  |
 | commonLabels | object | `{}` |  |
 | configuration.agentService.defaultAgent.defaultTimeout | string | `"10s"` |  |
-| configuration.agentService.defaultAgent.endpoint | string | `"dns:///flyteagent.flyte.svc.cluster.local:8000"` |  |
+| configuration.agentService.defaultAgent.endpoint | string | `"k8s://flyteagent:8000"` |  |
 | configuration.agentService.defaultAgent.insecure | bool | `true` |  |
 | configuration.agentService.defaultAgent.timeouts.GetTask | string | `"10s"` |  |
 | configuration.annotations | object | `{}` |  |

--- a/charts/flyte-binary/README.md
+++ b/charts/flyte-binary/README.md
@@ -22,7 +22,7 @@ Chart for basic single Flyte executable deployment
 | commonAnnotations | object | `{}` |  |
 | commonLabels | object | `{}` |  |
 | configuration.agentService.defaultAgent.defaultTimeout | string | `"10s"` |  |
-| configuration.agentService.defaultAgent.endpoint | string | `"k8s://flyteagent:8000"` |  |
+| configuration.agentService.defaultAgent.endpoint | string | `"k8s://flyteagent.flyte:8000"` |  |
 | configuration.agentService.defaultAgent.insecure | bool | `true` |  |
 | configuration.agentService.defaultAgent.timeouts.GetTask | string | `"10s"` |  |
 | configuration.annotations | object | `{}` |  |

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -171,7 +171,7 @@ configuration:
   # agentService Flyte Agent configuration
   agentService:
     defaultAgent:
-      endpoint: "k8s://flyteagent:8000"
+      endpoint: "k8s://flyteagent.flyte:8000"
       insecure: true
       timeouts:
         GetTask: 10s

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -171,7 +171,7 @@ configuration:
   # agentService Flyte Agent configuration
   agentService:
     defaultAgent:
-      endpoint: "dns:///flyteagent.flyte.svc.cluster.local:8000"
+      endpoint: "k8s://flyteagent:8000"
       insecure: true
       timeouts:
         GetTask: 10s

--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -211,9 +211,9 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.serviceMonitor.scrapeTimeout | string | `"30s"` | Sets the timeout after which request to scrape metrics will time out |
 | flyteadmin.tolerations | list | `[]` | tolerations for Flyteadmin deployment |
 | flyteagent.enabled | bool | `false` |  |
-| flyteagent.plugin_config.plugins.agent-service | object | `{"defaultAgent":{"endpoint":"dns:///flyteagent.flyte.svc.cluster.local:8000","insecure":true},"supportedTaskTypes":[]}` | Agent service configuration for propeller. |
-| flyteagent.plugin_config.plugins.agent-service.defaultAgent | object | `{"endpoint":"dns:///flyteagent.flyte.svc.cluster.local:8000","insecure":true}` | The default agent service to use for plugin tasks. |
-| flyteagent.plugin_config.plugins.agent-service.defaultAgent.endpoint | string | `"dns:///flyteagent.flyte.svc.cluster.local:8000"` | The agent service endpoint propeller should connect to. |
+| flyteagent.plugin_config.plugins.agent-service | object | `{"defaultAgent":{"endpoint":"k8s://flyteagent:8000","insecure":true},"supportedTaskTypes":[]}` | Agent service configuration for propeller. |
+| flyteagent.plugin_config.plugins.agent-service.defaultAgent | object | `{"endpoint":"k8s://flyteagent:8000","insecure":true}` | The default agent service to use for plugin tasks. |
+| flyteagent.plugin_config.plugins.agent-service.defaultAgent.endpoint | string | `"k8s://flyteagent:8000"` | The agent service endpoint propeller should connect to. |
 | flyteagent.plugin_config.plugins.agent-service.defaultAgent.insecure | bool | `true` | Whether the connection from propeller to the agent service should use TLS. |
 | flyteagent.plugin_config.plugins.agent-service.supportedTaskTypes | list | `[]` | The task types supported by the default agent. As of #5460 these are discovered automatically and don't need to be configured. |
 | flyteagent.podLabels | object | `{}` | Labels for flyteagent pods |

--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -211,9 +211,9 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.serviceMonitor.scrapeTimeout | string | `"30s"` | Sets the timeout after which request to scrape metrics will time out |
 | flyteadmin.tolerations | list | `[]` | tolerations for Flyteadmin deployment |
 | flyteagent.enabled | bool | `false` |  |
-| flyteagent.plugin_config.plugins.agent-service | object | `{"defaultAgent":{"endpoint":"k8s://flyteagent:8000","insecure":true},"supportedTaskTypes":[]}` | Agent service configuration for propeller. |
-| flyteagent.plugin_config.plugins.agent-service.defaultAgent | object | `{"endpoint":"k8s://flyteagent:8000","insecure":true}` | The default agent service to use for plugin tasks. |
-| flyteagent.plugin_config.plugins.agent-service.defaultAgent.endpoint | string | `"k8s://flyteagent:8000"` | The agent service endpoint propeller should connect to. |
+| flyteagent.plugin_config.plugins.agent-service | object | `{"defaultAgent":{"endpoint":"k8s://flyteagent.flyte:8000","insecure":true},"supportedTaskTypes":[]}` | Agent service configuration for propeller. |
+| flyteagent.plugin_config.plugins.agent-service.defaultAgent | object | `{"endpoint":"k8s://flyteagent.flyte:8000","insecure":true}` | The default agent service to use for plugin tasks. |
+| flyteagent.plugin_config.plugins.agent-service.defaultAgent.endpoint | string | `"k8s://flyteagent.flyte:8000"` | The agent service endpoint propeller should connect to. |
 | flyteagent.plugin_config.plugins.agent-service.defaultAgent.insecure | bool | `true` | Whether the connection from propeller to the agent service should use TLS. |
 | flyteagent.plugin_config.plugins.agent-service.supportedTaskTypes | list | `[]` | The task types supported by the default agent. As of #5460 these are discovered automatically and don't need to be configured. |
 | flyteagent.podLabels | object | `{}` | Labels for flyteagent pods |

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -288,7 +288,7 @@ flyteagent:
         # -- The default agent service to use for plugin tasks.
         defaultAgent:
           # -- The agent service endpoint propeller should connect to.
-          endpoint: "k8s://flyteagent:8000"
+          endpoint: "k8s://flyteagent.flyte:8000"
           # -- Whether the connection from propeller to the agent service should use TLS.
           insecure: true
         # -- The task types supported by the default agent. As of #5460 these are discovered automatically and don't

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -288,7 +288,7 @@ flyteagent:
         # -- The default agent service to use for plugin tasks.
         defaultAgent:
           # -- The agent service endpoint propeller should connect to.
-          endpoint: "dns:///flyteagent.flyte.svc.cluster.local:8000"
+          endpoint: "k8s://flyteagent:8000"
           # -- Whether the connection from propeller to the agent service should use TLS.
           insecure: true
         # -- The task types supported by the default agent. As of #5460 these are discovered automatically and don't

--- a/docker/sandbox-bundled/manifests/complete-agent.yaml
+++ b/docker/sandbox-bundled/manifests/complete-agent.yaml
@@ -486,7 +486,7 @@ data:
       agent-service:
         defaultAgent:
           defaultTimeout: 10s
-          endpoint: k8s://flyteagent:8000
+          endpoint: k8s://flyteagent.flyte:8000
           insecure: true
           timeouts:
             GetTask: 10s
@@ -823,7 +823,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: M2lnYno3RDhWN0lpRU92Uw==
+  haSharedSecret: bjlDbkZsVU1UVmpLdGU4TQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1254,7 +1254,7 @@ spec:
     metadata:
       annotations:
         checksum/cluster-resource-templates: 6fd9b172465e3089fcc59f738b92b8dc4d8939360c19de8ee65f68b0e7422035
-        checksum/configuration: c956f81766ea178b5218d5566636f86741024b4f529be904943801de2d61743a
+        checksum/configuration: 7841a55b7d0bd6a6d44f37ccf05297fb7c3338c1ebd9c2608d499e4f8c817383
         checksum/configuration-secret: 09216ffaa3d29e14f88b1f30af580d02a2a5e014de4d750b7f275cc07ed4e914
       labels:
         app.kubernetes.io/component: flyte-binary
@@ -1420,7 +1420,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: c2c1c411164573f85645c91e10c9a7d6c34528e489326386a02a36d4ae850d07
+        checksum/secret: fd8767b33da59722977568a2a3f4cee7ef850b02f579d8d5e381c038d5a20d42
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete-agent.yaml
+++ b/docker/sandbox-bundled/manifests/complete-agent.yaml
@@ -486,7 +486,7 @@ data:
       agent-service:
         defaultAgent:
           defaultTimeout: 10s
-          endpoint: dns:///flyteagent.flyte.svc.cluster.local:8000
+          endpoint: k8s://flyteagent:8000
           insecure: true
           timeouts:
             GetTask: 10s
@@ -823,7 +823,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: UnZJZHEzUExzbkJsOW1wYw==
+  haSharedSecret: M2lnYno3RDhWN0lpRU92Uw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1254,7 +1254,7 @@ spec:
     metadata:
       annotations:
         checksum/cluster-resource-templates: 6fd9b172465e3089fcc59f738b92b8dc4d8939360c19de8ee65f68b0e7422035
-        checksum/configuration: 5a537c05dbd27a7f2884eb78f4e762205c3bcc3248ab9e509ab7074c7e5f953d
+        checksum/configuration: c956f81766ea178b5218d5566636f86741024b4f529be904943801de2d61743a
         checksum/configuration-secret: 09216ffaa3d29e14f88b1f30af580d02a2a5e014de4d750b7f275cc07ed4e914
       labels:
         app.kubernetes.io/component: flyte-binary
@@ -1420,7 +1420,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: ce172103045f4215e361b4c109776a78fe06660a4ade01c7351ea07212e7cfb9
+        checksum/secret: c2c1c411164573f85645c91e10c9a7d6c34528e489326386a02a36d4ae850d07
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -805,7 +805,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: dDFiem04NjFzb29ZWHFtNA==
+  haSharedSecret: QWJDYjR5emdGOUwxMWM2cg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1369,7 +1369,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 529d34a9c4d3c82b9eec5028fcc30f26e923fa77a57eb29c4705d28c85355963
+        checksum/secret: 8922f419278788a894926bbb7a5f918aad17e796438e84617cd8b26c84b222e5
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -805,7 +805,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: QWJDYjR5emdGOUwxMWM2cg==
+  haSharedSecret: ZzdHam5sWUQ2RGlIVHBOSw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1369,7 +1369,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 8922f419278788a894926bbb7a5f918aad17e796438e84617cd8b26c84b222e5
+        checksum/secret: 3ce2fdef0e59a7eba350423dd49173ed960af107bc4c0873e80ea1cf5895e160
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: Y1V1RU03eGVhUDFFc1pSdQ==
+  haSharedSecret: RmtIWU9kOWoxbkRDWVY0cA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 66507f448be8010226a1ad2c741fb2866ef4372b68e61287c7500b47fae05572
+        checksum/secret: fc9cc214577a3c0d32f8c4813ad3a9891f017578b3e071e88fda5e3ea209410e
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: RmtIWU9kOWoxbkRDWVY0cA==
+  haSharedSecret: ckNscjBXTmJMdmF6QXJ5aw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: fc9cc214577a3c0d32f8c4813ad3a9891f017578b3e071e88fda5e3ea209410e
+        checksum/secret: ee0ad692a622e9665348e44e2168eb06e24ac7683fe357f9ca92ea77283fa4d7
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docs/user_guide/flyte_agents/developing_agents.md
+++ b/docs/user_guide/flyte_agents/developing_agents.md
@@ -198,7 +198,7 @@ plugins:
   agent-service:
     # By default, all requests will be sent to the default agent.
     defaultAgent:
-      endpoint: "k8s://flyteagent:8000"
+      endpoint: "k8s://flyteagent.flyte:8000"
       insecure: true
       timeouts:
         # CreateTask, GetTask and DeleteTask are for async agents.

--- a/docs/user_guide/flyte_agents/developing_agents.md
+++ b/docs/user_guide/flyte_agents/developing_agents.md
@@ -198,7 +198,7 @@ plugins:
   agent-service:
     # By default, all requests will be sent to the default agent.
     defaultAgent:
-      endpoint: "dns:///flyteagent.flyte.svc.cluster.local:8000"
+      endpoint: "k8s://flyteagent:8000"
       insecure: true
       timeouts:
         # CreateTask, GetTask and DeleteTask are for async agents.

--- a/flyteplugins/go/tasks/plugins/webapi/agent/config.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/config.go
@@ -40,9 +40,10 @@ var (
 			},
 		},
 		DefaultAgent: Deployment{
-			Endpoint:       "",
-			Insecure:       true,
-			DefaultTimeout: config.Duration{Duration: 10 * time.Second},
+			Endpoint:             "",
+			Insecure:             true,
+			DefaultTimeout:       config.Duration{Duration: 10 * time.Second},
+			DefaultServiceConfig: `{"loadBalancingConfig": [{"round_robin":{}}]}`,
 		},
 		// AsyncPlugin should be registered to at least one task type.
 		// Reference: https://github.com/flyteorg/flyte/blob/master/flyteplugins/go/tasks/pluginmachinery/registry.go#L27

--- a/flyteplugins/go/tasks/plugins/webapi/agent/config_test.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/config_test.go
@@ -39,3 +39,23 @@ func TestGetAndSetConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, &cfg, GetConfig())
 }
+
+func TestDefaultAgentConfig(t *testing.T) {
+	cfg := defaultConfig
+
+	assert.Equal(t, "", cfg.DefaultAgent.Endpoint)
+	assert.True(t, cfg.DefaultAgent.Insecure)
+	assert.Equal(t, 10*time.Second, cfg.DefaultAgent.DefaultTimeout.Duration)
+	assert.Equal(t, `{"loadBalancingConfig": [{"round_robin":{}}]}`, cfg.DefaultAgent.DefaultServiceConfig)
+
+	assert.Empty(t, cfg.DefaultAgent.Timeouts)
+
+	expectedTaskTypes := []string{"task_type_1", "task_type_2"}
+	assert.Equal(t, expectedTaskTypes, cfg.SupportedTaskTypes)
+
+	assert.Empty(t, cfg.AgentDeployments)
+
+	assert.Empty(t, cfg.AgentForTaskTypes)
+
+	assert.Equal(t, 10*time.Second, cfg.PollInterval.Duration)
+}


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
This PR adds a default gRPC service configuration to the agent plugin that enables round-robin load balancing.
This ensures consistent and fair distribution of requests across multiple agent instances.

## What changes were proposed in this pull request?
- Added `DefaultServiceConfig` in the default agent configuration with round-robin load balancing policy
- Default value set to: `{"loadBalancingConfig": [{"round_robin":{}}]}`
- change agent endpoint from `dns:///flyteagent.flyte.svc.cluster.local:8000` to `k8s://flyteagent.flyte:8000`
(`"Resolver"."Service Name"."Service Namespace"."Port")`

https://github.com/flyteorg/flyte/pull/6179/files#diff-98835a3d321cfb860916a188ca66ea98efe6c9f3a8314ea89ec2cfdf8ad50066R42-R47

## How was this patch tested?
unit test and sandbox.
```python
from flytekit import task, workflow
from flytekit.sensor.file_sensor import FileSensor

sensor = FileSensor(name="test_file_sensor")


@workflow()
def wf():
    sensor(path="s3://my-s3-bucket/a")

if __name__ == "__main__":
    import os
    from flytekit.clis.sdk_in_container import pyflyte
    from click.testing import CliRunner

    runner = CliRunner()
    path = os.path.realpath(__file__)
    
    for _ in range(100):  # Loop to trigger the workflow 100 times
        result = runner.invoke(pyflyte.main, ["run", "--remote", path, "wf"])
        print(result.output)

```

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process
```yaml
agent-service:
defaultAgent:
  defaultTimeout: 10s
  endpoint: k8s://flyteagent.flyte:8000
  insecure: true
  timeouts:
    GetTask: 10s
```

### Screenshots
<img width="981" alt="image" src="https://github.com/user-attachments/assets/30d0f7ea-73f8-411e-acbd-dd311588139a" />

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
Implementation of round-robin load balancing for Flyte agent service, transitioning from DNS-based ('dns:///') to Kubernetes native ('k8s://') service discovery. Updates include DefaultServiceConfig field implementation, endpoint configuration modifications, and security-related changes to shared secrets and checksums in sandbox and development manifests. Comprehensive test coverage included to validate configuration values.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>