### PR TITLE
Doc: Explain how to chain launch plans

### DIFF
--- a/docs/user_guide/advanced_composition/chaining_flyte_entities.md
+++ b/docs/user_guide/advanced_composition/chaining_flyte_entities.md
@@ -7,7 +7,7 @@
 ```
 
 Flytekit offers a mechanism for chaining Flyte entities using the `>>` operator.
-This is particularly valuable when chaining tasks and subworkflows without the need for data flow between the entities.
+This is particularly valuable when chaining tasks, subworkflows, and launch plans without the need for data flow between the entities.
 
 ```{note}
 To clone and run the example code on this page, see the [Flytesnacks repo][flytesnacks].
@@ -32,6 +32,16 @@ Just like tasks, you can chain {ref}`subworkflows <subworkflow>`.
 :lines: 34-49
 ```
 
+## Launch plans
+
+Like subworkflows, you can chain {ref}`launch plans <Launch plans>`.
+
+
+```{literalinclude} /examples/advanced_composition/advanced_composition/chain_entities.py
+:caption: advanced_composition/chain_entities.py
+:lines: 53-58
+```
+
 To run the provided workflows on the Flyte cluster, use the following commands:
 
 ```
@@ -46,8 +56,15 @@ pyflyte run --remote \
   chain_workflows_wf
 ```
 
+TODO: update commit hash after PR in flytesnacks is merged
+```
+pyflyte run --remote \
+  https://raw.githubusercontent.com/flyteorg/flytesnacks/69dbe4840031a85d79d9ded25f80397c6834752d/examples/advanced_composition/advanced_composition/chain_entities.py \
+  chain_launchplans_wf
+```
+
 :::{note}
-Chaining tasks and subworkflows is not supported in local environments.
+Chaining tasks, subworkflows, and launch plans is not supported in local environments.
 Follow the progress of this issue [here](https://github.com/flyteorg/flyte/issues/4080).
 :::
 


### PR DESCRIPTION
## Why are the changes needed?

We currently don't provide an example for launch plan chaining in the docs and users asked me about this.
See added example in https://github.com/flyteorg/flytesnacks/pull/1783.

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flytesnacks/pull/1783

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
