### PR TITLE
Update Event Docs

### DIFF
--- a/docs/deployment/configuration/cloud_event.rst
+++ b/docs/deployment/configuration/cloud_event.rst
@@ -66,7 +66,7 @@ To turn on, add the following to your FlyteAdmin:
            cloudEvents:
              enable: true
              gcp:
-               region: us-east-2
+               projectId: my-project-id
              eventsPublisher:
                eventTypes:
                - all # or node, task, workflow

--- a/docs/deployment/configuration/eventing.rst
+++ b/docs/deployment/configuration/eventing.rst
@@ -27,19 +27,39 @@ Configuration
 
 To turn on, add the following to your FlyteAdmin:
 
-.. code:: yaml
 
-  external_events.yaml: |
-    externalEvents:
-      enable: true
-      aws:
-        region: us-east-2
-      eventsPublisher:
-        eventTypes:
-        - all
-        topicName: arn:aws:sns:us-east-2:123456:123-my-topic
-      type: aws
+.. tabs::
 
+   .. tab:: AWS SNS
+   
+       .. code:: yaml
+   
+         cloud_events.yaml: |
+           cloudEvents:
+             enable: true
+             aws:
+               region: us-east-2
+             eventsPublisher:
+               eventTypes:
+               - all # or node, task, workflow
+               topicName: arn:aws:sns:us-east-2:123456:123-my-topic
+             type: aws
+   
+   .. tab:: GCP Pub/Sub
+   
+       .. code:: yaml
+   
+         cloud_events.yaml: |
+           cloudEvents:
+             enable: true
+             gcp:
+               projectId: my-project-id
+             eventsPublisher:
+               eventTypes:
+               - all # or node, task, workflow
+               topicName: my-topic
+             type: gcp
+   
 Helm
 ====
 


### PR DESCRIPTION
## Tracking issue
Closes  #3663 

## Why are the changes needed?

Documentation was incorrect. For GCP you need projectId instead of region.

## What changes were proposed in this pull request?

Setup correct Helm values for GCP.

## How was this patch tested?

Tested in CI. Updated a few lines in docs.

### Labels

**changed**

### Setup process

N/A

### Screenshots

N/A


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

N/A

## Docs link

N/A 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR updates event documentation by fixing configuration parameters and enhancing clarity. It removes outdated AWS examples, introduces a tabbed layout for AWS SNS and GCP Pub/Sub, and correctly uses projectId for GCP instead of region. These changes improve documentation accuracy and usability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>