### PR TITLE
[FIX] remove SYS_PTRACE and sharenamespace settings

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -26,8 +26,6 @@ const (
 	flyteDownloaderContainerName = "downloader"
 )
 
-var pTraceCapability = v1.Capability("SYS_PTRACE")
-
 func FlyteCoPilotContainer(name string, cfg config.FlyteCoPilotConfig, args []string, volumeMounts ...v1.VolumeMount) (v1.Container, error) {
 	cpu, err := resource.ParseQuantity(cfg.CPU)
 	if err != nil {

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -175,7 +175,6 @@ func AddCoPilotToContainer(ctx context.Context, cfg config.FlyteCoPilotConfig, c
 	if c.SecurityContext.Capabilities == nil {
 		c.SecurityContext.Capabilities = &v1.Capabilities{}
 	}
-	c.SecurityContext.Capabilities.Add = append(c.SecurityContext.Capabilities.Add, pTraceCapability)
 
 	if iFace != nil {
 		if iFace.GetInputs() != nil && len(iFace.GetInputs().GetVariables()) > 0 {
@@ -211,8 +210,6 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 
 	//nolint:protogetter
 	logger.Infof(ctx, "CoPilot Enabled for task [%s]", taskExecMetadata.GetTaskExecutionID().GetID().TaskId.GetName())
-	shareProcessNamespaceEnabled := true
-	coPilotPod.ShareProcessNamespace = &shareProcessNamespaceEnabled
 	primaryInitContainerName := ""
 	if iFace != nil {
 		if iFace.GetInputs() != nil && len(iFace.GetInputs().GetVariables()) > 0 {

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
@@ -227,34 +227,6 @@ func assertContainerHasVolumeMounts(t *testing.T, cfg config.FlyteCoPilotConfig,
 	}
 }
 
-func assertContainerHasPTrace(t *testing.T, c *v1.Container) {
-	assert.NotNil(t, c.SecurityContext)
-	assert.NotNil(t, c.SecurityContext.Capabilities)
-	assert.NotNil(t, c.SecurityContext.Capabilities.Add)
-	capFound := false
-	for _, cap := range c.SecurityContext.Capabilities.Add {
-		if cap == pTraceCapability {
-			capFound = true
-		}
-	}
-	assert.True(t, capFound, "ptrace not found?")
-}
-
-func assertPodHasSNPS(t *testing.T, pod *v1.PodSpec) {
-	assert.NotNil(t, pod.ShareProcessNamespace)
-	assert.True(t, *pod.ShareProcessNamespace)
-
-	found := false
-	for _, c := range pod.Containers {
-		if c.Name == "test" {
-			found = true
-			cntr := c
-			assertContainerHasPTrace(t, &cntr)
-		}
-	}
-	assert.False(t, found, "user container absent?")
-}
-
 func assertPodHasCoPilot(t *testing.T, cfg config.FlyteCoPilotConfig, pilot *core.DataLoadingConfig, iFace *core.TypedInterface, pod *v1.PodSpec) {
 	for _, c := range pod.Containers {
 		if c.Name == "test" {
@@ -367,7 +339,6 @@ func TestAddCoPilotToContainer(t *testing.T) {
 		pilot := &core.DataLoadingConfig{Enabled: true}
 		assert.NoError(t, AddCoPilotToContainer(ctx, cfg, &c, nil, pilot))
 		assertContainerHasVolumeMounts(t, cfg, pilot, nil, &c)
-		assertContainerHasPTrace(t, &c)
 	})
 
 	t.Run("happy-iface-empty-config", func(t *testing.T) {
@@ -388,7 +359,6 @@ func TestAddCoPilotToContainer(t *testing.T) {
 		}
 		pilot := &core.DataLoadingConfig{Enabled: true}
 		assert.NoError(t, AddCoPilotToContainer(ctx, cfg, &c, iface, pilot))
-		assertContainerHasPTrace(t, &c)
 		assertContainerHasVolumeMounts(t, cfg, pilot, iface, &c)
 	})
 
@@ -414,7 +384,6 @@ func TestAddCoPilotToContainer(t *testing.T) {
 			OutputPath: "out",
 		}
 		assert.NoError(t, AddCoPilotToContainer(ctx, cfg, &c, iface, pilot))
-		assertContainerHasPTrace(t, &c)
 		assertContainerHasVolumeMounts(t, cfg, pilot, iface, &c)
 	})
 
@@ -435,7 +404,6 @@ func TestAddCoPilotToContainer(t *testing.T) {
 			OutputPath: "out",
 		}
 		assert.NoError(t, AddCoPilotToContainer(ctx, cfg, &c, iface, pilot))
-		assertContainerHasPTrace(t, &c)
 		assertContainerHasVolumeMounts(t, cfg, pilot, iface, &c)
 	})
 
@@ -455,7 +423,6 @@ func TestAddCoPilotToContainer(t *testing.T) {
 			OutputPath: "out",
 		}
 		assert.NoError(t, AddCoPilotToContainer(ctx, cfg, &c, iface, pilot))
-		assertContainerHasPTrace(t, &c)
 		assertContainerHasVolumeMounts(t, cfg, pilot, iface, &c)
 	})
 }
@@ -543,7 +510,6 @@ func TestAddCoPilotToPod(t *testing.T) {
 		primaryInitContainerName, err := AddCoPilotToPod(ctx, cfg, &pod, iface, taskMetadata, inputPaths, opath, pilot)
 		assert.NoError(t, err)
 		assert.Equal(t, "test-downloader", primaryInitContainerName)
-		assertPodHasSNPS(t, &pod)
 		assertPodHasCoPilot(t, cfg, pilot, iface, &pod)
 	})
 
