### PR TITLE
Fix workflow equality check

### DIFF
--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/error.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/error.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"github.com/golang/protobuf/proto"
+
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytestdlib/utils"
 )
@@ -21,4 +23,24 @@ func (in *ExecutionError) UnmarshalJSON(b []byte) error {
 
 func (in *ExecutionError) DeepCopyInto(out *ExecutionError) {
 	*out = *in
+}
+
+func (in *ExecutionError) Equals(other *ExecutionError) bool {
+	if in == nil && other == nil {
+		return true
+	}
+
+	if in == nil || other == nil {
+		return false
+	}
+
+	if in.ExecutionError != nil && other.ExecutionError != nil {
+		if !proto.Equal(in.ExecutionError, other.ExecutionError) {
+			return false
+		}
+	} else if in.ExecutionError != other.ExecutionError {
+		return false
+	}
+
+	return true
 }

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
@@ -21,7 +21,6 @@ import (
 
 //go:generate mockery --all --with-expecter
 
-type CustomState map[string]interface{}
 type WorkflowID = string
 type TaskID = string
 type NodeID = string

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status.go
@@ -198,6 +198,25 @@ func (in *WorkflowNodeStatus) SetWorkflowNodePhase(phase WorkflowNodePhase) {
 	}
 }
 
+func (in *WorkflowNodeStatus) Equals(other *WorkflowNodeStatus) bool {
+	if in == nil && other == nil {
+		return true
+	}
+	if in == nil || other == nil {
+		return false
+	}
+
+	if in.ExecutionError != nil && other.ExecutionError != nil {
+		if !proto.Equal(in.ExecutionError, other.ExecutionError) {
+			return false
+		}
+	} else if in.ExecutionError != other.ExecutionError {
+		return false
+	}
+
+	return in.Phase == other.Phase
+}
+
 type GateNodePhase int
 
 const (
@@ -408,7 +427,6 @@ type NodeStatus struct {
 	SubNodeStatus map[NodeID]*NodeStatus `json:"subNodeStatus,omitempty"`
 	// We can store the outputs at this layer
 
-	// TODO not used delete
 	WorkflowNodeStatus *WorkflowNodeStatus `json:"workflowNodeStatus,omitempty"`
 
 	TaskNodeStatus    *TaskNodeStatus    `json:",omitempty"`
@@ -952,6 +970,10 @@ func (in *NodeStatus) Equals(other *NodeStatus) bool {
 		if !v.Equals(otherV) {
 			return false
 		}
+	}
+
+	if !in.WorkflowNodeStatus.Equals(other.WorkflowNodeStatus) {
+		return false
 	}
 
 	if in.Error != nil && other.Error != nil {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
@@ -30,7 +31,7 @@ func (in *MutableStruct) ResetDirty() {
 	in.isDirty = false
 }
 
-func (in MutableStruct) IsDirty() bool {
+func (in *MutableStruct) IsDirty() bool {
 	return in.isDirty
 }
 
@@ -157,7 +158,8 @@ func (in *DynamicNodeStatus) Equals(o *DynamicNodeStatus) bool {
 	if in == nil || o == nil {
 		return false
 	}
-	return in.Phase == o.Phase && in.Reason == o.Reason
+
+	return in.Phase == o.Phase && in.Reason == o.Reason && in.IsFailurePermanent == o.IsFailurePermanent && in.Error.Equals(o.Error)
 }
 
 type WorkflowNodePhase int
@@ -217,6 +219,18 @@ func (in *GateNodeStatus) SetGateNodePhase(phase GateNodePhase) {
 		in.SetDirty()
 		in.Phase = phase
 	}
+}
+
+func (in *GateNodeStatus) Equals(other *GateNodeStatus) bool {
+	if in == nil && other == nil {
+		return true
+	}
+
+	if in == nil || other == nil {
+		return false
+	}
+
+	return in.Phase == other.Phase
 }
 
 type ArrayNodePhase int
@@ -328,7 +342,7 @@ func (in *ArrayNodeStatus) SetTaskPhaseVersion(taskPhaseVersion uint32) {
 	}
 }
 
-func (in *ArrayNodeStatus) DeepCopyInto(out *ArrayNodeStatus) {
+func (in *ArrayNodeStatus) deepCopyInto(out *ArrayNodeStatus) {
 	*out = *in
 	out.MutableStruct = in.MutableStruct
 
@@ -345,30 +359,53 @@ func (in *ArrayNodeStatus) DeepCopy() *ArrayNodeStatus {
 	}
 
 	out := &ArrayNodeStatus{}
-	in.DeepCopyInto(out)
+	in.deepCopyInto(out)
 	return out
+}
+
+func (in *ArrayNodeStatus) Equals(other *ArrayNodeStatus) bool {
+	if in == nil && other == nil {
+		return true
+	}
+
+	if in == nil || other == nil {
+		return false
+	}
+
+	if in.ExecutionError != nil && other.ExecutionError != nil {
+		if !proto.Equal(in.ExecutionError, other.ExecutionError) {
+			return false
+		}
+	} else if in.ExecutionError != other.ExecutionError {
+		return false
+	}
+
+	return in.Phase == other.Phase &&
+		reflect.DeepEqual(in.SubNodePhases, other.SubNodePhases) &&
+		reflect.DeepEqual(in.SubNodeTaskPhases, other.SubNodeTaskPhases) &&
+		reflect.DeepEqual(in.SubNodeRetryAttempts, other.SubNodeRetryAttempts) &&
+		reflect.DeepEqual(in.SubNodeSystemFailures, other.SubNodeSystemFailures) &&
+		reflect.DeepEqual(in.SubNodeDeltaTimestamps, other.SubNodeDeltaTimestamps) &&
+		in.TaskPhaseVersion == other.TaskPhaseVersion
 }
 
 type NodeStatus struct {
 	MutableStruct
-	Phase                NodePhase     `json:"phase,omitempty"`
-	QueuedAt             *metav1.Time  `json:"queuedAt,omitempty"`
-	StartedAt            *metav1.Time  `json:"startedAt,omitempty"`
-	StoppedAt            *metav1.Time  `json:"stoppedAt,omitempty"`
-	LastUpdatedAt        *metav1.Time  `json:"lastUpdatedAt,omitempty"`
-	LastAttemptStartedAt *metav1.Time  `json:"laStartedAt,omitempty"`
-	Message              string        `json:"message,omitempty"`
-	DataDir              DataReference `json:"-"`
-	OutputDir            DataReference `json:"-"`
-	Attempts             uint32        `json:"attempts,omitempty"`
-	SystemFailures       uint32        `json:"systemFailures,omitempty"`
-	Cached               bool          `json:"cached,omitempty"`
+	Phase                NodePhase    `json:"phase,omitempty"`
+	QueuedAt             *metav1.Time `json:"queuedAt,omitempty"`
+	StartedAt            *metav1.Time `json:"startedAt,omitempty"`
+	StoppedAt            *metav1.Time `json:"stoppedAt,omitempty"`
+	LastUpdatedAt        *metav1.Time `json:"lastUpdatedAt,omitempty"`
+	LastAttemptStartedAt *metav1.Time `json:"laStartedAt,omitempty"`
+	Message              string       `json:"message,omitempty"`
+	Attempts             uint32       `json:"attempts,omitempty"`
+	SystemFailures       uint32       `json:"systemFailures,omitempty"`
+	Cached               bool         `json:"cached,omitempty"`
 
 	// This is useful only for branch nodes. If this is set, then it can be used to determine if execution can proceed
-	ParentNode    *NodeID                  `json:"parentNode,omitempty"`
-	ParentTask    *TaskExecutionIdentifier `json:"-"`
-	BranchStatus  *BranchNodeStatus        `json:"branchStatus,omitempty"`
-	SubNodeStatus map[NodeID]*NodeStatus   `json:"subNodeStatus,omitempty"`
+	ParentNode    *NodeID                `json:"parentNode,omitempty"`
+	BranchStatus  *BranchNodeStatus      `json:"branchStatus,omitempty"`
+	SubNodeStatus map[NodeID]*NodeStatus `json:"subNodeStatus,omitempty"`
 	// We can store the outputs at this layer
 
 	// TODO not used delete
@@ -383,6 +420,9 @@ type NodeStatus struct {
 
 	// Not Persisted
 	DataReferenceConstructor storage.ReferenceConstructor `json:"-"`
+	DataDir                  DataReference                `json:"-"`
+	OutputDir                DataReference                `json:"-"`
+	ParentTask               *TaskExecutionIdentifier     `json:"-"`
 }
 
 func (in *NodeStatus) IsDirty() bool {
@@ -467,13 +507,13 @@ func (in *NodeStatus) GetArrayNodeStatus() MutableArrayNodeStatus {
 	return in.ArrayNodeStatus
 }
 
-func (in NodeStatus) VisitNodeStatuses(visitor NodeStatusVisitFn) {
+func (in *NodeStatus) VisitNodeStatuses(visitor NodeStatusVisitFn) {
 	for n, s := range in.SubNodeStatus {
 		visitor(n, s)
 	}
 }
 
-func (in NodeStatus) GetDynamicNodeStatus() MutableDynamicNodeStatus {
+func (in *NodeStatus) GetDynamicNodeStatus() MutableDynamicNodeStatus {
 	if in.DynamicNodeStatus == nil {
 		return nil
 	}
@@ -739,7 +779,7 @@ func (in *NodeStatus) GetOrCreateWorkflowStatus() MutableWorkflowNodeStatus {
 	return in.WorkflowNodeStatus
 }
 
-func (in NodeStatus) GetTaskNodeStatus() ExecutableTaskNodeStatus {
+func (in *NodeStatus) GetTaskNodeStatus() ExecutableTaskNodeStatus {
 	// Explicitly return nil here to avoid a misleading non-nil interface.
 	if in.TaskNodeStatus == nil {
 		return nil
@@ -817,13 +857,11 @@ func (in *NodeStatus) SetOutputDir(d DataReference) {
 	in.OutputDir = d
 }
 
+// Equals compares this node status against another node status.
+// Note: The comparison omits unserialized values like parentTask, dataDir, outputDir
 func (in *NodeStatus) Equals(other *NodeStatus) bool {
 	// Assuming in is never nil
 	if other == nil {
-		return false
-	}
-
-	if in.IsDirty() != other.IsDirty() {
 		return false
 	}
 
@@ -831,6 +869,54 @@ func (in *NodeStatus) Equals(other *NodeStatus) bool {
 		if in.Phase == NodePhaseSucceeded || in.Phase == NodePhaseFailed {
 			return true
 		}
+	}
+
+	if in.Phase != other.Phase {
+		return false
+	}
+
+	if in.QueuedAt != nil && other.QueuedAt != nil {
+		if *in.QueuedAt != *other.QueuedAt {
+			return false
+		}
+	} else if in.QueuedAt != other.QueuedAt {
+		return false
+	}
+
+	if in.StartedAt != nil && other.StartedAt != nil {
+		if *in.StartedAt != *other.StartedAt {
+			return false
+		}
+	} else if in.StartedAt != other.StartedAt {
+		return false
+	}
+
+	if in.StoppedAt != nil && other.StoppedAt != nil {
+		if *in.StoppedAt != *other.StoppedAt {
+			return false
+		}
+	} else if in.StoppedAt != other.StoppedAt {
+		return false
+	}
+
+	if in.LastUpdatedAt != nil && other.LastUpdatedAt != nil {
+		if *in.LastUpdatedAt != *other.LastUpdatedAt {
+			return false
+		}
+	} else if in.LastUpdatedAt != other.LastUpdatedAt {
+		return false
+	}
+
+	if in.LastAttemptStartedAt != nil && other.LastAttemptStartedAt != nil {
+		if *in.LastAttemptStartedAt != *other.LastAttemptStartedAt {
+			return false
+		}
+	} else if in.LastAttemptStartedAt != other.LastAttemptStartedAt {
+		return false
+	}
+
+	if in.Message != other.Message {
+		return false
 	}
 
 	if in.Attempts != other.Attempts {
@@ -841,19 +927,7 @@ func (in *NodeStatus) Equals(other *NodeStatus) bool {
 		return false
 	}
 
-	if in.Phase != other.Phase {
-		return false
-	}
-
-	if !in.TaskNodeStatus.Equals(other.TaskNodeStatus) {
-		return false
-	}
-
-	if in.DataDir != other.DataDir {
-		return false
-	}
-
-	if in.OutputDir != other.OutputDir {
+	if in.Cached != other.Cached {
 		return false
 	}
 
@@ -863,10 +937,6 @@ func (in *NodeStatus) Equals(other *NodeStatus) bool {
 		}
 	} else if !(in.ParentNode == other.ParentNode) {
 		// Both are not nil
-		return false
-	}
-
-	if !reflect.DeepEqual(in.ParentTask, other.ParentTask) {
 		return false
 	}
 
@@ -884,7 +954,19 @@ func (in *NodeStatus) Equals(other *NodeStatus) bool {
 		}
 	}
 
-	return in.BranchStatus.Equals(other.BranchStatus) && in.DynamicNodeStatus.Equals(other.DynamicNodeStatus)
+	if in.Error != nil && other.Error != nil {
+		if !proto.Equal(in.Error, other.Error) {
+			return false
+		}
+	} else if in.Error != other.Error {
+		return false
+	}
+
+	return in.BranchStatus.Equals(other.BranchStatus) &&
+		in.TaskNodeStatus.Equals(other.TaskNodeStatus) &&
+		in.DynamicNodeStatus.Equals(other.DynamicNodeStatus) &&
+		in.GateNodeStatus.Equals(other.GateNodeStatus) &&
+		in.ArrayNodeStatus.Equals(other.ArrayNodeStatus)
 }
 
 func (in *NodeStatus) GetExecutionError() *core.ExecutionError {
@@ -892,33 +974,6 @@ func (in *NodeStatus) GetExecutionError() *core.ExecutionError {
 		return in.Error.ExecutionError
 	}
 	return nil
-}
-
-// THIS IS NOT AUTO GENERATED
-func (in *CustomState) DeepCopyInto(out *CustomState) {
-	if in == nil || *in == nil {
-		return
-	}
-
-	raw, err := json.Marshal(in)
-	if err != nil {
-		return
-	}
-
-	err = json.Unmarshal(raw, out)
-	if err != nil {
-		return
-	}
-}
-
-func (in *CustomState) DeepCopy() *CustomState {
-	if in == nil || *in == nil {
-		return nil
-	}
-
-	out := &CustomState{}
-	in.DeepCopyInto(out)
-	return out
 }
 
 type TaskNodeStatus struct {
@@ -984,23 +1039,23 @@ func (in *TaskNodeStatus) SetPhaseVersion(version uint32) {
 	in.SetDirty()
 }
 
-func (in TaskNodeStatus) GetPhase() int {
+func (in *TaskNodeStatus) GetPhase() int {
 	return in.Phase
 }
 
-func (in TaskNodeStatus) GetLastPhaseUpdatedAt() time.Time {
+func (in *TaskNodeStatus) GetLastPhaseUpdatedAt() time.Time {
 	return in.LastPhaseUpdatedAt
 }
 
-func (in TaskNodeStatus) GetPreviousNodeExecutionCheckpointPath() DataReference {
+func (in *TaskNodeStatus) GetPreviousNodeExecutionCheckpointPath() DataReference {
 	return in.PreviousNodeExecutionCheckpointPath
 }
 
-func (in TaskNodeStatus) GetPhaseVersion() uint32 {
+func (in *TaskNodeStatus) GetPhaseVersion() uint32 {
 	return in.PhaseVersion
 }
 
-func (in TaskNodeStatus) GetCleanupOnFailure() bool {
+func (in *TaskNodeStatus) GetCleanupOnFailure() bool {
 	return in.CleanupOnFailure
 }
 
@@ -1013,7 +1068,7 @@ func (in *TaskNodeStatus) UpdatePhase(phase int, phaseVersion uint32) {
 	in.PhaseVersion = phaseVersion
 }
 
-func (in *TaskNodeStatus) DeepCopyInto(out *TaskNodeStatus) {
+func (in *TaskNodeStatus) deepCopyInto(out *TaskNodeStatus) {
 	if in == nil {
 		return
 	}
@@ -1035,7 +1090,7 @@ func (in *TaskNodeStatus) DeepCopy() *TaskNodeStatus {
 	}
 
 	out := &TaskNodeStatus{}
-	in.DeepCopyInto(out)
+	in.deepCopyInto(out)
 	return out
 }
 
@@ -1046,5 +1101,13 @@ func (in *TaskNodeStatus) Equals(other *TaskNodeStatus) bool {
 	if in == nil || other == nil {
 		return false
 	}
-	return in.Phase == other.Phase && in.PhaseVersion == other.PhaseVersion && in.PluginStateVersion == other.PluginStateVersion && bytes.Equal(in.PluginState, other.PluginState) && in.BarrierClockTick == other.BarrierClockTick
+
+	return in.Phase == other.Phase &&
+		in.PhaseVersion == other.PhaseVersion &&
+		bytes.Equal(in.PluginState, other.PluginState) &&
+		in.PluginStateVersion == other.PluginStateVersion &&
+		in.BarrierClockTick == other.BarrierClockTick &&
+		in.LastPhaseUpdatedAt == other.LastPhaseUpdatedAt &&
+		in.PreviousNodeExecutionCheckpointPath == other.PreviousNodeExecutionCheckpointPath &&
+		in.CleanupOnFailure == other.CleanupOnFailure
 }

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status_test.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status_test.go
@@ -121,6 +121,15 @@ func TestNodeStatus_Equals(t *testing.T) {
 	}
 	assert.True(t, one.Equals(other))
 
+	one.WorkflowNodeStatus = &WorkflowNodeStatus{
+		Phase: WorkflowNodePhaseExecuting,
+	}
+	assert.False(t, one.Equals(other))
+	other.WorkflowNodeStatus = &WorkflowNodeStatus{
+		Phase: WorkflowNodePhaseExecuting,
+	}
+	assert.True(t, one.Equals(other))
+
 	one.SubNodeStatus[node].Phase = NodePhaseRunning
 	assert.False(t, one.Equals(other))
 	other.SubNodeStatus[node].Phase = NodePhaseRunning
@@ -324,6 +333,35 @@ func TestGateNodeStatus_Equals(t *testing.T) {
 	assert.False(t, one.Equals(other))
 
 	other.Phase = 5
+	assert.True(t, one.Equals(other))
+}
+
+func TestWorkflowNodeStatus_Equals(t *testing.T) {
+	var one *WorkflowNodeStatus
+	var other *WorkflowNodeStatus
+
+	assert.True(t, one.Equals(other))
+
+	one = &WorkflowNodeStatus{}
+	assert.False(t, one.Equals(other))
+
+	other = &WorkflowNodeStatus{}
+	assert.True(t, one.Equals(other))
+
+	one.Phase = 5
+	assert.False(t, one.Equals(other))
+
+	other.Phase = 5
+	assert.True(t, one.Equals(other))
+
+	one.ExecutionError = &core.ExecutionError{
+		Code: "1",
+	}
+	assert.False(t, one.Equals(other))
+
+	other.ExecutionError = &core.ExecutionError{
+		Code: "1",
+	}
 	assert.True(t, one.Equals(other))
 }
 


### PR DESCRIPTION
## Tracking issue
Closes #6520 

## Why are the changes needed?
The [core propeller logic has a branch which compares the workflow read from etcD to the workflow that may have been mutated by the propeller state machine logic](https://github.com/flyteorg/flyte/blob/master/flytepropeller/pkg/controller/handler.go#L320-L326).The intention is that if the workflow status is the same it does not bother writing the workflow to etcD. The comparator logic for this operation includes bugs where two workflow that have the same state are considered different and thus trigger an etcD write (or at least an API call). As such, a shockingly high amount of our workflow update are redundant, wasted API calls (~60%). 

![Screenshot 2025-07-03 at 1 47 34 PM](https://github.com/user-attachments/assets/2a44bd07-4aaa-43c2-9963-eac2af0f0bd8)

![Screenshot 2025-07-03 at 1 47 50 PM](https://github.com/user-attachments/assets/1e560072-a16b-4987-a6ef-2d1d10ad25ee)

## What changes were proposed in this pull request?
This pull request proposes to only set the `dirty` flags in TaskNodeStatus when a value is set that differs from the existing value. This should prevent workflows from being marked dirty during regular workflow processing, like from this [call site](https://github.com/flyteorg/flyte/blob/e3cabef618b167399f1ffe3ab4549584d2da527f/flytepropeller/pkg/controller/nodes/transformers.go#L256-L267).  

For posterity, I also eliminated fields now serialized to etcD from the `.Equals` comparator.

Depending on the running workflows this pull request has an opportunity to massively reduce k8s API and etcD load at scale. Previously k8s API and etcD load would scale linearly with running workflows due to how workflows are regularly queued and processed. With this change we have been able to run thousands of concurrent workflows with minimal k8s and etcD load (4-5 operations per second). 

## How was this patch tested?
Tested in our non-production environment where it has eliminated redundant workflow updates. Will be landing in our production environment soon.

No more redundant updates in non-prod
![Screenshot 2025-07-03 at 1 58 56 PM](https://github.com/user-attachments/assets/543c0534-87d3-49d4-a1b0-106bddd202ba)

Also eliminates many wasted API calls to update the workflow. 

![Screenshot 2025-07-03 at 2 06 51 PM](https://github.com/user-attachments/assets/50a340a6-e9f7-47de-9b7f-130c182ff10d)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request optimizes the workflow equality check in the Flyte propeller by implementing an Equals method for the WorkflowNodeStatus struct and ensuring 'dirty' flags in TaskNodeStatus are only set when values differ. This reduces unnecessary updates and API calls while streamlining the equality comparator by removing obsolete fields, enhancing overall performance. Tests have been added to validate the new functionality, contributing to performance improvements.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>