### PR TITLE
Make cloud events config type lowercase

### DIFF
--- a/flyteadmin/pkg/async/cloudevent/factory.go
+++ b/flyteadmin/pkg/async/cloudevent/factory.go
@@ -2,6 +2,7 @@ package cloudevent
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/NYTimes/gizmo/pubsub"
@@ -34,7 +35,7 @@ func NewCloudEventsPublisher(ctx context.Context, db repositoryInterfaces.Reposi
 	reconnectDelay := time.Duration(cloudEventsConfig.ReconnectDelaySeconds) * time.Second
 
 	var sender interfaces.Sender
-	switch cloudEventsConfig.Type {
+	switch strings.ToLower(cloudEventsConfig.Type) {
 	case common.AWS:
 		snsConfig := gizmoAWS.SNSConfig{
 			Topic: cloudEventsConfig.EventsPublisherConfig.TopicName,

--- a/flyteadmin/pkg/async/cloudevent/implementations/sender.go
+++ b/flyteadmin/pkg/async/cloudevent/implementations/sender.go
@@ -16,7 +16,7 @@ import (
 type Receiver = string
 
 const (
-	Kafka Receiver = "Kafka"
+	Kafka Receiver = "kafka"
 )
 
 // PubSubSender Implementation of Sender


### PR DESCRIPTION
## Tracking issue
Closes: https://github.com/flyteorg/flyte/issues/6402

## Why are the changes needed?
Normalizes cloud event type configuration to lowercase to avoid misconfiguration and match the documentation (specifically regarding Kafka).

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Existing unit tests.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR normalizes cloud event configuration types to lowercase to prevent misconfigurations and align with documentation standards. Changes include adding the 'strings' package import, modifying switch logic for lowercase conversion, and updating the Kafka receiver constant to match the new standard.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>