### PR TITLE
Union/upstream pod helper node preemption handling

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -1157,6 +1157,13 @@ func DemystifyFailure(ctx context.Context, status v1.PodStatus, info pluginsCore
 		}
 	}
 
+	// If the code remains 'UnknownError', it indicates that the kubelet did not have a chance
+	// to record a more specific failure before the node was terminated or preempted.
+	// In such cases, we classify the error as system-level and accept false positives
+	if code == "UnknownError" {
+		isSystemError = true
+	}
+
 	if isSystemError {
 		logger.Warnf(ctx, "Pod failed with a system error. Code: %s, Message: %s", code, message)
 		return pluginsCore.PhaseInfoSystemRetryableFailure(Interrupted, message, &info), nil

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -29,6 +29,9 @@ const Interrupted = "Interrupted"
 const PrimaryContainerNotFound = "PrimaryContainerNotFound"
 const SIGKILL = 137
 
+// unsignedSIGKILL = 256 - 9
+const unsignedSIGKILL = 247
+
 const defaultContainerTemplateName = "default"
 const defaultInitContainerTemplateName = "default-init"
 const primaryContainerTemplateName = "primary"
@@ -1018,7 +1021,7 @@ func DemystifySuccess(status v1.PodStatus, info pluginsCore.TaskInfo) (pluginsCo
 // DeterminePrimaryContainerPhase as the name suggests, given all the containers, will return a pluginsCore.PhaseInfo object
 // corresponding to the phase of the primaryContainer which is identified using the provided name.
 // This is useful in case of sidecars or pod jobs, where Flyte will monitor successful exit of a single container.
-func DeterminePrimaryContainerPhase(primaryContainerName string, statuses []v1.ContainerStatus, info *pluginsCore.TaskInfo) pluginsCore.PhaseInfo {
+func DeterminePrimaryContainerPhase(ctx context.Context, primaryContainerName string, statuses []v1.ContainerStatus, info *pluginsCore.TaskInfo) pluginsCore.PhaseInfo {
 	for _, s := range statuses {
 		if s.Name == primaryContainerName {
 			if s.State.Waiting != nil || s.State.Running != nil {
@@ -1026,16 +1029,33 @@ func DeterminePrimaryContainerPhase(primaryContainerName string, statuses []v1.C
 			}
 
 			if s.State.Terminated != nil {
-				if s.State.Terminated.ExitCode != 0 || strings.Contains(s.State.Terminated.Reason, OOMKilled) {
-					message := fmt.Sprintf("\r\n[%v] terminated with exit code (%v). Reason [%v]. Message: \n%v.",
-						s.Name,
-						s.State.Terminated.ExitCode,
-						s.State.Terminated.Reason,
-						s.State.Terminated.Message)
-					return pluginsCore.PhaseInfoRetryableFailure(
+				message := fmt.Sprintf("\r\n[%v] terminated with exit code (%v). Reason [%v]. Message: \n%v.",
+					s.Name,
+					s.State.Terminated.ExitCode,
+					s.State.Terminated.Reason,
+					s.State.Terminated.Message)
+
+				var phaseInfo pluginsCore.PhaseInfo
+				switch {
+				case strings.Contains(s.State.Terminated.Reason, OOMKilled):
+					// OOMKilled typically results in a SIGKILL signal, but we classify it as a user error
+					phaseInfo = pluginsCore.PhaseInfoRetryableFailure(
 						s.State.Terminated.Reason, message, info)
+				case isTerminatedWithSigKill(s.State):
+					// If the primary container exited with SIGKILL, we treat it as a system-level error
+					// (such as node termination or preemption).
+					// Note: this best-effort approach accepts some false positives.
+					phaseInfo = pluginsCore.PhaseInfoSystemRetryableFailure(
+						s.State.Terminated.Reason, message, info)
+				case s.State.Terminated.ExitCode != 0:
+					phaseInfo = pluginsCore.PhaseInfoRetryableFailure(
+						s.State.Terminated.Reason, message, info)
+				default:
+					return pluginsCore.PhaseInfoSuccess(info)
 				}
-				return pluginsCore.PhaseInfoSuccess(info)
+
+				logger.Infof(ctx, "Primary container terminated with issue. Message: '%s'", message)
+				return phaseInfo
 			}
 		}
 	}
@@ -1047,7 +1067,7 @@ func DeterminePrimaryContainerPhase(primaryContainerName string, statuses []v1.C
 
 // DemystifyFailure resolves the various Kubernetes pod failure modes to determine
 // the most appropriate course of action
-func DemystifyFailure(status v1.PodStatus, info pluginsCore.TaskInfo) (pluginsCore.PhaseInfo, error) {
+func DemystifyFailure(ctx context.Context, status v1.PodStatus, info pluginsCore.TaskInfo, primaryContainerName string) (pluginsCore.PhaseInfo, error) {
 	code := "UnknownError"
 	message := "Pod failed. No message received from kubernetes."
 	if len(status.Reason) > 0 {
@@ -1107,10 +1127,16 @@ func DemystifyFailure(status v1.PodStatus, info pluginsCore.TaskInfo) (pluginsCo
 		if containerState.Terminated != nil {
 			if strings.Contains(containerState.Terminated.Reason, OOMKilled) {
 				code = OOMKilled
-			} else if containerState.Terminated.ExitCode == SIGKILL {
+			} else if isTerminatedWithSigKill(containerState) {
 				// in some setups, node termination sends SIGKILL to all the containers running on that node. Capturing and
 				// tagging that correctly.
 				code = Interrupted
+				// If the primary container exited with SIGKILL, we treat it as a system-level error
+				// (such as node termination or preemption).
+				// Note: this best-effort approach accepts some false positives.
+				if c.Name == primaryContainerName {
+					isSystemError = true
+				}
 			}
 
 			if containerState.Terminated.ExitCode == 0 {
@@ -1126,9 +1152,11 @@ func DemystifyFailure(status v1.PodStatus, info pluginsCore.TaskInfo) (pluginsCo
 	}
 
 	if isSystemError {
+		logger.Infof(ctx, "Pod failed with a system error. Code: %s, Message: %s", code, message)
 		return pluginsCore.PhaseInfoSystemRetryableFailure(Interrupted, message, &info), nil
 	}
 
+	logger.Infof(ctx, "Pod failed with a user error. Code: %s, Message: %s", code, message)
 	return pluginsCore.PhaseInfoRetryableFailure(code, message, &info), nil
 }
 
@@ -1165,4 +1193,8 @@ func GetReportedAt(pod *v1.Pod) metav1.Time {
 	}
 
 	return reportedAt
+}
+
+func isTerminatedWithSigKill(state v1.ContainerState) bool {
+	return state.Terminated != nil && (state.Terminated.ExitCode == SIGKILL || state.Terminated.ExitCode == unsignedSIGKILL)
 }

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -1043,8 +1043,11 @@ func DeterminePrimaryContainerPhase(ctx context.Context, primaryContainerName st
 						s.State.Terminated.Reason, message, info)
 				case isTerminatedWithSigKill(s.State):
 					// If the primary container exited with SIGKILL, we treat it as a system-level error
-					// (such as node termination or preemption).
-					// Note: this best-effort approach accepts some false positives.
+					// (such as node termination or preemption). This best-effort approach accepts some false positives.
+					// In the case that node preemption terminates the kubelet *before* the kubelet is able to persist
+					// the pod's state to the Kubernetes API server, we rely on Kubernetes to eventually resolve
+					// the state. This will enable Propeller to eventually query the API server and determine that
+					// the pod no longer exists, which will then be counted as a system error.
 					phaseInfo = pluginsCore.PhaseInfoSystemRetryableFailure(
 						s.State.Terminated.Reason, message, info)
 				case s.State.Terminated.ExitCode != 0:
@@ -1054,7 +1057,7 @@ func DeterminePrimaryContainerPhase(ctx context.Context, primaryContainerName st
 					return pluginsCore.PhaseInfoSuccess(info)
 				}
 
-				logger.Infof(ctx, "Primary container terminated with issue. Message: '%s'", message)
+				logger.Warnf(ctx, "Primary container terminated with issue. Message: '%s'", message)
 				return phaseInfo
 			}
 		}
@@ -1132,8 +1135,11 @@ func DemystifyFailure(ctx context.Context, status v1.PodStatus, info pluginsCore
 				// tagging that correctly.
 				code = Interrupted
 				// If the primary container exited with SIGKILL, we treat it as a system-level error
-				// (such as node termination or preemption).
-				// Note: this best-effort approach accepts some false positives.
+				// (such as node termination or preemption). This best-effort approach accepts some false positives.
+				// In the case that node preemption terminates the kubelet *before* the kubelet is able to persist
+				// the pod's state to the Kubernetes API server, we rely on Kubernetes to eventually resolve
+				// the state. This will enable Propeller to eventually query the API server and determine that
+				// the pod no longer exists, which will then be counted as a system error.
 				if c.Name == primaryContainerName {
 					isSystemError = true
 				}
@@ -1152,11 +1158,11 @@ func DemystifyFailure(ctx context.Context, status v1.PodStatus, info pluginsCore
 	}
 
 	if isSystemError {
-		logger.Infof(ctx, "Pod failed with a system error. Code: %s, Message: %s", code, message)
+		logger.Warnf(ctx, "Pod failed with a system error. Code: %s, Message: %s", code, message)
 		return pluginsCore.PhaseInfoSystemRetryableFailure(Interrupted, message, &info), nil
 	}
 
-	logger.Infof(ctx, "Pod failed with a user error. Code: %s, Message: %s", code, message)
+	logger.Warnf(ctx, "Pod failed with a user error. Code: %s, Message: %s", code, message)
 	return pluginsCore.PhaseInfoRetryableFailure(code, message, &info), nil
 }
 

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -1694,8 +1694,8 @@ func TestDemystifyFailure(t *testing.T) {
 		}, pluginsCore.TaskInfo{}, "primary-container")
 		assert.Nil(t, err)
 		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
-		assert.Equal(t, "Interrupted", phaseInfo.Err().Code)
-		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().Kind)
+		assert.Equal(t, "Interrupted", phaseInfo.Err().GetCode())
+		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().GetKind())
 	})
 
 	t.Run("GKE kubelet graceful node shutdown", func(t *testing.T) {
@@ -1833,9 +1833,9 @@ func TestDeterminePrimaryContainerPhase(t *testing.T) {
 			},
 		}, info)
 		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
-		assert.Equal(t, "foo", phaseInfo.Err().Code)
-		assert.Equal(t, core.ExecutionError_USER, phaseInfo.Err().Kind)
-		assert.Equal(t, "\r\n[primary] terminated with exit code (1). Reason [foo]. Message: \nfoo failed.", phaseInfo.Err().Message)
+		assert.Equal(t, "foo", phaseInfo.Err().GetCode())
+		assert.Equal(t, core.ExecutionError_USER, phaseInfo.Err().GetKind())
+		assert.Equal(t, "\r\n[primary] terminated with exit code (1). Reason [foo]. Message: \nfoo failed.", phaseInfo.Err().GetMessage())
 	})
 	t.Run("primary container failed - SIGKILL", func(t *testing.T) {
 		phaseInfo := DeterminePrimaryContainerPhase(ctx, primaryContainerName, []v1.ContainerStatus{
@@ -1851,9 +1851,9 @@ func TestDeterminePrimaryContainerPhase(t *testing.T) {
 			},
 		}, info)
 		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
-		assert.Equal(t, "foo", phaseInfo.Err().Code)
-		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().Kind)
-		assert.Equal(t, "\r\n[primary] terminated with exit code (137). Reason [foo]. Message: \nfoo failed.", phaseInfo.Err().Message)
+		assert.Equal(t, "foo", phaseInfo.Err().GetCode())
+		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().GetKind())
+		assert.Equal(t, "\r\n[primary] terminated with exit code (137). Reason [foo]. Message: \nfoo failed.", phaseInfo.Err().GetMessage())
 	})
 	t.Run("primary container failed - SIGKILL unsigned", func(t *testing.T) {
 		phaseInfo := DeterminePrimaryContainerPhase(ctx, primaryContainerName, []v1.ContainerStatus{
@@ -1869,9 +1869,9 @@ func TestDeterminePrimaryContainerPhase(t *testing.T) {
 			},
 		}, info)
 		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
-		assert.Equal(t, "foo", phaseInfo.Err().Code)
-		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().Kind)
-		assert.Equal(t, "\r\n[primary] terminated with exit code (247). Reason [foo]. Message: \nfoo failed.", phaseInfo.Err().Message)
+		assert.Equal(t, "foo", phaseInfo.Err().GetCode())
+		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().GetKind())
+		assert.Equal(t, "\r\n[primary] terminated with exit code (247). Reason [foo]. Message: \nfoo failed.", phaseInfo.Err().GetMessage())
 	})
 	t.Run("primary container succeeded", func(t *testing.T) {
 		phaseInfo := DeterminePrimaryContainerPhase(ctx, primaryContainerName, []v1.ContainerStatus{
@@ -1908,9 +1908,9 @@ func TestDeterminePrimaryContainerPhase(t *testing.T) {
 			},
 		}, info)
 		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
-		assert.Equal(t, core.ExecutionError_USER, phaseInfo.Err().Kind)
-		assert.Equal(t, OOMKilled, phaseInfo.Err().Code)
-		assert.Equal(t, "\r\n[primary] terminated with exit code (0). Reason [OOMKilled]. Message: \nfoo failed.", phaseInfo.Err().Message)
+		assert.Equal(t, core.ExecutionError_USER, phaseInfo.Err().GetKind())
+		assert.Equal(t, OOMKilled, phaseInfo.Err().GetCode())
+		assert.Equal(t, "\r\n[primary] terminated with exit code (0). Reason [OOMKilled]. Message: \nfoo failed.", phaseInfo.Err().GetMessage())
 	})
 	t.Run("primary container failed with OOMKilled - SIGKILL", func(t *testing.T) {
 		phaseInfo := DeterminePrimaryContainerPhase(ctx, primaryContainerName, []v1.ContainerStatus{
@@ -1926,9 +1926,9 @@ func TestDeterminePrimaryContainerPhase(t *testing.T) {
 			},
 		}, info)
 		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
-		assert.Equal(t, core.ExecutionError_USER, phaseInfo.Err().Kind)
-		assert.Equal(t, OOMKilled, phaseInfo.Err().Code)
-		assert.Equal(t, "\r\n[primary] terminated with exit code (137). Reason [OOMKilled]. Message: \nfoo failed.", phaseInfo.Err().Message)
+		assert.Equal(t, core.ExecutionError_USER, phaseInfo.Err().GetKind())
+		assert.Equal(t, OOMKilled, phaseInfo.Err().GetCode())
+		assert.Equal(t, "\r\n[primary] terminated with exit code (137). Reason [OOMKilled]. Message: \nfoo failed.", phaseInfo.Err().GetMessage())
 	})
 }
 

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -1627,8 +1627,8 @@ func TestDemystifyFailure(t *testing.T) {
 		phaseInfo, err := DemystifyFailure(ctx, v1.PodStatus{}, pluginsCore.TaskInfo{}, "")
 		assert.Nil(t, err)
 		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
-		assert.Equal(t, "Interrupted", phaseInfo.Err().Code)
-		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().Kind)
+		assert.Equal(t, "Interrupted", phaseInfo.Err().GetCode())
+		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().GetKind())
 	})
 
 	t.Run("known-error", func(t *testing.T) {

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -1627,8 +1627,8 @@ func TestDemystifyFailure(t *testing.T) {
 		phaseInfo, err := DemystifyFailure(ctx, v1.PodStatus{}, pluginsCore.TaskInfo{}, "")
 		assert.Nil(t, err)
 		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
-		assert.Equal(t, "UnknownError", phaseInfo.Err().GetCode())
-		assert.Equal(t, core.ExecutionError_USER, phaseInfo.Err().GetKind())
+		assert.Equal(t, "Interrupted", phaseInfo.Err().Code)
+		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().Kind)
 	})
 
 	t.Run("known-error", func(t *testing.T) {

--- a/flyteplugins/go/tasks/plugins/k8s/pod/container_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/pod/container_test.go
@@ -446,7 +446,7 @@ func TestContainerTaskExecutor_GetTaskStatus(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
 		ec := phaseInfo.Err().GetCode()
-		assert.Equal(t, "UnknownError", ec)
+		assert.Equal(t, "Interrupted", ec)
 	})
 
 	t.Run("failConditionUnschedulable", func(t *testing.T) {


### PR DESCRIPTION
## Why are the changes needed?
Do a best effort to count node preemptions as system errors

## What changes were proposed in this pull request?
- Count primary container terminated w/ sigkill as system errors instead of user errors. Count OOMKilled as user error still
- Count unknown reason for failed pods as system errors. This should catch scenarios where a node terminates before a kubelet is able to update state.


## How was this patch tested?
- added unit tests
- has been running in union tenants


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances pod failure classification in Flyte, focusing on node preemption scenarios. SIGKILL terminations are now treated as system errors while OOMKilled remains a user error. Unknown pod failures are reclassified as system errors to better handle node termination cases. The changes primarily affect pod helper components.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 3
</div>