### PR TITLE
Use child dir for branch taken

### DIFF
--- a/flytepropeller/pkg/controller/nodes/branch/handler.go
+++ b/flytepropeller/pkg/controller/nodes/branch/handler.go
@@ -161,7 +161,7 @@ func (b *branchHandler) recurseDownstream(ctx context.Context, nCtx interfaces.N
 	if downstreamStatus.IsComplete() {
 		childOutputsPath := v1alpha1.GetOutputsFile(childOutputDir)
 		outputsPath := v1alpha1.GetOutputsFile(nCtx.NodeStatus().GetOutputDir())
-		if err := nCtx.DataStore().CopyRaw(ctx, childOutputsPath, outputsPath, storage.Options{}); err != nil {
+		if err := nCtx.DataStore().CopyRaw(ctx, childOutputsPath, outputsPath, storage.Options{}); err != nil && !storage.IsNotFound(err) {
 			errMsg := fmt.Sprintf("Failed to copy child node outputs from [%v] to [%v]", childOutputsPath, outputsPath)
 			return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoFailure(core.ExecutionError_SYSTEM, errors.OutputsNotFoundError, errMsg, nil)), nil
 		}


### PR DESCRIPTION
## Why are the changes needed?

https://github.com/flyteorg/flyte/pull/6120 fixed a bug where we were repurposing the output dir, leading to races on data availability. However, once moving to explicit dirs and a copy, we introduced a bug where try and fail to copy a subworflow's output when there is none.

Repro
```
import flytekit as fl
from flytekit.core.task import Echo

echo = Echo(name="echo")

@fl.task
def t1():
    pass

@fl.workflow
def sub():
    t1()

@fl.workflow
def cond_wf(val: str):
    _ = (
        fl.conditional("conditional")
        .if_(val != "")
        .then(
            sub()
        )
        .else_()
        .then(echo())
    )
```

## How was this patch tested?

- [x] Add unittests
- [x] Repro example resolved when running locally

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flyte/pull/6120 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes a critical bug in branch node handler by ignoring non-critical 'not found' errors during raw output copying. The update enhances error handling, improves subworkflow output management, and reduces race condition risks. Test suite improvements include a new flag to simulate output presence and updated test expectations.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>