### PR TITLE
[Doc] Adding a hint that secretManager locally get the secret with env_var or the pair including group and key.

### DIFF
--- a/docs/user_guide/productionizing/secrets.md
+++ b/docs/user_guide/productionizing/secrets.md
@@ -105,6 +105,7 @@ Never print secret values! The example above is just for demonstration purposes.
 - In case Flyte fails to access the secret, an error is raised.
 - The `Secret` group and key are required parameters during declaration
   and usage. Failure to specify will cause a {py:class}`ValueError`.
+- You need set environment variable and get the secret by `env_var`, `group` or `key` when you run tasks locally.
 :::
 
 ### Multiple keys grouped into one secret


### PR DESCRIPTION
## Tracking issue
Related to #6302 

## Why are the changes needed?

A hint describes that the secret manager try to get the secret by env_var or the pair including group and key when running the task locally.

## How was this patch tested?

Running "make html" command in docs folder. 

### Labels
- **changed*


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

Related to #6302 

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
