### PR TITLE
Return NotFound error when decks uri is empty (#642)

### DIFF
--- a/flyteadmin/dataproxy/service.go
+++ b/flyteadmin/dataproxy/service.go
@@ -179,7 +179,7 @@ func (s Service) CreateDownloadLink(ctx context.Context, req *service.CreateDown
 	}
 
 	if len(nativeURL) == 0 {
-		return nil, errors.NewFlyteAdminErrorf(codes.Internal, "no deckUrl found for request [%+v]", req)
+		return nil, errors.NewFlyteAdminErrorf(codes.NotFound, "no deckUrl found for request [%+v]", req)
 	}
 
 	ref := storage.DataReference(nativeURL)


### PR DESCRIPTION
## Why are the changes needed?
A deck url not found in node closure shouldn't result in an internal error and instead should return NotFound grpc code

## What changes were proposed in this pull request?

Changing the returned grpc code for the API

## How was this patch tested?

Tested by verifying the UI calls are no longer returning 500 and instead returning 404 
 <div id='description'>
<h3>Summary by Bito</h3>
The PR implements improved error handling in the data proxy service, changing error codes from Internal to NotFound for missing deck URLs. The test suite underwent significant refactoring with the introduction of CreateDownloadLinkDependencies struct and setup function. Additional test cases were implemented to validate error code behavior for empty deck URLs.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>