### PR TITLE
Provide overrides for flyteadmin readiness and liveness probes

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -188,10 +188,12 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.image.repository | string | `"cr.flyte.org/flyteorg/flyteadmin"` | Docker image for Flyteadmin deployment |
 | flyteadmin.image.tag | string | `"v1.15.3"` |  |
 | flyteadmin.initialProjects | list | `["flytesnacks","flytetester","flyteexamples"]` | Initial projects to create |
+| flyteadmin.livenessProbe | string | `"exec:\n  command: [ \"sh\", \"-c\", \"reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \\\"$reply\\\" -lt 200 -o \\\"$reply\\\" -ge 400 ]; then exit 1; fi;\",\"grpc_health_probe\", \"-addr=:8089\"]\ninitialDelaySeconds: 20\nperiodSeconds: 5"` |  |
 | flyteadmin.nodeSelector | object | `{}` | nodeSelector for Flyteadmin deployment |
 | flyteadmin.podAnnotations | object | `{}` | Annotations for Flyteadmin pods |
 | flyteadmin.podLabels | object | `{}` | Labels for Flyteadmin pods |
 | flyteadmin.priorityClassName | string | `""` | Sets priorityClassName for flyteadmin pod(s). |
+| flyteadmin.readinessProbe | string | `"exec:\n  command: [ \"sh\", \"-c\", \"reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \\\"$reply\\\" -lt 200 -o \\\"$reply\\\" -ge 400 ]; then exit 1; fi;\",\"grpc_health_probe\", \"-addr=:8089\"]\ninitialDelaySeconds: 15"` | Default readinessProbe and livenessProbe for Flyteadmin deployment |
 | flyteadmin.replicaCount | int | `1` | Replicas count for Flyteadmin deployment |
 | flyteadmin.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flyteadmin deployment |
 | flyteadmin.secrets | object | `{}` |  |

--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -170,14 +170,13 @@ spec:
         - containerPort: {{ .Values.configmap.adminServer.server.grpc.port }}
         - containerPort: {{ .Values.configmap.adminServer.flyteadmin.profilerPort }}
         readinessProbe:
-          exec:
-            command: [ "sh", "-c", "reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \"$reply\" -lt 200 -o \"$reply\" -ge 400 ]; then exit 1; fi;","grpc_health_probe", "-addr=:8089"]
-          initialDelaySeconds: 15
+        {{- with .Values.flyteadmin.readinessProbe -}}
+        {{- . | nindent 10 }}
+        {{- end }}
         livenessProbe:
-          exec:
-            command: [ "sh", "-c", "reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \"$reply\" -lt 200 -o \"$reply\" -ge 400 ]; then exit 1; fi;","grpc_health_probe", "-addr=:8089"]
-          initialDelaySeconds: 20
-          periodSeconds: 5
+        {{- with .Values.flyteadmin.livenessProbe -}}
+        {{- . | nindent 10 }}
+        {{- end }}
         resources: {{- toYaml .Values.flyteadmin.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -33,6 +33,16 @@ flyteadmin:
   env: []
   # -- Additional flyteadmin environment variables from a reference (ie: Secret or ConfigMap)
   envFrom: []
+  # -- Default readinessProbe and livenessProbe for Flyteadmin deployment
+  readinessProbe: |-
+    exec:
+      command: [ "sh", "-c", "reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \"$reply\" -lt 200 -o \"$reply\" -ge 400 ]; then exit 1; fi;","grpc_health_probe", "-addr=:8089"]
+    initialDelaySeconds: 15
+  livenessProbe: |-
+    exec:
+      command: [ "sh", "-c", "reply=$(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:8088/healthcheck); if [ \"$reply\" -lt 200 -o \"$reply\" -ge 400 ]; then exit 1; fi;","grpc_health_probe", "-addr=:8089"]
+    initialDelaySeconds: 20
+    periodSeconds: 5
   # -- Default resources requests and limits for Flyteadmin deployment
   resources:
     limits:

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: R2Y5TjJiMXJWeGl6cEVYeg==
+  haSharedSecret: QXNPU1hzMFVXakFoOHRrZQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: d16fd6f9a37fa084c02366a2ac36d91c589a8f8c0ed6bf6a525b1142aa3b8689
+        checksum/secret: cdd763d69f7b1d911c90ab0d597f2cd48a122a4ec24d83277582016763362007
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: SUZqWDFOSThuSHZGdlNHeg==
+  haSharedSecret: UllnZHptaVBlY29iUGZLUw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: b7358657815c05ca593cf3ccbc66ce0369e17f9fae7986c0d6edf6abc5cb512d
+        checksum/secret: df53900dab73552f2582a5448003cd53b04b48808283c627eb948262c90635a7
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: VzFrSUF4ZHZnNGRnbU5ZUw==
+  haSharedSecret: TmUxblNpWEV6d2hFcGhDSA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 41e6ba30ebee486d51ee181e08956b050f64f835be9fa2a967f27b9ad57df570
+        checksum/secret: a9d8526d62f1c0cb04b433fae0121c2458e687cb9e9226da2e08966e9e503e31
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## Why are the changes needed?
Certain flyte images may not have access to curl binaries which may cause readiness and liveness probes to fail for flyteadmin.

This PR adds readiness and liveness probe of flyteadmin to be overridable but keeping the original ones as defaults in the values file.

This makes sure there are no differences in the generated file

## What changes were proposed in this pull request?
Introduce value overrides for both readiness and livesProbe for flyteadmin deployment

## How was this patch tested?
No diff between the original generated helm manifest


### Labels


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the Flyteadmin deployment by making readiness and liveness probes configurable via the values file, while preserving original defaults. It also updates checksums for several secrets to ensure security integrity.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, requiring minimal effort to review.
-->
</div>