### PR TITLE
update action/cache@v3 (#660)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -152,7 +152,7 @@ jobs:
       - uses: insightsengineering/disk-space-reclaimer@v1
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cache/go-build


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
`action/cache@v2` is deprecated

## What changes were proposed in this pull request?
updating to `action/cache@v3`

## How was this patch tested?
github workflow tests

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
N/A

## Docs link
N/A
