### PR TITLE
Allow configuring deployment annotations in Helm chart

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -75,7 +75,8 @@ helm install gateway bitnami/contour -n flyte
 | cloud_events.kafka.tlsConfig.keyPath | string | `"/etc/ssl/certs/kafka-client.key"` | Path to the client private key |
 | cloud_events.kafka.version | string | `"3.7.0"` | The version of Kafka |
 | cloud_events.type | string | `"aws"` |  |
-| cluster_resource_manager | object | `{"config":{"cluster_resources":{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}},"enabled":true,"nodeSelector":{},"podAnnotations":{},"podEnv":{},"podLabels":{},"prometheus":{"enabled":false,"path":"/metrics","port":10254},"resources":{},"service_account_name":"flyteadmin","standaloneDeployment":false,"templates":[{"key":"aa_namespace","value":"apiVersion: v1\nkind: Namespace\nmetadata:\n  name: {{ namespace }}\nspec:\n  finalizers:\n  - kubernetes\n"},{"key":"ab_project_resource_quota","value":"apiVersion: v1\nkind: ResourceQuota\nmetadata:\n  name: project-quota\n  namespace: {{ namespace }}\nspec:\n  hard:\n    limits.cpu: {{ projectQuotaCpu }}\n    limits.memory: {{ projectQuotaMemory }}\n"}]}` | Configuration for the Cluster resource manager component. This is an optional component, that enables automatic cluster configuration. This is useful to set default quotas, manage namespaces etc that map to a project/domain |
+| cluster_resource_manager | object | `{"annotations":{},"config":{"cluster_resources":{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}},"enabled":true,"nodeSelector":{},"podAnnotations":{},"podEnv":{},"podLabels":{},"prometheus":{"enabled":false,"path":"/metrics","port":10254},"resources":{},"service_account_name":"flyteadmin","standaloneDeployment":false,"templates":[{"key":"aa_namespace","value":"apiVersion: v1\nkind: Namespace\nmetadata:\n  name: {{ namespace }}\nspec:\n  finalizers:\n  - kubernetes\n"},{"key":"ab_project_resource_quota","value":"apiVersion: v1\nkind: ResourceQuota\nmetadata:\n  name: project-quota\n  namespace: {{ namespace }}\nspec:\n  hard:\n    limits.cpu: {{ projectQuotaCpu }}\n    limits.memory: {{ projectQuotaMemory }}\n"}]}` | Configuration for the Cluster resource manager component. This is an optional component, that enables automatic cluster configuration. This is useful to set default quotas, manage namespaces etc that map to a project/domain |
+| cluster_resource_manager.annotations | object | `{}` | Annotations for ClusterResource deployment |
 | cluster_resource_manager.config | object | `{"cluster_resources":{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}}` | Configmap for ClusterResource parameters |
 | cluster_resource_manager.config.cluster_resources | object | `{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}` | ClusterResource parameters Refer to the [structure](https://pkg.go.dev/github.com/lyft/flyteadmin@v0.3.37/pkg/runtime/interfaces#ClusterResourceConfig) to customize. |
 | cluster_resource_manager.config.cluster_resources.refreshInterval | string | `"5m"` | How frequently to run the sync process |
@@ -140,6 +141,7 @@ helm install gateway bitnami/contour -n flyte
 | datacatalog.additionalVolumeMounts | list | `[]` | Appends additional volume mounts to the main container's spec. May include template values. |
 | datacatalog.additionalVolumes | list | `[]` | Appends additional volumes to the deployment spec. May include template values. |
 | datacatalog.affinity | object | `{}` | affinity for Datacatalog deployment |
+| datacatalog.annotations | object | `{}` | Annotations for Datacatalog deployment |
 | datacatalog.configPath | string | `"/etc/datacatalog/config/*.yaml"` | Default regex string for searching configuration files |
 | datacatalog.enabled | bool | `true` |  |
 | datacatalog.extraArgs | object | `{}` | Appends extra command line arguments to the main command |
@@ -175,6 +177,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.additionalVolumeMounts | list | `[]` | Appends additional volume mounts to the main container's spec. May include template values. |
 | flyteadmin.additionalVolumes | list | `[]` | Appends additional volumes to the deployment spec. May include template values. |
 | flyteadmin.affinity | object | `{}` | affinity for Flyteadmin deployment |
+| flyteadmin.annotations | object | `{}` | Annotations for Flyteadmin deployment |
 | flyteadmin.configPath | string | `"/etc/flyte/config/*.yaml"` | Default regex string for searching configuration files |
 | flyteadmin.enabled | bool | `true` |  |
 | flyteadmin.env | list | `[]` | Additional flyteadmin container environment variables  e.g. SendGrid's API key  - name: SENDGRID_API_KEY    value: "<your sendgrid api key>"  e.g. secret environment variable (you can combine it with .additionalVolumes): - name: SENDGRID_API_KEY   valueFrom:     secretKeyRef:       name: sendgrid-secret       key: api_key |
@@ -218,6 +221,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteconnector.plugin_config.plugins.connector-service.supportedTaskTypes | list | `[]` | The task types supported by the default agent. As of #5460 these are discovered automatically and don't need to be configured. |
 | flyteconnector.podLabels | object | `{}` | Labels for flyteconnector pods |
 | flyteconsole.affinity | object | `{}` | affinity for Flyteconsole deployment |
+| flyteconsole.annotations | object | `{}` | Annotations for Flyteconsole deployment |
 | flyteconsole.enabled | bool | `true` |  |
 | flyteconsole.ga.enabled | bool | `false` |  |
 | flyteconsole.ga.tracking_id | string | `"G-0QW4DJWJ20"` |  |
@@ -246,6 +250,7 @@ helm install gateway bitnami/contour -n flyte
 | flytepropeller.additionalVolumeMounts | list | `[]` | Appends additional volume mounts to the main container's spec. May include template values. |
 | flytepropeller.additionalVolumes | list | `[]` | Appends additional volumes to the deployment spec. May include template values. |
 | flytepropeller.affinity | object | `{}` | affinity for Flytepropeller deployment |
+| flytepropeller.annotations | object | `{}` | Annotations for Flytepropeller deployment |
 | flytepropeller.clusterName | string | `""` | Defines the cluster name used in events sent to Admin |
 | flytepropeller.configPath | string | `"/etc/flyte/config/*.yaml"` | Default regex string for searching configuration files |
 | flytepropeller.createCRDs | bool | `true` | Whether to install the flyteworkflows CRD with helm |
@@ -283,6 +288,7 @@ helm install gateway bitnami/contour -n flyte
 | flytescheduler.additionalVolumeMounts | list | `[]` | Appends additional volume mounts to the main container's spec. May include template values. |
 | flytescheduler.additionalVolumes | list | `[]` | Appends additional volumes to the deployment spec. May include template values. |
 | flytescheduler.affinity | object | `{}` | affinity for Flytescheduler deployment |
+| flytescheduler.annotations | object | `{}` | Annotations for Flytescheduler deployment |
 | flytescheduler.configPath | string | `"/etc/flyte/config/*.yaml"` | Default regex string for searching configuration files |
 | flytescheduler.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | flytescheduler.image.repository | string | `"cr.flyte.org/flyteorg/flytescheduler"` | Docker image for Flytescheduler deployment |
@@ -321,6 +327,7 @@ helm install gateway bitnami/contour -n flyte
 | storage.s3.endpoint | string | `""` | endpoint URL of s3-compatible service |
 | storage.s3.secretKey | string | `""` | AWS IAM user secret access key to use for S3 bucket auth, only used if authType is set to accesskey |
 | storage.type | string | `"sandbox"` | Sets the storage type. Supported values are sandbox, s3, gcs and custom. |
+| webhook.annotations | object | `{}` | Annotations for webhook deployment |
 | webhook.autoscaling.enabled | bool | `false` |  |
 | webhook.autoscaling.maxReplicas | int | `10` |  |
 | webhook.autoscaling.metrics[0].resource.name | string | `"cpu"` |  |

--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ template "flyteadmin.name" . }}
   namespace: {{ template "flyte.namespace" . }}
   labels: {{ include "flyteadmin.labels" . | nindent 4 }}
