### PR TITLE
Set the max parallelism on the execution model correctly when triggered by launch plan

### DIFF
--- a/flyteadmin/pkg/manager/impl/execution_manager.go
+++ b/flyteadmin/pkg/manager/impl/execution_manager.go
@@ -1077,7 +1077,7 @@ func (m *ExecutionManager) launchExecution(
 	}
 
 	// Set the max parallelism based on the execution config (calculated based on multiple levels of settings)
-	requestSpec.MaxParallelism = executionConfig.MaxParallelism
+	requestSpec.MaxParallelism = executionConfig.GetMaxParallelism()
 
 	createExecModelInput := transformers.CreateExecutionModelInput{
 		WorkflowExecutionID: workflowExecutionID,

--- a/flyteadmin/pkg/manager/impl/execution_manager.go
+++ b/flyteadmin/pkg/manager/impl/execution_manager.go
@@ -1076,6 +1076,9 @@ func (m *ExecutionManager) launchExecution(
 		notificationsSettings = make([]*admin.Notification, 0)
 	}
 
+	// Set the max parallelism based on the execution config (calculated based on multiple levels of settings)
+	requestSpec.MaxParallelism = executionConfig.MaxParallelism
+
 	createExecModelInput := transformers.CreateExecutionModelInput{
 		WorkflowExecutionID: workflowExecutionID,
 		RequestSpec:         requestSpec,

--- a/flyteadmin/pkg/manager/impl/execution_manager_test.go
+++ b/flyteadmin/pkg/manager/impl/execution_manager_test.go
@@ -59,6 +59,7 @@ const (
 	principal             = "principal"
 	rawOutput             = "raw_output"
 	executionClusterLabel = "execution_cluster_label"
+	launchPlanParallelism = int32(42)
 )
 
 var spec = testutils.GetExecutionRequest().GetSpec()
@@ -179,6 +180,8 @@ func getMockExecutionsConfigProvider() runtimeInterfaces.Configuration {
 
 func setDefaultLpCallbackForExecTest(repository interfaces.Repository) {
 	lpSpec := testutils.GetSampleLpSpecForTest()
+
+	lpSpec.MaxParallelism = launchPlanParallelism
 	lpSpec.Labels = &admin.Labels{
 		Values: map[string]string{
 			"label1": "1",
@@ -319,6 +322,7 @@ func TestCreateExecution(t *testing.T) {
 			assert.True(t, proto.Equal(spec.GetClusterAssignment(), &clusterAssignment))
 			assert.Equal(t, "launch_plan", input.LaunchEntity)
 			assert.Equal(t, spec.GetMetadata().GetSystemMetadata().GetNamespace(), "project-domain")
+			assert.Equal(t, launchPlanParallelism, spec.GetMaxParallelism())
 			return nil
 		})
 	setDefaultLpCallbackForExecTest(repository)


### PR DESCRIPTION
## Tracking issue
Example: Closes #4568

## Why are the changes needed?
Our team spent a lot of time debugging why it seemed like max parallelism configuration from launch plans was not translating into workflows kicked off from the launch plan. After digging into the code it turns out the max parallelism is set on the CR but not the execution model stored in the DB so the max parallelism is never reflected in the UI.

## What changes were proposed in this pull request?
Updates the execution model to have the max parallelism value from the execution config which is calculated based on the launch plan parallelism or platform/project defaults. 

## How was this patch tested?
Unit tests and tested in our production environment.

### Setup process

### Screenshots

Displaying platform defaults 
![Screenshot 2025-02-24 at 10 06 24 AM](https://github.com/user-attachments/assets/c7c56827-1a1d-4db5-8f1e-e2dbe75b25de)


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off. 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR addresses a critical issue in max parallelism configuration propagation from launch plans to the execution model. The implementation ensures proper setting of max parallelism values from execution configs to request specifications when workflows are triggered from launch plans. The changes include validation checks and corresponding test cases.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>