### PR TITLE
Define env var for docsearch API key in dev-docs build script

### DIFF
--- a/script/local_build_docs.sh
+++ b/script/local_build_docs.sh
@@ -38,6 +38,10 @@ if [ -n "$FLYTESNACKS_LOCAL_PATH" ]; then
   DOCKER_ENV+=("--env" "FLYTESNACKS_LOCAL_PATH=/flytesnacks")
 fi
 
+if [ -n "$DOCSEARCH_API_KEY" ]; then
+  DOCKER_ENV+=("--env" "DOCSEARCH_API_KEY=$DOCSEARCH_API_KEY")
+fi
+
 DOCKER_CMD=("docker" "run" "--platform" "linux/amd64" "--rm" "--pull" "never" "${DOCKER_ENV[@]}" "${DOCKER_PORT_MAPPING[@]}" "${DOCKER_VOLUME_MAPPING[@]}" "flyte-dev-docs:latest" "${BUILD_CMD[@]}")
 
 echo "${DOCKER_CMD[*]}"


### PR DESCRIPTION
## Why are the changes needed?
We need the env var to be present, otherwise `make dev-docs` fails with:
```
...
You must provide your Algolia search API key for DocSearch to work.
...
```


## What changes were proposed in this pull request?
Pipe an env var called `DOCSEARCH_API_KEY` to the command used to build dev docs.


## How was this patch tested?
set the env var and ran `make dev-docs` successfully.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request introduces a feature improvement by adding an environment variable, DOCSEARCH_API_KEY, to the local build script for documentation, enhancing the build process for development documentation.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>