### PR TITLE
Add on failure node passing err message doc

### DIFF
--- a/docs/user_guide/development_lifecycle/failure_node.md
+++ b/docs/user_guide/development_lifecycle/failure_node.md
@@ -22,14 +22,14 @@ To clone and run the example code on this page, see the [Flytesnacks repo][flyte
 
 ```{literalinclude} /examples/development_lifecycle/development_lifecycle/failure_node.py
 :caption: development_lifecycle/failure_node.py
-:lines: 1-6
+:lines: 1-7
 ```
 
 Create a task that will fail during execution:
 
 ```{literalinclude} /examples/development_lifecycle/development_lifecycle/failure_node.py
 :caption: development_lifecycle/failure_node.py
-:lines: 10-18
+:lines: 11-19
 ```
 
 Create a task that will be executed if any of the tasks in the workflow fail:
@@ -55,7 +55,7 @@ By setting the failure policy to `FAIL_AFTER_EXECUTABLE_NODES_COMPLETE` to ensur
 
 ```{literalinclude} /examples/development_lifecycle/development_lifecycle/failure_node.py
 :caption: development_lifecycle/failure_node.py
-:lines: 42-53
+:lines: 43-54
 ```
 
 You can also set the `on_failure` to a workflow. This workflow will be executed if any of the tasks in the workflow fail:

--- a/docs/user_guide/development_lifecycle/failure_node.md
+++ b/docs/user_guide/development_lifecycle/failure_node.md
@@ -42,7 +42,8 @@ Create a task that will be executed if any of the tasks in the workflow fail:
 Specify the `on_failure` to a cleanup task. This task will be executed if any of the tasks in the workflow fail:
 
 :::{note}
-The input of `clean_up` should be the exact same as the input of the workflow.
+The inputs of `clean_up` must exactly match the workflow's inputs. Additionally, the `err` parameter will be 
+populated with the error message encountered during execution.
 :::
 
 ```{literalinclude} /examples/development_lifecycle/development_lifecycle/failure_node.py


### PR DESCRIPTION
## Tracking issue
Related to #6181 
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?
In this [PR](https://github.com/flyteorg/flyte/pull/6181), the error message will be passed to the on_failure node if an error occurs during workflow execution. We have added the relevant documentation in this PR.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Added a note explaining how to pass the error message to the on_failure node.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [X] All commits are signed-off.

## Related PRs
[PR](https://github.com/flyteorg/flytesnacks/pull/1778)
<!-- Add related pull requests for reviewers to check -->

## Docs link
[https://flyte--6209.org.readthedocs.build/en/6209/user_guide/development_lifecycle/failure_node.html](https://flyte--6209.org.readthedocs.build/en/6209/user_guide/development_lifecycle/failure_node.html)
<!-- Add documentation link built by CI jobs here, and specify the changed place -->
