### PR TITLE
upstream bound inputs support

### DIFF
--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/array.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/array.go
@@ -5,6 +5,7 @@ type ArrayNodeSpec struct {
 	Parallelism     *uint32
 	MinSuccesses    *uint32
 	MinSuccessRatio *float32
+	BoundInputs     []string
 }
 
 func (a *ArrayNodeSpec) GetSubNodeSpec() *NodeSpec {
@@ -21,4 +22,8 @@ func (a *ArrayNodeSpec) GetMinSuccesses() *uint32 {
 
 func (a *ArrayNodeSpec) GetMinSuccessRatio() *float32 {
 	return a.MinSuccessRatio
+}
+
+func (a *ArrayNodeSpec) GetBoundInputs() []string {
+	return a.BoundInputs
 }

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
@@ -259,6 +259,7 @@ type ExecutableArrayNode interface {
 	GetParallelism() *uint32
 	GetMinSuccesses() *uint32
 	GetMinSuccessRatio() *float32
+	GetBoundInputs() []string
 }
 
 type ExecutableWorkflowNodeStatus interface {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks/ExecutableArrayNode.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks/ExecutableArrayNode.go
@@ -20,6 +20,53 @@ func (_m *ExecutableArrayNode) EXPECT() *ExecutableArrayNode_Expecter {
 	return &ExecutableArrayNode_Expecter{mock: &_m.Mock}
 }
 
+// GetBoundInputs provides a mock function with given fields:
+func (_m *ExecutableArrayNode) GetBoundInputs() []string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBoundInputs")
+	}
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	return r0
+}
+
+// ExecutableArrayNode_GetBoundInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBoundInputs'
+type ExecutableArrayNode_GetBoundInputs_Call struct {
+	*mock.Call
+}
+
+// GetBoundInputs is a helper method to define mock.On call
+func (_e *ExecutableArrayNode_Expecter) GetBoundInputs() *ExecutableArrayNode_GetBoundInputs_Call {
+	return &ExecutableArrayNode_GetBoundInputs_Call{Call: _e.mock.On("GetBoundInputs")}
+}
+
+func (_c *ExecutableArrayNode_GetBoundInputs_Call) Run(run func()) *ExecutableArrayNode_GetBoundInputs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ExecutableArrayNode_GetBoundInputs_Call) Return(_a0 []string) *ExecutableArrayNode_GetBoundInputs_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ExecutableArrayNode_GetBoundInputs_Call) RunAndReturn(run func() []string) *ExecutableArrayNode_GetBoundInputs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetMinSuccessRatio provides a mock function with given fields:
 func (_m *ExecutableArrayNode) GetMinSuccessRatio() *float32 {
 	ret := _m.Called()

--- a/flytepropeller/pkg/compiler/transformers/k8s/node.go
+++ b/flytepropeller/pkg/compiler/transformers/k8s/node.go
@@ -203,6 +203,8 @@ func buildNodeSpec(n *core.Node, tasks []*core.CompiledTask, errs errors.Compile
 		case *core.ArrayNode_MinSuccessRatio:
 			nodeSpec.ArrayNode.MinSuccessRatio = &successCriteria.MinSuccessRatio
 		}
+
+		nodeSpec.ArrayNode.BoundInputs = arrayNode.GetBoundInputs()
 	default:
 		if n.GetId() == v1alpha1.StartNodeID {
 			nodeSpec.Kind = v1alpha1.NodeKindStart

--- a/flytepropeller/pkg/controller/nodes/array/handler.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler.go
@@ -245,7 +245,7 @@ func (a *arrayNodeHandler) Handle(ctx context.Context, nCtx interfaces.NodeExecu
 
 		if size == -1 {
 			// handles case where all inputs are bound
-			if len(arrayNode.GetBoundInputs()) == len(literalMap.Literals) {
+			if len(arrayNode.GetBoundInputs()) == len(literalMap.GetLiterals()) {
 				size = 1
 			} else {
 				return handler.DoTransition(handler.TransitionTypeEphemeral,

--- a/flytepropeller/pkg/controller/nodes/array/handler.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"time"
 
@@ -207,6 +208,11 @@ func (a *arrayNodeHandler) Handle(ctx context.Context, nCtx interfaces.NodeExecu
 		for key, variable := range literalMap.GetLiterals() {
 			literalType := validators.LiteralTypeForLiteral(variable)
 			err := validators.ValidateLiteralType(literalType)
+
+			if slices.Contains(arrayNode.GetBoundInputs(), key) {
+				continue
+			}
+
 			if err != nil {
 				errMsg := fmt.Sprintf("Failed to validate literal type for [%s] with err: %s", key, err)
 				return handler.DoTransition(handler.TransitionTypeEphemeral,
@@ -238,9 +244,14 @@ func (a *arrayNodeHandler) Handle(ctx context.Context, nCtx interfaces.NodeExecu
 		}
 
 		if size == -1 {
-			return handler.DoTransition(handler.TransitionTypeEphemeral,
-				handler.PhaseInfoFailure(idlcore.ExecutionError_USER, errors.InvalidArrayLength, "no input array provided", nil),
-			), nil
+			// handles case where all inputs are bound
+			if len(arrayNode.GetBoundInputs()) == len(literalMap.Literals) {
+				size = 1
+			} else {
+				return handler.DoTransition(handler.TransitionTypeEphemeral,
+					handler.PhaseInfoFailure(idlcore.ExecutionError_USER, errors.InvalidArrayLength, "no input array provided", nil),
+				), nil
+			}
 		}
 
 		// initialize ArrayNode state
@@ -769,7 +780,7 @@ func (a *arrayNodeHandler) buildArrayNodeContext(ctx context.Context, nCtx inter
 		return nil, nil, nil, nil, nil, nil, err
 	}
 
-	inputLiteralMap, err := constructLiteralMap(inputs, subNodeIndex)
+	inputLiteralMap, err := constructLiteralMap(inputs, subNodeIndex, arrayNode)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, err
 	}


### PR DESCRIPTION
## Tracking issue
fixes: https://linear.app/unionai/issue/BB-3499/cannot-pass-arguments-of-type-list-to-a-partial-function-that-will-be
fixes: https://github.com/flyteorg/flyte/issues/4325

Related: https://github.com/flyteorg/flytekit/pull/3185 + https://github.com/flyteorg/flytekit/pull/3187

## Why are the changes needed?
Add list support for mapping over partials

## What changes were proposed in this pull request?
Upstream some of the bound inputs support for private fork. ArrayNode handler now has context to determine which inputs are bound.

## How was this patch tested?
```
from flytekit import map_task, task, workflow

import functools
import typing


@task
def demo_task(strings: typing.List[str], num: int) -> str:
    return f"{num}".join(strings)


@workflow
def demo_wf(strings: typing.List[str] = ["a", "b", "c"], nums: typing.List[int] = [1, 2]) -> None:
    map_task(functools.partial(demo_task, strings=strings))(num=nums)
```
![image](https://github.com/user-attachments/assets/b80fc3da-35bd-4fd7-abce-4eb4b0b11507)

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request introduces support for bound inputs in array nodes by adding a new GetBoundInputs API method and corresponding field for tracking bound inputs in array node specifications. The changes encompass API modifications, internal transformation logic updates, and handler implementation adjustments, with comprehensive test coverage for the new functionality.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 3
</div>