### PR TITLE
add: nats as cloud events sender

### DIFF
--- a/docs/deployment/configuration/cloud_event.rst
+++ b/docs/deployment/configuration/cloud_event.rst
@@ -32,8 +32,9 @@ Supported Implementations
 Event egress can be configured to work with **AWS** using
 `SQS <https://aws.amazon.com/sqs/>`_ and
 `SNS <https://aws.amazon.com/sns/>`_,
-**GCP** `Cloud Pub/Sub <https://cloud.google.com/pubsub>`_, or
-`Apache Kafka <https://kafka.apache.org/>`_
+**GCP** `Cloud Pub/Sub <https://cloud.google.com/pubsub>`_,
+`Apache Kafka <https://kafka.apache.org/>`_, or
+`NATS <https://https://nats.io/>`_
 
 *************
 Configuration
@@ -87,6 +88,21 @@ To turn on, add the following to your FlyteAdmin:
                - all
                topicName: myTopic
              type: kafka
+
+   .. tab:: Nats
+   
+       .. code:: yaml
+   
+         cloud_events.yaml: |
+           cloudEvents:
+             enable: true
+             nats:
+               servers: 127.0.0.1:4222
+             eventsPublisher:
+               eventTypes:
+               - all
+               topicName: myTopic # this will be used as NATS subject
+             type: nats
 
 Helm
 ======

--- a/flyteadmin/go.mod
+++ b/flyteadmin/go.mod
@@ -156,6 +156,9 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nats-io/nats.go v1.31.0 // indirect
+	github.com/nats-io/nkeys v0.4.6 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncw/swift v1.0.53 // indirect
 	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/ory/go-acc v0.2.6 // indirect
