### PR TITLE
Fix: fastcache should not cache lookup on failed node

### DIFF
--- a/flytepropeller/pkg/controller/nodes/executor.go
+++ b/flytepropeller/pkg/controller/nodes/executor.go
@@ -977,7 +977,7 @@ func (c *nodeExecutor) handleNotYetStartedNode(ctx context.Context, dag executor
 	}
 
 	var cacheStatus *catalog.Status
-	if cacheHandler, ok := h.(interfaces.CacheableNodeHandler); p.GetPhase() != handler.EPhaseSkip && ok {
+	if cacheHandler, ok := h.(interfaces.CacheableNodeHandler); p.GetPhase() != handler.EPhaseSkip && p.GetPhase() != handler.EPhaseFailed && ok {
 		cacheable, _, err := cacheHandler.IsCacheable(ctx, nCtx)
 		if err != nil {
 			logger.Errorf(ctx, "failed to determine if node is cacheable with err '%s'", err.Error())


### PR DESCRIPTION
## Why are the changes needed?

See [here](https://github.com/flyteorg/flyte/pull/4524#issuecomment-2633583071) for bug description.

> Looking at [this line](https://github.com/flyteorg/flyte/blob/master/flytepropeller/pkg/controller/nodes/executor.go#L980-L980) (the check you linked), the easy fix is to add && p.GetPhase() != handler.EPhaseFailed as you suggest. I'm wondering if we can consolidate these to p.GetPhase() == EPhaseQueued"? because the preExecute` function returns Queued whenever the inputs correctly resolve. Anything else would not require a cache lookup. ([source](https://github.com/flyteorg/flyte/pull/4524#issuecomment-2638104081))

@hamersaw let's go for the `p.GetPhase() != handler.EPhaseFailed` because I'm convinced this is a correct fix and I'm not 100% sure consolidating to ` p.GetPhase() == EPhaseQueued` is.

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

[<!-- Add related pull requests for reviewers to check -->](https://github.com/flyteorg/flyte/pull/4524)

