### PR TITLE
fix(flytectl): arbitrary file access during archive extraction tempDir

### DIFF
--- a/flytectl/cmd/register/register_util.go
+++ b/flytectl/cmd/register/register_util.go
@@ -599,7 +599,12 @@ func readAndCopyArchive(src io.Reader, tempDir string, unarchivedFiles []string)
 		}
 		// Location to untar. FilePath couldn't be used here due to,
 		// G305: File traversal when extracting zip archive
-		target := tempDir + "/" + header.Name
+		cleanedName := filepath.Clean(header.Name)
+		target := filepath.Join(tempDir, cleanedName)
+		// Ensure the target path is within the tempDir
+		if !strings.HasPrefix(target, tempDir) {
+			return unarchivedFiles, fmt.Errorf("invalid file path: %s", header.Name)
+		}
 		if header.Typeflag == tar.TypeDir {
 			if _, err := os.Stat(target); err != nil {
 				if err := os.MkdirAll(target, 0755); err != nil {

--- a/flytectl/pkg/filesystemutils/file_system_utils.go
+++ b/flytectl/pkg/filesystemutils/file_system_utils.go
@@ -40,12 +40,22 @@ func ExtractTar(ss io.Reader, destination string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.Mkdir(header.Name, 0755); err != nil {
+			targetPath := filepath.Join(destination, header.Name)
+			// Ensure the target path is within the destination directory
+			if !strings.HasPrefix(filepath.Clean(targetPath), filepath.Clean(destination)) {
+				return fmt.Errorf("invalid file path: %s", header.Name)
+			}
+			if err := os.Mkdir(targetPath, 0755); err != nil {
 				return err
 			}
 		case tar.TypeReg:
 			fmt.Printf("Creating Flyte configuration file at: %s\n", destination)
-			outFile, err := os.Create(destination)
+			targetPath := filepath.Join(destination, header.Name)
+			// Ensure the target path is within the destination directory
+			if !strings.HasPrefix(filepath.Clean(targetPath), filepath.Clean(destination)) {
+				return fmt.Errorf("invalid file path: %s", header.Name)
+			}
+			outFile, err := os.Create(targetPath)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
https://github.com/flyteorg/flyte/blob/cfcea4dd8181e038bc4e4de2d0c0021b1eab02d9/flytectl/pkg/filesystemutils/file_system_utils.go#L31-L31
https://github.com/flyteorg/flyte/blob/cfcea4dd8181e038bc4e4de2d0c0021b1eab02d9/flytectl/pkg/filesystemutils/file_system_utils.go#L43-L48
https://github.com/flyteorg/flyte/blob/cfcea4dd8181e038bc4e4de2d0c0021b1eab02d9/flytectl/cmd/register/register_util.go#L593-L602


Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. archive paths. zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (..). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.


fix the issue, we need to validate the `header.Name` field to ensure it does not contain directory traversal elements like `..` and that it resolves to a path within the intended destination directory. This can be achieved by constructing the full path using `filepath.Join(destination, header.Name)` and then checking that the resulting path is within the `destination` directory using `filepath.Rel` or similar methods.

fix:
- Construct the full path for each archive entry using `filepath.Join(destination, header.Name)`.
- Use `filepath.Rel` to ensure the resulting path is within the `destination` directory.
- Reject any paths that attempt to traverse outside the `destination` directory.
- Using `filepath.Clean` to normalize the `header.Name` path.
- Constructing the `target` path using `filepath.Join(tempDir, cleanedName)` to ensure proper path joining.
- Verifying that the resulting `target` path is within `tempDir` by checking that it has the `tempDir` prefix.

This approach ensures that malicious paths in the tar archive cannot escape the `tempDir` directory.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request addresses a critical security vulnerability related to directory traversal attacks by implementing robust validation of file paths during file extraction. These changes enhance the safety of the file extraction process in the Flyte control tool.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and focused on security enhancements, making the review process relatively simple.
-->
</div>