### PR TITLE
Set MaxConcurrentStreams for flyteadmin grpc server

### DIFF
--- a/flyteadmin/pkg/config/config.go
+++ b/flyteadmin/pkg/config/config.go
@@ -51,6 +51,7 @@ type GrpcConfig struct {
 	ServerReflection         bool `json:"serverReflection" pflag:",Enable GRPC Server Reflection"`
 	MaxMessageSizeBytes      int  `json:"maxMessageSizeBytes" pflag:",The max size in bytes for incoming gRPC messages"`
 	EnableGrpcLatencyMetrics bool `json:"enableGrpcLatencyMetrics" pflag:",Enable grpc latency metrics. Note Histograms metrics can be expensive on Prometheus servers."`
+	MaxConcurrentStreams     int  `json:"maxConcurrentStreams" pflag:",Limit on the number of concurrent streams to each ServerTransport."`
 }
 
 // KubeClientConfig contains the configuration used by flyteadmin to configure its internal Kubernetes Client.

--- a/flyteadmin/pkg/config/serverconfig_flags.go
+++ b/flyteadmin/pkg/config/serverconfig_flags.go
@@ -68,6 +68,7 @@ func (cfg ServerConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "grpc.serverReflection"), defaultServerConfig.GrpcConfig.ServerReflection, "Enable GRPC Server Reflection")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "grpc.maxMessageSizeBytes"), defaultServerConfig.GrpcConfig.MaxMessageSizeBytes, "The max size in bytes for incoming gRPC messages")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "grpc.enableGrpcLatencyMetrics"), defaultServerConfig.GrpcConfig.EnableGrpcLatencyMetrics, "Enable grpc latency metrics. Note Histograms metrics can be expensive on Prometheus servers.")
+	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "grpc.maxConcurrentStreams"), defaultServerConfig.GrpcConfig.MaxConcurrentStreams, "Limit on the number of concurrent streams to each ServerTransport.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "thirdPartyConfig.flyteClient.clientId"), defaultServerConfig.DeprecatedThirdPartyConfig.FlyteClientConfig.ClientID, "public identifier for the app which handles authorization for a Flyte deployment")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "thirdPartyConfig.flyteClient.redirectUri"), defaultServerConfig.DeprecatedThirdPartyConfig.FlyteClientConfig.RedirectURI, "This is the callback uri registered with the app which handles authorization for a Flyte deployment")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "thirdPartyConfig.flyteClient.scopes"), defaultServerConfig.DeprecatedThirdPartyConfig.FlyteClientConfig.Scopes, "Recommended scopes for the client to request.")

--- a/flyteadmin/pkg/config/serverconfig_flags_test.go
+++ b/flyteadmin/pkg/config/serverconfig_flags_test.go
@@ -351,6 +351,20 @@ func TestServerConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_grpc.maxConcurrentStreams", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("grpc.maxConcurrentStreams", testValue)
+			if vInt, err := cmdFlags.GetInt("grpc.maxConcurrentStreams"); err == nil {
+				testDecodeJson_ServerConfig(t, fmt.Sprintf("%v", vInt), &actual.GrpcConfig.MaxConcurrentStreams)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_thirdPartyConfig.flyteClient.clientId", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/flyteadmin/pkg/server/service.go
+++ b/flyteadmin/pkg/server/service.go
@@ -141,7 +141,7 @@ func newGRPCServer(ctx context.Context, pluginRegistry *plugins.Registry, cfg *c
 		serverOpts = append(serverOpts, grpc.MaxRecvMsgSize(cfg.GrpcConfig.MaxMessageSizeBytes), grpc.MaxSendMsgSize(cfg.GrpcConfig.MaxMessageSizeBytes))
 	}
 	if cfg.GrpcConfig.MaxConcurrentStreams > 0 {
-		serverOpts = append(serverOpts, grpc.MaxConcurrentStreams(uint32(cfg.GrpcConfig.MaxConcurrentStreams)))
+		serverOpts = append(serverOpts, grpc.MaxConcurrentStreams(uint32(cfg.GrpcConfig.MaxConcurrentStreams))) // #nosec G115
 	}
 	serverOpts = append(serverOpts, opts...)
 	grpcServer := grpc.NewServer(serverOpts...)

--- a/flyteadmin/pkg/server/service.go
+++ b/flyteadmin/pkg/server/service.go
@@ -140,6 +140,9 @@ func newGRPCServer(ctx context.Context, pluginRegistry *plugins.Registry, cfg *c
 	if cfg.GrpcConfig.MaxMessageSizeBytes > 0 {
 		serverOpts = append(serverOpts, grpc.MaxRecvMsgSize(cfg.GrpcConfig.MaxMessageSizeBytes), grpc.MaxSendMsgSize(cfg.GrpcConfig.MaxMessageSizeBytes))
 	}
+	if cfg.GrpcConfig.MaxConcurrentStreams > 0 {
+		serverOpts = append(serverOpts, grpc.MaxConcurrentStreams(uint32(cfg.GrpcConfig.MaxConcurrentStreams)))
+	}
 	serverOpts = append(serverOpts, opts...)
 	grpcServer := grpc.NewServer(serverOpts...)
 	grpcprometheus.Register(grpcServer)


### PR DESCRIPTION
## Tracking issue
N/A (internal stability enhancement)

## Why are the changes needed?
Under high load, FlyteAdmin currently accepts all gRPC requests without constraint due to the lack of a MaxConcurrentStreams configuration. This can lead to unbounded in-flight requests, resulting in excessive memory usage, DB connection exhaustion, increased latency, and eventual cancellations or INTERNAL errors.

Adding a MaxConcurrentStreams limit allows the gRPC server to enforce backpressure at the transport layer, ensuring that only a bounded number of requests are actively processed at a time. This helps stabilize system behavior under bursty or sustained traffic conditions, particularly for high-volume APIs coming from propeller

## What changes were proposed in this pull request?
Introduced MaxConcurrentStreams as a configurable field in the FlyteAdmin gRPC server configuration.

Updated the grpc.NewServer initialization to apply this limit when set.

Default behavior remains unchanged (unbounded) unless explicitly configured.


## How was this patch tested?
Trivial change as it keeps the old behavior if unset.
Unit test for config changes

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

## Docs link

