### PR TITLE
Move external command execution from token source provider to token source

### DIFF
--- a/flyteidl/clients/go/admin/token_source_provider.go
+++ b/flyteidl/clients/go/admin/token_source_provider.go
@@ -120,15 +120,24 @@ func NewExternalTokenSourceProvider(command []string) (TokenSourceProvider, erro
 }
 
 func (e ExternalTokenSourceProvider) GetTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
-	output, err := externalprocess.Execute(e.command)
+	return &externalCommandTokenSource{
+		command: e.command,
+	}, nil
+}
+
+type externalCommandTokenSource struct {
+	command []string
+}
+
+func (s *externalCommandTokenSource) Token() (*oauth2.Token, error) {
+	output, err := externalprocess.Execute(s.command)
 	if err != nil {
 		return nil, err
 	}
-
-	return oauth2.StaticTokenSource(&oauth2.Token{
+	return &oauth2.Token{
 		AccessToken: strings.Trim(string(output), "\t \n"),
 		TokenType:   "bearer",
-	}), nil
+	}, nil
 }
 
 type PKCETokenSourceProvider struct {


### PR DESCRIPTION
## Tracking issue

#6254 

## Why are the changes needed?

External command doesn't get called again if authentication starts failing due to the returned token.

## What changes were proposed in this pull request?

Create a new externalCommandTokenSource that runs the external command instead of the token source provider.
This results in:
- The external command is called as part of the `MaterialiseCredentials` function instead of the `getTokenSourceAndMetadata` function that is synchronized (in the `flyteidl/go/client/admin/auth_interceptor.go`).
- If the token in the token cache results in an `Unauthenticated` response from the flyte admin, the external command is called again.

## How was this patch tested?

- Deployed the change to a flytepropeller instance using `ExternalCommand` auth that returns an expiring token
- Waited for the expiry of the token and checked whether authentication still works

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

The issue resulted from the following PR: #5686 

