### PR TITLE
Update `DemystifyFailure` to respect `NodeShutdown` (#724)

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -38,6 +38,10 @@ const primaryContainerTemplateName = "primary"
 const primaryInitContainerTemplateName = "primary-init"
 const PrimaryContainerKey = "primary_container_name"
 
+// nodePreemptionStatusReasons are the status reasons that a pod's respective node
+// is preempted by the scheduler
+var nodePreemptionStatusReasons = sets.NewString("Shutdown", "Terminated", "NodeShutdown")
+
 // AddRequiredNodeSelectorRequirements adds the provided v1.NodeSelectorRequirement
 // objects to an existing v1.Affinity object. If there are no existing required
 // node selectors, the new v1.NodeSelectorRequirement will be added as-is.
@@ -1202,8 +1206,8 @@ func DemystifyFailure(ctx context.Context, status v1.PodStatus, info pluginsCore
 	//
 
 	var isSystemError bool
-	// In some versions of GKE the reason can also be "Terminated"
-	if code == "Shutdown" || code == "Terminated" {
+	// In some versions of GKE the reason can also be "Terminated" or "NodeShutdown"
+	if nodePreemptionStatusReasons.Has(code) {
 		isSystemError = true
 	}
 

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -1699,50 +1699,27 @@ func TestDemystifyFailure(t *testing.T) {
 		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().GetKind())
 	})
 
-	t.Run("GKE kubelet graceful node shutdown", func(t *testing.T) {
-		containerReason := "some reason"
-		phaseInfo, err := DemystifyFailure(ctx, v1.PodStatus{
-			Message: "Pod Node is in progress of shutting down, not admitting any new pods",
-			Reason:  "Shutdown",
-			ContainerStatuses: []v1.ContainerStatus{
-				{
-					LastTerminationState: v1.ContainerState{
-						Terminated: &v1.ContainerStateTerminated{
-							Reason:   containerReason,
-							ExitCode: SIGKILL,
-						},
-					},
-				},
-			},
-		}, pluginsCore.TaskInfo{}, "")
-		assert.Nil(t, err)
-		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
-		assert.Equal(t, "Interrupted", phaseInfo.Err().GetCode())
-		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().GetKind())
-		assert.Contains(t, phaseInfo.Err().GetMessage(), containerReason)
-	})
-
-	t.Run("GKE kubelet graceful node shutdown", func(t *testing.T) {
-		containerReason := "some reason"
-		phaseInfo, err := DemystifyFailure(ctx, v1.PodStatus{
-			Message: "Foobar",
-			Reason:  "Terminated",
-			ContainerStatuses: []v1.ContainerStatus{
-				{
-					LastTerminationState: v1.ContainerState{
-						Terminated: &v1.ContainerStateTerminated{
-							Reason:   containerReason,
-							ExitCode: SIGKILL,
-						},
-					},
-				},
-			},
-		}, pluginsCore.TaskInfo{}, "")
-		assert.Nil(t, err)
-		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
-		assert.Equal(t, "Interrupted", phaseInfo.Err().GetCode())
-		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().GetKind())
-		assert.Contains(t, phaseInfo.Err().GetMessage(), containerReason)
+	t.Run("GKE node preemption", func(t *testing.T) {
+		for _, reason := range []string{
+			"Terminated",
+			"Shutdown",
+			"NodeShutdown",
+		} {
+			t.Run(reason, func(t *testing.T) {
+				message := "Test pod status message"
+				phaseInfo, err := DemystifyFailure(ctx, v1.PodStatus{
+					Message: message,
+					Reason:  reason,
+					// Can't always rely on GCP returining container statuses when node is preempted
+					ContainerStatuses: []v1.ContainerStatus{},
+				}, pluginsCore.TaskInfo{}, "")
+				assert.Nil(t, err)
+				assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
+				assert.Equal(t, "Interrupted", phaseInfo.Err().Code)
+				assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().Kind)
+				assert.Equal(t, message, phaseInfo.Err().Message)
+			})
+		}
 	})
 }
 

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -1715,9 +1715,9 @@ func TestDemystifyFailure(t *testing.T) {
 				}, pluginsCore.TaskInfo{}, "")
 				assert.Nil(t, err)
 				assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
-				assert.Equal(t, "Interrupted", phaseInfo.Err().Code)
-				assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().Kind)
-				assert.Equal(t, message, phaseInfo.Err().Message)
+				assert.Equal(t, "Interrupted", phaseInfo.Err().GetCode())
+				assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().GetKind())
+				assert.Equal(t, message, phaseInfo.Err().GetMessage())
 			})
 		}
 	})


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
`NodeShutdown` observed in more rare cases where GCP preempts nodes. Update `DemystifyFailure` to respect `NodeShutdown` reason and count it as retryable system error.

## What changes were proposed in this pull request?
^^^

## How was this patch tested?
local and cloud deployment

### Labels
- **fixed**: For any bug fixed.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances node preemption handling in the Flyte plugin by adding 'NodeShutdown' as a retryable system error. It updates the logic in the `DemystifyFailure` function and includes test cases to validate the new behavior, improving robustness against GCP node preemptions.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, making the review process relatively quick.
</div>