### PR TITLE
Only enqueue workflows if flytepropeller is leader

### DIFF
--- a/boilerplate/flyte/end2end/test_run.py
+++ b/boilerplate/flyte/end2end/test_run.py
@@ -95,6 +95,7 @@ def schedule_workflow_groups(
         non_succeeded_executions = []
         for execution in executions:
             if execution.closure.phase != WorkflowExecutionPhase.SUCCEEDED:
+                print(f"workflow is in {execution.closure.phase}")
                 non_succeeded_executions.append(execution)
         # Report failing cases
         if len(non_succeeded_executions) != 0:

--- a/flytepropeller/pkg/controller/controller.go
+++ b/flytepropeller/pkg/controller/controller.go
@@ -162,7 +162,7 @@ func (c *Controller) enqueueFlyteWorkflow(obj interface{}) {
 	}
 	key := wf.GetK8sWorkflowID()
 	if !c.leader.Load() {
-		logger.Debug(ctx, "Ignoring workflow [%v]  as non-leader", key)
+		logger.Debug(ctx, "Ignoring workflow [%v] as non-leader", key)
 		return
 	}
 	logger.Infof(ctx, "==> Enqueueing workflow [%v]", key)


### PR DESCRIPTION
## Tracking issue
Closes #6435 

## Why are the changes needed?
Without these changes followers/replicas in highly available deployments will enqueue workflows until they saturate the work queue. Once the work queue is saturated these workflows may become very stale. Once a follower does become a leader it will need to churn through these stale workflows that might not even exist anymore.

## What changes were proposed in this pull request?

Added a thread safe bool for whether the propeller is leader and check it before enqueueing workflows. 

## How was this patch tested?
Not yet but will test in our development environment.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off. 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements leader-only workflow enqueuing in HA flytepropeller deployments using an atomic boolean flag, preventing followers from adding stale workflows to the queue. It enhances system reliability and consistency during leadership transitions, and refines workflow handling. The changes also improve logging of workflow phases for failed executions to facilitate better monitoring and debugging.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>