### PR TITLE
Enable 0 workers replicaSpec for pytorchjob

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
@@ -145,16 +145,22 @@ func (p pytorchOperatorResourceHandler) BuildResource(ctx context.Context, taskC
 			"Invalid TaskSpecification, unsupported task template version [%v] key", taskTemplate.GetTaskTypeVersion())
 	}
 
+	jobSpec := kubeflowv1.PyTorchJobSpec{}
 	if *workerReplicaSpec.Replicas <= 0 {
-		return nil, fmt.Errorf("number of workers must be greater than 0")
-	}
-
-	jobSpec := kubeflowv1.PyTorchJobSpec{
-		PyTorchReplicaSpecs: map[commonOp.ReplicaType]*commonOp.ReplicaSpec{
-			kubeflowv1.PyTorchJobReplicaTypeMaster: masterReplicaSpec,
-			kubeflowv1.PyTorchJobReplicaTypeWorker: workerReplicaSpec,
-		},
-		RunPolicy: runPolicy,
+		jobSpec = kubeflowv1.PyTorchJobSpec{
+			PyTorchReplicaSpecs: map[commonOp.ReplicaType]*commonOp.ReplicaSpec{
+				kubeflowv1.PyTorchJobReplicaTypeMaster: masterReplicaSpec,
+			},
+			RunPolicy: runPolicy,
+		}
+	} else {
+		jobSpec = kubeflowv1.PyTorchJobSpec{
+			PyTorchReplicaSpecs: map[commonOp.ReplicaType]*commonOp.ReplicaSpec{
+				kubeflowv1.PyTorchJobReplicaTypeMaster: masterReplicaSpec,
+				kubeflowv1.PyTorchJobReplicaTypeWorker: workerReplicaSpec,
+			},
+			RunPolicy: runPolicy,
+		}
 	}
 
 	if elasticPolicy != nil {

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
@@ -146,17 +146,16 @@ func (p pytorchOperatorResourceHandler) BuildResource(ctx context.Context, taskC
 	}
 
 	jobSpec := kubeflowv1.PyTorchJobSpec{}
-	if *workerReplicaSpec.Replicas <= 0 {
-		replicaSpecs := map[commonOp.ReplicaType]*commonOp.ReplicaSpec{
-			kubeflowv1.PyTorchJobReplicaTypeMaster: masterReplicaSpec,
-		}
-		if workerReplicaSpec != nil {
-			replicaSpecs[kubeflowv1.PyTorchJobReplicaTypeWorker] = workerReplicaSpec
-		}
-		jobSpec = kubeflowv1.PyTorchJobSpec{
-			PyTorchReplicaSpecs: replicaSpecs,
-			RunPolicy: runPolicy,
-		}
+	replicaSpecs := map[commonOp.ReplicaType]*commonOp.ReplicaSpec{
+		kubeflowv1.PyTorchJobReplicaTypeMaster: masterReplicaSpec,
+	}
+	if *workerReplicaSpec.Replicas > 0 {
+		replicaSpecs[kubeflowv1.PyTorchJobReplicaTypeWorker] = workerReplicaSpec
+	}
+
+	jobSpec = kubeflowv1.PyTorchJobSpec{
+		PyTorchReplicaSpecs: replicaSpecs,
+		RunPolicy:           runPolicy,
 	}
 
 	if elasticPolicy != nil {

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
@@ -147,18 +147,14 @@ func (p pytorchOperatorResourceHandler) BuildResource(ctx context.Context, taskC
 
 	jobSpec := kubeflowv1.PyTorchJobSpec{}
 	if *workerReplicaSpec.Replicas <= 0 {
-		jobSpec = kubeflowv1.PyTorchJobSpec{
-			PyTorchReplicaSpecs: map[commonOp.ReplicaType]*commonOp.ReplicaSpec{
-				kubeflowv1.PyTorchJobReplicaTypeMaster: masterReplicaSpec,
-			},
-			RunPolicy: runPolicy,
+		replicaSpecs := map[commonOp.ReplicaType]*commonOp.ReplicaSpec{
+			kubeflowv1.PyTorchJobReplicaTypeMaster: masterReplicaSpec,
 		}
-	} else {
+		if workerReplicaSpec != nil {
+			replicaSpecs[kubeflowv1.PyTorchJobReplicaTypeWorker] = workerReplicaSpec
+		}
 		jobSpec = kubeflowv1.PyTorchJobSpec{
-			PyTorchReplicaSpecs: map[commonOp.ReplicaType]*commonOp.ReplicaSpec{
-				kubeflowv1.PyTorchJobReplicaTypeMaster: masterReplicaSpec,
-				kubeflowv1.PyTorchJobReplicaTypeWorker: workerReplicaSpec,
-			},
+			PyTorchReplicaSpecs: replicaSpecs,
 			RunPolicy: runPolicy,
 		}
 	}

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
@@ -746,7 +746,7 @@ func TestReplicaCounts(t *testing.T) {
 		contains           []commonOp.ReplicaType
 		notContains        []commonOp.ReplicaType
 	}{
-		{"NoWorkers", 0, true, nil, nil},
+		{"NoWorkers", 0, false, []commonOp.ReplicaType{kubeflowv1.PyTorchJobReplicaTypeMaster}, []commonOp.ReplicaType{}},
 		{"Works", 1, false, []commonOp.ReplicaType{kubeflowv1.PyTorchJobReplicaTypeMaster, kubeflowv1.PyTorchJobReplicaTypeWorker}, []commonOp.ReplicaType{}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -1266,7 +1266,7 @@ func TestBuildResourcePytorchV1WithDifferentWorkersNumber(t *testing.T) {
 			pytorchJob, ok := res.(*kubeflowv1.PyTorchJob)
 			assert.True(t, ok)
 
-			if taskConfig.WorkerReplicas.Replicas == 0 {
+			if taskConfig.GetWorkerReplicas().GetReplicas() == 0 {
 				// Should only contain master spec
 				assert.Equal(t, 1, len(pytorchJob.Spec.PyTorchReplicaSpecs))
 				assert.Contains(t, pytorchJob.Spec.PyTorchReplicaSpecs, kubeflowv1.PyTorchJobReplicaTypeMaster)

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
@@ -1210,29 +1210,88 @@ func TestBuildResourcePytorchV1WithElastic(t *testing.T) {
 	}
 }
 
-func TestBuildResourcePytorchV1WithZeroWorker(t *testing.T) {
+func TestBuildResourcePytorchV1WithDifferentWorkersNumber(t *testing.T) {
 	taskConfigs := []*kfplugins.DistributedPyTorchTrainingTask{
 		{
+			// Test case 1: Zero workers - should only have master
 			WorkerReplicas: &kfplugins.DistributedPyTorchTrainingReplicaSpec{
 				Replicas: 0,
 			},
+			MasterReplicas: &kfplugins.DistributedPyTorchTrainingReplicaSpec{
+				Image: testImageMaster,
+				Resources: &core.Resources{
+					Requests: []*core.Resources_ResourceEntry{
+						{Name: core.Resources_CPU, Value: "250m"},
+						{Name: core.Resources_MEMORY, Value: "250Mi"},
+					},
+					Limits: []*core.Resources_ResourceEntry{
+						{Name: core.Resources_CPU, Value: "500m"},
+						{Name: core.Resources_MEMORY, Value: "500Mi"},
+					},
+				},
+			},
 		},
 		{
+			// Test case 2: One worker - should have both master and worker
 			WorkerReplicas: &kfplugins.DistributedPyTorchTrainingReplicaSpec{
-				Common: &kfplugins.CommonReplicaSpec{
-					Replicas: 0,
+				Replicas: 1,
+			},
+			MasterReplicas: &kfplugins.DistributedPyTorchTrainingReplicaSpec{
+				Image: testImageMaster,
+				Resources: &core.Resources{
+					Requests: []*core.Resources_ResourceEntry{
+						{Name: core.Resources_CPU, Value: "250m"},
+						{Name: core.Resources_MEMORY, Value: "250Mi"},
+					},
+					Limits: []*core.Resources_ResourceEntry{
+						{Name: core.Resources_CPU, Value: "500m"},
+						{Name: core.Resources_MEMORY, Value: "500Mi"},
+					},
 				},
 			},
 		},
 	}
 
-	for _, taskConfig := range taskConfigs {
-		pytorchResourceHandler := pytorchOperatorResourceHandler{}
+	for i, taskConfig := range taskConfigs {
+		t.Run(fmt.Sprintf("Case %d", i+1), func(t *testing.T) {
+			pytorchResourceHandler := pytorchOperatorResourceHandler{}
 
-		taskTemplate := dummyPytorchTaskTemplate("job5", taskConfig)
-		taskTemplate.TaskTypeVersion = 1
-		_, err := pytorchResourceHandler.BuildResource(context.TODO(), dummyPytorchTaskContext(taskTemplate, resourceRequirements, nil, "", k8s.PluginState{}))
-		assert.Error(t, err)
+			taskTemplate := dummyPytorchTaskTemplate("job5", taskConfig)
+			taskTemplate.TaskTypeVersion = 1
+
+			res, err := pytorchResourceHandler.BuildResource(context.TODO(), dummyPytorchTaskContext(taskTemplate, resourceRequirements, nil, "", k8s.PluginState{}))
+			assert.NoError(t, err)
+			assert.NotNil(t, res)
+
+			pytorchJob, ok := res.(*kubeflowv1.PyTorchJob)
+			assert.True(t, ok)
+
+			if taskConfig.WorkerReplicas.Replicas == 0 {
+				// Should only contain master spec
+				assert.Equal(t, 1, len(pytorchJob.Spec.PyTorchReplicaSpecs))
+				assert.Contains(t, pytorchJob.Spec.PyTorchReplicaSpecs, kubeflowv1.PyTorchJobReplicaTypeMaster)
+				assert.NotContains(t, pytorchJob.Spec.PyTorchReplicaSpecs, kubeflowv1.PyTorchJobReplicaTypeWorker)
+
+				// Verify master spec details
+				masterSpec := pytorchJob.Spec.PyTorchReplicaSpecs[kubeflowv1.PyTorchJobReplicaTypeMaster]
+				assert.Equal(t, int32(1), *masterSpec.Replicas)
+				assert.Equal(t, testImageMaster, masterSpec.Template.Spec.Containers[0].Image)
+			} else {
+				// Should contain both master and worker specs
+				assert.Equal(t, 2, len(pytorchJob.Spec.PyTorchReplicaSpecs))
+				assert.Contains(t, pytorchJob.Spec.PyTorchReplicaSpecs, kubeflowv1.PyTorchJobReplicaTypeMaster)
+				assert.Contains(t, pytorchJob.Spec.PyTorchReplicaSpecs, kubeflowv1.PyTorchJobReplicaTypeWorker)
+
+				// Verify master spec details
+				masterSpec := pytorchJob.Spec.PyTorchReplicaSpecs[kubeflowv1.PyTorchJobReplicaTypeMaster]
+				assert.Equal(t, int32(1), *masterSpec.Replicas)
+				assert.Equal(t, testImageMaster, masterSpec.Template.Spec.Containers[0].Image)
+
+				// Verify worker spec details
+				workerSpec := pytorchJob.Spec.PyTorchReplicaSpecs[kubeflowv1.PyTorchJobReplicaTypeWorker]
+				assert.Equal(t, int32(1), *workerSpec.Replicas)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why are the changes needed?

Currently, PyTorchJob allows not to specify Worker in case only one worker (Master) is needed for the job. Current functionality of the plugin doesn't allow to do so, however, in some cases we still want to achieve a Master-only PyTorchJob.

## What changes were proposed in this pull request?
 
Made a change so `pytorch` plugin is no longer complains about a 0-replica worker, but instead - if replicas=0 is passed, plugin just doesn't render it. 

I understand this isn't a best design for the moment, but that is a least-invasive approach to achieve it without changing e.g `pyflyte` validation behavior (if e.g we accept that worker=None could be passed to the PyTorch `task_config`. 

## How was this patch tested?

We are running the fork code in our production environment

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off. 
 <div id='description'>
<h3>Summary by Bito</h3>
Enhanced PyTorch operator plugin to support master-only configurations by removing the requirement for worker replicas. Modified replica specification logic to make worker specs optional. Updated test suite to validate both zero-worker and single-worker configurations.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>