### PR TITLE
[Docs] Add Slurm agent setup

### DIFF
--- a/docs/deployment/agents/databricks.rst
+++ b/docs/deployment/agents/databricks.rst
@@ -178,7 +178,7 @@ Specify agent configuration
     Create a file named ``values-override.yaml`` and add the following config to it:
 
     .. code-block:: yaml
-      :emphasize-lines: 9
+      :emphasize-lines: 8,13
 
         enabled_plugins:
           tasks:

--- a/docs/deployment/agents/index.md
+++ b/docs/deployment/agents/index.md
@@ -35,6 +35,8 @@ If you are using a managed deployment of Flyte, you will need to contact your de
   - Submit requests to OpenAI GPT models for asynchronous batch processing.
 * - {ref}`LinkedIn K8s Service Batch <deployment-agent-setup-k8sservice>`
   - Configuring your Flyte deployment for the K8s service agent.
+* - {ref}`Slurm Agent <deployment-agent-setup-slurm>`
+  - Configuring your Flyte deployment for the Slurm agent.
 ```
 
 ```{toctree}
@@ -52,4 +54,5 @@ sensor
 snowflake
 openai_batch
 k8sservice
+slurm
 ```

--- a/docs/deployment/agents/slurm.rst
+++ b/docs/deployment/agents/slurm.rst
@@ -81,7 +81,7 @@ Please make sure that ``uid`` is equal to ``gid`` to avoid some troubles:
 
 .. code-block:: shell
 
-  adduser --system --uid <uid> --group --home /var/lib/slurm slurm
+  sudo adduser --system --uid <uid> --group --home /var/lib/slurm slurm
 
 .. note::
  
@@ -112,7 +112,8 @@ First, you can download the Slurm source from `here <https://www.schedmd.com/dow
 
 .. code-block:: shell
 
-  wget -P <your-dir> https://download.schedmd.com/slurm/slurm-24.05.5.tar.bz2
+  mkdir <your-clean-dir> && cd <your-clean-dir>
+  wget https://download.schedmd.com/slurm/slurm-24.05.5.tar.bz2
 
 .. note::
 
@@ -124,7 +125,7 @@ Then, Debian packages can be built following this `official guide <https://slurm
 
   # Install basic Debian package build requirements
   sudo apt-get update
-  sudo apt-get install build-essential fakeroot devscripts equivs
+  sudo apt-get install -y build-essential fakeroot devscripts equivs
 
   # (Optional) Install dependencies if missing
   sudo apt install -y \
@@ -140,13 +141,20 @@ Then, Debian packages can be built following this `official guide <https://slurm
   # cd to the directory containing the Slurm source
   cd slurm-24.05.5
 
+  # (Optional) Enable source packages for Ubuntu 24.04
+  # For details, please refer to
+  # https://manpages.debian.org/stretch/apt/sources.list.5.en.html
+  # and https://askubuntu.com/questions/1512042/
+  sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+  sudo apt update
+
   # Install the Slurm package dependencies
-  sudo mk-build-deps -i Debian/control
+  sudo mk-build-deps -i debian/control
 
   # Build the Slurm packages
   debuild -b -uc -us
 
-Debian packages are built and placed under the parent directory ``<your-dir>``. Since the single-host Slurm cluster functions as both a controller and a compute node, the following packages are required: ``slurm-smd``, ``slurm-smd-client`` (for CLI), ``slurm-smd-slurmctld``, and ``slurm-smd-slurmd``.
+Debian packages are built and placed under the parent directory ``<your-clean-dir>``. Since the single-host Slurm cluster functions as both a controller and a compute node, the following packages are required: ``slurm-smd``, ``slurm-smd-client`` (for CLI), ``slurm-smd-slurmctld``, and ``slurm-smd-slurmd``.
 
 .. code-block:: shell
 
@@ -186,7 +194,9 @@ The following key-value pairs need to be set manually. Please leave the other op
   SlurmdLogFile=/var/log/slurm/slurmd.log
 
   # == Compute Nodes == 
-  NodeName=localhost CPUs=16 RealMemory=30528 Sockets=1 CoresPerSocket=8 ThreadsPerCore=2 State=UNKNOWN
+  # For checking CPU info, please use `lscpu | egrep 'Socket|Thread|CPU\(s\)'`
+  # For checking Mem info, please use `free -m` and write "available" value
+  NodeName=localhost CPUs=<cpus> RealMemory=<available-mem> Sockets=<sockets> CoresPerSocket=<cores-per-socket> ThreadsPerCore=<threads-per-core> State=UNKNOWN
   PartitionName=debug Nodes=ALL Default=YES MaxTime=INFINITE State=UP
 
 After completing the form, submit it, copy the content, and save it to ``/etc/slurm/slurm.conf``.
