### PR TITLE
fix typo: specify -> specific

### DIFF
--- a/docs/user_guide/customizing_dependencies/imagespec.md
+++ b/docs/user_guide/customizing_dependencies/imagespec.md
@@ -74,7 +74,7 @@ image_spec = ImageSpec(
 )
 ```
 
-## Import modules only in a specify imageSpec environment
+## Import modules only in a specific imageSpec environment
 
 `is_container()` is used to determine whether the task is utilizing the image constructed from the `ImageSpec`.
 If the task is indeed using the image built from the `ImageSpec`, it will return true.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Just fixing a grammatical error in the docs. Text said "in a specify imageSpec environment" instead of "in a _specific_ imageSpec environment"