+  {{- if .Values.flyteadmin.annotations }}
+  annotations:
+    {{- with .Values.flyteadmin.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: {{ .Values.flyteadmin.replicaCount }}
   selector:

--- a/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   name: syncresources
   namespace: {{ template "flyte.namespace" . }}
   labels: {{ include "flyteclusterresourcesync.labels" . | nindent 4 }}
+  {{- if .Values.cluster_resource_manager.annotations }}
+  annotations:
+    {{- with .Values.cluster_resource_manager.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/flyte-core/templates/console/deployment.yaml
+++ b/charts/flyte-core/templates/console/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ template "flyteconsole.name" . }}
   namespace: {{ template "flyte.namespace" . }}
   labels: {{ include "flyteconsole.labels" . | nindent 4 }}
+  {{- if .Values.flyteconsole.annotations }}
+  annotations:
+    {{- with .Values.flyteconsole.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: {{ .Values.flyteconsole.replicaCount }}
   selector:

--- a/charts/flyte-core/templates/datacatalog/deployment.yaml
+++ b/charts/flyte-core/templates/datacatalog/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ template "datacatalog.name" . }}
   namespace: {{ template "flyte.namespace" . }}
   labels: {{ include "datacatalog.labels" . | nindent 4 }}
+  {{- if .Values.datacatalog.annotations }}
+  annotations:
+    {{- with .Values.datacatalog.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: {{ .Values.datacatalog.replicaCount }}
   selector:

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -6,6 +6,12 @@ metadata:
   name: {{ template "flytescheduler.name" . }}
   namespace: {{ template "flyte.namespace" . }}
   labels: {{ include "flytescheduler.labels" . | nindent 4 }}
+  {{- if .Values.flytescheduler.annotations }}
+  annotations:
+    {{- with .Values.flytescheduler.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -10,6 +10,12 @@ metadata:
   name: {{ template "flytepropeller.name" . }}
   labels: {{ include "flytepropeller.labels" . | nindent 4 }}
   {{- end }}
+  {{- if .Values.flytepropeller.annotations }}
+  annotations:
+    {{- with .Values.flytepropeller.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: {{ .Values.flytepropeller.replicaCount }}
   selector:

--- a/charts/flyte-core/templates/propeller/webhook.yaml
+++ b/charts/flyte-core/templates/propeller/webhook.yaml
@@ -16,6 +16,12 @@ metadata:
   namespace: {{ template "flyte.namespace" . }}
   labels:
     app: {{ template "flyte-pod-webhook.name" . }}
+  {{- if .Values.webhook.annotations }}
+  annotations:
+    {{- with .Values.webhook.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -96,6 +96,8 @@ flyteadmin:
       # -- Specifies the verbs (actions) that this ClusterRole can perform on the specified resources
       verbs:
         - "*"
+  # -- Annotations for Flyteadmin deployment
+  annotations: {}
   # -- Annotations for Flyteadmin pods
   podAnnotations: {}
   # -- Labels for Flyteadmin pods
@@ -172,6 +174,8 @@ flytescheduler:
     annotations: {}
     # -- ImagePullSecrets to automatically assign to the service account
     imagePullSecrets: []
+  # -- Annotations for Flytescheduler deployment
+  annotations: {}
   # -- Annotations for Flytescheduler pods
   podAnnotations: {}
   # -- Additional Flytescheduler container environment variables
@@ -244,6 +248,8 @@ datacatalog:
     annotations: {}
     # -- ImagePullSecrets to automatically assign to the service account
     imagePullSecrets: []
+  # -- Annotations for Datacatalog deployment
+  annotations: {}
   # -- Annotations for Datacatalog pods
   podAnnotations: {}
   # -- Additional Datacatalog container environment variables
@@ -347,6 +353,8 @@ flytepropeller:
     annotations: {}
     # -- ImagePullSecrets to automatically assign to the service account
     imagePullSecrets: []
+  # -- Annotations for Flytepropeller deployment
+  annotations: {}
   # -- Annotations for Flytepropeller pods
   podAnnotations: {}
   # -- Additional Flytepropeller container environment variables
@@ -426,6 +434,8 @@ flyteconsole:
       enabled: false
     annotations: {}
     type: ClusterIP
+  # -- Annotations for Flyteconsole deployment
+  annotations: {}
   # -- Annotations for Flyteconsole pods
   podAnnotations: {}
   # -- Additional Flyteconsole container environment variables
@@ -511,6 +521,8 @@ webhook:
     annotations:
       projectcontour.io/upstream-protocol.h2c: grpc
     type: ClusterIP
+  # -- Annotations for webhook deployment
+  annotations: {}
   # -- Annotations for webhook pods
   podAnnotations: {}
   # -- Additional webhook container environment variables
@@ -1020,6 +1032,8 @@ cluster_resource_manager:
   standaloneDeployment: false
   # -- Service account name to run with
   service_account_name: flyteadmin
+  # -- Annotations for ClusterResource deployment
+  annotations: {}
   # -- Annotations for ClusterResource pods
   podAnnotations: {}
   # -- Additional ClusterResource container environment variables

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: dDhUSDlQck51dnFVSTduMg==
+  haSharedSecret: R2tpOVdnOUNNekFZeGtMaQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 04928920cb69d1f836f82a07d9b7e32680228c7efd43c29fa31fa5ba72575e96
+        checksum/secret: 23fb1a6a44e55aff781b0f4a22687ce339b7299c272f269d5fb4f0d133f7259c
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: YzNMSlpVejNFRlU3RWVWSw==
+  haSharedSecret: bVpMWjVrTFhGTmhKQzFzOQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: a0fd913151be70ee1278900861927d071e841f3d9d33ad78a99426237dc9c520
+        checksum/secret: 410b44467551a12b04f8ad8d9e812b438fc4f799e438fe1b889775ee2d448674
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: N2d5NnVxT0s0ZGxhMTVOaQ==
+  haSharedSecret: N1lNUXhmdm9kWmp3OWV2Ng==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: b485fd7c1fcffef69e40b17f1a9ea72058a48e5666064b49c94b2d7c2b2c13f5
+        checksum/secret: ce8c74e95e89cc135192cb4a1fc4cbc9f85860d16200d2c79a31376c446d18ae
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?

There is no feasible way to manage Flyte database secret rotation from **external secret source** when installing Flyte through Helm charts in AWS EKS (I doubt it's possible in other clouds either). This is a common approach taken with AWS RDS, where AWS manages the database secret rotation automatically through secrets manager. While [external secrets operator](https://external-secrets.io/latest/) is able to update Kubernetes native secrets based on changes in an external source (e.g. AWS Secrets Manager), it doesn't restart pods mounting those secrets, leaving the rotation incomplete in this case.

## What changes were proposed in this pull request?

Add ability to annotate Kubernetes deployments created by the flyte-core Helm chart. This makes it possible to use external operators, such as [Reloader](https://github.com/stakater/Reloader), to rotate the **pods** using the secrets.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Labels

- **added**: Ability to configure Helm chart deployment annotations

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly (auto-updated)
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR adds configurable deployment annotations to Helm charts, enabling integration with external secret management tools like Reloader. It implements conditional annotation blocks across deployment templates based on configuration values, updates values.yaml with annotation guidance, and fixes secret rotation in Docker manifests for improved security.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>