@@ -249,6 +259,7 @@ This setup consists of three main components: a client (localhost), a remote Slu
 
   # Install flytekit
   git clone https://github.com/flyteorg/flytekit.git
+  cd flytekit
   gh pr checkout 3005
   make setup && pip install -e .
 
@@ -265,6 +276,7 @@ To run user-defined task functions on the Slurm cluster, you need to install the
 
   # Install flytekit
   git clone https://github.com/flyteorg/flytekit.git
+  cd flytekit
   gh pr checkout 3005
   make setup && pip install -e .
 

--- a/docs/deployment/agents/slurm.rst
+++ b/docs/deployment/agents/slurm.rst
@@ -1,0 +1,217 @@
+.. _deployment-agent-setup-slurm:
+
+Slurm agent
+===========
+
+This guide provides a comprehensive overview of setting up an environment to test the Slurm agent locally and enabling the agent in your Flyte deployment. Before proceeding, the first and foremost step is to spin up your own Slurm cluster, as it serves as the foundation for the setup. 
+
+Spin up a Slurm cluster
+-----------------------
+
+Setting up a Slurm cluster can be challenging due to the limited detail in the `official instructions <https://slurm.schedmd.com/quickstart_admin.html#quick_start>`_. This tutorial simplifies the process, focusing on configuring a single-host Slurm cluster with ``slurmctld`` (central management daemon) and ``slurmd`` (compute node daemon).
+
+Install MUNGE
+~~~~~~~~~~~~~
+
+.. epigraph::
+  
+  `MUNGE <https://dun.github.io/munge/>`_ is an authentication service, allowing a process to authenticate the UID and GID of another local or remote process within a group of hosts having common users and groups.
+
+1. Install necessary packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: shell
+
+  sudo apt install munge libmunge2 libmunge-dev
+
+2. Generate and verify a MUNGE credential
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After a MUNGE credential is generated, you can decode and verify the encoded token as follows:
+
+.. code-block:: shell
+
+  munge -n | unmunge | grep STATUS
+
+.. note::
+
+  A status of ``STATUS: Success(0)`` is expected and the MUNGE key is stored at ``/etc/munge/munge.key``. If the key is absent, please run the following command to create one manually:
+
+  .. code:: shell
+
+    sudo /usr/sbin/create-munge-key
+
+3. Change the ownership and permissions of specific MUNGE-related directories
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``munged`` daemon should run as the non-privileged "munge" user, which is created automatically. You can modify directory ownership and permissions as below:
+
+.. code-block:: shell
+
+  sudo chown -R munge: /etc/munge/ /var/log/munge/ /var/lib/munge/ /run/munge/
+  sudo chmod 0700 /etc/munge/ /var/log/munge/ /var/lib/munge/
+  sudo chmod 0755 /run/munge/
+  sudo chmod 0700 /etc/munge/munge.key
+  sudo chown -R munge: /etc/munge/munge.key
+
+4. Start MUNGE
+^^^^^^^^^^^^^^
+
+Please make ``munged`` start at boot and restart the service:
+
+.. code-block:: shell
+
+  sudo systemctl enable munge
+  sudo systemctl restart munge
+
+.. note::
+
+  To check if the daemon runs as expected, you can either use ``systemctl status munge`` or inspect the log file under ``/var/log/munge``.
+
+Create a dedicated Slurm user 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. epigraph::
+  
+  The *SlurmUser* must be created as needed prior to starting Slurm and must exist on all nodes in your cluster.
+
+  -- `Slurm Super Quick Start <https://slurm.schedmd.com/quickstart_admin.html#quick_start>`_
+
+Please make sure that ``uid`` is equal to ``gid`` to avoid some troubles: 
+
+.. code-block:: shell
+
+  adduser --system --uid <uid> --group --home /var/lib/slurm slurm
+
+.. note::
+ 
+  A system user usually has an ``uid`` in the range of 0-999, please refer to the section `Add a system user <https://manpages.ubuntu.com/manpages/oracular/en/man8/adduser.8.html>`_.
+
+Once the system user is created, you can verify it using the following command:
+
+.. code-block:: shell
+
+  cat /etc/passwd | grep <uid>
+
+It's of vital importance to set correct ownership of specific Slurm-related directories to prevent access issue. Directories mentioned below will be created automatically when the Slurm services start. However, manually creating them and altering the ownership beforehand help reduce erros:
+
+Properly setting ownership of specific Slurm-related directories is crucial to avoid access issues. These directories are created automatically when Slurm services start, but manually creating them and adjusting ownership beforehand can make setup easier:
+
+.. code-block:: shell
+
+  sudo mkdir -p /var/spool/slurmctld /var/spool/slurmd /var/log/slurm
+  sudo chown -R slurm: /var/spool/slurmctld /var/spool/slurmd /var/log/slurm
+
+Run the Slurm cluster 
+~~~~~~~~~~~~~~~~~~~~~
+
+1. Install Slurm packages
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+First, you can download the Slurm source from `here <https://www.schedmd.com/download-slurm/>`_ (we'll use version ``24.05.5`` for illustration):
+
+.. code-block:: shell
+
+  wget -P <your-dir> https://download.schedmd.com/slurm/slurm-24.05.5.tar.bz2
+
+.. note::
+
+  We recommend to download the file to a clean directory because all Debian packages will be generate under this path. 
+
+Then, Debian packages can be built following this `official guide <https://slurm.schedmd.com/quickstart_admin.html#debuild>`_:
+
+.. code-block:: shell
+
+  # Install basic Debian package build requirements
+  sudo apt-get update
+  sudo apt-get install build-essential fakeroot devscripts equivs
+
+  # (Optional) Install dependencies if missing
+  sudo apt install -y \
+      libncurses-dev libgtk2.0-dev libpam0g-dev libperl-dev liblua5.3-dev \
+      libhwloc-dev dh-exec librrd-dev libipmimonitoring-dev hdf5-helpers \
+      libfreeipmi-dev libhdf5-dev man2html-base libcurl4-openssl-dev \
+      libpmix-dev libhttp-parser-dev libyaml-dev libjson-c-dev \
+      libjwt-dev liblz4-dev libmariadb-dev libdbus-1-dev librdkafka-dev
+
+  # Unpack the distributed tarball
+  tar -xaf slurm-24.05.5.tar.bz2
+
+  # cd to the directory containing the Slurm source
+  cd slurm-24.05.5
+
+  # Install the Slurm package dependencies
+  sudo mk-build-deps -i Debian/control
+
+  # Build the Slurm packages
+  debuild -b -uc -us
+
+Debian pakcages are built and placed under the parent directory ``<your-dir>``. Since the single-host Slurm cluster functions as both a controller and a compute node, the following packages are required: ``slurm-smd``, ``slurm-smd-client`` (for CLI), ``slurm-smd-slurmctld``, and ``slurm-smd-slurmd``.
+
+.. code-block:: shell
+
+  # cd to the parent directory
+  cd ..
+
+  sudo dpkg -i slurm-smd_24.05.5-1_amd64.deb
+  sudo dpkg -i slurm-smd-client_24.05.5-1_amd64.deb
+  sudo dpkg -i slurm-smd-slurmctld_24.05.5-1_amd64.deb
+  sudo dpkg -i slurm-smd-slurmd_24.05.5-1_amd64.deb
+
+.. note::
+
+  Please refer to `Installing Packages <https://slurm.schedmd.com/quickstart_admin.html#pkg_install>`_ for package selection.
+
+
+2. Generate a Slurm configuration file 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After installation, generate a valid ``slurm.conf`` file for the Slurm cluster. We recommend using the `official configurator <https://slurm.schedmd.com/configurator.html>`_ to create it.
+
+The following key-value pairs need to be set manually. Please leave the other options unchanged, as the default settings are sufficient for running ``slurmctld`` and ``slurmd``.
+
+.. code-block:: ini 
+
+  # == Cluster Name ==
+  ClusterName=localcluster
+
+  # == Control Machines ==
+  SlurmctldHost=localhost
+
+  # == Process Tracking ==
+  ProctrackType=proctrack/linuxproc
+
+  # == Event Logging ==
+  SlurmctldLogFile=/var/log/slurm/slurmctld.log
+  SlurmdLogFile=/var/log/slurm/slurmd.log
+
+  # == Compute Nodes == 
+  NodeName=localhost CPUs=16 RealMemory=30528 Sockets=1 CoresPerSocket=8 ThreadsPerCore=2 State=UNKNOWN
+  PartitionName=debug Nodes=ALL Default=YES MaxTime=INFINITE State=UP
+
+After completing the form, submit it, copy the content, and save it to ``/etc/slurm/slurm.conf``.
+
+.. note::
+
+  For a sample configuration file, please refer to this `slurm.conf <https://github.com/JiangJiaWei1103/Slurm-101/blob/main/slurm.conf>`_.
+
+3. Start daemons
+^^^^^^^^^^^^^^^^
+
+Finally, enable ``slurmctld`` and ``slurmd`` to start at boot and restart them.
+
+.. code-block:: shell
+
+  # For controller
+  sudo systemctl enable slurmctld
+  sudo systemctl restart slurmctld
+
+  # For compute
+  sudo systemctl enable slurmd
+
+You can verify the status of the daemons using ``systemctl status <daemon>`` or check the logs in ``/var/log/slurm/slurmctld.log`` and ``/var/log/slurm/slurmd.log`` to ensure the Slurm cluster is running correctly.
+
+
+
+
+

--- a/docs/deployment/agents/slurm.rst
+++ b/docs/deployment/agents/slurm.rst
@@ -218,6 +218,7 @@ Finally, enable ``slurmctld`` and ``slurmd`` to start at boot and restart them.
 
   # For compute
   sudo systemctl enable slurmd
+  sudo systemctl restart slurmd
 
 You can verify the status of the daemons using ``systemctl status <daemon>`` or check the logs in ``/var/log/slurm/slurmctld.log`` and ``/var/log/slurm/slurmd.log`` to ensure the Slurm cluster is running correctly.
 

--- a/docs/deployment/agents/slurm.rst
+++ b/docs/deployment/agents/slurm.rst
@@ -93,7 +93,7 @@ Once the system user is created, you can verify it using the following command:
 
   cat /etc/passwd | grep <uid>
 
-It's of vital importance to set correct ownership of specific Slurm-related directories to prevent access issue. Directories mentioned below will be created automatically when the Slurm services start. However, manually creating them and altering the ownership beforehand help reduce erros:
+It's of vital importance to set correct ownership of specific Slurm-related directories to prevent access issue. Directories mentioned below will be created automatically when the Slurm services start. However, manually creating them and altering the ownership beforehand help reduce errors:
 
 Properly setting ownership of specific Slurm-related directories is crucial to avoid access issues. These directories are created automatically when Slurm services start, but manually creating them and adjusting ownership beforehand can make setup easier:
 
@@ -146,7 +146,7 @@ Then, Debian packages can be built following this `official guide <https://slurm
   # Build the Slurm packages
   debuild -b -uc -us
 
-Debian pakcages are built and placed under the parent directory ``<your-dir>``. Since the single-host Slurm cluster functions as both a controller and a compute node, the following packages are required: ``slurm-smd``, ``slurm-smd-client`` (for CLI), ``slurm-smd-slurmctld``, and ``slurm-smd-slurmd``.
+Debian packages are built and placed under the parent directory ``<your-dir>``. Since the single-host Slurm cluster functions as both a controller and a compute node, the following packages are required: ``slurm-smd``, ``slurm-smd-client`` (for CLI), ``slurm-smd-slurmctld``, and ``slurm-smd-slurmd``.
 
 .. code-block:: shell
 

--- a/docs/deployment/agents/slurm.rst
+++ b/docs/deployment/agents/slurm.rst
@@ -400,7 +400,7 @@ Specify agent configuration
           kubectl edit configmap flyte-sandbox-config -n flyte
 
         .. code-block:: yaml
-          :emphasize-lines: 7,8,12
+          :emphasize-lines: 7,8,13
 
           tasks:
             task-plugins:

--- a/docs/deployment/agents/slurm.rst
+++ b/docs/deployment/agents/slurm.rst
@@ -208,7 +208,7 @@ After completing the form, submit it, copy the content, and save it to ``/etc/sl
 3. Start daemons
 ^^^^^^^^^^^^^^^^
 
-Finally, enable ``slurmctld`` and ``slurmd`` to start at boot and restart them.
+Then, enable ``slurmctld`` and ``slurmd`` to start at boot and restart them.
 
 .. code-block:: shell
 
@@ -221,6 +221,37 @@ Finally, enable ``slurmctld`` and ``slurmd`` to start at boot and restart them.
   sudo systemctl restart slurmd
 
 You can verify the status of the daemons using ``systemctl status <daemon>`` or check the logs in ``/var/log/slurm/slurmctld.log`` and ``/var/log/slurm/slurmd.log`` to ensure the Slurm cluster is running correctly.
+
+4. Try some Slurm commands
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Finally, run the following commands to ensure that a Slurm job can be submitted successfully:
+
+* ``sinfo``: View information about Slurm nodes and partitions
+
+.. code-block:: shell
+
+  root@rockwei:/etc/slurm# sinfo
+  PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+  debug*       up   infinite      1   idle localhost
+
+.. note::
+
+  Here's a small tip to enable job submission when the state is set to ``drain``. Simply change the state back to ``idle`` as shown below:
+
+  .. code-block:: shell
+
+    scontrol update nodename=<your-nodename> state=idle
+
+* ``srun``: Run a parallel job on cluster managed by Slurm
+
+.. code-block:: shell
+
+  root@rockwei:/etc/slurm# srun -N 1 hostname
+  rockwei
+
+If both commands execute successfully and return the expected results, you can proceed with testing the Slurm agent.
+
 
 Test your Slurm agent locally
 -----------------------------

--- a/docs/deployment/agents/slurm.rst
+++ b/docs/deployment/agents/slurm.rst
@@ -269,7 +269,11 @@ The Slurm agent on the highest level has three core methods to interact with a S
 
 In its simplest form, the Slurm agent supports running a batch script using ``sbatch`` on a Slurm cluster, as shown below:
 
-.. image:: https://github.com/JiangJiaWei1103/flytekit/blob/slurm-agent-dev/plugins/flytekit-slurm/assets/basic_arch.png?raw=true
+.. image:: https://github.com/flyteorg/static-resources/blob/main/flytekit/plugins/slurm/basic_arch.png?raw=true
+
+For Python function tasks, the Slurm agent supports running a batch script using ``sbatch`` on a Slurm cluster with ``pyflyte-fast-execute`` as entrypoint, as shown below:
+
+.. image:: https://github.com/flyteorg/static-resources/blob/main/flytekit/plugins/slurm/slurm_function_task.png?raw=true
 
 Set up a local test environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -289,15 +293,7 @@ This setup consists of three main components: a client (localhost), a remote Slu
 
 .. code-block:: shell
 
-  # Install flytekit
-  git clone https://github.com/flyteorg/flytekit.git
-  cd flytekit
-  gh pr checkout 3005
-  make setup && pip install -e .
-
-  # Install the Slurm agent
-  cd plugins/flytekit-slurm/
-  pip install -e .
+  pip install flytekitplugins-slurm
 
 2. Install the Slurm agent on the Slurm cluster
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -306,15 +302,7 @@ To run user-defined task functions on the Slurm cluster, you need to install the
 
 .. code-block:: shell
 
-  # Install flytekit
-  git clone https://github.com/flyteorg/flytekit.git
-  cd flytekit
-  gh pr checkout 3005
-  make setup && pip install -e .
-
-  # Install the Slurm agent
-  cd plugins/flytekit-slurm/
-  pip install -e .
+  pip install flytekitplugins-slurm
 
 3. Set up SSH configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -382,3 +370,14 @@ For advanced use cases where user-defined task functions are executed on the Slu
       aws_secret_access_key = <aws-secret-access-key>
 
 Once configured, both machines will have access to the Amazon S3 bucket.
+
+If you are running the Slurm agent on an AWS EC2 instance, you will need to:
+
+1. Add an IAM role to the EC2 instance under the "Security" settings
+2. Configure the IAM role with appropriate read and write permissions to access Flyte's blob store
+
+.. note::
+
+  You can verify your S3 access by running ``aws s3 ls`` in the terminal.
+  
+  This command will list all accessible S3 buckets if your credentials are configured correctly.


### PR DESCRIPTION
## Tracking issue
Issue: https://github.com/flyteorg/flyte/issues/3936

Related to https://github.com/flyteorg/flytekit/pull/3005

## Why are the changes needed?
Provide users with a step-by-step guide to setting up the Slurm agent from scratch.

## What changes were proposed in this pull request?
Add documentation on setting up the Slurm agent for both local testing and deployment. The documentation includes following sections:
1. Spin up a Slurm cluster
2. Test your Slurm agent locally

## How was this patch tested?

### Labels
- **added**: For new features.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytekit/pull/3005

## Docs link
https://flyte--6231.org.readthedocs.build/en/6231/deployment/agents/slurm.html 
 <div id='description'>
<h3>Summary by Bito</h3>
Documentation enhancement PR focused on Slurm agent setup and configuration in Flyte. Provides detailed instructions for cluster setup, SSH configuration, AWS S3 integration, and deployment scenarios. Includes both local testing and production deployment guidelines. Minor updates to Databricks agent documentation included.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>