### PR TITLE
Make plugin metric registration thread safe

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/handler.go
+++ b/flytepropeller/pkg/controller/nodes/task/handler.go
@@ -440,11 +440,11 @@ func (t Handler) fetchPluginTaskMetrics(pluginID, taskType string) (*taskMetrics
 
 	// Acquire read lock for fast read, this is the happy case
 	t.taskMetricsMapMutex.RLock()
-	maybeTaskMetrics, ok := t.taskMetricsMap[metricNameKey]
+	existingTaskMetrics, ok := t.taskMetricsMap[metricNameKey]
 	t.taskMetricsMapMutex.RUnlock()
 
 	if ok {
-		return maybeTaskMetrics, nil
+		return existingTaskMetrics, nil
 	}
 
 	// Acquire write lock since we may need to populate the map. We use a lock to avoid panics for concurrent writes
@@ -453,10 +453,10 @@ func (t Handler) fetchPluginTaskMetrics(pluginID, taskType string) (*taskMetrics
 	defer t.taskMetricsMapMutex.Unlock()
 
 	// check condition again
-	maybeTaskMetrics, ok = t.taskMetricsMap[metricNameKey]
+	existingTaskMetrics, ok = t.taskMetricsMap[metricNameKey]
 
 	if ok {
-		return maybeTaskMetrics, nil
+		return existingTaskMetrics, nil
 	}
 
 	newTaskMetrics := &taskMetrics{


### PR DESCRIPTION
## Tracking issue
Closes #4046 

## Why are the changes needed?
Propeller workers sometimes panic on startup, thus killing the workers/goroutines for the duration of the process.

Previously this code could panic due to concurrent map access as well as duplicate prometheus metrics being registered. Ultimately the issue occurs when plugins are being exercised for the first time on startup by the Flyte Propeller workers. If these workers are executing the same plugin in parallel they may race and cause issues.

## What changes were proposed in this pull request?
This pull request makes the plugin metric registration thread safe by guarding operations on the map with a read/write mutex. Specifically it guards the read-modify-write operation with a write lock. 

## How was this patch tested?

None yet, but will be tested in our production environment in the next few days.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request resolves a critical issue and enhances thread safety in Flyte Propeller workers by implementing read/write mutex locks for task metrics registration. This prevents race conditions and duplicate metric registrations, improving system reliability and stability in concurrent plugin environments.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>