@@ -557,7 +523,6 @@ func TestAddCoPilotToPod(t *testing.T) {
 		primaryInitContainerName, err := AddCoPilotToPod(ctx, cfg, &pod, nil, taskMetadata, inputPaths, opath, pilot)
 		assert.NoError(t, err)
 		assert.Empty(t, primaryInitContainerName)
-		assertPodHasSNPS(t, &pod)
 		assertPodHasCoPilot(t, cfg, pilot, nil, &pod)
 	})
 
@@ -579,7 +544,6 @@ func TestAddCoPilotToPod(t *testing.T) {
 		primaryInitContainerName, err := AddCoPilotToPod(ctx, cfg, &pod, iface, taskMetadata, inputPaths, opath, pilot)
 		assert.NoError(t, err)
 		assert.Equal(t, "test-downloader", primaryInitContainerName)
-		assertPodHasSNPS(t, &pod)
 		assertPodHasCoPilot(t, cfg, pilot, iface, &pod)
 	})
 
@@ -600,7 +564,6 @@ func TestAddCoPilotToPod(t *testing.T) {
 		primaryInitContainerName, err := AddCoPilotToPod(ctx, cfg, &pod, iface, taskMetadata, inputPaths, opath, pilot)
 		assert.NoError(t, err)
 		assert.Empty(t, primaryInitContainerName)
-		assertPodHasSNPS(t, &pod)
 		assertPodHasCoPilot(t, cfg, pilot, iface, &pod)
 	})
 


### PR DESCRIPTION
## Tracking issue
 

## Why are the changes needed?

We remove the shared namespace process watcher in the PR #6501 and use the new signal watcher instead. Therefor, the config related to shared namespace process watcher can be removed.


## What changes were proposed in this pull request?

- Remove `SYS_PTRACE` and `ShareProcessNamespace` settings

## How was this patch tested?

None

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

Follow up #6501

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the CoPilot configuration by removing redundant settings related to the SYS_PTRACE capability and ShareProcessNamespace configuration. These modifications aim to simplify the code, improve maintainability, and reduce redundancy. Corresponding tests for these settings have also been removed.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>