### PR TITLE
Remove mockery fork logic

### DIFF
--- a/boilerplate/flyte/golang_test_targets/download_tooling.sh
+++ b/boilerplate/flyte/golang_test_targets/download_tooling.sh
@@ -35,22 +35,6 @@ pushd "$tmp_dir"
 for tool in "${tools[@]}"; do
 	echo "Installing ${tool}"
 	GO111MODULE=on go install $tool
-	# If tool is our mockery fork, we need to rename the binary to mockery-fork
-	if [[ $tool == "github.com/EngHabu/mockery/cmd/mockery" ]]; then
-		echo "Renaming mockery to mockery-fork"
-		mv $(go env GOPATH)/bin/mockery $(go env GOPATH)/bin/mockery-fork
-	fi
-	# If tool is named vektra/mockery/v2, we need to rename the binary to mockery-v2
-	if [[ $tool == "github.com/vektra/mockery/v2@v2.40.3" ]]; then
-		echo "Renaming mockery to mockery-v2"
-		mv $(go env GOPATH)/bin/mockery $(go env GOPATH)/bin/mockery-v2
-	fi
 done
-
-# Rename the mockery-fork binary to mockery to maintain compatibility with the existing uses
-if [ -f $(go env GOPATH)/bin/mockery-fork ]; then
-	echo "Renaming mockery-fork to mockery"
-	mv $(go env GOPATH)/bin/mockery-fork $(go env GOPATH)/bin/mockery
-fi
 
 popd

