### PR TITLE
Revert "Pin flytekit to 1.15.0 to unblock functional tests"

### DIFF
--- a/.github/workflows/single-binary.yml
+++ b/.github/workflows/single-binary.yml
@@ -176,7 +176,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install uv
-          uv pip install --system flytekit==1.15.0 flytekitplugins-deck-standard==1.15.0 "numpy<2.0.0" pyarrow pandas
+          uv pip install --system flytekit flytekitplugins-deck-standard "numpy<2.0.0" pyarrow pandas
           uv pip freeze
       - name: Checkout flytesnacks
         uses: actions/checkout@v4


### PR DESCRIPTION
Reverts flyteorg/flyte#6330

Preemptively getting this out, while we waiting for https://github.com/flyteorg/flytekit/pull/3188/ and the next flytekit release.