### PR TITLE
Support Volcano scheduler integration by enabling PodGroup creation for podTask in Propeller

### DIFF
--- a/flyteplugins/go.mod
+++ b/flyteplugins/go.mod
@@ -150,6 +150,7 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
+	volcano.sh/apis v1.8.2 // indirect
 )
 
 replace (

--- a/flyteplugins/go.sum
+++ b/flyteplugins/go.sum
@@ -804,3 +804,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+s
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
+volcano.sh/apis v1.8.2 h1:MJ1EXpdQeKG+XEhb/I3liWgMFzkgW3qCcj6qdhTuvfA=
+volcano.sh/apis v1.8.2/go.mod h1:h+xbUpkjfRaHjktAi8h+7JNnNahjwhRSgpN9FUUwNXQ=

--- a/flyteplugins/go/tasks/config_load_test.go
+++ b/flyteplugins/go/tasks/config_load_test.go
@@ -58,6 +58,7 @@ func TestLoadConfig(t *testing.T) {
 		assert.True(t, expectedMemory.Equal(k8sConfig.DefaultMemoryRequest))
 		assert.Equal(t, map[string]string{"x/interruptible": "true"}, k8sConfig.InterruptibleNodeSelector)
 		assert.Equal(t, "x/flyte", k8sConfig.InterruptibleTolerations[0].Key)
+		assert.Equal(t, false, k8sConfig.EnableCreatePodGroupForPod)
 		assert.Equal(t, "interruptible", k8sConfig.InterruptibleTolerations[0].Value)
 		assert.NotNil(t, k8sConfig.DefaultPodSecurityContext)
 		assert.NotNil(t, k8sConfig.DefaultPodSecurityContext.FSGroup)

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/config.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/config.go
@@ -220,6 +220,9 @@ type K8sPluginConfig struct {
 	AddTolerationsForExtendedResources []string `json:"add-tolerations-for-extended-resources" pflag:",Name of the extended resources for which tolerations should be added."`
 
 	EnableDistributedErrorAggregation bool `json:"enable-distributed-error-aggregation" pflag:",If true, will aggregate errors of different worker pods for distributed tasks."`
+
+	// EnableCreatePodGroupForPod enables creating volcano podgroups for pods.
+	EnableCreatePodGroupForPod bool `json:"enable-create-pod-group-for-pod" pflag:",If true, propeller won't create volcano podgroups."`
 }
 
 // FlyteCoPilotConfig specifies configuration for the Flyte CoPilot system. FlyteCoPilot, allows running flytekit-less containers

--- a/flyteplugins/go/tasks/plugins/k8s/pod/plugin.go
+++ b/flyteplugins/go/tasks/plugins/k8s/pod/plugin.go
@@ -12,10 +12,13 @@ import (
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery"
 	pluginsCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s"
+	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/k8s"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/tasklog"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
+	"k8s.io/client-go/kubernetes/scheme"
+	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
 const (
@@ -260,6 +263,11 @@ func (plugin) GetProperties() k8s.PluginProperties {
 }
 
 func init() {
+	if config.GetK8sPluginConfig().EnableCreatePodGroupForPod {
+		if err := volcanov1beta1.AddToScheme(scheme.Scheme); err != nil {
+			panic(err)
+		}
+	}
 	// Register ContainerTaskType and SidecarTaskType plugin entries. These separate task types
 	// still exist within the system, only now both are evaluated using the same internal pod plugin
 	// instance. This simplifies migration as users may keep the same configuration but are

--- a/flyteplugins/go/tasks/testdata/config.yaml
+++ b/flyteplugins/go/tasks/testdata/config.yaml
@@ -40,6 +40,7 @@ plugins:
     default-security-context:
       allowPrivilegeEscalation: false
     enable-host-networking-pod: true
+    enable-create-pod-group-for-pod: false
     default-pod-dns-config:
       options:
         - name: "ndots"

--- a/flytepropeller/go.mod
+++ b/flytepropeller/go.mod
@@ -162,6 +162,7 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
+	volcano.sh/apis v1.8.2 // indirect
 )
 
 replace (

--- a/flytepropeller/go.sum
+++ b/flytepropeller/go.sum
@@ -872,3 +872,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+s
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
+volcano.sh/apis v1.8.2 h1:MJ1EXpdQeKG+XEhb/I3liWgMFzkgW3qCcj6qdhTuvfA=
+volcano.sh/apis v1.8.2/go.mod h1:h+xbUpkjfRaHjktAi8h+7JNnNahjwhRSgpN9FUUwNXQ=

--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -41,6 +41,7 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
+	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
 const (
@@ -196,6 +197,93 @@ func (e *PluginManager) getPodEffectiveResourceLimits(ctx context.Context, pod *
 	return podRequestedResources
 }
 
+// getRequestResource will get the actual request resource.
+// It will first check if there is a defined request resource, if not, it will use the limit resource as the request.
+func getRequestResource(resources v1.ResourceRequirements) v1.ResourceList {
+	merged := v1.ResourceList{}
+	for name, req := range resources.Requests {
+		merged[name] = req
+	}
+	// If resources don't have requests, it defaults limit if that is explicitly specified.
+	for name, lim := range resources.Limits {
+		if _, ok := merged[name]; !ok {
+			merged[name] = lim
+		}
+	}
+	return merged
+}
+
+// createPodGroupForPod will build the associated volcano podgroup for a pod.
+func createPodGroupForPod(taskCtx pluginsCore.TaskExecutionMetadata, pod *v1.Pod) *volcanov1beta1.PodGroup {
+	// minResources is a concept in Volcano. A PodGroup will be enqueued when the required minResources
+	// are available in the cluster. Enqueue is a pre-filtering step before resource allocation,
+	// so strict computation is not necessary as long as the PodGroup meets the criteria for enqueuing.
+	//
+	// The minResources value is determined by:
+	// - The the total resources requested by all main containers.
+	// - The highest individual resource request among the init containers.
+	minResources := v1.ResourceList{}
+	for _, c := range pod.Spec.Containers {
+		requestResources := getRequestResource(c.Resources)
+		for name, quantity := range requestResources {
+			if q, ok := minResources[name]; !ok {
+				minResources[name] = quantity.DeepCopy()
+			} else {
+				q.Add(quantity)
+				minResources[name] = q
+			}
+		}
+	}
+	// InitContainers are run sequentially before other containers start, so the highest
+	// init container resource is compared against the sum of app containers to determine
+	// the effective usage.
+	for _, c := range pod.Spec.InitContainers {
+		requestResources := getRequestResource(c.Resources)
+		for name, quantity := range requestResources {
+			if value, ok := minResources[name]; !ok || quantity.Cmp(value) > 0 {
+				minResources[name] = quantity.DeepCopy()
+			}
+		}
+	}
+	podGroup := &volcanov1beta1.PodGroup{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: volcanov1beta1.SchemeGroupVersion.String(),
+			Kind:       "PodGroup",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pod.Name,
+			Namespace:       pod.Namespace,
+			OwnerReferences: []metav1.OwnerReference{taskCtx.GetOwnerReference()},
+			Annotations:     map[string]string{},
+			Labels:          map[string]string{},
+		},
+		Spec: volcanov1beta1.PodGroupSpec{
+			MinMember:         1,
+			PriorityClassName: pod.Spec.PriorityClassName,
+			MinResources:      &minResources,
+		},
+	}
+	if pod.Labels != nil {
+		for k, v := range pod.Labels {
+			podGroup.Labels[k] = v
+		}
+	}
+	if pod.Annotations != nil {
+		for k, v := range pod.Annotations {
+			podGroup.Annotations[k] = v
+		}
+	}
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	if queueName, ok := pod.Annotations[volcanov1beta1.QueueNameAnnotationKey]; ok {
+		podGroup.Spec.Queue = queueName
+	}
+	// This is to prevent volcano from creating the podgroup for the pod
+	pod.Annotations[volcanov1beta1.KubeGroupNameAnnotationKey] = podGroup.Name
+	return podGroup
+}
+
 func (e *PluginManager) launchResource(ctx context.Context, tCtx pluginsCore.TaskExecutionContext) (pluginsCore.Transition, error) {
 	tmpl, err := tCtx.TaskReader().Read(ctx)
 	if err != nil {
@@ -231,6 +319,19 @@ func (e *PluginManager) launchResource(ctx context.Context, tCtx pluginsCore.Tas
 
 		cfg := nodeTaskConfig.GetConfig()
 		backOffHandler := e.backOffController.GetOrCreateHandler(ctx, key, cfg.BackOffConfig.BaseSecond, cfg.BackOffConfig.MaxDuration.Duration)
+
+		if config.GetK8sPluginConfig().EnableCreatePodGroupForPod {
+			podGroup := createPodGroupForPod(k8sTaskCtxMetadata, pod)
+			err := e.kubeClient.GetClient().Create(ctx, podGroup)
+			if err != nil {
+				if !k8serrors.IsAlreadyExists(err) {
+					reason := k8serrors.ReasonForError(err)
+					return pluginsCore.UnknownTransition, errors.Wrapf(stdErrors.ErrorCode(reason), err, "failed to create volcano podgroup for pod")
+				}
+				// The error is IsAlreadyExists
+				logger.Warnf(ctx, "PodGroup [%s] is already exists. Err: %v", podGroup.Name, err)
+			}
+		}
 
 		err = backOffHandler.Handle(ctx, func() error {
 			return e.kubeClient.GetClient().Create(ctx, o)

--- a/go.mod
+++ b/go.mod
@@ -235,6 +235,7 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
+	volcano.sh/apis v1.8.2 // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -2082,3 +2082,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+s
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
+volcano.sh/apis v1.8.2 h1:MJ1EXpdQeKG+XEhb/I3liWgMFzkgW3qCcj6qdhTuvfA=
+volcano.sh/apis v1.8.2/go.mod h1:h+xbUpkjfRaHjktAi8h+7JNnNahjwhRSgpN9FUUwNXQ=


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

Support [Volcano scheduler](https://volcano.sh/en/docs/schduler_introduction/) integration by enabling PodGroup creation for podTask in Propeller. Volcano is a Kubernetes-native batch scheduler optimized for high-performance, AI/ML, and big data workloads.

Before this change, all podTasks associated with a FlyteWorkflow shared a single PodGroup, which was automatically created just once by the Volcano controller when the first podTask was launched. Subsequent podTasks reused this PodGroup, which introduced limitations. Specifically, different podTasks could not be scheduled with different Volcano queues or job priorities, since the shared PodGroup enforced a single queue and priority for all.

This change enables Propeller to create individual Volcano PodGroups for each podTask, allowing them to specify distinct queues and job priorities for scheduling.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

1. The plugin manager for the k8s pod plugin creates Volcano PodGroups before creating the corresponding pods for podTasks. The PodGroup will have the same name as the pod, ensuring unique mapping between PodGroup and Pod. It also adds the PodGroup name to the pod’s annotations, ensuring that the Volcano PodGroup controller [does not create the PodGroup again](https://github.com/volcano-sh/volcano/blob/master/pkg/controllers/podgroup/pg_controller.go#L168).
2. Each PodGroup inherits the queue and priority from its Pod.
3. Introduced a feature flag `enable-create-pod-group-for-pod` in the config to control whether this feature is enabled. The default value is false to ensure backward compatibility.
4. Regarding PodGroup garbage collection, the PodGroup is deleted by Kubernetes' GC. Since the PodGroup's owner reference points to a FlyteWorkflow, the deletion process follows a cascading effect. When the FlyteWorkflow is deleted, Kubernetes GC removes the associated PodGroup due to the absence of a living owner reference.

## How was this patch tested?
Unit tests added
Used internally at Linkedin.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
