### PR TITLE
fix: typos in documentation files

### DIFF
--- a/flyteplugins/go/tasks/plugins/array/k8s/config_flags_test.go
+++ b/flyteplugins/go/tasks/plugins/array/k8s/config_flags_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var dereferencableKindsConfig = map[reflect.Kind]struct{}{
+var dereferenceableKindsConfig = map[reflect.Kind]struct{}{
 	reflect.Array: {}, reflect.Chan: {}, reflect.Map: {}, reflect.Ptr: {}, reflect.Slice: {},
 }
 
 // Checks if t is a kind that can be dereferenced to get its underlying type.
 func canGetElementConfig(t reflect.Kind) bool {
-	_, exists := dereferencableKindsConfig[t]
+	_, exists := dereferenceableKindsConfig[t]
 	return exists
 }
 

--- a/flyteplugins/go/tasks/plugins/presto/config/config_flags_test.go
+++ b/flyteplugins/go/tasks/plugins/presto/config/config_flags_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var dereferencableKindsConfig = map[reflect.Kind]struct{}{
+var dereferenceableKindsConfig = map[reflect.Kind]struct{}{
 	reflect.Array: {}, reflect.Chan: {}, reflect.Map: {}, reflect.Ptr: {}, reflect.Slice: {},
 }
 
 // Checks if t is a kind that can be dereferenced to get its underlying type.
 func canGetElementConfig(t reflect.Kind) bool {
-	_, exists := dereferencableKindsConfig[t]
+	_, exists := dereferenceableKindsConfig[t]
 	return exists
 }
 

--- a/flytestdlib/logger/config_flags_test.go
+++ b/flytestdlib/logger/config_flags_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var dereferencableKindsConfig = map[reflect.Kind]struct{}{
+var dereferenceableKindsConfig = map[reflect.Kind]struct{}{
 	reflect.Array: {}, reflect.Chan: {}, reflect.Map: {}, reflect.Ptr: {}, reflect.Slice: {},
 }
 
 // Checks if t is a kind that can be dereferenced to get its underlying type.
 func canGetElementConfig(t reflect.Kind) bool {
-	_, exists := dereferencableKindsConfig[t]
+	_, exists := dereferenceableKindsConfig[t]
 	return exists
 }
 


### PR DESCRIPTION
<div id='description'>
<h3>Summary by Bito</h3>
Fixed a consistent typo in variable naming across multiple test files, changing 'dereferencableKindsConfig' to 'dereferenceableKindsConfig'. This change enhances code readability and maintains consistent spelling conventions throughout the project's test suite.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>