--- a/datacatalog/pkg/manager/interfaces/artifact.go
+++ b/datacatalog/pkg/manager/interfaces/artifact.go
@@ -6,7 +6,7 @@ import (
 	idl_datacatalog "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 )
 
-//go:generate mockery-v2 --name=ArtifactManager --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=ArtifactManager --output=../mocks --case=underscore --with-expecter
 
 type ArtifactManager interface {
 	CreateArtifact(ctx context.Context, request *idl_datacatalog.CreateArtifactRequest) (*idl_datacatalog.CreateArtifactResponse, error)

--- a/datacatalog/pkg/repositories/interfaces/artifact_repo.go
+++ b/datacatalog/pkg/repositories/interfaces/artifact_repo.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 )
 
-//go:generate mockery-v2 --name=ArtifactRepo --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=ArtifactRepo --output=../mocks --case=underscore --with-expecter
 
 type ArtifactRepo interface {
 	Create(ctx context.Context, in models.Artifact) error

--- a/datacatalog/pkg/repositories/interfaces/dataset_repo.go
+++ b/datacatalog/pkg/repositories/interfaces/dataset_repo.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 )
 
-//go:generate mockery-v2 --name=DatasetRepo --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=DatasetRepo --output=../mocks --case=underscore --with-expecter
 
 type DatasetRepo interface {
 	Create(ctx context.Context, in models.Dataset) error

--- a/datacatalog/pkg/repositories/interfaces/partition_repo.go
+++ b/datacatalog/pkg/repositories/interfaces/partition_repo.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 )
 
-//go:generate mockery-v2 --name=PartitionRepo --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=PartitionRepo --output=../mocks --case=underscore --with-expecter
 
 type PartitionRepo interface {
 	Create(ctx context.Context, in models.Partition) error

--- a/datacatalog/pkg/repositories/interfaces/reservation_repo.go
+++ b/datacatalog/pkg/repositories/interfaces/reservation_repo.go
@@ -7,7 +7,7 @@ import (
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 )
 
-//go:generate mockery-v2 --name=ReservationRepo --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=ReservationRepo --output=../mocks --case=underscore --with-expecter
 
 // Interface to interact with Reservation Table
 type ReservationRepo interface {

--- a/datacatalog/pkg/repositories/interfaces/tag_repo.go
+++ b/datacatalog/pkg/repositories/interfaces/tag_repo.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 )
 
-//go:generate mockery-v2 --name=TagRepo --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=TagRepo --output=../mocks --case=underscore --with-expecter
 
 type TagRepo interface {
 	Create(ctx context.Context, in models.Tag) error

--- a/flyteadmin/auth/interfaces/context.go
+++ b/flyteadmin/auth/interfaces/context.go
@@ -17,7 +17,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 type HandlerRegisterer interface {
 	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))

--- a/flyteadmin/auth/interfaces/cookie.go
+++ b/flyteadmin/auth/interfaces/cookie.go
@@ -9,7 +9,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 )
 
-//go:generate mockery-v2 --name=CookieHandler --output=mocks/ --case=underscore --with-expecter
+//go:generate mockery --name=CookieHandler --output=mocks/ --case=underscore --with-expecter
 
 type CookieHandler interface {
 	SetTokenCookies(ctx context.Context, writer http.ResponseWriter, token *oauth2.Token) error

--- a/flyteadmin/pkg/async/cloudevent/interfaces/publisher.go
+++ b/flyteadmin/pkg/async/cloudevent/interfaces/publisher.go
@@ -6,7 +6,7 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-//go:generate mockery-v2 --name=Publisher --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=Publisher --output=../mocks --case=underscore --with-expecter
 
 // Publisher Defines the interface for Publishing execution event to other services (AWS pub/sub, Kafka).
 type Publisher interface {

--- a/flyteadmin/pkg/async/cloudevent/interfaces/sender.go
+++ b/flyteadmin/pkg/async/cloudevent/interfaces/sender.go
@@ -6,7 +6,7 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
-//go:generate mockery-v2 --name=Sender --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=Sender --output=../mocks --case=underscore --with-expecter
 
 // Sender Defines the interface for sending cloudevents.
 type Sender interface {

--- a/flyteadmin/pkg/async/events/interfaces/node_execution.go
+++ b/flyteadmin/pkg/async/events/interfaces/node_execution.go
@@ -4,7 +4,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=NodeExecutionEventWriter --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=NodeExecutionEventWriter --output=../mocks --case=underscore --with-expecter
 
 type NodeExecutionEventWriter interface {
 	Run()

--- a/flyteadmin/pkg/async/events/interfaces/workflow_execution.go
+++ b/flyteadmin/pkg/async/events/interfaces/workflow_execution.go
@@ -4,7 +4,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=WorkflowExecutionEventWriter --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=WorkflowExecutionEventWriter --output=../mocks --case=underscore --with-expecter
 
 type WorkflowExecutionEventWriter interface {
 	Run()

--- a/flyteadmin/pkg/async/notifications/implementations/sendgrid_emailer.go
+++ b/flyteadmin/pkg/async/notifications/implementations/sendgrid_emailer.go
@@ -19,7 +19,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
-//go:generate mockery-v2 --all --case=underscore --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --output=../mocks --case=underscore --with-expecter
 
 type SendgridClient interface {
 	Send(email *mail.SGMailV3) (*rest.Response, error)

--- a/flyteadmin/pkg/async/notifications/interfaces/emailer.go
+++ b/flyteadmin/pkg/async/notifications/interfaces/emailer.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=Emailer --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=Emailer --output=../mocks --case=underscore --with-expecter
 
 // The implementation of Emailer needs to be passed to the implementation of Processor
 // in order for emails to be sent.

--- a/flyteadmin/pkg/async/notifications/interfaces/processor.go
+++ b/flyteadmin/pkg/async/notifications/interfaces/processor.go
@@ -1,6 +1,6 @@
 package interfaces
 
-//go:generate mockery-v2 --name=Processor --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=Processor --output=../mocks --case=underscore --with-expecter
 
 // Exposes the common methods required for a subscriber.
 // There is one ProcessNotification per type.

--- a/flyteadmin/pkg/async/notifications/interfaces/publisher.go
+++ b/flyteadmin/pkg/async/notifications/interfaces/publisher.go
@@ -6,7 +6,7 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-//go:generate mockery-v2 --name=Publisher --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=Publisher --output=../mocks --case=underscore --with-expecter
 
 // Note on Notifications
 

--- a/flyteadmin/pkg/async/notifications/interfaces/smtp_client.go
+++ b/flyteadmin/pkg/async/notifications/interfaces/smtp_client.go
@@ -8,7 +8,7 @@ import (
 
 // This interface is introduced to allow for mocking of the smtp.Client object.
 
-//go:generate mockery-v2 --name=SMTPClient --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=SMTPClient --output=../mocks --case=underscore --with-expecter
 type SMTPClient interface {
 	Hello(localName string) error
 	Extension(ext string) (bool, string)

--- a/flyteadmin/pkg/async/schedule/interfaces/event_scheduler.go
+++ b/flyteadmin/pkg/async/schedule/interfaces/event_scheduler.go
@@ -27,7 +27,7 @@ type RemoveScheduleInput struct {
 	ScheduleNamePrefix string
 }
 
-//go:generate mockery-v2 --name=EventScheduler --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=EventScheduler --output=../mocks --case=underscore --with-expecter
 
 type EventScheduler interface {
 	// Schedules an event.

--- a/flyteadmin/pkg/async/schedule/interfaces/workflow_executor.go
+++ b/flyteadmin/pkg/async/schedule/interfaces/workflow_executor.go
@@ -1,6 +1,6 @@
 package interfaces
 
-//go:generate mockery-v2 --name=WorkflowExecutor --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=WorkflowExecutor --output=../mocks --case=underscore --with-expecter
 
 // Handles responding to scheduled workflow execution events and creating executions.
 type WorkflowExecutor interface {

--- a/flyteadmin/pkg/clusterresource/interfaces/admin.go
+++ b/flyteadmin/pkg/clusterresource/interfaces/admin.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=FlyteAdminDataProvider --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=FlyteAdminDataProvider --output=../mocks --case=underscore --with-expecter
 
 type FlyteAdminDataProvider interface {
 	GetClusterResourceAttributes(ctx context.Context, project, domain string) (*admin.ClusterResourceAttributes, error)

--- a/flyteadmin/pkg/data/interfaces/remote.go
+++ b/flyteadmin/pkg/data/interfaces/remote.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=RemoteURLInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=RemoteURLInterface --output=../mocks --case=underscore --with-expecter
 
 // Defines an interface for fetching pre-signed URLs.
 type RemoteURLInterface interface {

--- a/flyteadmin/pkg/executioncluster/interfaces/execution_target_provider.go
+++ b/flyteadmin/pkg/executioncluster/interfaces/execution_target_provider.go
@@ -7,7 +7,7 @@ import (
 	"github.com/flyteorg/flyte/flyteadmin/pkg/runtime/interfaces"
 )
 
-//go:generate mockery-v2 --all --case=underscore --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --output=../mocks --case=underscore --with-expecter
 
 type ExecutionTargetProvider interface {
 	GetExecutionTarget(initializationErrorCounter prometheus.Counter, k8sCluster interfaces.ClusterConfig) (*executioncluster.ExecutionTarget, error)

--- a/flyteadmin/pkg/manager/interfaces/execution.go
+++ b/flyteadmin/pkg/manager/interfaces/execution.go
@@ -7,7 +7,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=ExecutionInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=ExecutionInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Workflow Executions
 type ExecutionInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/launch_plan.go
+++ b/flyteadmin/pkg/manager/interfaces/launch_plan.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=LaunchPlanInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=LaunchPlanInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Launch Plans
 type LaunchPlanInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/metrics.go
+++ b/flyteadmin/pkg/manager/interfaces/metrics.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=MetricsInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=MetricsInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte execution metrics
 type MetricsInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/named_entity.go
+++ b/flyteadmin/pkg/manager/interfaces/named_entity.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=NamedEntityInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=NamedEntityInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing metadata associated with NamedEntityIdentifiers
 type NamedEntityInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/node_execution.go
+++ b/flyteadmin/pkg/manager/interfaces/node_execution.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=NodeExecutionInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=NodeExecutionInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Workflow NodeExecutions
 type NodeExecutionInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/project.go
+++ b/flyteadmin/pkg/manager/interfaces/project.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=ProjectInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=ProjectInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing projects (and domains).
 type ProjectInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/resource.go
+++ b/flyteadmin/pkg/manager/interfaces/resource.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=ResourceInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=ResourceInterface --output=../mocks --case=underscore --with-expecter
 
 // ResourceInterface manages project, domain and workflow -specific attributes.
 type ResourceInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/signal.go
+++ b/flyteadmin/pkg/manager/interfaces/signal.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=SignalInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=SignalInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Signals
 type SignalInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/task.go
+++ b/flyteadmin/pkg/manager/interfaces/task.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=TaskInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=TaskInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Tasks
 type TaskInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/task_execution.go
+++ b/flyteadmin/pkg/manager/interfaces/task_execution.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=TaskExecutionInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=TaskExecutionInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Workflow TaskExecutions
 type TaskExecutionInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/version.go
+++ b/flyteadmin/pkg/manager/interfaces/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=VersionInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=VersionInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte admin version
 type VersionInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/workflow.go
+++ b/flyteadmin/pkg/manager/interfaces/workflow.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery-v2 --name=WorkflowInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=WorkflowInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Workflows
 type WorkflowInterface interface {

--- a/flyteadmin/pkg/repositories/interfaces/execution_event_repo.go
+++ b/flyteadmin/pkg/repositories/interfaces/execution_event_repo.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteadmin/pkg/repositories/models"
 )
 
-//go:generate mockery-v2 --name=ExecutionEventRepoInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=ExecutionEventRepoInterface --output=../mocks --case=underscore --with-expecter
 
 type ExecutionEventRepoInterface interface {
 	// Inserts a workflow execution event into the database store.

--- a/flyteadmin/pkg/repositories/interfaces/node_execution_event_repo.go
+++ b/flyteadmin/pkg/repositories/interfaces/node_execution_event_repo.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteadmin/pkg/repositories/models"
 )
 
-//go:generate mockery-v2 --name=NodeExecutionEventRepoInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=NodeExecutionEventRepoInterface --output=../mocks --case=underscore --with-expecter
 
 type NodeExecutionEventRepoInterface interface {
 	// Inserts a node execution event into the database store.

--- a/flyteadmin/pkg/repositories/interfaces/signal_repo.go
+++ b/flyteadmin/pkg/repositories/interfaces/signal_repo.go
@@ -7,7 +7,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
-//go:generate mockery-v2 --name=SignalRepoInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=SignalRepoInterface --output=../mocks --case=underscore --with-expecter
 
 // Defines the interface for interacting with signal models.
 type SignalRepoInterface interface {

--- a/flyteadmin/pkg/runtime/interfaces/cluster_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/cluster_configuration.go
@@ -51,7 +51,7 @@ type Clusters struct {
 	DefaultExecutionLabel string                     `json:"defaultExecutionLabel"`
 }
 
-//go:generate mockery-v2 --name ClusterConfiguration --case=underscore --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name ClusterConfiguration --case=underscore --output=../mocks --case=underscore --with-expecter
 
 // Provides values set in runtime configuration files.
 // These files can be changed without requiring a full server restart.

--- a/flyteadmin/pkg/runtime/interfaces/cluster_pools.go
+++ b/flyteadmin/pkg/runtime/interfaces/cluster_pools.go
@@ -1,6 +1,6 @@
 package interfaces
 
-//go:generate mockery-v2 --name ClusterPoolAssignmentConfiguration --output=mocks --case=underscore --with-expecter
+//go:generate mockery --name ClusterPoolAssignmentConfiguration --output=mocks --case=underscore --with-expecter
 
 type ClusterPoolAssignment struct {
 	Pool string `json:"pool"`

--- a/flyteadmin/pkg/runtime/interfaces/namespace_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/namespace_configuration.go
@@ -6,7 +6,7 @@ type NamespaceMappingConfig struct {
 	TemplateData TemplateData `json:"templateData"`
 }
 
-//go:generate mockery-v2 --name NamespaceMappingConfiguration --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name NamespaceMappingConfiguration --output=../mocks --case=underscore --with-expecter
 
 type NamespaceMappingConfiguration interface {
 	GetNamespaceTemplate() string

--- a/flyteadmin/pkg/runtime/interfaces/quality_of_service_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/quality_of_service_configuration.go
@@ -8,7 +8,7 @@ import (
 type TierName = string
 
 // Just incrementally start using mockery, replace with -all when working on https://github.com/flyteorg/flyte/issues/149
-//go:generate mockery-v2 --name QualityOfServiceConfiguration --output=mocks --case=underscore --with-expecter
+//go:generate mockery --name QualityOfServiceConfiguration --output=mocks --case=underscore --with-expecter
 
 type QualityOfServiceSpec struct {
 	QueueingBudget config.Duration `json:"queueingBudget"`

--- a/flyteadmin/pkg/workflowengine/interfaces/builder.go
+++ b/flyteadmin/pkg/workflowengine/interfaces/builder.go
@@ -5,7 +5,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery-v2 --name FlyteWorkflowBuilder --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name FlyteWorkflowBuilder --output=../mocks --case=underscore --with-expecter
 
 // FlyteWorkflowBuilder produces a v1alpha1.FlyteWorkflow definition from a compiled workflow closure and execution inputs
 type FlyteWorkflowBuilder interface {

--- a/flyteadmin/pkg/workflowengine/interfaces/executor.go
+++ b/flyteadmin/pkg/workflowengine/interfaces/executor.go
@@ -10,7 +10,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery-v2 --name=WorkflowExecutor --output=../mocks/ --case=underscore --with-expecter
+//go:generate mockery --name=WorkflowExecutor --output=../mocks/ --case=underscore --with-expecter
 
 type TaskResources struct {
 	Defaults runtime.TaskResourceSet

--- a/flyteadmin/scheduler/executor/executor.go
+++ b/flyteadmin/scheduler/executor/executor.go
@@ -7,7 +7,7 @@ import (
 	"github.com/flyteorg/flyte/flyteadmin/scheduler/repositories/models"
 )
 
-//go:generate mockery-v2 --name Executor --output=mocks --case=underscore --with-expecter
+//go:generate mockery --name Executor --output=mocks --case=underscore --with-expecter
 
 // Executor allows the ability to create scheduled executions on admin
 type Executor interface {

--- a/flyteadmin/scheduler/repositories/interfaces/schedulable_entity_repo.go
+++ b/flyteadmin/scheduler/repositories/interfaces/schedulable_entity_repo.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteadmin/scheduler/repositories/models"
 )
 
-//go:generate mockery-v2 --name=SchedulableEntityRepoInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=SchedulableEntityRepoInterface --output=../mocks --case=underscore --with-expecter
 
 // SchedulableEntityRepoInterface : An Interface for interacting with the schedulable entity in the database
 type SchedulableEntityRepoInterface interface {

--- a/flyteadmin/scheduler/repositories/interfaces/schedule_entities_snapshot_repo.go
+++ b/flyteadmin/scheduler/repositories/interfaces/schedule_entities_snapshot_repo.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flyteadmin/scheduler/repositories/models"
 )
 
-//go:generate mockery-v2 --name=ScheduleEntitiesSnapShotRepoInterface --output=../mocks --case=underscore --with-expecter
+//go:generate mockery --name=ScheduleEntitiesSnapShotRepoInterface --output=../mocks --case=underscore --with-expecter
 
 // ScheduleEntitiesSnapShotRepoInterface : An Interface for interacting with the snapshot of schedulable entities in the database
 type ScheduleEntitiesSnapShotRepoInterface interface {

--- a/flytectl/cmd/update/interfaces/updater.go
+++ b/flytectl/cmd/update/interfaces/updater.go
@@ -7,7 +7,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
-//go:generate mockery-v2 --name=Updater --case=underscore --with-expecter
+//go:generate mockery --name=Updater --case=underscore --with-expecter
 
 type Updater interface {
 	UpdateNamedEntity(ctx context.Context, name, project, domain string, rsType core.ResourceType, cmdCtx cmdCore.CommandContext) error

--- a/flytectl/pkg/docker/docker.go
+++ b/flytectl/pkg/docker/docker.go
@@ -13,7 +13,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 type Docker interface {
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)

--- a/flytectl/pkg/ext/deleter.go
+++ b/flytectl/pkg/ext/deleter.go
@@ -7,7 +7,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // AdminDeleterExtInterface Interface for exposing the update capabilities from the admin
 type AdminDeleterExtInterface interface {

--- a/flytectl/pkg/ext/fetcher.go
+++ b/flytectl/pkg/ext/fetcher.go
@@ -8,7 +8,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // AdminFetcherExtInterface Interface for exposing the fetch capabilities from the admin and also allow this to be injectable into other
 // modules. eg : create execution which requires to fetch launchplan details to construct the execution spec.

--- a/flytectl/pkg/ext/updater.go
+++ b/flytectl/pkg/ext/updater.go
@@ -7,7 +7,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // AdminUpdaterExtInterface Interface for exposing the update capabilities from the admin
 type AdminUpdaterExtInterface interface {

--- a/flytectl/pkg/github/githubutil.go
+++ b/flytectl/pkg/github/githubutil.go
@@ -51,7 +51,7 @@ var (
 	arch = platformutil.Arch(runtime.GOARCH)
 )
 
-//go:generate mockery-v2 --name=GHRepoService --case=underscore --with-expecter
+//go:generate mockery --name=GHRepoService --case=underscore --with-expecter
 
 type GHRepoService interface {
 	GetLatestRelease(ctx context.Context, owner, repo string) (*github.RepositoryRelease, *github.Response, error)

--- a/flytectl/pkg/k8s/k8s.go
+++ b/flytectl/pkg/k8s/k8s.go
@@ -16,7 +16,7 @@ type K8s interface {
 	CoreV1() corev1.CoreV1Interface
 }
 
-//go:generate mockery-v2 --name=ContextOps --case=underscore --with-expecter
+//go:generate mockery --name=ContextOps --case=underscore --with-expecter
 type ContextOps interface {
 	CheckConfig() error
 	CopyContext(srcConfigAccess clientcmd.ConfigAccess, srcCtxName, targetCtxName, targetNamespace string) error

--- a/flytectl/pkg/visualize/graphvizer.go
+++ b/flytectl/pkg/visualize/graphvizer.go
@@ -2,7 +2,7 @@ package visualize
 
 import graphviz "github.com/awalterschulze/gographviz"
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 type Graphvizer interface {
 	AddEdge(src, dst string, directed bool, attrs map[string]string) error

--- a/flyteidl/clients/go/admin/cache/token_cache.go
+++ b/flyteidl/clients/go/admin/cache/token_cache.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 var (
 	ErrNotFound = fmt.Errorf("secret not found in keyring")

--- a/flyteidl/clients/go/admin/client.go
+++ b/flyteidl/clients/go/admin/client.go
@@ -20,7 +20,7 @@ import (
 )
 
 // IDE "Go Generate File". This will create a mocks/AdminServiceClient.go file
-//go:generate mockery-v2 --dir ../../../gen/pb-go/flyteidl/service --name AdminServiceClient --output ../admin/mocks --with-expecter
+//go:generate mockery --dir ../../../gen/pb-go/flyteidl/service --name AdminServiceClient --output ../admin/mocks --with-expecter
 
 // Clientset contains the clients exposed to communicate with various admin services.
 type Clientset struct {

--- a/flyteidl/clients/go/admin/token_source_provider.go
+++ b/flyteidl/clients/go/admin/token_source_provider.go
@@ -25,7 +25,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
-//go:generate mockery-v2 --name TokenSource --with-expecter
+//go:generate mockery --name TokenSource --with-expecter
 type TokenSource interface {
 	Token() (*oauth2.Token, error)
 }

--- a/flyteidl/generate_mocks.sh
+++ b/flyteidl/generate_mocks.sh
@@ -2,6 +2,6 @@
 set -e
 set -x
 
-mockery-v2 --dir=gen/pb-go/flyteidl/service/ --all --output=clients/go/admin/mocks --with-expecter
-mockery-v2 --dir=gen/pb-go/flyteidl/datacatalog/ --name=DataCatalogClient --output=clients/go/datacatalog/mocks --with-expecter
-mockery-v2 --dir=gen/pb-go/flyteidl/cacheservice/ --name=CacheServiceClient --output=clients/go/cacheservice/mocks --with-expecter
+mockery --dir=gen/pb-go/flyteidl/service/ --all --output=clients/go/admin/mocks --with-expecter
+mockery --dir=gen/pb-go/flyteidl/datacatalog/ --name=DataCatalogClient --output=clients/go/datacatalog/mocks --with-expecter
+mockery --dir=gen/pb-go/flyteidl/cacheservice/ --name=CacheServiceClient --output=clients/go/cacheservice/mocks --with-expecter

--- a/flyteplugins/go/tasks/pluginmachinery/catalog/client.go
+++ b/flyteplugins/go/tasks/pluginmachinery/catalog/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // Metadata to be associated with the catalog object
 type Metadata struct {

--- a/flyteplugins/go/tasks/pluginmachinery/core/exec_context.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/exec_context.go
@@ -9,7 +9,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // An interface to access a remote/sharable location that contains the serialized TaskTemplate
 type TaskTemplatePath interface {

--- a/flyteplugins/go/tasks/pluginmachinery/core/exec_metadata.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/exec_metadata.go
@@ -8,7 +8,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // TaskOverrides interface to expose any overrides that have been set for this task (like resource overrides etc)
 type TaskOverrides interface {

--- a/flyteplugins/go/tasks/pluginmachinery/core/plugin.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/plugin.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/utils/strings/slices"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // https://github.com/flyteorg/flytepropeller/blob/979fabe1d1b22b01645259a03b8096f227681d08/pkg/utils/encoder.go#L25-L26
 const minGeneratedNameLength = 8

--- a/flyteplugins/go/tasks/pluginmachinery/core/secret_manager.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/secret_manager.go
@@ -2,7 +2,7 @@ package core
 
 import "context"
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 type SecretManager interface {
 	Get(ctx context.Context, key string) (string, error)
 }

--- a/flyteplugins/go/tasks/pluginmachinery/internal/webapi/cache.go
+++ b/flyteplugins/go/tasks/pluginmachinery/internal/webapi/cache.go
@@ -16,7 +16,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 const (
 	BadReturnCodeError stdErrors.ErrorCode = "RETURNED_UNKNOWN"

--- a/flyteplugins/go/tasks/pluginmachinery/io/iface.go
+++ b/flyteplugins/go/tasks/pluginmachinery/io/iface.go
@@ -7,7 +7,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // InputFilePaths contains the different ways available for downstream systems to retrieve inputs.
 // If using Files for IO with tasks, then the input will be written to this path. All the files are always created in a

--- a/flyteplugins/go/tasks/pluginmachinery/k8s/plugin.go
+++ b/flyteplugins/go/tasks/pluginmachinery/k8s/plugin.go
@@ -10,7 +10,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // PluginEntry is a structure that is used to indicate to the system a K8s plugin
 type PluginEntry struct {

--- a/flyteplugins/go/tasks/pluginmachinery/webapi/plugin.go
+++ b/flyteplugins/go/tasks/pluginmachinery/webapi/plugin.go
@@ -16,7 +16,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // A Lazy loading function, that will load the plugin. Plugins should be initialized in this method. It is guaranteed
 // that the plugin loader will be called before any Handle/Abort/Finalize functions are invoked

--- a/flyteplugins/go/tasks/pluginmachinery/workqueue/queue.go
+++ b/flyteplugins/go/tasks/pluginmachinery/workqueue/queue.go
@@ -15,7 +15,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 //go:generate enumer --type=WorkStatus
 
 type WorkItemID = string

--- a/flyteplugins/go/tasks/plugins/array/awsbatch/client.go
+++ b/flyteplugins/go/tasks/plugins/array/awsbatch/client.go
@@ -19,7 +19,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/utils"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // AWS Batch Client interface.
 type Client interface {

--- a/flyteplugins/go/tasks/plugins/array/core/state.go
+++ b/flyteplugins/go/tasks/plugins/array/core/state.go
@@ -17,7 +17,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 //go:generate enumer -type=Phase
 
 type Phase uint8

--- a/flyteplugins/go/tasks/plugins/hive/client/qubole_client.go
+++ b/flyteplugins/go/tasks/plugins/hive/client/qubole_client.go
@@ -66,7 +66,7 @@ type RequestBody struct {
 	Files        string   `json:"files,omitempty"`
 }
 
-//go:generate mockery-v2 --all --case=snake --with-expecter
+//go:generate mockery --all --case=snake --with-expecter
 
 // Interface to interact with QuboleClient for hive tasks
 type QuboleClient interface {

--- a/flyteplugins/go/tasks/plugins/presto/client/presto_client.go
+++ b/flyteplugins/go/tasks/plugins/presto/client/presto_client.go
@@ -17,7 +17,7 @@ type PrestoExecuteResponse struct {
 	NextURI string `json:"nextUri,omitempty"`
 }
 
-//go:generate mockery-v2 --all --case=snake --with-expecter
+//go:generate mockery --all --case=snake --with-expecter
 
 // Interface to interact with PrestoClient for Presto tasks
 type PrestoClient interface {

--- a/flytepropeller/events/node_event_recorder.go
+++ b/flytepropeller/events/node_event_recorder.go
@@ -16,7 +16,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery-v2 --all --output=mocks --case=underscore --with-expecter
+//go:generate mockery --all --output=mocks --case=underscore --with-expecter
 
 // NodeEventRecorder records Node events
 type NodeEventRecorder interface {

--- a/flytepropeller/events/task_event_recorder.go
+++ b/flytepropeller/events/task_event_recorder.go
@@ -16,7 +16,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery-v2 --all --output=mocks --case=underscore --with-expecter
+//go:generate mockery --all --output=mocks --case=underscore --with-expecter
 
 // Recorder for Task events
 type TaskEventRecorder interface {

--- a/flytepropeller/events/workflow_event_recorder.go
+++ b/flytepropeller/events/workflow_event_recorder.go
@@ -16,7 +16,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery-v2 --all --output=mocks --case=underscore --with-expecter
+//go:generate mockery --all --output=mocks --case=underscore --with-expecter
 
 // Recorder for Workflow events
 type WorkflowEventRecorder interface {

--- a/flytepropeller/manager/shardstrategy/shard_strategy.go
+++ b/flytepropeller/manager/shardstrategy/shard_strategy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery-v2 --name ShardStrategy --case=underscore --with-expecter
+//go:generate mockery --name ShardStrategy --case=underscore --with-expecter
 
 // ShardStrategy defines necessary functionality for a sharding strategy.
 type ShardStrategy interface {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
@@ -19,7 +19,7 @@ import (
 // The intention of these interfaces is to decouple the algorithm and usage from the actual CRD definition.
 // this would help in ease of changes underneath without affecting the code.
 
-//go:generate mockery-v2 --all --with-expecter
+//go:generate mockery --all --with-expecter
 
 type CustomState map[string]interface{}
 type WorkflowID = string

--- a/flytepropeller/pkg/compiler/common/builder.go
+++ b/flytepropeller/pkg/compiler/common/builder.go
@@ -19,7 +19,7 @@ const (
 	EdgeDirectionUpstream
 )
 
-//go:generate mockery-v2 --all --output=mocks --case=underscore --with-expecter
+//go:generate mockery --all --output=mocks --case=underscore --with-expecter
 
 // A mutable workflow used during the build of the intermediate layer.
 type WorkflowBuilder interface {

--- a/flytepropeller/pkg/controller/executors/dag_structure.go
+++ b/flytepropeller/pkg/controller/executors/dag_structure.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery-v2 --name DAGStructure --name DAGStructureWithStartNode --case=underscore --with-expecter
+//go:generate mockery --name DAGStructure --name DAGStructureWithStartNode --case=underscore --with-expecter
 
 // An interface that captures the Directed Acyclic Graph structure in which the nodes are connected.
 // If NodeLookup and DAGStructure are used together a traversal can be implemented.

--- a/flytepropeller/pkg/controller/executors/execution_context.go
+++ b/flytepropeller/pkg/controller/executors/execution_context.go
@@ -4,7 +4,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 type TaskDetailsGetter interface {
 	GetTask(id v1alpha1.TaskID) (v1alpha1.ExecutableTask, error)

--- a/flytepropeller/pkg/controller/executors/kube.go
+++ b/flytepropeller/pkg/controller/executors/kube.go
@@ -13,7 +13,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
-//go:generate mockery-v2 --name Client --case=underscore --with-expecter
+//go:generate mockery --name Client --case=underscore --with-expecter
 
 // Client is a friendlier controller-runtime client that gets passed to executors
 type Client interface {

--- a/flytepropeller/pkg/controller/executors/node_lookup.go
+++ b/flytepropeller/pkg/controller/executors/node_lookup.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery-v2 --name NodeLookup --case=underscore --with-expecter
+//go:generate mockery --name NodeLookup --case=underscore --with-expecter
 
 // NodeLookup provides a structure that enables looking up all nodes within the current execution hierarchy/context.
 // NOTE: execution hierarchy may change the nodes available, this is because when a SubWorkflow is being executed, only

--- a/flytepropeller/pkg/controller/executors/workflow.go
+++ b/flytepropeller/pkg/controller/executors/workflow.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery-v2 --name Workflow --case=underscore --with-expecter
+//go:generate mockery --name Workflow --case=underscore --with-expecter
 
 type Workflow interface {
 	Initialize(ctx context.Context) error

--- a/flytepropeller/pkg/controller/interfaces/rate_limiter.go
+++ b/flytepropeller/pkg/controller/interfaces/rate_limiter.go
@@ -7,8 +7,8 @@ import (
 	"golang.org/x/time/rate"
 )
 
-//go:generate mockery-v2 --name Limiter --output ../mocks --case=snake --with-expecter
-//go:generate mockery-v2 --name Reservation --output ../mocks --case=snake --with-expecter
+//go:generate mockery --name Limiter --output ../mocks --case=snake --with-expecter
+//go:generate mockery --name Reservation --output ../mocks --case=snake --with-expecter
 
 type Limiter interface {
 	Allow() bool

--- a/flytepropeller/pkg/controller/nodes/array/handler.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler.go
@@ -48,7 +48,7 @@ var (
 	}
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // arrayNodeHandler is a handle implementation for processing array nodes
 type arrayNodeHandler struct {

--- a/flytepropeller/pkg/controller/nodes/dynamic/handler.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/handler.go
@@ -22,7 +22,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 const dynamicNodeID = "dynamic-node"
 

--- a/flytepropeller/pkg/controller/nodes/gate/handler.go
+++ b/flytepropeller/pkg/controller/nodes/gate/handler.go
@@ -18,7 +18,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // SignalServiceClient is a SignalServiceClient wrapper interface used specifically for generating
 // mocks for testing

--- a/flytepropeller/pkg/controller/nodes/interfaces/handler.go
+++ b/flytepropeller/pkg/controller/nodes/interfaces/handler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // NodeExecutor defines the interface for handling a single Flyte Node of any Node type.
 type NodeExecutor interface {

--- a/flytepropeller/pkg/controller/nodes/interfaces/handler_factory.go
+++ b/flytepropeller/pkg/controller/nodes/interfaces/handler_factory.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery-v2 --name HandlerFactory --case=underscore --with-expecter
+//go:generate mockery --name HandlerFactory --case=underscore --with-expecter
 
 type HandlerFactory interface {
 	GetHandler(kind v1alpha1.NodeKind) (NodeHandler, error)

--- a/flytepropeller/pkg/controller/nodes/interfaces/node.go
+++ b/flytepropeller/pkg/controller/nodes/interfaces/node.go
@@ -9,7 +9,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // p of the node
 type NodePhase int

--- a/flytepropeller/pkg/controller/nodes/interfaces/node_exec_context.go
+++ b/flytepropeller/pkg/controller/nodes/interfaces/node_exec_context.go
@@ -15,7 +15,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 type TaskReader interface {
 	Read(ctx context.Context) (*core.TaskTemplate, error)

--- a/flytepropeller/pkg/controller/nodes/output_resolver.go
+++ b/flytepropeller/pkg/controller/nodes/output_resolver.go
@@ -14,7 +14,7 @@ import (
 
 type VarName = string
 
-//go:generate mockery-v2 --name=OutputResolver --case=underscore --with-expecter
+//go:generate mockery --name=OutputResolver --case=underscore --with-expecter
 
 type OutputResolver interface {
 	// Extracts a subset of node outputs to literals.

--- a/flytepropeller/pkg/controller/nodes/recovery/client.go
+++ b/flytepropeller/pkg/controller/nodes/recovery/client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 )
 
-//go:generate mockery-v2 --name Client --output=mocks --case=underscore --with-expecter
+//go:generate mockery --name Client --output=mocks --case=underscore --with-expecter
 
 type Client interface {
 	RecoverNodeExecution(ctx context.Context, execID *core.WorkflowExecutionIdentifier, nodeID string) (*admin.NodeExecution, error)

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/launchplan.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/launchplan.go
@@ -8,7 +8,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // LaunchContext is a simple context that is used to start an execution of a LaunchPlan. It encapsulates enough parent information
 // to tie the executions

--- a/flytepropeller/pkg/controller/nodes/task/resourcemanager/redis_client.go
+++ b/flytepropeller/pkg/controller/nodes/task/resourcemanager/redis_client.go
@@ -9,7 +9,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
-//go:generate mockery-v2 --name RedisClient --case=underscore --with-expecter
+//go:generate mockery --name RedisClient --case=underscore --with-expecter
 
 type RedisClient interface {
 	// A pass-through method. Getting the cardinality of the Redis set

--- a/flytepropeller/pkg/controller/workflowstore/iface.go
+++ b/flytepropeller/pkg/controller/workflowstore/iface.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery-v2 --all --with-expecter
+//go:generate mockery --all --with-expecter
 
 type PriorityClass int
 

--- a/flytepropeller/pkg/webhook/global_secrets.go
+++ b/flytepropeller/pkg/webhook/global_secrets.go
@@ -12,7 +12,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 type GlobalSecretProvider interface {
 	GetForSecret(ctx context.Context, secret *coreIdl.Secret) (string, error)

--- a/flytestdlib/cache/auto_refresh.go
+++ b/flytestdlib/cache/auto_refresh.go
@@ -13,7 +13,7 @@ const (
 	ErrNotFound errors.ErrorCode = "NOT_FOUND"
 )
 
-//go:generate mockery-v2 --all --with-expecter
+//go:generate mockery --all --with-expecter
 
 // AutoRefresh with regular GetOrCreate and Delete along with background asynchronous refresh. Caller provides
 // callbacks for create, refresh and delete item.

--- a/flytestdlib/fastcheck/iface.go
+++ b/flytestdlib/fastcheck/iface.go
@@ -14,7 +14,7 @@ import (
 // resolution
 // The Data-structure is thread-safe and can be accessed by multiple threads concurrently.
 
-//go:generate mockery-v2 --name Filter --case=underscore --with-expecter
+//go:generate mockery --name Filter --case=underscore --with-expecter
 
 type Filter interface {
 	// Contains returns a True if the id was previously seen or false otherwise

--- a/flytestdlib/random/weighted_random_list.go
+++ b/flytestdlib/random/weighted_random_list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // Interface to use the Weighted Random
 type WeightedRandomList interface {

--- a/flytestdlib/storage/storage.go
+++ b/flytestdlib/storage/storage.go
@@ -105,7 +105,7 @@ type SignedURLResponse struct {
 	RequiredRequestHeaders map[string]string
 }
 
-//go:generate mockery-v2 --name RawStore --case=underscore --with-expecter
+//go:generate mockery --name RawStore --case=underscore --with-expecter
 
 // RawStore defines a low level interface for accessing and storing bytes.
 type RawStore interface {
@@ -134,7 +134,7 @@ type RawStore interface {
 	Delete(ctx context.Context, reference DataReference) error
 }
 
-//go:generate mockery-v2 --name ReferenceConstructor --case=underscore --with-expecter
+//go:generate mockery --name ReferenceConstructor --case=underscore --with-expecter
 
 // ReferenceConstructor defines an interface for building data reference paths.
 type ReferenceConstructor interface {
@@ -154,7 +154,7 @@ type ProtobufStore interface {
 	WriteProtobuf(ctx context.Context, reference DataReference, opts Options, msg proto.Message) error
 }
 
-//go:generate mockery-v2 --name ComposedProtobufStore --case=underscore --with-expecter
+//go:generate mockery --name ComposedProtobufStore --case=underscore --with-expecter
 
 // ComposedProtobufStore interface includes all the necessary data to allow a ProtobufStore to interact with storage
 // through a RawStore.

--- a/flytestdlib/utils/auto_refresh_cache.go
+++ b/flytestdlib/utils/auto_refresh_cache.go
@@ -12,7 +12,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
-//go:generate mockery-v2 --all --case=underscore --with-expecter
+//go:generate mockery --all --case=underscore --with-expecter
 
 // AutoRefreshCache with regular GetOrCreate and Delete along with background asynchronous refresh. Caller provides
 // callbacks for create, refresh and delete item.


### PR DESCRIPTION
## Tracking issue
Related to https://github.com/flyteorg/flyte/commit/d5499e8d737d4e75b6d4ac1753a542560143b870

## Why are the changes needed?
Cleans up old logic for handling multiple versions of mockery.

## What changes were proposed in this pull request?
Remove logic for handling the old fork of mockery. 

## How was this patch tested?
Unit Tests 

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR streamlines mock generation tooling by removing legacy code handling multiple mockery versions and standardizing on a single mockery implementation. The changes involve updating go:generate directives across packages to use the standard mockery command, removing fork logic, and simplifying the build process.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 5
</div>