### PR TITLE
Add aws secret mamager support to env_var

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/taskexec_context.go
+++ b/flytepropeller/pkg/controller/nodes/task/taskexec_context.go
@@ -233,8 +233,7 @@ func ComputePreviousCheckpointPath(ctx context.Context, length int, nCtx interfa
 		return nCtx.NodeStateReader().GetTaskNodeState().PreviousNodeExecutionCheckpointURI, nil
 	}
 	// Otherwise derive previous checkpoint path from the prior attempt
-	prevAttempt := currentAttempt - 1
-	prevRawOutputPrefix, _, err := ComputeRawOutputPrefix(ctx, length, nCtx, currentNodeUniqueID, prevAttempt)
+	prevRawOutputPrefix, _, err := ComputeRawOutputPrefix(ctx, length, nCtx, currentNodeUniqueID, currentAttempt-1)
 	if err != nil {
 		return "", err
 	}

--- a/flytepropeller/pkg/controller/nodes/task/taskexec_context.go
+++ b/flytepropeller/pkg/controller/nodes/task/taskexec_context.go
@@ -233,7 +233,8 @@ func ComputePreviousCheckpointPath(ctx context.Context, length int, nCtx interfa
 		return nCtx.NodeStateReader().GetTaskNodeState().PreviousNodeExecutionCheckpointURI, nil
 	}
 	// Otherwise derive previous checkpoint path from the prior attempt
-	prevRawOutputPrefix, _, err := ComputeRawOutputPrefix(ctx, length, nCtx, currentNodeUniqueID, currentAttempt-1)
+	prevAttempt := currentAttempt - 1
+	prevRawOutputPrefix, _, err := ComputeRawOutputPrefix(ctx, length, nCtx, currentNodeUniqueID, prevAttempt)
 	if err != nil {
 		return "", err
 	}

--- a/flytepropeller/pkg/webhook/aws_secret_manager.go
+++ b/flytepropeller/pkg/webhook/aws_secret_manager.go
@@ -104,11 +104,16 @@ func (i AWSSecretManagerInjector) Inject(ctx context.Context, secret *core.Secre
 				Value: "",
 			},
 		}
+		if secret.GetEnvVar() != "" {
+			extraEnvVar := CreateVolumeMountEnvVarForSecretWithEnvName(secret)
+			envVars = append(envVars, extraEnvVar)
+		}
 
 		for _, envVar := range envVars {
 			p.Spec.InitContainers = AppendEnvVars(p.Spec.InitContainers, envVar)
 			p.Spec.Containers = AppendEnvVars(p.Spec.Containers, envVar)
 		}
+
 	case core.Secret_ENV_VAR:
 		fallthrough
 	default:

--- a/flytepropeller/pkg/webhook/aws_secret_manager.go
+++ b/flytepropeller/pkg/webhook/aws_secret_manager.go
@@ -113,7 +113,6 @@ func (i AWSSecretManagerInjector) Inject(ctx context.Context, secret *core.Secre
 			p.Spec.InitContainers = AppendEnvVars(p.Spec.InitContainers, envVar)
 			p.Spec.Containers = AppendEnvVars(p.Spec.Containers, envVar)
 		}
-
 	case core.Secret_ENV_VAR:
 		fallthrough
 	default:

--- a/flytepropeller/pkg/webhook/aws_secret_manager_test.go
+++ b/flytepropeller/pkg/webhook/aws_secret_manager_test.go
@@ -16,12 +16,17 @@ func TestAWSSecretManagerInjector_Inject(t *testing.T) {
 	injector := NewAWSSecretManagerInjector(config.DefaultConfig.AWSSecretManagerConfig)
 	p := &corev1.Pod{
 		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{},
+			Containers: []corev1.Container{
+				{
+					Name: "container1",
+				},
+			},
 		},
 	}
 	inputSecret := &core.Secret{
-		Group: "arn",
-		Key:   "name",
+		Group:  "arn",
+		Key:    "name",
+		EnvVar: "MY_SECRET_VAR",
 	}
 
 	expected := &corev1.Pod{
@@ -58,6 +63,10 @@ func TestAWSSecretManagerInjector_Inject(t *testing.T) {
 							Name:  "FLYTE_SECRETS_FILE_PREFIX",
 							Value: "",
 						},
+						{
+							Name:  "MY_SECRET_VAR",
+							Value: "/etc/flyte/secrets/arn/name",
+						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -68,7 +77,32 @@ func TestAWSSecretManagerInjector_Inject(t *testing.T) {
 					Resources: config.DefaultConfig.AWSSecretManagerConfig.Resources,
 				},
 			},
-			Containers: []corev1.Container{},
+			Containers: []corev1.Container{
+				{
+					Name: "container1",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "FLYTE_SECRETS_DEFAULT_DIR",
+							Value: "/etc/flyte/secrets",
+						},
+						{
+							Name:  "FLYTE_SECRETS_FILE_PREFIX",
+							Value: "",
+						},
+						{
+							Name:  "MY_SECRET_VAR",
+							Value: "/etc/flyte/secrets/arn/name",
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "aws-secret-vol",
+							MountPath: "/etc/flyte/secrets",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/6304

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
The `env_var` was not supported with the AWS secret manager.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR adds `env_var` support to AWS.


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests were added. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request adds support for an env_var option in the AWS secret manager integration. The production code now injects an extra environment variable when a secret has a non-empty env_var value. Test files have been updated comprehensively to check for correct container configurations and volume mounts.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>