### PR TITLE
Allow rollout strategy to be configured in Helm charts

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -75,7 +75,7 @@ helm install gateway bitnami/contour -n flyte
 | cloud_events.kafka.tlsConfig.keyPath | string | `"/etc/ssl/certs/kafka-client.key"` | Path to the client private key |
 | cloud_events.kafka.version | string | `"3.7.0"` | The version of Kafka |
 | cloud_events.type | string | `"aws"` |  |
-| cluster_resource_manager | object | `{"annotations":{},"config":{"cluster_resources":{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}},"enabled":true,"nodeSelector":{},"podAnnotations":{},"podEnv":{},"podLabels":{},"prometheus":{"enabled":false,"path":"/metrics","port":10254},"resources":{},"service_account_name":"flyteadmin","standaloneDeployment":false,"templates":[{"key":"aa_namespace","value":"apiVersion: v1\nkind: Namespace\nmetadata:\n  name: {{ namespace }}\nspec:\n  finalizers:\n  - kubernetes\n"},{"key":"ab_project_resource_quota","value":"apiVersion: v1\nkind: ResourceQuota\nmetadata:\n  name: project-quota\n  namespace: {{ namespace }}\nspec:\n  hard:\n    limits.cpu: {{ projectQuotaCpu }}\n    limits.memory: {{ projectQuotaMemory }}\n"}]}` | Configuration for the Cluster resource manager component. This is an optional component, that enables automatic cluster configuration. This is useful to set default quotas, manage namespaces etc that map to a project/domain |
+| cluster_resource_manager | object | `{"annotations":{},"config":{"cluster_resources":{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}},"enabled":true,"nodeSelector":{},"podAnnotations":{},"podEnv":{},"podLabels":{},"prometheus":{"enabled":false,"path":"/metrics","port":10254},"resources":{},"service_account_name":"flyteadmin","standaloneDeployment":false,"strategy":{},"templates":[{"key":"aa_namespace","value":"apiVersion: v1\nkind: Namespace\nmetadata:\n  name: {{ namespace }}\nspec:\n  finalizers:\n  - kubernetes\n"},{"key":"ab_project_resource_quota","value":"apiVersion: v1\nkind: ResourceQuota\nmetadata:\n  name: project-quota\n  namespace: {{ namespace }}\nspec:\n  hard:\n    limits.cpu: {{ projectQuotaCpu }}\n    limits.memory: {{ projectQuotaMemory }}\n"}]}` | Configuration for the Cluster resource manager component. This is an optional component, that enables automatic cluster configuration. This is useful to set default quotas, manage namespaces etc that map to a project/domain |
 | cluster_resource_manager.annotations | object | `{}` | Annotations for ClusterResource deployment |
 | cluster_resource_manager.config | object | `{"cluster_resources":{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}}` | Configmap for ClusterResource parameters |
 | cluster_resource_manager.config.cluster_resources | object | `{"customData":[{"production":[{"projectQuotaCpu":{"value":"5"}},{"projectQuotaMemory":{"value":"4000Mi"}}]},{"staging":[{"projectQuotaCpu":{"value":"2"}},{"projectQuotaMemory":{"value":"3000Mi"}}]},{"development":[{"projectQuotaCpu":{"value":"4"}},{"projectQuotaMemory":{"value":"3000Mi"}}]}],"refreshInterval":"5m","standaloneDeployment":false,"templatePath":"/etc/flyte/clusterresource/templates"}` | ClusterResource parameters Refer to the [structure](https://pkg.go.dev/github.com/lyft/flyteadmin@v0.3.37/pkg/runtime/interfaces#ClusterResourceConfig) to customize. |
@@ -162,6 +162,7 @@ helm install gateway bitnami/contour -n flyte
 | datacatalog.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Datacatalog pods |
 | datacatalog.serviceAccount.create | bool | `true` | Should a service account be created for Datacatalog |
 | datacatalog.serviceAccount.imagePullSecrets | list | `[]` | ImagePullSecrets to automatically assign to the service account |
+| datacatalog.strategy | object | `{}` |  |
 | datacatalog.tolerations | list | `[]` | tolerations for Datacatalog deployment |
 | db.admin.database.dbname | string | `"flyteadmin"` |  |
 | db.admin.database.host | string | `"postgres"` |  |
@@ -212,6 +213,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.serviceMonitor.interval | string | `"60s"` | Sets the interval at which metrics will be scraped by prometheus |
 | flyteadmin.serviceMonitor.labels | object | `{}` | Sets the labels for the service monitor which are required by the prometheus to auto-detect the service monitor and start scrapping the metrics |
 | flyteadmin.serviceMonitor.scrapeTimeout | string | `"30s"` | Sets the timeout after which request to scrape metrics will time out |
+| flyteadmin.strategy | object | `{}` |  |
 | flyteadmin.tolerations | list | `[]` | tolerations for Flyteadmin deployment |
 | flyteconnector.enabled | bool | `false` |  |
 | flyteconnector.plugin_config.plugins.connector-service | object | `{"defaultConnector":{"endpoint":"k8s://flyteconnector.flyte:8000","insecure":true},"supportedTaskTypes":[]}` | Agent service configuration for propeller. |
@@ -245,6 +247,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteconsole.serviceMonitor.interval | string | `"60s"` | Sets the interval at which metrics will be scraped by prometheus |
 | flyteconsole.serviceMonitor.labels | object | `{}` | Sets the labels for the service monitor which are required by the prometheus to auto-detect the service monitor and start scrapping the metrics |
 | flyteconsole.serviceMonitor.scrapeTimeout | string | `"30s"` | Sets the timeout after which request to scrape metrics will time out |
+| flyteconsole.strategy | object | `{}` |  |
 | flyteconsole.tolerations | list | `[]` | tolerations for Flyteconsole deployment |
 | flytepropeller.additionalContainers | list | `[]` | Appends additional containers to the deployment spec. May include template values. |
 | flytepropeller.additionalVolumeMounts | list | `[]` | Appends additional volume mounts to the main container's spec. May include template values. |
@@ -282,6 +285,7 @@ helm install gateway bitnami/contour -n flyte
 | flytepropeller.serviceMonitor.interval | string | `"60s"` | Sets the interval at which metrics will be scraped by prometheus |
 | flytepropeller.serviceMonitor.labels | object | `{}` | Sets the labels for the service monitor which are required by the prometheus to auto-detect the service monitor and start scrapping the metrics |
 | flytepropeller.serviceMonitor.scrapeTimeout | string | `"30s"` | Sets the timeout after which request to scrape metrics will time out |
+| flytepropeller.strategy | object | `{}` |  |
 | flytepropeller.terminationMessagePolicy | string | `"FallbackToLogsOnError"` | Error reporting |
 | flytepropeller.tolerations | list | `[]` | tolerations for Flytepropeller deployment |
 | flytescheduler.additionalContainers | list | `[]` | Appends additional containers to the deployment spec. May include template values. |
@@ -306,6 +310,7 @@ helm install gateway bitnami/contour -n flyte
 | flytescheduler.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Flytescheduler pods |
 | flytescheduler.serviceAccount.create | bool | `true` | Should a service account be created for Flytescheduler |
 | flytescheduler.serviceAccount.imagePullSecrets | list | `[]` | ImagePullSecrets to automatically assign to the service account |
+| flytescheduler.strategy | object | `{}` |  |
 | flytescheduler.tolerations | list | `[]` | tolerations for Flytescheduler deployment |
 | secrets.adminOauthClientCredentials.clientId | string | `"flytepropeller"` |  |
 | secrets.adminOauthClientCredentials.clientSecret | string | `"foobar"` |  |
@@ -357,6 +362,7 @@ helm install gateway bitnami/contour -n flyte
 | webhook.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to the webhook |
 | webhook.serviceAccount.create | bool | `true` | Should a service account be created for the webhook |
 | webhook.serviceAccount.imagePullSecrets | list | `[]` | ImagePullSecrets to automatically assign to the service account |
+| webhook.strategy | object | `{}` |  |
 | webhook.topologySpreadConstraints | object | `{}` | TopologySpreadConstraints for webhook deployment |
 | workflow_notifications | object | `{"config":{},"enabled":false}` | **Optional Component** Workflow notifications module is an optional dependency. Flyte uses cloud native pub-sub systems to notify users of various events in their workflows |
 | workflow_scheduler | object | `{"config":{},"enabled":false,"type":""}` | **Optional Component** Flyte uses a cloud hosted Cron scheduler to run workflows on a schedule. The following module is optional. Without, this module, you will not have scheduled launchplans / workflows. Docs: https://docs.flyte.org/en/latest/howto/enable_and_use_schedules.html#setting-up-scheduled-workflows |

--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -15,6 +15,9 @@ spec:
   replicas: {{ .Values.flyteadmin.replicaCount }}
   selector:
     matchLabels: {{ include "flyteadmin.selectorLabels" . | nindent 6 }}
+  {{- with .Values.flyteadmin.strategy }}
+  strategy: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
@@ -15,6 +15,9 @@ spec:
   replicas: 1
   selector:
     matchLabels: {{ include "flyteclusterresourcesync.selectorLabels" . | nindent 6 }}
+  {{- with .Values.cluster_resource_manager.strategy }}
+  strategy: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/flyte-core/templates/console/deployment.yaml
+++ b/charts/flyte-core/templates/console/deployment.yaml
@@ -15,6 +15,9 @@ spec:
   replicas: {{ .Values.flyteconsole.replicaCount }}
   selector:
     matchLabels: {{ include "flyteconsole.selectorLabels" . | nindent 6 }}
+  {{- with .Values.flyteconsole.strategy }}
+  strategy: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/flyte-core/templates/datacatalog/deployment.yaml
+++ b/charts/flyte-core/templates/datacatalog/deployment.yaml
@@ -15,6 +15,9 @@ spec:
   replicas: {{ .Values.datacatalog.replicaCount }}
   selector:
     matchLabels: {{ include "datacatalog.selectorLabels" . | nindent 6 }}
+  {{- with .Values.datacatalog.strategy }}
+  strategy: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -16,6 +16,9 @@ spec:
   replicas: 1
   selector:
     matchLabels: {{ include "flytescheduler.selectorLabels" . | nindent 6 }}
+  {{- with .Values.flytescheduler.strategy }}
+  strategy: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -24,6 +24,9 @@ spec:
     {{- else }}
     matchLabels: {{ include "flytepropeller.selectorLabels" . | nindent 6 }}
     {{- end }}
+  {{- with .Values.flytepropeller.strategy }}
+  strategy: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/flyte-core/templates/propeller/webhook.yaml
+++ b/charts/flyte-core/templates/propeller/webhook.yaml
@@ -26,6 +26,9 @@ spec:
   selector:
     matchLabels:
       app: {{ template "flyte-pod-webhook.name" . }}
+  {{- with .Values.webhook.strategy }}
+  strategy: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -43,6 +43,8 @@ flyteadmin:
       cpu: 10m
       ephemeral-storage: 50Mi
       memory: 50Mi
+  # Strategy for Flyteadmin deployment
+  strategy: {}
   # -- Default regex string for searching configuration files
   configPath: /etc/flyte/config/*.yaml
   # -- Initial projects to create
@@ -163,6 +165,8 @@ flytescheduler:
       cpu: 10m
       ephemeral-storage: 50Mi
       memory: 50Mi
+  # Strategy for Flytescheduler deployment
+  strategy: {}
   # -- Default regex string for searching configuration files
   configPath: /etc/flyte/config/*.yaml
 
@@ -231,6 +235,8 @@ datacatalog:
       cpu: 10m
       ephemeral-storage: 50Mi
       memory: 50Mi
+  # Strategy for Datacatalog deployment
+  strategy: {}
   # -- Default regex string for searching configuration files
   configPath: /etc/datacatalog/config/*.yaml
   # -- Service settings for Datacatalog
@@ -329,6 +335,8 @@ flytepropeller:
       cpu: 10m
       ephemeral-storage: 50Mi
       memory: 100Mi
+  # Strategy for Flytepropeller deployment
+  strategy: {}
   # -- If manager is set to true this can be used to give the flytepropeller-manager different resource requests than the sharded flyte propeller pods
   manager_resources:
     resources:
@@ -428,6 +436,8 @@ flyteconsole:
     requests:
       cpu: 10m
       memory: 50Mi
+  # Strategy for Flyteconsole deployment
+  strategy: {}
   # -- Service settings for Flyteconsole
   service:
     appProtocols:
@@ -549,6 +559,9 @@ webhook:
       cpu: 200m
       ephemeral-storage: 500Mi
       memory: 500Mi
+
+  # Strategy for webhook deployment
+  strategy: {}
 
   autoscaling:
     enabled: false
@@ -1050,6 +1063,8 @@ cluster_resource_manager:
   nodeSelector: {}
   # -- Resources for ClusterResource deployment
   resources: {}
+  # Strategy for ClusterResource deployment
+  strategy: {}
   # -- Configmap for ClusterResource parameters
   config:
     # -- ClusterResource parameters

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: MU5oRkF5V1pWc042eUMwTw==
+  haSharedSecret: MUVDdmNNcGp5elptYUZVYw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 85e1c09e96d353100c24e440cf19c6803faabbe8ae9772c68be514d63306bf11
+        checksum/secret: 7667fa65354f64f5bd5e1a3411aeb426ca1b1dfd30da0dc5b839882e544c3df3
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: ZGxuM0FJU2tLSEUyWnVpdQ==
+  haSharedSecret: MHNmNm1uWUNZRlhYZ2ZKQw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 4b55fc712d2321398f6a5f21e03959ed9342f94ecfead0d2fa718b7607d9d5cb
+        checksum/secret: 5552105ec2becfef1a96b9c0ac4042b77f032a97d10e1ecae99b1ea0ec439b8c
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: Y0VZcUJuUHI3T2E5VVBMQw==
+  haSharedSecret: RFQxTHcyeUFnaW1BVDB0dw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: a3c49e5709ff8077c1082421919bb459a0ac2db9d8e9fc3d0e9712a93c0f95dc
+        checksum/secret: 7b643c488e0e560009c4feb885d6ed2dc09b13c91d975ab577a8c86fbec6cf10
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## Tracking issue
Closes #6446

## Why are the changes needed?
This allows users to customize the rollout strategy of different flyte components.

## What changes were proposed in this pull request?
Makes the rollout strategy configurable for different flyte components.

## How was this patch tested?
It was not tested.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances Flyte deployment flexibility by introducing configurable rollout strategies for various components, including updates to deployment YAML files and adjustments to secrets and checksums. These modifications aim to improve customization and streamline the deployment process.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, making the review process relatively quick.
</div>