### PR TITLE
Upstream: Ensure that k8s plugins (dask, kfoperator) have resource requests and limits set

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/dask/dask_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/dask/dask_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	daskAPI "github.com/dask/dask-kubernetes/v2023/dask_kubernetes/operator/go_client/pkg/apis/kubernetes.dask.org/v1"
+	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -48,16 +49,23 @@ var (
 	testLabels            = map[string]string{"label-1": "val1"}
 	testPlatformResources = v1.ResourceRequirements{
 		Requests: v1.ResourceList{
-			v1.ResourceCPU: resource.MustParse("4"),
+			v1.ResourceCPU:    resource.MustParse("4"),
+			v1.ResourceMemory: resource.MustParse("10G"),
 		},
 		Limits: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("5"),
-			v1.ResourceMemory: resource.MustParse("17G"),
+			v1.ResourceCPU:    resource.MustParse("10"),
+			v1.ResourceMemory: resource.MustParse("24G"),
 		},
 	}
 	defaultResources = v1.ResourceRequirements{
-		Requests: testPlatformResources.Requests,
-		Limits:   testPlatformResources.Requests,
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("2"),
+			v1.ResourceMemory: resource.MustParse("8G"),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("8"),
+			v1.ResourceMemory: resource.MustParse("17G"),
+		},
 	}
 	podTemplate = &v1.PodTemplate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -318,9 +326,9 @@ func TestBuildResourceDaskHappyPath(t *testing.T) {
 		"--name",
 		"$(DASK_WORKER_NAME)",
 		"--nthreads",
-		"4",
+		"8",
 		"--memory-limit",
-		"1Gi",
+		"17G",
 	}, workerSpec.Containers[0].Args)
 	assert.Equal(t, workerSpec.RestartPolicy, v1.RestartPolicyAlways)
 }
@@ -387,6 +395,55 @@ func TestBuildResourceDaskDefaultResoureRequirements(t *testing.T) {
 	assert.Contains(t, workerSpec.Containers[0].Args, "2G")
 }
 
