### PR TITLE
Fix release script for beta versions

### DIFF
--- a/script/prepare_artifacts.sh
+++ b/script/prepare_artifacts.sh
@@ -14,6 +14,11 @@ for file in ./deployment/**/flyte_generated.yaml; do
     fi
 done
 
+# Normalize VERSION if it's a beta (e.g., v1.16.0b0 → v1.16.0-beta.0)
+if [[ "$VERSION" =~ b[0-9]+ ]]; then
+  VERSION=$(echo "${VERSION}" | sed -E 's/b([0-9]+)/-beta.\1/')
+fi
+
 grep -rlZ "version:[^P]*# VERSION" ./charts/flyte/Chart.yaml | xargs -0 sed -i "s/version:[^P]*# VERSION/version: ${VERSION} # VERSION/g"
 sed "s/v0.1.10/${VERSION}/g" ./charts/flyte/README.md  > temp.txt && mv temp.txt ./charts/flyte/README.md
 


### PR DESCRIPTION
## Why are the changes needed?
Releasing beta release charts fail https://github.com/flyteorg/flyte/actions/runs/15454959519/job/43505569848

## What changes were proposed in this pull request?

When the released version is beta then format the semver for release to be compatible with helm

## How was this patch tested?
Independently tested the changed portion

```
cat a.sh                                                                                                 .venv-new-2
# Normalize VERSION if it's a beta (e.g., v1.16.0b0 → v1.16.0-beta.0)
if [[ "$VERSION" =~ b[0-9]+ ]]; then
  VERSION=$(echo "${VERSION}" | sed -E 's/b([0-9]+)/-beta.\1/')
fi
echo $VERSION
```

```
VERSION=v1.15.3 sh a.sh                                                                               
v1.15.3
```

```
VERSION=v1.16.0b0 sh a.sh                                                                                .venv-new-2
v1.16.0-beta.0
```

### Labels


- **fixed**: For any bug fixed.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes an issue with the release script that caused failures for beta version releases. It implements new logic for formatting beta versions to ensure compatibility with Helm, and the changes have been independently tested for effectiveness.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>