### PR TITLE
refactor: Adjust CoPilot init and Pod status logic

### DIFF
--- a/flyte-single-binary-local.yaml
+++ b/flyte-single-binary-local.yaml
@@ -56,6 +56,8 @@ plugins:
     cloudwatch-enabled: false
     stackdriver-enabled: false
   k8s:
+    co-pilot:
+      image: pingsutw/copilot:test
     default-env-vars:
       - FLYTE_AWS_ENDPOINT: http://flyte-sandbox-minio.flyte:9000
       - FLYTE_AWS_ACCESS_KEY_ID: minio
@@ -85,7 +87,7 @@ storage:
       region: us-east-1
       disable_ssl: true
       v2_signing: true
-      endpoint: http://localhost:30002
+      endpoint: http://host.docker.internal:30002
       auth_type: accesskey
       access_key_id: minio
       secret_key: miniostorage

--- a/flyte-single-binary-local.yaml
+++ b/flyte-single-binary-local.yaml
@@ -56,8 +56,6 @@ plugins:
     cloudwatch-enabled: false
     stackdriver-enabled: false
   k8s:
-    co-pilot:
-      image: pingsutw/copilot:test
     default-env-vars:
       - FLYTE_AWS_ENDPOINT: http://flyte-sandbox-minio.flyte:9000
       - FLYTE_AWS_ACCESS_KEY_ID: minio
@@ -87,7 +85,7 @@ storage:
       region: us-east-1
       disable_ssl: true
       v2_signing: true
-      endpoint: http://host.docker.internal:30002
+      endpoint: http://localhost:30002
       auth_type: accesskey
       access_key_id: minio
       secret_key: miniostorage

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -271,7 +271,8 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 			if err != nil {
 				return primaryInitContainerName, err
 			}