+func TestBuildResourceDaskAdjustResoureRequirements(t *testing.T) {
+	flyteWorkflowResources := v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("1"),
+			v1.ResourceMemory: resource.MustParse("2G"),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceCPU: resource.MustParse("16"), // Higher than platform limits
+			// Unset memory should be defaulted to from the request
+		},
+	}
+
+	daskResourceHandler := daskResourceHandler{}
+	taskTemplate := dummyDaskTaskTemplate("", nil, "")
+	taskContext := dummyDaskTaskContext(taskTemplate, &flyteWorkflowResources, nil, false, k8s.PluginState{})
+	r, err := daskResourceHandler.BuildResource(context.TODO(), taskContext)
+	assert.Nil(t, err)
+	assert.NotNil(t, r)
+	daskJob, ok := r.(*daskAPI.DaskJob)
+	assert.True(t, ok)
+
+	expectedResources := v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("1"),
+			v1.ResourceMemory: resource.MustParse("2G"),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    testPlatformResources.Limits[v1.ResourceCPU],
+			v1.ResourceMemory: flyteWorkflowResources.Requests[v1.ResourceMemory],
+		},
+	}
+
+	// Job
+	jobSpec := daskJob.Spec.Job.Spec
+	assert.Equal(t, expectedResources, jobSpec.Containers[0].Resources)
+
+	// Scheduler
+	schedulerSpec := daskJob.Spec.Cluster.Spec.Scheduler.Spec
+	assert.Equal(t, expectedResources, schedulerSpec.Containers[0].Resources)
+
+	// Default Workers
+	workerSpec := daskJob.Spec.Cluster.Spec.Worker.Spec
+	assert.Equal(t, expectedResources, workerSpec.Containers[0].Resources)
+	assert.Contains(t, workerSpec.Containers[0].Args, "--nthreads")
+	assert.Contains(t, workerSpec.Containers[0].Args, "10") // from the adjusted, platform limits
+	assert.Contains(t, workerSpec.Containers[0].Args, "--memory-limit")
+	assert.Contains(t, workerSpec.Containers[0].Args, "2G")
+}
+
 func TestBuildResourcesDaskCustomResoureRequirements(t *testing.T) {
 	protobufResources := core.Resources{
 		Requests: []*core.Resources_ResourceEntry{
@@ -406,7 +463,13 @@ func TestBuildResourcesDaskCustomResoureRequirements(t *testing.T) {
 			},
 		},
 	}
-	expectedResources, _ := flytek8s.ToK8sResourceRequirements(&protobufResources)
+	expectedPbResources := proto.Clone(&protobufResources).(*core.Resources)
+	// We expect the unset memory request to come from the set memory limit
+	expectedPbResources.Requests = append(expectedPbResources.Requests, &core.Resources_ResourceEntry{
+		Name:  core.Resources_MEMORY,
+		Value: "15G",
+	})
+	expectedResources, _ := flytek8s.ToK8sResourceRequirements(expectedPbResources)
 
 	flyteWorkflowResources := v1.ResourceRequirements{
 		Requests: v1.ResourceList{

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator.go
@@ -328,6 +328,7 @@ func ToReplicaSpecWithOverrides(ctx context.Context, taskCtx pluginsCore.TaskExe
 		if err != nil {
 			return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "invalid TaskSpecification on Resources [%v], Err: [%v]", resources, err.Error())
 		}
+		*resources = flytek8s.ApplyK8sResourceOverrides(taskCtx.TaskExecutionMetadata(), resources)
 		taskCtxOptions = append(taskCtxOptions, flytek8s.WithResources(resources))
 	}
 	newTaskCtx := flytek8s.NewPluginTaskExecutionContext(taskCtx, taskCtxOptions...)


### PR DESCRIPTION
## Why are the changes needed?

When a user specifies dask scheduler or worker requests, but not limits, k8s pod scheduling fails with

```
95s         Warning   FailedCreate                        replicaset/a2bjwpn2f5h8666jxmv4-fofhakuy-0-default-worker-944f52ccec-6d86b47fff   Error creating: pods "a2bjwpn2f5h8666jxmv4-fofhakuy-0-default-worker-944f52ccec-k6p94" is forbidden: failed quota: project-quota: must specify limits.cpu for: dask-worker; limits.memory for: dask-worker
85s         Warning   FailedCreate                        replicaset/a2bjwpn2f5h8666jxmv4-fofhakuy-0-default-worker-c20eb58c04-686775db55   (combined from similar events): Error creating: pods "a2bjwpn2f5h8666jxmv4-fofhakuy-0-default-worker-c20eb58c04-2kgxq" is forbidden: failed quota: project-quota: must specify limits.cpu for: dask-worker; limits.memory for: dask-worker
85s         Warning   FailedCreate                        replicaset/a2bjwpn2f5h8666jxmv4-fofhakuy-0-default-worker-944f52ccec-6d86b47fff   (combined from similar events): Error creating: pods "a2bjwpn2f5h8666jxmv4-fofhakuy-0-default-worker-944f52ccec-r667v" is forbidden: failed quota: project-quota: must specify limits.cpu for: dask-worker; limits.memory for: dask-worker
```

## What changes were proposed in this pull request?

This change follows existing container and k8s pod task logic to ensure that when one of requests or limits are not set, the unspecified value comes from the specified one, or otherwise both values come from the platform defaults.

## How was this patch tested?
Ran locally on a flyte deployment, verified after changes that worker pods god scheduled

```
8m11s       Normal    SuccessfulCreate                    replicaset/azpkkgg9cwsr6nbmq2k5-fofhakuy-0-default-worker-c44f7b7bd9-79f8584d77   Created pod: azpkkgg9cwsr6nbmq2k5-fofhakuy-0-default-worker-c44f7b7bd9-bptqq
8m12s       Normal    ScalingReplicaSet                   deployment/azpkkgg9cwsr6nbmq2k5-fofhakuy-0-default-worker-c44f7b7bd9              Scaled up replica set azpkkgg9cwsr6nbmq2k5-fofhakuy-0-default-worker-c44f7b7bd9-79f8584d77 to 1
...
8m12s       Normal    SuccessfulCreate                    replicaset/azpkkgg9cwsr6nbmq2k5-fofhakuy-0-default-worker-1755145870-6d8c6d5b79   Created pod: azpkkgg9cwsr6nbmq2k5-fofhakuy-0-default-worker-1755145870-tltd9
```

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances Kubernetes resource management by implementing proper resource requests and limits handling through a new ApplyK8sResourceOverrides utility. The changes focus on preventing pod scheduling failures in quota-restricted environments by ensuring both CPU and memory limits are properly specified. The implementation includes safeguards for platform-defined defaults when values are unspecified.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>