### PR TITLE
Making ArrayNode taskPhaseVersion increment retries configurable (#698)

### DIFF
--- a/flytepropeller/pkg/controller/config/config.go
+++ b/flytepropeller/pkg/controller/config/config.go
@@ -122,8 +122,10 @@ var (
 		CreateFlyteWorkflowCRD:   false,
 		NodeExecutionWorkerCount: 8,
 		ArrayNode: ArrayNodeConfig{
-			EventVersion:               0,
-			DefaultParallelismBehavior: ParallelismBehaviorUnlimited,
+			EventVersion:                0,
+			DefaultParallelismBehavior:  ParallelismBehaviorUnlimited,
+			UseMapPluginLogs:            false,
+			MaxTaskPhaseVersionAttempts: 3,
 		},
 		LiteralOffloadingConfig: LiteralOffloadingConfig{
 			Enabled: false, // Default keep this disabled and we will followup when flytekit is released with the offloaded changes.
@@ -346,9 +348,10 @@ const (
 )
 
 type ArrayNodeConfig struct {
-	EventVersion               int                 `json:"event-version" pflag:",ArrayNode eventing version. 0 => legacy (drop-in replacement for maptask), 1 => new"`
-	DefaultParallelismBehavior ParallelismBehavior `json:"default-parallelism-behavior" pflag:",Default parallelism behavior for array nodes"`
-	UseMapPluginLogs           bool                `json:"use-map-plugin-logs" pflag:",Override subNode log links with those configured for the map plugin logs"`
+	EventVersion                int                 `json:"event-version" pflag:",ArrayNode eventing version. 0 => legacy (drop-in replacement for maptask), 1 => new"`
+	DefaultParallelismBehavior  ParallelismBehavior `json:"default-parallelism-behavior" pflag:",Default parallelism behavior for array nodes"`
+	UseMapPluginLogs            bool                `json:"use-map-plugin-logs" pflag:",Override subNode log links with those configured for the map plugin logs"`
+	MaxTaskPhaseVersionAttempts int                 `json:"max-task-phase-version-attempts" pflag:",Maximum number of attempts for incrementing the task phase version on events to bypass the already exists error"`
 }
 
 // GetConfig extracts the Configuration from the global config module in flytestdlib and returns the corresponding type-casted object.

--- a/flytepropeller/pkg/controller/config/config_flags.go
+++ b/flytepropeller/pkg/controller/config/config_flags.go
@@ -113,6 +113,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "array-node-config.event-version"), defaultConfig.ArrayNode.EventVersion, "ArrayNode eventing version. 0 => legacy (drop-in replacement for maptask),  1 => new")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "array-node-config.default-parallelism-behavior"), defaultConfig.ArrayNode.DefaultParallelismBehavior, "Default parallelism behavior for array nodes")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "array-node-config.use-map-plugin-logs"), defaultConfig.ArrayNode.UseMapPluginLogs, "Override subNode log links with those configured for the map plugin logs")
+	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "array-node-config.max-task-phase-version-attempts"), defaultConfig.ArrayNode.MaxTaskPhaseVersionAttempts, "Maximum number of attempts for incrementing the task phase version on events to bypass the already exists error")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "literal-offloading-config.Enabled"), defaultConfig.LiteralOffloadingConfig.Enabled, "")
 	cmdFlags.StringToString(fmt.Sprintf("%v%v", prefix, "literal-offloading-config.supported-sdk-versions"), defaultConfig.LiteralOffloadingConfig.SupportedSDKVersions, "Maps flytekit and union SDK names to minimum supported version that can handle reading offloaded literals.")
 	cmdFlags.Int64(fmt.Sprintf("%v%v", prefix, "literal-offloading-config.min-size-in-mb-for-offloading"), defaultConfig.LiteralOffloadingConfig.MinSizeInMBForOffloading, "Size of a literal at which to trigger offloading")

--- a/flytepropeller/pkg/controller/config/config_flags_test.go
+++ b/flytepropeller/pkg/controller/config/config_flags_test.go
@@ -981,6 +981,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_array-node-config.max-task-phase-version-attempts", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("array-node-config.max-task-phase-version-attempts", testValue)
+			if vInt, err := cmdFlags.GetInt("array-node-config.max-task-phase-version-attempts"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt), &actual.ArrayNode.MaxTaskPhaseVersionAttempts)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_literal-offloading-config.Enabled", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/flytepropeller/pkg/controller/nodes/array/handler.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler.go
@@ -665,7 +665,7 @@ func (a *arrayNodeHandler) Handle(ctx context.Context, nCtx interfaces.NodeExecu
 			arrayNodeState.TaskPhaseVersion++
 		}
 
-		const maxRetries = 3
+		maxRetries := config.GetConfig().ArrayNode.MaxTaskPhaseVersionAttempts
 		retries := 0
 		for retries <= maxRetries {
 			err := eventRecorder.finalize(ctx, nCtx, taskPhase, arrayNodeState.TaskPhaseVersion, a.eventConfig)


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
This PR makes the ArrayNode `taskPhaseVersion` increment retries configurable. This value is used to resend `TaskExecutionEvents` in the case of ArrayNode eventing failures. It is necessary because ArrayNode uses the `ExternalResourceInfo` fields to populate subNode execution metadata, all of these are included in a singular event. So the `TaskPhaseVersion` is not necessarily correlated to a single phase (as subNode phases can change). To ensure these are populated we need to increment.

## What changes were proposed in this pull request?
^^^

## How was this patch tested?
The default value is the current value (ie. 3) so there should be no concerns about merging.

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process
N/A

### Screenshots
N/A

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs
N/A

## Docs link
N/A 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR refactors ArrayNode configuration to make taskPhaseVersion increment retries configurable, replacing hard-coded constants with dynamic values. It updates configuration structures, CLI flag registration, and handler logic. New unit tests verify flag registration and parsing functionality.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>