@@ -226,6 +229,7 @@ require (
 	github.com/Shopify/sarama v1.26.4
 	github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737 // indirect
 	github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2 v2.8.0
+	github.com/cloudevents/sdk-go/protocol/nats/v2 v2.15.2
 	github.com/imdario/mergo v0.3.13 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect

--- a/flyteadmin/go.sum
+++ b/flyteadmin/go.sum
@@ -148,6 +148,8 @@ github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.8.0 h1:hRguaVL9rVsO8
 github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.8.0/go.mod h1:Ba4CS2d+naAK8tGd6nm5ftGIWuHim+1lryAaIxhuh1k=
 github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2 v2.8.0 h1:48wFAj3LK/G80FqXgKzyciQF9BU3W+RwucGwWY1Tk0M=
 github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2 v2.8.0/go.mod h1:m41mqM/Pa9pzPPNrvWwY3M7llCuzciKk5tqH0m6Rz9I=
+github.com/cloudevents/sdk-go/protocol/nats/v2 v2.15.2 h1:grQPId+rXCeR5RcmK5uBlissnlot7kBlHd8YJ7iZOPg=
+github.com/cloudevents/sdk-go/protocol/nats/v2 v2.15.2/go.mod h1:KQA5rf2uSgtCnXsAFyFXtwiDboL/pB6gsg4VTErhfLA=
 github.com/cloudevents/sdk-go/v2 v2.8.0/go.mod h1:GpCBmUj7DIRiDhVvsK5d6WCbgTWs8DxAWTRtAwQmIXs=
 github.com/cloudevents/sdk-go/v2 v2.15.2 h1:54+I5xQEnI73RBhWHxbI1XJcqOFOVJN85vb41+8mHUc=
 github.com/cloudevents/sdk-go/v2 v2.15.2/go.mod h1:lL7kSWAE/V8VI4Wh0jbL2v/jvqsm6tjmaQBSvxcv4uE=
@@ -1012,6 +1014,12 @@ github.com/moul/http2curl v0.0.0-20170919181001-9ac6cf4d929b/go.mod h1:8UbvGypXm
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nats-io/nats.go v1.31.0 h1:/WFBHEc/dOKBF6qf1TZhrdEfTmOZ5JzdJ+Y3m6Y/p7E=
+github.com/nats-io/nats.go v1.31.0/go.mod h1:di3Bm5MLsoB4Bx61CBTsxuarI36WbhAwOm8QrW39+i8=
+github.com/nats-io/nkeys v0.4.6 h1:IzVe95ru2CT6ta874rt9saQRkWfe2nFj1NtvYSLqMzY=
+github.com/nats-io/nkeys v0.4.6/go.mod h1:4DxZNzenSVd1cYQoAa8948QY3QDjrHfcfVADymtkpts=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/ncw/swift v1.0.53 h1:luHjjTNtekIEvHg5KdAFIBaH7bWfNkefwFnpDffSIks=
 github.com/ncw/swift v1.0.53/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/nicksnyder/go-i18n v1.10.0/go.mod h1:HrK7VCrbOvQoUAQ7Vpy7i87N7JZZZ7R2xBGjv0j365Q=

--- a/flyteadmin/pkg/async/cloudevent/factory.go
+++ b/flyteadmin/pkg/async/cloudevent/factory.go
@@ -10,6 +10,9 @@ import (
 	gizmoGCP "github.com/NYTimes/gizmo/pubsub/gcp"
 	"github.com/Shopify/sarama"
 	"github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
+	nats "github.com/nats-io/nats.go"
+
+	cenats "github.com/cloudevents/sdk-go/protocol/nats/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 
 	"github.com/flyteorg/flyte/flyteadmin/pkg/async"
@@ -85,6 +88,25 @@ func NewCloudEventsPublisher(ctx context.Context, db repositoryInterfaces.Reposi
 			panic(err)
 		}
 		sender = &cloudEventImplementations.KafkaSender{Client: client}
+
+	case cloudEventImplementations.Nats:
+		natsOptions := []nats.Option{nats.ReconnectWait(reconnectDelay), nats.MaxReconnects(reconnectAttempts), nats.Name("flyteadmin")}
+		if cloudEventsConfig.NatsConfig.TokenAuthConfig.Enabled {
+			natsOptions = append(natsOptions, nats.Token(cloudEventsConfig.NatsConfig.TokenAuthConfig.Token))
+		}
+		if cloudEventsConfig.NatsConfig.UserPassAuthConfig.Enabled {
+			natsOptions = append(natsOptions, nats.UserInfo(cloudEventsConfig.NatsConfig.UserPassAuthConfig.User, cloudEventsConfig.NatsConfig.UserPassAuthConfig.Password))
+		}
+		natsSender, err := cenats.NewSender(strings.Join(cloudEventsConfig.NatsConfig.Servers, ","), cloudEventsConfig.EventsPublisherConfig.TopicName, natsOptions)
+		if err != nil {
+			panic(err)
+		}
+		client, err := cloudevents.NewClient(natsSender, cloudevents.WithTimeNow(), cloudevents.WithUUIDs())
+		if err != nil {
+			logger.Fatalf(ctx, "failed to create nats client, %v", err)
+			panic(err)
+		}
+		sender = &cloudEventImplementations.NatsSender{Client: client}
 
 	case common.Sandbox:
 		var publisher pubsub.Publisher

--- a/flyteadmin/pkg/async/cloudevent/factory_test.go
+++ b/flyteadmin/pkg/async/cloudevent/factory_test.go
@@ -103,3 +103,21 @@ func TestInvalidKafkaConfig(t *testing.T) {
 	NewCloudEventsPublisher(context.Background(), db, mockStore, url, cfg, remoteCfg, promutils.NewTestScope())
 	t.Errorf("did not panic")
 }
+
+func TestInvalidNatsConfig(t *testing.T) {
+	defer func() { r := recover(); assert.NotNil(t, r) }()
+	cfg := runtimeInterfaces.CloudEventsConfig{
+		Enable:                true,
+		Type:                  implementations.Nats,
+		EventsPublisherConfig: runtimeInterfaces.EventsPublisherConfig{TopicName: "topic"},
+		NatsConfig:            runtimeInterfaces.NatsConfig{},
+	}
+	db := mocks.NewMockRepository()
+	mockStore := getMockStore()
+	url := &dataMocks.RemoteURLInterface{}
+
+	NewCloudEventsPublisher(context.Background(), db, mockStore, url, cfg, remoteCfg, promutils.NewTestScope())
+	cfg.NatsConfig.Servers = []string{"localhost:4222"}
+	NewCloudEventsPublisher(context.Background(), db, mockStore, url, cfg, remoteCfg, promutils.NewTestScope())
+	t.Errorf("did not panic")
+}

--- a/flyteadmin/pkg/async/cloudevent/implementations/cloudevent_publisher_test.go
+++ b/flyteadmin/pkg/async/cloudevent/implementations/cloudevent_publisher_test.go
@@ -28,6 +28,12 @@ func (s mockKafkaSender) Send(ctx context.Context, notificationType string, even
 	return errorPublish
 }
 
+type mockNatsSender struct{}
+
+func (s mockNatsSender) Send(ctx context.Context, notificationType string, event cloudevents.Event) error {
+	return errorPublish
+}
+
 var errorPublish = errors.New("publish() returns an error")
 var testCloudEventPublisher pubsubtest.TestPublisher
 var mockCloudEventPublisher pubsub.Publisher = &testCloudEventPublisher
@@ -196,6 +202,9 @@ func TestCloudEventPublisher_PublishError(t *testing.T) {
 		proto.MessageName(taskRequest), taskRequest))
 
 	currentEventPublisher = NewCloudEventsPublisher(&mockKafkaSender{}, promutils.NewTestScope(), []string{"*"})
+	assert.Equal(t, errorPublish, currentEventPublisher.Publish(context.Background(),
+		proto.MessageName(taskRequest), taskRequest))
+	currentEventPublisher = NewCloudEventsPublisher(&mockNatsSender{}, promutils.NewTestScope(), []string{"*"})
 	assert.Equal(t, errorPublish, currentEventPublisher.Publish(context.Background(),
 		proto.MessageName(taskRequest), taskRequest))
 }

