### PR TITLE
fix: Correct error handling in delete function

### DIFF
--- a/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/agent/plugin.go
@@ -257,7 +257,10 @@ func (p *Plugin) Delete(ctx context.Context, taskCtx webapi.DeleteContext) error
 		ResourceMeta: metadata.AgentResourceMeta,
 	}
 	_, err = client.DeleteTask(finalCtx, request)
-	return fmt.Errorf("failed to delete task from agent with %v", err)
+	if err != nil {
+		return fmt.Errorf("failed to delete task from agent with %v", err)
+	}
+	return nil
 }
 
 func (p *Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phase core.PhaseInfo, err error) {


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Failed to delete the task since we always return err on delete 

## What changes were proposed in this pull request?
check if the error is nil first

## How was this patch tested?
Run an agent task and terminate it

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
 
 <div id='description'>
<h3>Summary by Bito</h3>
Fixed a critical bug in the agent plugin's Delete function by correcting error handling logic. The function now properly returns nil for successful deletions and only returns errors when actual error conditions occur, replacing the previous implementation that always returned an error.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>