### PR TITLE
Add version details to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -4,6 +4,13 @@ title: "[BUG] "
 labels: bug,untriaged
 body:
   - type: textarea
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: "Flyte & Flytekit version"
+      description: "What version of Flyte & Flytekit are you experiencing the bug on?"
+  - type: textarea
     id: steps-to-reproduce
     validations:
       required: true


### PR DESCRIPTION
## Why are the changes needed?

It is helpful to understand which version of Flyte a user is running when they are reporting a bug in the event that the bug is fixed in later versions of Flyte.  
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the bug report template by adding a new field for users to specify the version of Flyte and Flytekit. This improvement aims to provide essential context for diagnosing issues, thereby streamlining the resolution of version-specific bugs.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve template modifications, making the review process relatively simple.
-->
</div>