### PR TITLE
Clear inputs from dynamic closure to avoid bloating the event message

### DIFF
--- a/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow_test.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow_test.go
@@ -586,6 +586,41 @@ func Test_dynamicNodeHandler_buildContextualDynamicWorkflow_withLaunchPlans(t *t
 	})
 }
 
+func TestClearNodeInputs_WithCoreBindings(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("clear inputs for regular nodes with core bindings", func(t *testing.T) {
+		nodes := []*core.Node{
+			{Inputs: []*core.Binding{{Var: "input1"}}},
+			{Inputs: []*core.Binding{{Var: "input2"}}},
+		}
+		clearNodeInputs(ctx, nodes)
+		for _, node := range nodes {
+			assert.Nil(t, node.Inputs)
+		}
+	})
+
+	t.Run("clear inputs for array nodes with core bindings", func(t *testing.T) {
+		nodes := []*core.Node{
+			{
+				Inputs: []*core.Binding{{Var: "input1"}},
+				Target: &core.Node_ArrayNode{
+					ArrayNode: &core.ArrayNode{
+						Node: &core.Node{Inputs: []*core.Binding{{Var: "input2"}}},
+					},
+				},
+			},
+		}
+		clearNodeInputs(ctx, nodes)
+		for _, node := range nodes {
+			assert.Nil(t, node.Inputs)
+			if arrayNode, ok := node.Target.(*core.Node_ArrayNode); ok {
+				assert.Nil(t, arrayNode.ArrayNode.Node.Inputs)
+			}
+		}
+	})
+}
+
 type existsMetadata struct{}
 
 func (e existsMetadata) ContentMD5() string {


### PR DESCRIPTION
## Tracking issue
Upstream changes from union

## Why are the changes needed?
The dynamic closure contains inputs for all dynamic nodes. However, these inputs are included when constructing node events sent to the admin, despite not being used by any clients. A comparison of Flyte Console and FlyteKit confirms this redundancy as they use GetNodeExecutionData to fetch this data along with for outputs.

Sending such large inputs in the dynamic closure occasionally exceeds gRPC limits, causing execution failures. Even when the payload remains within the limit, its large size (in MBs) results in sluggish UI performance, as clients must process and render unnecessary data.

## What changes were proposed in this pull request?
We remove node inputs before sending the event to the admin, enhancing UI performance when fetching the dynamic closure for the node view. This also prevents cases where exceeding gRPC limits would cause dynamic node execution to fail.




## How was this patch tested?

Verified by running a large dynamic workflow which contained large inputs and verified the page loads sped up which called the dynamic workflow api.

Notice before and after number of bytes loaded


### Before the change (3.9 MB)
<img width="1615" alt="Screenshot 2025-02-04 at 5 41 36 PM" src="https://github.com/user-attachments/assets/f607ba29-fe9c-4a22-9c0a-f225d565f2eb" />

### After the change
<img width="1559" alt="Screenshot 2025-02-04 at 6 02 34 PM" src="https://github.com/user-attachments/assets/8afebdb4-f3c3-475f-8b88-7c22026539eb" />

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

## Docs link
