### PR TITLE
[FIX] Error when using different primary container name in driver and executor

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -746,20 +746,20 @@ func MergeBasePodSpecOntoTemplate(templatePodSpec *v1.PodSpec, basePodSpec *v1.P
 					return nil, err
 				}
 			}
-		}
+		} else {
+			// Check for any name matching template containers
+			for _, templateContainer := range templatePodSpec.Containers {
+				if templateContainer.Name != container.Name {
+					continue
+				}
 
-		// Check for any name matching template containers
-		for _, templateContainer := range templatePodSpec.Containers {
-			if templateContainer.Name != container.Name {
-				continue
-			}
-
-			if mergedContainer == nil {
-				mergedContainer = &templateContainer
-			} else {
-				err := mergo.Merge(mergedContainer, templateContainer, mergo.WithOverride, mergo.WithAppendSlice)
-				if err != nil {
-					return nil, err
+				if mergedContainer == nil {
+					mergedContainer = &templateContainer
+				} else {
+					err := mergo.Merge(mergedContainer, templateContainer, mergo.WithOverride, mergo.WithAppendSlice)
+					if err != nil {
+						return nil, err
+					}
 				}
 			}
 		}

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -35,7 +35,7 @@ const unsignedSIGKILL = 247
 const defaultContainerTemplateName = "default"
 const defaultInitContainerTemplateName = "default-init"
 const primaryContainerTemplateName = "primary"
-const primaryInitContainerTemplateName = "primary-init"
+const PrimaryInitContainerTemplateName = "primary-init"
 const PrimaryContainerKey = "primary_container_name"
 
 // AddRequiredNodeSelectorRequirements adds the provided v1.NodeSelectorRequirement
@@ -716,7 +716,7 @@ func MergeBasePodSpecOntoTemplate(templatePodSpec *v1.PodSpec, basePodSpec *v1.P
 	for i := 0; i < len(templatePodSpec.InitContainers); i++ {
 		if templatePodSpec.InitContainers[i].Name == defaultInitContainerTemplateName {
 			defaultInitContainerTemplate = &templatePodSpec.InitContainers[i]
-		} else if templatePodSpec.InitContainers[i].Name == primaryInitContainerTemplateName {
+		} else if templatePodSpec.InitContainers[i].Name == PrimaryInitContainerTemplateName {
 			primaryInitContainerTemplate = &templatePodSpec.InitContainers[i]
 		}
 	}

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -2100,7 +2100,7 @@ func TestMergeWithBasePodTemplate(t *testing.T) {
 		}
 
 		primaryInitContainerTemplate := v1.Container{
-			Name:                   primaryInitContainerTemplateName,
+			Name:                   PrimaryInitContainerTemplateName,
 			TerminationMessagePath: "/dev/primary-init-termination-log",
 		}
 

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -10,6 +10,11 @@ import (
 
 	sparkOp "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	sparkOpConfig "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/plugins"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/errors"
@@ -22,10 +27,6 @@ import (
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/tasklog"
 	pluginsUtils "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/flyteorg/flyte/flytestdlib/utils"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const KindSparkApplication = "SparkApplication"

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
@@ -10,6 +10,12 @@ import (
 
 	sj "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	sparkOp "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/types/known/structpb"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/plugins"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/logs"
@@ -21,11 +27,6 @@ import (
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/k8s"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
 	stdlibUtils "github.com/flyteorg/flyte/flytestdlib/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"google.golang.org/protobuf/types/known/structpb"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const sparkMainClass = "MainClass"


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?

There's a bug in Spark after this PR: https://github.com/flyteorg/flyte/pull/6262. For example, When setting primary container name in driver pod named "driver-primary", the error of `invalid TaskSpecification, container [driver-primary] not defined` is raised.

![image](https://github.com/user-attachments/assets/7bcbad11-1a1d-46a1-8573-302eec59686c)


<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

Use `MergeBasePodSpecOntoTemplate` that enables setting `primaryContainerName` and `primaryInitContainerName`.

## How was this patch tested?

Unittest is added to check if setting primary container name that's not  "primary" in driver and executor, spark can perform as expected.

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
