### PR TITLE
[WIP] [TEST] Testing the behaviour when primary container name is different to the one in basePodSpec

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -2321,9 +2321,9 @@ func TestMergePodSpecsPrimaryContainerName(t *testing.T) {
 	assert.Equal(t, 2, len(primaryContainer.VolumeMounts))
 	assert.Equal(t, 2, len(primaryContainer.Env))
 
-    // WARN: the other container in podSpec is also included
-    assert.Equal(t, 2, len(mergedPodSpec.Containers))
-    assert.Equal(t, mergedPodSpec.Containers[1].Name, podSpec.Containers[1].Name)
+	// WARN: the other container in podSpec is also included
+	assert.Equal(t, 2, len(mergedPodSpec.Containers))
+	assert.Equal(t, mergedPodSpec.Containers[1].Name, podSpec.Containers[1].Name)
 
 	// validate primary init container
 	primaryInitContainer := mergedPodSpec.InitContainers[0]


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

Add the test to validate the behaviour of `MergePodSpec` is as expected.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
Implementation of test cases for MergePodSpec functionality, focusing on container name mismatch scenarios. Tests verify proper merging of container specifications, including volume mounts, environment variables, and tolerations. Changes include improvements in pod_helper_test.go with better formatting and consistent indentation for test assertions.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>