### PR TITLE
fix: really assign string scp claim

### DIFF
--- a/flyteadmin/auth/authzserver/claims_verifier.go
+++ b/flyteadmin/auth/authzserver/claims_verifier.go
@@ -52,7 +52,7 @@ func verifyClaims(expectedAudience sets.String, claimsRaw map[string]interface{}
 		case []interface{}:
 			scopes = sets.NewString(interfaceSliceToStringSlice(sct)...)
 		case string:
-			sets.NewString(fmt.Sprintf("%v", scopesClaim))
+			scopes = sets.NewString(fmt.Sprintf("%v", scopesClaim))
 		default:
 			return nil, fmt.Errorf("failed getting scope claims due to  unknown type %T with value %v", sct, sct)
 		}

--- a/flyteadmin/auth/authzserver/claims_verifier_test.go
+++ b/flyteadmin/auth/authzserver/claims_verifier_test.go
@@ -79,12 +79,12 @@ func Test_verifyClaims(t *testing.T) {
 		identityCtx, err := verifyClaims(sets.NewString("https://myserver", "https://myserver2"),
 			map[string]interface{}{
 				"aud": []string{"https://myserver"},
-				"scp": "all",
+				"scp": "my-scope",
 			})
 
 		assert.NoError(t, err)
 		assert.Equal(t, "https://myserver", identityCtx.Audience())
-		assert.Equal(t, sets.NewString("all"), identityCtx.Scopes())
+		assert.Equal(t, sets.NewString("my-scope"), identityCtx.Scopes())
 	})
 	t.Run("unknown scope", func(t *testing.T) {
 		identityCtx, err := verifyClaims(sets.NewString("https://myserver", "https://myserver2"),


### PR DESCRIPTION
## Why are the changes needed?
because before this change string formatted claims were ignored.

## How was this patch tested?

I did run it against keycloak, which was forced to send `scp` claim as string. I.e. `"scp": "all"`

### Labels

- **fixed**: String formatted scp claim now works 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes a critical bug in the authentication module where string formatted scp claims were incorrectly handled. The fix corrects assignment logic in the claims verifier and updates test cases to verify proper scope value processing. The implementation was verified against keycloak to ensure robustness.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>