--- a/flyteadmin/pkg/async/cloudevent/implementations/sender.go
+++ b/flyteadmin/pkg/async/cloudevent/implementations/sender.go
@@ -17,6 +17,7 @@ type Receiver = string
 
 const (
 	Kafka Receiver = "kafka"
+	Nats  Receiver = "nats"
 )
 
 // PubSubSender Implementation of Sender
@@ -49,6 +50,18 @@ func (s *KafkaSender) Send(ctx context.Context, notificationType string, event c
 		kafka_sarama.WithMessageKey(ctx, sarama.StringEncoder(event.ID())),
 		event,
 	); cloudevents.IsUndelivered(result) {
+		return fmt.Errorf("failed to send cloud event: %v", result)
+	}
+	return nil
+}
+
+// Nats Implementation of Sender
+type NatsSender struct {
+	Client cloudevents.Client
+}
+
+func (s *NatsSender) Send(ctx context.Context, notificationType string, event cloudevents.Event) error {
+	if result := s.Client.Send(ctx, event); cloudevents.IsUndelivered(result) {
 		return fmt.Errorf("failed to send cloud event: %v", result)
 	}
 	return nil

--- a/flyteadmin/pkg/async/cloudevent/implementations/sender_test.go
+++ b/flyteadmin/pkg/async/cloudevent/implementations/sender_test.go
@@ -38,3 +38,10 @@ func TestKafkaSender(t *testing.T) {
 	err := kafkaSender.Send(context.Background(), "test", cloudEvent)
 	assert.Nil(t, err)
 }
+
+func TestNatsSender(t *testing.T) {
+	natsSender := NatsSender{mockCloudEventClient{}}
+	cloudEvent := cloudevents.NewEvent()
+	err := natsSender.Send(context.Background(), "test", cloudEvent)
+	assert.Nil(t, err)
+}

--- a/flyteadmin/pkg/async/cloudevent/interfaces/publisher.go
+++ b/flyteadmin/pkg/async/cloudevent/interfaces/publisher.go
@@ -8,7 +8,7 @@ import (
 
 //go:generate mockery --name=Publisher --output=../mocks --case=underscore --with-expecter
 
-// Publisher Defines the interface for Publishing execution event to other services (AWS pub/sub, Kafka).
+// Publisher Defines the interface for Publishing execution event to other services (AWS pub/sub, Kafka, Nats).
 type Publisher interface {
 	// Publish The notificationType is inferred from the Notification object in the Execution Spec.
 	Publish(ctx context.Context, notificationType string, msg proto.Message) error

--- a/flyteadmin/pkg/async/cloudevent/interfaces/sender.go
+++ b/flyteadmin/pkg/async/cloudevent/interfaces/sender.go
@@ -10,6 +10,6 @@ import (
 
 // Sender Defines the interface for sending cloudevents.
 type Sender interface {
-	// Send a cloud event to other services (AWS pub/sub, Kafka).
+	// Send a cloud event to other services (AWS pub/sub, Kafka, Nats).
 	Send(ctx context.Context, notificationType string, event cloudevents.Event) error
 }

--- a/flyteadmin/pkg/runtime/interfaces/application_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/application_configuration.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Shopify/sarama"
+
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"golang.org/x/time/rate"
 
@@ -321,6 +322,31 @@ func (k KafkaConfig) UpdateSaramaConfig(ctx context.Context, s *sarama.Config) {
 			s.Net.TLS.Config.Certificates = []tls.Certificate{cert}
 		}
 	}
+}
+
+type NatsUserPassAuthConfig struct {
+	// Whether to use user/pass authentication
+	Enabled bool `json:"enabled"`
+	// Username to be used when connecting to the server.
+	User string `json:"user"`
+	// Password to be used when connecting to a server.
+	Password string `json:"password"`
+}
+type NatsTokenAuthConfig struct {
+	// Whether to use token authentication
+	Enabled bool `json:"enabled"`
+	// Token to be used when connecting to the server.
+	Token string `json:"token"`
+}
+
+// This section holds configs for Nats clients
+type NatsConfig struct {
+	// nats broker addresses
+	Servers []string `json:"servers"`
+	// Username/password authentication config
+	UserPassAuthConfig NatsUserPassAuthConfig `json:"userAuthentication"`
+	// Token authentication config
+	TokenAuthConfig NatsTokenAuthConfig `json:"tokenAuthentication"`
 }
 
 // This section holds configuration for the event scheduler used to schedule workflow executions.
@@ -641,6 +667,7 @@ type CloudEventsConfig struct {
 	AWSConfig   AWSConfig   `json:"aws"`
 	GCPConfig   GCPConfig   `json:"gcp"`
 	KafkaConfig KafkaConfig `json:"kafka"`
+	NatsConfig  NatsConfig  `json:"nats"`
 	// Publish events to a pubsub tops
 	EventsPublisherConfig EventsPublisherConfig `json:"eventsPublisher"`
 	// Number of times to attempt recreating a notifications processor client should there be any disruptions.


### PR DESCRIPTION
## Why are the changes needed?

To add a new cloud events egress.

## What changes were proposed in this pull request?

To support NATS as **cloud events sender** other than the existing ones.

## How was this patch tested?

- Added proper unit tests

### Setup process

- Install Flyte
- Create NATS Docker container
- Check the `NATS` tab at docs page`flyte/deployment/flyte-configuration/cloud_events/#configuration` to properly configure  Flyte to send cloud-events via Nats

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [*] I updated the documentation accordingly.
- [*] All new and existing tests passed.
- [*] All commits are signed-off.


## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces NATS as a new cloud events sender, enhancing the system's capabilities. It includes updates to the publisher and sender interfaces, new configuration options, and comprehensive documentation. Unit tests have been added to ensure functionality.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>