### PR TITLE
Fix PodTemplate resource state pollution between workflow runs

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_template_store.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_template_store.go
@@ -41,15 +41,16 @@ func (p *PodTemplateStore) Delete(podTemplate *v1.PodTemplate) {
 
 // LoadOrDefault returns the PodTemplate with the specified name in the given namespace. If one
 // does not exist it attempts to retrieve the one associated with the defaultNamespace.
+// Returns a deep copy of the cached PodTemplate to prevent state pollution between workflows.
 func (p *PodTemplateStore) LoadOrDefault(namespace string, podTemplateName string) *v1.PodTemplate {
 	if value, ok := p.Load(podTemplateName); ok {
 		podTemplates := value.(*sync.Map)
 		if podTemplate, ok := podTemplates.Load(namespace); ok {
-			return podTemplate.(*v1.PodTemplate)
+			return podTemplate.(*v1.PodTemplate).DeepCopy()
 		}
 
 		if podTemplate, ok := podTemplates.Load(p.defaultNamespace); ok {
-			return podTemplate.(*v1.PodTemplate)
+			return podTemplate.(*v1.PodTemplate).DeepCopy()
 		}
 	}
 


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/6529

## Why are the changes needed?
Without that, in cases where `podTemplate` is involved we could get unexpected resource overrides from previous runs. 

## What changes were proposed in this pull request?
I changed LoadOrDefault() to return a deep copy of the cached pod template, this ensures that each workflow gets its own independent copy of the pod template, preventing any mutations from affecting other workflows

## How was this patch tested?
I've tested it in the Flyte multi-cluster environment of ours (devel)

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
This is a follow-up for https://github.com/flyteorg/flyte/pull/6483 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request resolves resource state pollution in PodTemplate management within the Flyte framework by ensuring each workflow has an independent PodTemplate copy. This change is vital for preserving workflow execution integrity, particularly in multi-cluster setups.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>