### PR TITLE
utilize sync maps to map project mappings of prom watches

### DIFF
--- a/flyteadmin/pkg/manager/impl/execution_manager.go
+++ b/flyteadmin/pkg/manager/impl/execution_manager.go
@@ -1357,7 +1357,7 @@ func (m *ExecutionManager) emitScheduledWorkflowMetrics(
 	domainKey := execution.GetId().GetDomain()
 	watchVal, ok := domainCounterMap.Load(domainKey)
 	if !ok {
-		newWatch, err := m.systemMetrics.Scope.NewSubScope(execution.GetId().GetProject()).NewSubScope(execution.GetId().GetDomain()).NewStopWatch(
+		newWatch, err := m.systemMetrics.Scope.NewSubScope(execution.GetId().GetProject()).NewSubScope(domainKey).NewStopWatch(
 			"scheduled_execution_delay",
 			"delay between scheduled execution time and time execution was observed running",
 			time.Nanosecond)
@@ -1395,7 +1395,7 @@ func (m *ExecutionManager) emitOverallWorkflowExecutionTime(
 	domainKey := executionModel.Domain
 	watchVal, ok := domainCounterMap.Load(domainKey)
 	if !ok {
-		newWatch, err := m.systemMetrics.Scope.NewSubScope(executionModel.Project).NewSubScope(executionModel.Domain).NewStopWatch(
+		newWatch, err := m.systemMetrics.Scope.NewSubScope(executionModel.Project).NewSubScope(domainKey).NewStopWatch(
 			"workflow_execution_duration",
 			"overall time from when when a workflow create request was sent to k8s to the workflow terminating",
 			time.Nanosecond)


### PR DESCRIPTION
## Tracking issue
closes: https://github.com/flyteorg/flyte/issues/6038

## Why are the changes needed?
Error with concurrent map writes and reads when emitting workflow metrics shown in https://github.com/flyteorg/flyte/issues/6038 due to this [map](https://github.com/flyteorg/flyte/blob/ea00864d3731be95f893f2211b8176ed313d7dbb/flyteadmin/pkg/manager/impl/execution_manager.go#L1882) 


## What changes were proposed in this pull request?
Utilize sync map instead of map

## How was this patch tested?
- tested locally
```
➜  ~ curl -s http://localhost:10254/metrics | grep -i scheduled_execution_delay  
# HELP flyte:admin:admin:execution_manager:flytesnacks:development:scheduled_execution_delay_ns delay between scheduled execution time and time execution was observed running
# TYPE flyte:admin:admin:execution_manager:flytesnacks:development:scheduled_execution_delay_ns summary
flyte:admin:admin:execution_manager:flytesnacks:development:scheduled_execution_delay_ns{quantile="0.5"} 4.9674e+07
flyte:admin:admin:execution_manager:flytesnacks:development:scheduled_execution_delay_ns{quantile="0.9"} 4.9674e+07
flyte:admin:admin:execution_manager:flytesnacks:development:scheduled_execution_delay_ns{quantile="0.99"} 4.9674e+07
flyte:admin:admin:execution_manager:flytesnacks:development:scheduled_execution_delay_ns_sum 4.9674e+07
flyte:admin:admin:execution_manager:flytesnacks:development:scheduled_execution_delay_ns_count 1
# HELP flyte:admin:admin:execution_manager:test:development:scheduled_execution_delay_ns delay between scheduled execution time and time execution was observed running
# TYPE flyte:admin:admin:execution_manager:test:development:scheduled_execution_delay_ns summary
flyte:admin:admin:execution_manager:test:development:scheduled_execution_delay_ns{quantile="0.5"} 5.0094e+07
flyte:admin:admin:execution_manager:test:development:scheduled_execution_delay_ns{quantile="0.9"} 5.0094e+07
flyte:admin:admin:execution_manager:test:development:scheduled_execution_delay_ns{quantile="0.99"} 5.0094e+07
flyte:admin:admin:execution_manager:test:development:scheduled_execution_delay_ns_sum 5.0094e+07
flyte:admin:admin:execution_manager:test:development:scheduled_execution_delay_ns_count 1
➜  ~ curl -s http://localhost:10254/metrics | grep -i workflow_execution_duration
# HELP flyte:admin:admin:execution_manager:flytesnacks:development:workflow_execution_duration_ns overall time from when when a workflow create request was sent to k8s to the workflow terminating
# TYPE flyte:admin:admin:execution_manager:flytesnacks:development:workflow_execution_duration_ns summary
flyte:admin:admin:execution_manager:flytesnacks:development:workflow_execution_duration_ns{quantile="0.5"} 1.9783062e+10
flyte:admin:admin:execution_manager:flytesnacks:development:workflow_execution_duration_ns{quantile="0.9"} 1.9783062e+10
flyte:admin:admin:execution_manager:flytesnacks:development:workflow_execution_duration_ns{quantile="0.99"} 1.9783062e+10
flyte:admin:admin:execution_manager:flytesnacks:development:workflow_execution_duration_ns_sum 1.9783062e+10
flyte:admin:admin:execution_manager:flytesnacks:development:workflow_execution_duration_ns_count 1
# HELP flyte:admin:admin:execution_manager:test:development:workflow_execution_duration_ns overall time from when when a workflow create request was sent to k8s to the workflow terminating
# TYPE flyte:admin:admin:execution_manager:test:development:workflow_execution_duration_ns summary
flyte:admin:admin:execution_manager:test:development:workflow_execution_duration_ns{quantile="0.5"} 1.9784882e+10
flyte:admin:admin:execution_manager:test:development:workflow_execution_duration_ns{quantile="0.9"} 1.9784882e+10
flyte:admin:admin:execution_manager:test:development:workflow_execution_duration_ns{quantile="0.99"} 1.9784882e+10
flyte:admin:admin:execution_manager:test:development:workflow_execution_duration_ns_sum 1.9784882e+10
flyte:admin:admin:execution_manager:test:development:workflow_execution_duration_ns_count 1
```


### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements thread-safe metrics collection by replacing regular maps with sync.Map for project and domain-scoped stopwatch metrics. The changes focus on ScheduledExecutionDelays and WorkflowExecutionDurations metrics, introducing proper concurrency handling and type safety through a dedicated ProjectDomainStopWatchMap wrapper type.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>