### PR TITLE
Don't error out for getting metrics of array node

### DIFF
--- a/flyteadmin/pkg/manager/impl/metrics_manager.go
+++ b/flyteadmin/pkg/manager/impl/metrics_manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
+	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
@@ -427,7 +428,8 @@ func (m *MetricsManager) parseNodeExecution(ctx context.Context, nodeExecution *
 				err = fmt.Errorf("failed to identify workflow node type for node: %+v", target)
 			}
 		default:
-			err = fmt.Errorf("failed to identify node type for node: %+v", target)
+			logger.Warnf(ctx, "unsupported node type")
+			// We don't error out here so that users can still get metrics of other nodes
 		}
 
 		if err != nil {


### PR DESCRIPTION

## Why are the changes needed?
Currently if we get the metrics of an execution containing array nodes, we'll get 504 because we haven't implemented the functionality for array node. However, users may still want to get the metrics of other nodes.

## What changes were proposed in this pull request?
Don't error out for getting metrics of array node

## How was this patch tested?

Tested with sandbox
Before:
![Screenshot 2025-02-28 at 12 50 10 PM](https://github.com/user-attachments/assets/99b003ec-7421-4490-a16b-bc0ced35c739)
After:
![Screenshot 2025-02-28 at 12 50 43 PM](https://github.com/user-attachments/assets/c7332680-aee0-4647-9b27-622f2a5abb2c)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes an issue with array node metrics in Flyte admin by replacing error throwing with warning logs, allowing the system to continue processing other node metrics. The changes improve system resilience and ensure metrics availability even when encountering unimplemented node types.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>