-			coPilotPod.InitContainers = append(coPilotPod.InitContainers, sidecar)
+			// Let the sidecar container start before the downloader; it will ensure the signal watcher is started before the main container finishes.
+			coPilotPod.InitContainers = append([]v1.Container{sidecar}, coPilotPod.InitContainers...)
 
 			coPilotPod.TerminationGracePeriodSeconds = (*int64)(&cfg.Timeout.Duration)
 		}

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
@@ -228,7 +228,8 @@ func assertContainerHasVolumeMounts(t *testing.T, cfg config.FlyteCoPilotConfig,
 }
 
 func assertPodHasCoPilot(t *testing.T, cfg config.FlyteCoPilotConfig, pilot *core.DataLoadingConfig, iFace *core.TypedInterface, pod *v1.PodSpec) {
-	for _, c := range pod.Containers {
+	containers := append(pod.Containers, pod.InitContainers...)
+	for _, c := range containers {
 		if c.Name == "test" {
 			cntr := c
 			assertContainerHasVolumeMounts(t, cfg, pilot, iFace, &cntr)
@@ -510,6 +511,8 @@ func TestAddCoPilotToPod(t *testing.T) {
 		primaryInitContainerName, err := AddCoPilotToPod(ctx, cfg, &pod, iface, taskMetadata, inputPaths, opath, pilot)
 		assert.NoError(t, err)
 		assert.Equal(t, "test-downloader", primaryInitContainerName)
+		assert.Equal(t, pod.InitContainers[0].Name, cfg.NamePrefix+flyteSidecarContainerName)
+		assert.Equal(t, pod.InitContainers[1].Name, cfg.NamePrefix+flyteDownloaderContainerName)
 		assertPodHasCoPilot(t, cfg, pilot, iface, &pod)
 	})
 

--- a/flyteplugins/go/tasks/plugins/k8s/pod/plugin.go
+++ b/flyteplugins/go/tasks/plugins/k8s/pod/plugin.go
@@ -122,7 +122,7 @@ func (p plugin) BuildResource(ctx context.Context, taskCtx pluginsCore.TaskExecu
 	// set primaryContainerKey annotation if this is a Sidecar task or, as an optimization, if there is only a single
 	// container. this plugin marks the task complete if the primary Container is complete, so if there is only one
 	// container we can mark the task as complete before the Pod has been marked complete.
-	if taskTemplate.GetType() == SidecarTaskType || (len(podSpec.Containers) == 1 && taskTemplate.GetType() != rawContainerTaskType) {
+	if taskTemplate.GetType() == SidecarTaskType || len(podSpec.Containers) == 1 {
 		objectMeta.Annotations[flytek8s.PrimaryContainerKey] = primaryContainerName
 	}
 

--- a/flyteplugins/go/tasks/plugins/k8s/pod/plugin.go
+++ b/flyteplugins/go/tasks/plugins/k8s/pod/plugin.go
@@ -122,7 +122,7 @@ func (p plugin) BuildResource(ctx context.Context, taskCtx pluginsCore.TaskExecu
 	// set primaryContainerKey annotation if this is a Sidecar task or, as an optimization, if there is only a single
 	// container. this plugin marks the task complete if the primary Container is complete, so if there is only one
 	// container we can mark the task as complete before the Pod has been marked complete.
-	if taskTemplate.GetType() == SidecarTaskType || len(podSpec.Containers) == 1 {
+	if taskTemplate.GetType() == SidecarTaskType || (len(podSpec.Containers) == 1 && taskTemplate.GetType() != rawContainerTaskType) {
 		objectMeta.Annotations[flytek8s.PrimaryContainerKey] = primaryContainerName
 	}
 
@@ -208,10 +208,18 @@ func DemystifyPodStatus(ctx context.Context, pod *v1.Pod, info pluginsCore.TaskI
 		// DO NOTHING
 	default:
 		if !primaryContainerExists {
-			// if all of the containers in the Pod are complete, as an optimization, we can declare the task as
+			// if all of the containers and sidecars in the Pod are complete, as an optimization, we can declare the task as
 			// succeeded rather than waiting for the Pod to be marked completed.
 			allSuccessfullyTerminated := len(pod.Status.ContainerStatuses) > 0
 			for _, s := range pod.Status.ContainerStatuses {
+				if s.State.Waiting != nil || s.State.Running != nil || (s.State.Terminated != nil && s.State.Terminated.ExitCode != 0) {
+					allSuccessfullyTerminated = false
+				}
+			}
+
+			// Init container will become sidecar if the restart policy is set to Always
+			// https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#sidecar-containers-and-pod-lifecycle
+			for _, s := range pod.Status.InitContainerStatuses {
 				if s.State.Waiting != nil || s.State.Running != nil || (s.State.Terminated != nil && s.State.Terminated.ExitCode != 0) {
 					allSuccessfullyTerminated = false
 				}


### PR DESCRIPTION
## Why are the changes needed?
Containers task sometimes fails because

1. Propeller fails to read the output because it tries to get the output before the sidecar completes.
2. The sidecar is terminated before it can upload the file because the main container finishes before the signal watcher is created. As a result, the sidecar doesn’t handle the SIGTERM signal properly and gets killed by Kubernetes

## What changes were proposed in this pull request?

* Modified `AddCoPilotToPod` to prepend the sidecar container to the list of init containers, ensuring the sidecar starts before the downloader. This guarantees the signal watcher is active before the main container completes. 

* Updated `DemystifyPodStatus` to check the status of init containers in addition to regular containers. This ensures that tasks are only marked as succeeded when both containers and sidecars have completed successfully. 

* Adjusted `assertPodHasCoPilot` to include init containers in the validation loop, ensuring volume mounts are correctly asserted for all containers.

* Added assertions in `TestAddCoPilotToPod` to verify the order and naming of init containers, ensuring the sidecar and downloader are correctly configured.

## How was this patch tested?

```python
from flytekit import ContainerTask, kwtypes


greeting_task = ContainerTask(
    name="test",
    image="alpine:latest",
    input_data_dir="/var/inputs",
    output_data_dir="/var/outputs",
    inputs=kwtypes(name=str),
    outputs=kwtypes(greeting=str),
    command=["/bin/sh", "-c", "sleep 100 | echo 'Hello, my name is {{.inputs.name}}.' | tee -a /var/outputs/greeting"],
)
```

### Screenshots
<img width="1909" alt="Screenshot 2025-07-03 at 5 01 46 PM" src="https://github.com/user-attachments/assets/e9cf0be7-f718-44fc-8ce7-cd203e52efdd" />


