### PR TITLE
Remove Deck URI in when `OutputReader` is nil

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/handler.go
+++ b/flytepropeller/pkg/controller/nodes/task/handler.go
@@ -104,13 +104,15 @@ func (p *pluginRequestedTransition) RemoveDeckURIIfDeckNotExists(ctx context.Con
 	}
 
 	exists, err := reader.DeckExists(ctx)
-	if err != nil || !exists {
+	if err != nil {
+		p.execInfo.OutputInfo.DeckURI = nil
+		return regErrors.Wrapf(err, "failed to check existence of deck file")
+	}
+
+	if !exists {
 		p.execInfo.OutputInfo.DeckURI = nil
 	}
 
-	if err != nil {
-		return regErrors.Wrapf(err, "failed to check existence of deck file")
-	}
 	return nil
 }
 

--- a/flytepropeller/pkg/controller/nodes/task/handler.go
+++ b/flytepropeller/pkg/controller/nodes/task/handler.go
@@ -777,7 +777,7 @@ func (t Handler) Handle(ctx context.Context, nCtx interfaces.NodeExecutionContex
 	return pluginTrns.FinalTransition(ctx)
 }
 
-func (t Handler) ValidateOutput(ctx context.Context, nodeID v1alpha1.NodeID, i io.InputReader,
+func (t *Handler) ValidateOutput(ctx context.Context, nodeID v1alpha1.NodeID, i io.InputReader,
 	r io.OutputReader, outputCommitter io.OutputWriter, executionConfig v1alpha1.ExecutionConfig,
 	tr ioutils.SimpleTaskReader) (*io.ExecutionError, error) {
 


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5574
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
if the reader is `nil`, we should remove the deck URI.
we should only check if the reader exists, then the deck will exist.
Note: it's possible to render deck in agent's any task and now it's only possible when executing `databricks agent`.
related code snippet: https://github.com/flyteorg/flyte/blob/1f533ab556d670fd6254318114fcc0437377890c/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go#L365-L385

## What changes were proposed in this pull request?
if the reader is `nil`, remove the deck URI.

## How was this patch tested?
remote execution with a sensor agent task.

### Setup process
single binary.

### Screenshots
<img width="1265" alt="image" src="https://github.com/user-attachments/assets/3efa5b47-e92d-4aef-855c-3f9bab702a05" />

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances the task handler by improving Deck URI removal logic when deck files are absent. The changes include adding null checks for OutputInfo, separating error handling from existence checks, and modifying the ValidateOutput method signature. These modifications result in more robust code with clearer error handling patterns.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>