### PR TITLE
Pass an error message to the failure node

### DIFF
--- a/flytepropeller/pkg/controller/executors/failure_node_lookup.go
+++ b/flytepropeller/pkg/controller/executors/failure_node_lookup.go
@@ -3,6 +3,7 @@ package executors
 import (
 	"context"
 
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
@@ -10,6 +11,7 @@ type FailureNodeLookup struct {
 	NodeLookup
 	FailureNode       v1alpha1.ExecutableNode
 	FailureNodeStatus v1alpha1.ExecutableNodeStatus
+	OriginalError     *core.ExecutionError
 }
 
 func (f FailureNodeLookup) GetNode(nodeID v1alpha1.NodeID) (v1alpha1.ExecutableNode, bool) {
@@ -35,10 +37,15 @@ func (f FailureNodeLookup) FromNode(id v1alpha1.NodeID) ([]v1alpha1.NodeID, erro
 	return nil, nil
 }
 
-func NewFailureNodeLookup(nodeLookup NodeLookup, failureNode v1alpha1.ExecutableNode, failureNodeStatus v1alpha1.ExecutableNodeStatus) NodeLookup {
+func (f FailureNodeLookup) GetOriginalError() *core.ExecutionError {
+	return f.OriginalError
+}
+
+func NewFailureNodeLookup(nodeLookup NodeLookup, failureNode v1alpha1.ExecutableNode, failureNodeStatus v1alpha1.ExecutableNodeStatus, originalError *core.ExecutionError) NodeLookup {
 	return FailureNodeLookup{
 		NodeLookup:        nodeLookup,
 		FailureNode:       failureNode,
 		FailureNodeStatus: failureNodeStatus,
+		OriginalError:     originalError,
 	}
 }

--- a/flytepropeller/pkg/controller/executors/failure_node_lookup.go
+++ b/flytepropeller/pkg/controller/executors/failure_node_lookup.go
@@ -37,8 +37,8 @@ func (f FailureNodeLookup) FromNode(id v1alpha1.NodeID) ([]v1alpha1.NodeID, erro
 	return nil, nil
 }
 
-func (f FailureNodeLookup) GetOriginalError() *core.ExecutionError {
-	return f.OriginalError
+func (f FailureNodeLookup) GetOriginalError() (*core.ExecutionError, error) {
+	return f.OriginalError, nil
 }
 
 func NewFailureNodeLookup(nodeLookup NodeLookup, failureNode v1alpha1.ExecutableNode, failureNodeStatus v1alpha1.ExecutableNodeStatus, originalError *core.ExecutionError) NodeLookup {

--- a/flytepropeller/pkg/controller/executors/failure_node_lookup_test.go
+++ b/flytepropeller/pkg/controller/executors/failure_node_lookup_test.go
@@ -36,6 +36,7 @@ func TestNewFailureNodeLookup(t *testing.T) {
 	assert.Equal(t, nl, typed.NodeLookup)
 	assert.Equal(t, en, typed.FailureNode)
 	assert.Equal(t, ns, typed.FailureNodeStatus)
+	assert.Equal(t, execErr, typed.OriginalError)
 }
 
 func TestNewTestFailureNodeLookup(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/executor.go
+++ b/flytepropeller/pkg/controller/nodes/executor.go
@@ -772,7 +772,10 @@ func (c *nodeExecutor) preExecute(ctx context.Context, dag executors.DAGStructur
 					if err != nil {
 						return handler.PhaseInfoFailure(core.ExecutionError_SYSTEM, "FailureNodeError", err.Error(), nil), nil
 					} else if originalErr != nil {
-						ResolveOnFailureNodeInput(ctx, nodeInputs, node.GetID(), originalErr)
+						err = ResolveOnFailureNodeInput(ctx, nodeInputs, node.GetID(), originalErr)
+						if err != nil {
+							return handler.PhaseInfoFailure(core.ExecutionError_SYSTEM, "FailureNodeInputResolvingError", err.Error(), nil), nil
+						}
 					}
 				}
 				p := common.CheckOffloadingCompat(ctx, nCtx, nodeInputs.GetLiterals(), node, c.literalOffloadingConfig)

--- a/flytepropeller/pkg/controller/nodes/executor.go
+++ b/flytepropeller/pkg/controller/nodes/executor.go
@@ -768,9 +768,9 @@ func (c *nodeExecutor) preExecute(ctx context.Context, dag executors.DAGStructur
 				// Resolve error input if current node is an on failure node
 				failureNodeLookup, ok := nCtx.ContextualNodeLookup().(executors.FailureNodeLookup)
 				if ok {
-					originalErr := failureNodeLookup.GetOriginalError()
+					originalErr, _ := failureNodeLookup.GetOriginalError()
 					if originalErr != nil {
-						ResolveErrorInput(ctx, nodeInputs, node.GetID(), originalErr)
+						ResolveOnFailureNodeInput(ctx, nodeInputs, node.GetID(), originalErr)
 					}
 				}
 				p := common.CheckOffloadingCompat(ctx, nCtx, nodeInputs.GetLiterals(), node, c.literalOffloadingConfig)

--- a/flytepropeller/pkg/controller/nodes/executor.go
+++ b/flytepropeller/pkg/controller/nodes/executor.go
@@ -765,6 +765,14 @@ func (c *nodeExecutor) preExecute(ctx context.Context, dag executors.DAGStructur
 			}
 
 			if nodeInputs != nil {
+				// Resolve error input if current node is an on failure node
+				failureNodeLookup, ok := nCtx.ContextualNodeLookup().(executors.FailureNodeLookup)
+				if ok {
+					originalErr := failureNodeLookup.GetOriginalError()
+					if originalErr != nil {
+						ResolveErrorInput(ctx, nodeInputs, node.GetID(), originalErr)
+					}
+				}
 				p := common.CheckOffloadingCompat(ctx, nCtx, nodeInputs.GetLiterals(), node, c.literalOffloadingConfig)
 				if p != nil {
 					return *p, nil

--- a/flytepropeller/pkg/controller/nodes/executor.go
+++ b/flytepropeller/pkg/controller/nodes/executor.go
@@ -768,8 +768,10 @@ func (c *nodeExecutor) preExecute(ctx context.Context, dag executors.DAGStructur
 				// Resolve error input if current node is an on failure node
 				failureNodeLookup, ok := nCtx.ContextualNodeLookup().(executors.FailureNodeLookup)
 				if ok {
-					originalErr, _ := failureNodeLookup.GetOriginalError()
-					if originalErr != nil {
+					originalErr, err := failureNodeLookup.GetOriginalError()
+					if err != nil {
+						return handler.PhaseInfoFailure(core.ExecutionError_SYSTEM, "FailureNodeError", err.Error(), nil), nil
+					} else if originalErr != nil {
 						ResolveOnFailureNodeInput(ctx, nodeInputs, node.GetID(), originalErr)
 					}
 				}

--- a/flytepropeller/pkg/controller/nodes/resolve.go
+++ b/flytepropeller/pkg/controller/nodes/resolve.go
@@ -106,11 +106,10 @@ func Resolve(ctx context.Context, outputResolver OutputResolver, nl executors.No
 	}, nil
 }
 
-func ResolveErrorInput(ctx context.Context, nodeInputs *core.LiteralMap, nodeID v1alpha1.NodeID, execErr *core.ExecutionError) {
+func ResolveOnFailureNodeInput(ctx context.Context, nodeInputs *core.LiteralMap, nodeID v1alpha1.NodeID, execErr *core.ExecutionError) {
 	literals := nodeInputs.GetLiterals()
 	if literal, exists := literals["err"]; exists {
 		// make new Scalar for literal map
-		logger.Debugf(ctx, "Processing literal for key 'err'")
 		errorUnion := &core.Scalar_Union{
 			Union: &core.Union{
 				Value: &core.Literal{

--- a/flytepropeller/pkg/controller/nodes/resolve.go
+++ b/flytepropeller/pkg/controller/nodes/resolve.go
@@ -117,7 +117,7 @@ func ResolveOnFailureNodeInput(ctx context.Context, nodeInputs *core.LiteralMap,
 						Scalar: &core.Scalar{
 							Value: &core.Scalar_Error{
 								Error: &core.Error{
-									Message: execErr.GetMessage(),
+									Message:      execErr.GetMessage(),
 									FailedNodeId: nodeID,
 								},
 							},
@@ -135,9 +135,9 @@ func ResolveOnFailureNodeInput(ctx context.Context, nodeInputs *core.LiteralMap,
 			},
 		}
 		literal.Value = &core.Literal_Scalar{
-            Scalar: &core.Scalar{
+			Scalar: &core.Scalar{
 				Value: errorUnion,
 			},
-        }
+		}
 	}
 }

--- a/flytepropeller/pkg/controller/nodes/resolve.go
+++ b/flytepropeller/pkg/controller/nodes/resolve.go
@@ -106,8 +106,7 @@ func Resolve(ctx context.Context, outputResolver OutputResolver, nl executors.No
 	}, nil
 }
 
-func ResolveOnFailureNodeInput(ctx context.Context, nodeInputs *core.LiteralMap, nodeID v1alpha1.NodeID, execErr *core.ExecutionError) {
-	literals := nodeInputs.GetLiterals()
+func ResolveErrorInputLiteralData(ctx context.Context, literals map[string]*core.Literal,  nodeID v1alpha1.NodeID, execErr *core.ExecutionError) {
 	if literal, exists := literals["err"]; exists {
 		// make new Scalar for literal map
 		errorUnion := &core.Scalar_Union{
@@ -140,4 +139,14 @@ func ResolveOnFailureNodeInput(ctx context.Context, nodeInputs *core.LiteralMap,
 			},
 		}
 	}
+}
+
+func ResolveOnFailureNodeInput(ctx context.Context, nodeInputs *core.LiteralMap, nodeID v1alpha1.NodeID, execErr *core.ExecutionError) error {
+	literals := nodeInputs.GetLiterals()
+	if literals != nil {
+		ResolveErrorInputLiteralData(ctx, literals, nodeID, execErr)
+	} else {
+		return errors.Errorf(errors.BindingResolutionError, "id", nodeID, "Node inputs are empty")
+	}
+	return nil
 }

--- a/flytepropeller/pkg/controller/nodes/resolve.go
+++ b/flytepropeller/pkg/controller/nodes/resolve.go
@@ -106,7 +106,7 @@ func Resolve(ctx context.Context, outputResolver OutputResolver, nl executors.No
 	}, nil
 }
 
-func ResolveErrorInputLiteralData(ctx context.Context, literals map[string]*core.Literal,  nodeID v1alpha1.NodeID, execErr *core.ExecutionError) {
+func ResolveErrorInputLiteralData(ctx context.Context, literals map[string]*core.Literal, nodeID v1alpha1.NodeID, execErr *core.ExecutionError) {
 	if literal, exists := literals["err"]; exists {
 		// make new Scalar for literal map
 		errorUnion := &core.Scalar_Union{

--- a/flytepropeller/pkg/controller/nodes/resolve_test.go
+++ b/flytepropeller/pkg/controller/nodes/resolve_test.go
@@ -500,7 +500,7 @@ func TestResolveErrorInput(t *testing.T) {
 			Message: "node failure",
 		}
 		expectedLiterals := make(map[string]*core.Literal, 1)
-		errorLiteral, _ := coreutils.MakeLiteral(&core.Error{Message: execErr.Message, FailedNodeId: nID})
+		errorLiteral, _ := coreutils.MakeLiteral(&core.Error{Message: execErr.GetMessage(), FailedNodeId: nID})
 		expectedLiterals["err"] = &core.Literal{
 			Value: &core.Literal_Scalar{
 				Scalar: &core.Scalar{

--- a/flytepropeller/pkg/controller/nodes/resolve_test.go
+++ b/flytepropeller/pkg/controller/nodes/resolve_test.go
@@ -468,9 +468,9 @@ func TestResolve(t *testing.T) {
 
 }
 
-func TestResolveOnFailureNodeInput(t *testing.T) {
+func TestResolveErrorInputLiteralData(t *testing.T) {
 	ctx := context.Background()
-	t.Run("ResolveErrorInputs", func(t *testing.T) {
+	t.Run("ResolveErrorInputsLiteralData", func(t *testing.T) {
 		noneLiteral, _ := coreutils.MakeLiteral(nil)
 		inputLiterals := make(map[string]*core.Literal, 1)
 		inputLiterals["err"] = &core.Literal{
@@ -491,9 +491,6 @@ func TestResolveOnFailureNodeInput(t *testing.T) {
 					},
 				},
 			},
-		}
-		inputLiteralMap := &core.LiteralMap{
-			Literals: inputLiterals,
 		}
 		nID := "fn"
 		execErr := &core.ExecutionError{
@@ -521,12 +518,23 @@ func TestResolveOnFailureNodeInput(t *testing.T) {
 				},
 			},
 		}
-		expectedLiteralMap := &core.LiteralMap{
-			Literals: expectedLiterals,
-		}
 		// Execute resolve
-		ResolveOnFailureNodeInput(ctx, inputLiteralMap, nID, execErr)
-		flyteassert.EqualLiteralMap(t, expectedLiteralMap, inputLiteralMap)
+		ResolveErrorInputLiteralData(ctx, inputLiterals, nID, execErr)
+		flyteassert.EqualLiterals(t, inputLiterals["err"], expectedLiterals["err"])
 	})
+}
 
+func TestResolveOnFailureNodeInput(t *testing.T) {
+	ctx := context.Background()
+	t.Run("ResolveWithNilInputs", func(t *testing.T) {
+		nID := "fn"
+		execErr := &core.ExecutionError{
+			Message: "node failure",
+		}
+		nilLiteralMap := &core.LiteralMap{
+			Literals: nil,
+		}
+		err := ResolveOnFailureNodeInput(ctx, nilLiteralMap, nID, execErr)
+		assert.Error(t, err)
+	})
 }

--- a/flytepropeller/pkg/controller/nodes/resolve_test.go
+++ b/flytepropeller/pkg/controller/nodes/resolve_test.go
@@ -500,29 +500,29 @@ func TestResolveErrorInput(t *testing.T) {
 			Message: "node failure",
 		}
 		expectedLiterals := make(map[string]*core.Literal, 1)
-			errorLiteral, _ := coreutils.MakeLiteral(&core.Error{Message: execErr.Message, FailedNodeId: nID,})
-			expectedLiterals["err"] = &core.Literal{
-				Value: &core.Literal_Scalar{
-					Scalar: &core.Scalar{
-						Value: &core.Scalar_Union{
-							Union: &core.Union{
-								Value: errorLiteral,
-								Type: &core.LiteralType{
-									Type: &core.LiteralType_Simple{
-										Simple: core.SimpleType_ERROR,
-									},
-									Structure: &core.TypeStructure{
-										Tag: "FlyteError",
-									},
+		errorLiteral, _ := coreutils.MakeLiteral(&core.Error{Message: execErr.Message, FailedNodeId: nID})
+		expectedLiterals["err"] = &core.Literal{
+			Value: &core.Literal_Scalar{
+				Scalar: &core.Scalar{
+					Value: &core.Scalar_Union{
+						Union: &core.Union{
+							Value: errorLiteral,
+							Type: &core.LiteralType{
+								Type: &core.LiteralType_Simple{
+									Simple: core.SimpleType_ERROR,
+								},
+								Structure: &core.TypeStructure{
+									Tag: "FlyteError",
 								},
 							},
 						},
 					},
 				},
-			}
-			expectedLiteralMap := &core.LiteralMap{
-				Literals: expectedLiterals,
-			}
+			},
+		}
+		expectedLiteralMap := &core.LiteralMap{
+			Literals: expectedLiterals,
+		}
 		// Execute resolve
 		ResolveOnFailureNodeInput(ctx, inputLiteralMap, nID, execErr)
 		flyteassert.EqualLiteralMap(t, expectedLiteralMap, inputLiteralMap)

--- a/flytepropeller/pkg/controller/nodes/resolve_test.go
+++ b/flytepropeller/pkg/controller/nodes/resolve_test.go
@@ -468,7 +468,7 @@ func TestResolve(t *testing.T) {
 
 }
 
-func TestResolveErrorInput(t *testing.T) {
+func TestResolveOnFailureNodeInput(t *testing.T) {
 	ctx := context.Background()
 	t.Run("ResolveErrorInputs", func(t *testing.T) {
 		noneLiteral, _ := coreutils.MakeLiteral(nil)
@@ -500,7 +500,8 @@ func TestResolveErrorInput(t *testing.T) {
 			Message: "node failure",
 		}
 		expectedLiterals := make(map[string]*core.Literal, 1)
-		errorLiteral, _ := coreutils.MakeLiteral(&core.Error{Message: execErr.GetMessage(), FailedNodeId: nID})
+		errorLiteral, err := coreutils.MakeLiteral(&core.Error{Message: execErr.GetMessage(), FailedNodeId: nID})
+		assert.NoError(t, err)
 		expectedLiterals["err"] = &core.Literal{
 			Value: &core.Literal_Scalar{
 				Scalar: &core.Scalar{

--- a/flytepropeller/pkg/controller/nodes/subworkflow/subworkflow.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/subworkflow.go
@@ -169,7 +169,7 @@ func (s *subworkflowHandler) HandleFailureNodeOfSubWorkflow(ctx context.Context,
 		status := nCtx.NodeStatus()
 		subworkflowNodeLookup := executors.NewNodeLookup(subworkflow, status, subworkflow)
 		failureNodeStatus := status.GetNodeExecutionStatus(ctx, failureNode.GetID())
-		failureNodeLookup := executors.NewFailureNodeLookup(subworkflowNodeLookup, failureNode, failureNodeStatus)
+		failureNodeLookup := executors.NewFailureNodeLookup(subworkflowNodeLookup, failureNode, failureNodeStatus, originalError)
 
 		state, err := s.nodeExecutor.RecursiveNodeHandler(ctx, execContext, failureNodeLookup, failureNodeLookup, failureNode)
 		if err != nil {

--- a/flytepropeller/pkg/controller/workflow/executor.go
+++ b/flytepropeller/pkg/controller/workflow/executor.go
@@ -203,7 +203,7 @@ func (c *workflowExecutor) handleFailureNode(ctx context.Context, w *v1alpha1.Fl
 	execcontext := executors.NewExecutionContext(w, w, w, nil, executors.InitializeControlFlow())
 
 	failureNodeStatus := w.GetExecutionStatus().GetNodeExecutionStatus(ctx, failureNode.GetID())
-	failureNodeLookup := executors.NewFailureNodeLookup(w, failureNode, failureNodeStatus)
+	failureNodeLookup := executors.NewFailureNodeLookup(w, failureNode, failureNodeStatus, execErr)
 	state, handlerErr := c.nodeExecutor.RecursiveNodeHandler(ctx, execcontext, failureNodeLookup, failureNodeLookup, failureNode)
 	c.updateExecutionStats(ctx, execcontext)
 

--- a/flytepropeller/pkg/utils/assert/literals.go
+++ b/flytepropeller/pkg/utils/assert/literals.go
@@ -22,6 +22,9 @@ func EqualLiteralType(t *testing.T, lt1 *core.LiteralType, lt2 *core.LiteralType
 	}
 	structure1 := lt1.GetStructure()
 	structure2 := lt2.GetStructure()
+	if (structure1 == nil && structure2 != nil) || (structure1 != nil && structure2 == nil) {
+		assert.FailNow(t, "One of the structures is nil while the other is not")
+	}
 	if structure1 != nil && structure2 != nil {
 		assert.Equal(t, structure1.GetTag(), structure2.GetTag())
 	}

--- a/flytepropeller/pkg/utils/assert/literals.go
+++ b/flytepropeller/pkg/utils/assert/literals.go
@@ -20,8 +20,11 @@ func EqualLiteralType(t *testing.T, lt1 *core.LiteralType, lt2 *core.LiteralType
 	default:
 		assert.FailNow(t, "Not yet implemented for types %v", reflect.TypeOf(lt1.GetType()))
 	}
-
-	assert.Equal(t, lt1.GetStructure().GetTag(), lt2.GetStructure().GetTag())
+	structure1 := lt1.GetStructure()
+	structure2 := lt2.GetStructure()
+	if structure1 != nil && structure2 != nil {
+		assert.Equal(t, structure1.GetTag(), structure2.GetTag())
+	}
 }
 
 func EqualPrimitive(t *testing.T, p1 *core.Primitive, p2 *core.Primitive) {

--- a/flytepropeller/pkg/utils/assert/literals.go
+++ b/flytepropeller/pkg/utils/assert/literals.go
@@ -9,6 +9,21 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
+func EqualLiteralType(t *testing.T, lt1 *core.LiteralType, lt2 *core.LiteralType) {
+	if !assert.Equal(t, lt1 == nil, lt2 == nil) {
+		assert.FailNow(t, "One of the values is nil")
+	}
+	assert.Equal(t, reflect.TypeOf(lt1.GetType()), reflect.TypeOf(lt2.GetType()))
+	switch lt1.GetType().(type) {
+	case *core.LiteralType_Simple:
+		assert.Equal(t, lt1.GetType().(*core.LiteralType_Simple).Simple, lt2.GetType().(*core.LiteralType_Simple).Simple)
+	default:
+		assert.FailNow(t, "Not yet implemented for types %v", reflect.TypeOf(lt1.GetType()))
+	}
+
+	assert.Equal(t, lt1.GetStructure().GetTag(), lt2.GetStructure().GetTag())
+}
+
 func EqualPrimitive(t *testing.T, p1 *core.Primitive, p2 *core.Primitive) {
 	if !assert.Equal(t, p1 == nil, p2 == nil) {
 		assert.FailNow(t, "One of the values is nil")
@@ -27,6 +42,23 @@ func EqualPrimitive(t *testing.T, p1 *core.Primitive, p2 *core.Primitive) {
 	}
 }
 
+func EqualError(t *testing.T, e1 *core.Error, e2 *core.Error) {
+	if !assert.Equal(t, e1 == nil, e2 == nil) {
+		assert.FailNow(t, "One of the values is nil")
+	}
+	assert.Equal(t, e1.GetMessage(), e2.GetMessage())
+	assert.Equal(t, e1.GetFailedNodeId(), e2.GetFailedNodeId())
+}
+
+func EqualUnion(t *testing.T, u1 *core.Union, u2 *core.Union) {
+	if !assert.Equal(t, u1 == nil, u2 == nil) {
+		assert.FailNow(t, "One of the values is nil")
+	}
+	assert.Equal(t, reflect.TypeOf(u1.GetValue()), reflect.TypeOf(u2.GetValue()))
+	EqualLiterals(t, u1.GetValue(), u2.GetValue())
+	EqualLiteralType(t, u1.GetType(), u2.GetType())
+}
+
 func EqualScalar(t *testing.T, p1 *core.Scalar, p2 *core.Scalar) {
 	if !assert.Equal(t, p1 == nil, p2 == nil) {
 		assert.FailNow(t, "One of the values is nil")
@@ -38,6 +70,10 @@ func EqualScalar(t *testing.T, p1 *core.Scalar, p2 *core.Scalar) {
 	switch p1.GetValue().(type) {
 	case *core.Scalar_Primitive:
 		EqualPrimitive(t, p1.GetPrimitive(), p2.GetPrimitive())
+	case *core.Scalar_Error:
+		EqualError(t, p1.GetError(), p2.GetError())
+	case *core.Scalar_Union:
+		EqualUnion(t, p1.GetUnion(), p2.GetUnion())
 	default:
 		assert.FailNow(t, "Not yet implemented for types %v", reflect.TypeOf(p1.GetValue()))
 	}


### PR DESCRIPTION
## Tracking issue
Closes #4574 

<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?
In flytekit, we add err promise to the failure node [input interface](https://github.com/flyteorg/flytekit/pull/840/files#diff-b1a8538044c80e14d7998344a528dccb59cf54c9735de724f39d345e5f8dfcf5R290-R293). This err message explains why the workflow failed. However, propeller doesn't pass an error message as an input to the failure node. Therefore, current error message in the failure node is always None.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
1. In `FailureNodeLookup`, we added a new attribute `OriginalError` to store runtime execution error.
2. In `NodeExecutor`, `preExecute` func will call a new func `ResolveOnFailureNodeInput` if current execution node is an on failure node, and the new func will inject execution error if `err` input existed in the workflow.
3. Update flytepropeller/pkg/utils/assert/literals.go to support more literal map assertion test.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
4. If there is design documentation, please add the link.
-->

## How was this patch tested?
We designed a workflow that triggers the `clean_up` on failure node, which includes an `err` input with a default value of None. During workflow execution in the backend, we expected the error message to be passed to the on failure node.

```
import typing
from click.testing import CliRunner

from flytekit import task, workflow, ImageSpec, WorkflowFailurePolicy
from flytekit.clis.sdk_in_container import pyflyte
from flytekit.types.error.error import FlyteError

@task
def create_cluster(name: str):
    print(f"Creating cluster: {name}")


@task
def t1(a: int, b: str):
    print('Execute P1')
    print(f"{a} {b}")
    raise ValueError("Fail!")


@task
def delete_cluster(name: str):
    print(f"Deleting cluster {name}")


@task
def clean_up(name: str, err: typing.Optional[FlyteError] = None):  # err is always None for now
    print('execute clean up')
    print(f"Deleting cluster {name} due to {err}")
    print(err)


@workflow(on_failure=clean_up)
def wf(name: str = "my_cluster"):
    c = create_cluster(name=name)
    t = t1(a=1, b="2")
    d = delete_cluster(name=name)
    c >> t >> d
```

The error message was passed into `err` input as we expected

![image](https://github.com/user-attachments/assets/4e49bdea-af23-4ed3-b121-6e91cc1f1ff3)

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] All new and existing tests passed.
- [X] All commits are signed-off. 
 <div id='description'>
<h3>Summary by Bito</h3>
Implementation of error message propagation to failure nodes in Flyte workflows, enhancing error handling capabilities. Changes include adding OriginalError field to FailureNodeLookup, modifications to node executor, and splitting error resolution logic. The implementation includes new assertions in failure node lookup tests and improvements to literal type comparison functionality in assert utilities. These updates enable better debugging capabilities and workflow failure information access.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>