### PR TITLE
[Docs] Fixing the broken link to Architecture Overview in Deployment Guide

### DIFF
--- a/docs/deployment/deployment/multicluster.rst
+++ b/docs/deployment/deployment/multicluster.rst
@@ -19,7 +19,7 @@ Scaling Beyond Kubernetes
 
 .. tip::
    
-   As described in the `Architecture Overview <https://docs.flyte.org/en/latest/concepts/architecture.html>`_,
+   As described in the :doc:`Architecture Overview </user_guide/concepts/component_architecture/index>`,
    the Flyte ``Control Plane`` sends workflows off to the ``Data Plane`` for
    execution. The data plane fulfills these workflows by launching pods in
    Kubernetes.


### PR DESCRIPTION
## Tracking issue
Related #6369 

## Why are the changes needed?

 Fixs the broken link to Architecture Overview in Deployment Guide.

## What changes were proposed in this pull request?

Updating the link to Architecture Overview with index of Component Architecture

## How was this patch tested?

following the "Contributing doc" steps and run the "make html" in the docs folder

### Labels
- **fixed**

This is important to improve the readability of release notes.

### Setup process

### Screenshots
![6369-updating-broken-link](https://github.com/user-attachments/assets/90bd08f5-97ca-4be5-96c5-6a51f767839f)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

https://flyte--6373.org.readthedocs.build/en/6373/index.html
 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request fixes a broken link in the Deployment Guide by updating the reference to the Architecture Overview using a Sphinx directive. The change improves documentation navigability and consistency without introducing broader changes, directly addressing the documentation link error.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>