### PR TITLE
Configure ray pod runtime class based on custom pod specs

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -540,10 +540,13 @@ func mergeCustomPodSpec(primaryContainer *v1.Container, podSpec *v1.PodSpec, k8s
 			continue
 		}
 
-		// Just handle resources for now
 		if len(container.Resources.Requests) > 0 || len(container.Resources.Limits) > 0 {
 			primaryContainer.Resources = container.Resources
 		}
+	}
+
+	if customPodSpec.RuntimeClassName != nil {
+		podSpec.RuntimeClassName = customPodSpec.RuntimeClassName
 	}
 
 	return podSpec, nil

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -454,7 +454,9 @@ func TestBuildResourceRayCustomK8SPod(t *testing.T) {
 	expectedWorkerResources, err := flytek8s.ToK8sResourceRequirements(workerResources)
 	require.NoError(t, err)
 
-	headPodSpec := &corev1.PodSpec{
+	nvidiaRuntimeClassName := "nvidia-cdi"
+
+	headPodSpecCustomResources := &corev1.PodSpec{
 		Containers: []corev1.Container{
 			{
 				Name:      "ray-head",
@@ -462,7 +464,7 @@ func TestBuildResourceRayCustomK8SPod(t *testing.T) {
 			},
 		},
 	}
-	workerPodSpec := &corev1.PodSpec{
+	workerPodSpecCustomResources := &corev1.PodSpec{
 		Containers: []corev1.Container{
 			{
 				Name:      "ray-worker",
@@ -471,14 +473,24 @@ func TestBuildResourceRayCustomK8SPod(t *testing.T) {
 		},
 	}
 
+	headPodSpecCustomRuntimeClass := &corev1.PodSpec{
+		RuntimeClassName: &nvidiaRuntimeClassName,
+	}
+	workerPodSpecCustomRuntimeClass := &corev1.PodSpec{
+		RuntimeClassName: &nvidiaRuntimeClassName,
+	}
+
 	params := []struct {
-		name                       string
-		taskResources              *corev1.ResourceRequirements
-		headK8SPod                 *core.K8SPod
-		workerK8SPod               *core.K8SPod
-		expectedSubmitterResources *corev1.ResourceRequirements
-		expectedHeadResources      *corev1.ResourceRequirements
-		expectedWorkerResources    *corev1.ResourceRequirements
+		name                              string
+		taskResources                     *corev1.ResourceRequirements
+		headK8SPod                        *core.K8SPod
+		workerK8SPod                      *core.K8SPod
+		expectedSubmitterResources        *corev1.ResourceRequirements
+		expectedHeadResources             *corev1.ResourceRequirements
+		expectedWorkerResources           *corev1.ResourceRequirements
+		expectedSubmitterRuntimeClassName *string
+		expectedHeadRuntimeClassName      *string
+		expectedWorkerRuntimeClassName    *string
 	}{
 		{
 			name:                       "task resources",
@@ -491,14 +503,29 @@ func TestBuildResourceRayCustomK8SPod(t *testing.T) {
 			name:          "custom worker and head resources",
 			taskResources: resourceRequirements,
 			headK8SPod: &core.K8SPod{
-				PodSpec: transformStructToStructPB(t, headPodSpec),
+				PodSpec: transformStructToStructPB(t, headPodSpecCustomResources),
 			},
 			workerK8SPod: &core.K8SPod{
-				PodSpec: transformStructToStructPB(t, workerPodSpec),
+				PodSpec: transformStructToStructPB(t, workerPodSpecCustomResources),
 			},
 			expectedSubmitterResources: resourceRequirements,
 			expectedHeadResources:      expectedHeadResources,
 			expectedWorkerResources:    expectedWorkerResources,
+		},
+		{
+			name:                       "custom runtime class name",
+			taskResources:              resourceRequirements,
+			expectedSubmitterResources: resourceRequirements,
+			expectedHeadResources:      resourceRequirements,
+			expectedWorkerResources:    resourceRequirements,
+			headK8SPod: &core.K8SPod{
+				PodSpec: transformStructToStructPB(t, headPodSpecCustomRuntimeClass),
+			},
+			workerK8SPod: &core.K8SPod{
+				PodSpec: transformStructToStructPB(t, workerPodSpecCustomRuntimeClass),
+			},
+			expectedHeadRuntimeClassName:   &nvidiaRuntimeClassName,
+			expectedWorkerRuntimeClassName: &nvidiaRuntimeClassName,
 		},
 	}
 
@@ -531,18 +558,23 @@ func TestBuildResourceRayCustomK8SPod(t *testing.T) {
 				&submitterPodResources,
 			)
 
-			headPodResources := rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources
+			headPodSpec := rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec
+			headPodResources := headPodSpec.Containers[0].Resources
 			assert.EqualValues(t,
 				p.expectedHeadResources,
 				&headPodResources,
 			)
 
+			assert.EqualValues(t, p.expectedHeadRuntimeClassName, headPodSpec.RuntimeClassName)
+
 			for _, workerGroupSpec := range rayJob.Spec.RayClusterSpec.WorkerGroupSpecs {
-				workerPodResources := workerGroupSpec.Template.Spec.Containers[0].Resources
+				workerPodSpec := workerGroupSpec.Template.Spec
+				workerPodResources := workerPodSpec.Containers[0].Resources
 				assert.EqualValues(t,
 					p.expectedWorkerResources,
 					&workerPodResources,
 				)
+				assert.EqualValues(t, p.expectedWorkerRuntimeClassName, workerPodSpec.RuntimeClassName)
 			}
 		})
 	}


### PR DESCRIPTION
## Tracking issue
Closes #6198 

## Why are the changes needed?
When you run GPU workloads on a ray cluster you need to configure the runtime class for GPU pods. Folks need a way to do this without also configuring the runtime class (and associated GPUs) for the submitter pod, which never needs GPUs.

## What changes were proposed in this pull request?
Runtime class names are pulled out of the custom head/worker pod specs and injected into the pod templates set on the kuberay CR.

## How was this patch tested?
Unit tests

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off. 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements runtime class name configuration support for Ray pod specifications, focusing on GPU workload requirements. The changes enable separate runtime class settings for head and worker pods while maintaining submitter pod independence. The implementation includes custom pod spec handling and kuberay CR pod template integration.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>