### PR TITLE
Add support for otel configuration in helm chart

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -123,6 +123,13 @@ helm install gateway bitnami/contour -n flyte
 | configmap.enabled_plugins.tasks.task-plugins.enabled-plugins | list | `["container","sidecar","k8s-array","connector-service","echo"]` | [Enabled Plugins](https://pkg.go.dev/github.com/lyft/flyteplugins/go/tasks/config#Config). Enable sagemaker*, athena if you install the backend plugins |
 | configmap.k8s | object | `{"plugins":{"k8s":{"default-cpus":"100m","default-env-vars":[],"default-memory":"100Mi"}}}` | Kubernetes specific Flyte configuration |
 | configmap.k8s.plugins.k8s | object | `{"default-cpus":"100m","default-env-vars":[],"default-memory":"100Mi"}` | Configuration section for all K8s specific plugins [Configuration structure](https://pkg.go.dev/github.com/lyft/flyteplugins/go/tasks/pluginmachinery/flytek8s/config) |
+| configmap.otel | object | `{"otel":{"file":"/tmp/trace.txt","jaeger":{"endpoint":"http://localhost:14268/api/traces"},"otlpgrpc":{"endpoint":"http://localhost:4317"},"otlphttp":{"endpoint":"http://localhost:4318/v1/traces"},"sampler":{"parentSampler":"always"},"type":"noop"}}` | Open Telemetry Configuration |
+| configmap.otel.otel.file | string | `"/tmp/trace.txt"` | Configuration for the file exporter type |
+| configmap.otel.otel.jaeger | object | `{"endpoint":"http://localhost:14268/api/traces"}` | Configuration for the jaeger exporter type |
+| configmap.otel.otel.otlphttp | object | `{"endpoint":"http://localhost:4318/v1/traces"}` | Configuration for the otlp exporter type |
+| configmap.otel.otel.sampler | object | `{"parentSampler":"always"}` | Configuration for sampling of traces |
+| configmap.otel.otel.sampler.parentSampler | string | `"always"` | Configuration for the parent based sampler |
+| configmap.otel.otel.type | string | `"noop"` | The type of exporter to use |
 | configmap.remoteData.remoteData.region | string | `"us-east-1"` |  |
 | configmap.remoteData.remoteData.scheme | string | `"local"` |  |
 | configmap.remoteData.remoteData.signedUrls.durationMinutes | int | `3` |  |

--- a/charts/flyte-core/templates/admin/configmap.yaml
+++ b/charts/flyte-core/templates/admin/configmap.yaml
@@ -28,6 +28,9 @@ data:
 {{- with .Values.configmap.logger }}
   logger.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
 {{- end }}
+{{- with .Values.configmap.otel }}
+  otel.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
+{{- end }}
 {{- with .Values.configmap.adminServer }}
   server.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
 {{- end }}

--- a/charts/flyte-core/templates/datacatalog/configmap.yaml
+++ b/charts/flyte-core/templates/datacatalog/configmap.yaml
@@ -9,6 +9,9 @@ data:
 {{- with .Values.db.datacatalog }}
   db.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
 {{- end }}
+{{- with .Values.configmap.otel }}
+  otel.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
+{{- end }}
 {{- with .Values.configmap.logger }}
   logger.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
 {{- end }}

--- a/charts/flyte-core/templates/propeller/configmap.yaml
+++ b/charts/flyte-core/templates/propeller/configmap.yaml
@@ -30,6 +30,9 @@ data:
 {{- with .Values.configmap.logger }}
   logger.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
 {{- end }}
+{{- with .Values.configmap.otel }}
+  otel.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
+{{- end }}
 {{- with .Values.configmap.qubole }}
   qubole.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
 {{- end }}

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -853,6 +853,28 @@ configmap:
       - id: production
         name: production
 
+  # -- Open Telemetry Configuration
+  otel:
+    otel:
+      # -- The type of exporter to use
+      type: noop
+      # -- Configuration for the file exporter type
+      file: "/tmp/trace.txt"
+      # -- Configuration for the jaeger exporter type
+      jaeger:
+        endpoint: "http://localhost:14268/api/traces"
+        # -- Configuration for the otlpgrpc exporter type
+      otlpgrpc:
+        endpoint: "http://localhost:4317"
+      # -- Configuration for the otlp exporter type
+      otlphttp:
+        endpoint: "http://localhost:4318/v1/traces"
+      # -- Configuration for sampling of traces
+      sampler:
+        # -- Configuration for the parent based sampler
+        parentSampler: always
+
+
   # Refer to the full [structure](https://pkg.go.dev/github.com/lyft/flyteadmin@v0.3.37/pkg/runtime/interfaces#ApplicationConfig) for documentation.
   schedulerConfig:
     scheduler:

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -130,6 +130,18 @@ data:
       name: staging
     - id: production
       name: production
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   server.yaml: | 
     auth:
       appAuth:
@@ -380,6 +392,18 @@ data:
       passwordPath: /etc/db/pass.txt
       port: 5432
       username: flyteadmin
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   server.yaml: | 
     application:
       grpcMaxRecvMsgSizeMBs: 6
@@ -507,6 +531,18 @@ data:
         default-cpus: 100m
         default-env-vars: []
         default-memory: 100Mi
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   resource_manager.yaml: | 
     propeller:
       resourcemanager:
@@ -848,7 +884,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c943b200cd0bed97fe456c0c713dd79cdc4e22133495cac89db3fc55e9b79c7"
+        configChecksum: "1a3b03ce2201b7f44bd9e8d17d00e1ef9d227362fc9b4e45f3d08b56f7e1530"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -1170,7 +1206,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b33f5d90f29b33dc6980bf47d7ac39d9955e0275fec16a356777fa864b90e7f"
+        configChecksum: "a296db3de9a904e87ff0f51ab5ac2f025193cdfb92ea5621af5d46a70699ac9"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -1274,7 +1310,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e66708079659fcb71e5d56a4c050b58dc9085c97d599d2cd867968b1a20babc"
+        configChecksum: "ecda597a26eaad8f7d1611096e736f0870b74b7c13e915deb99c16e5545cc99"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -1360,7 +1396,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0-b4
       annotations:
-        configChecksum: "e66708079659fcb71e5d56a4c050b58dc9085c97d599d2cd867968b1a20babc"
+        configChecksum: "ecda597a26eaad8f7d1611096e736f0870b74b7c13e915deb99c16e5545cc99"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -111,6 +111,18 @@ data:
       name: staging
     - id: production
       name: production
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   server.yaml: | 
     auth:
       appAuth:
@@ -346,6 +358,18 @@ data:
       passwordPath: /etc/db/pass.txt
       port: 5432
       username: flyteadmin
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   server.yaml: | 
     application:
       grpcMaxRecvMsgSizeMBs: 6
@@ -558,7 +582,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "391e8e126d669f751ac1a03de0b45fe7969a0fe58f3dfead9bb7be1b5d951ff"
+        configChecksum: "c26f85c2c14e2d92b7ffe4c931918a375a459870b142caad4f9b97947e467ad"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -880,7 +904,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b33f5d90f29b33dc6980bf47d7ac39d9955e0275fec16a356777fa864b90e7f"
+        configChecksum: "a296db3de9a904e87ff0f51ab5ac2f025193cdfb92ea5621af5d46a70699ac9"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -984,7 +1008,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "391e8e126d669f751ac1a03de0b45fe7969a0fe58f3dfead9bb7be1b5d951ff"
+        configChecksum: "c26f85c2c14e2d92b7ffe4c931918a375a459870b142caad4f9b97947e467ad"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte

--- a/deployment/eks/flyte_helm_dataplane_generated.yaml
+++ b/deployment/eks/flyte_helm_dataplane_generated.yaml
@@ -164,6 +164,18 @@ data:
         default-cpus: 100m
         default-env-vars: []
         default-memory: 100Mi
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   resource_manager.yaml: | 
     propeller:
       resourcemanager:
@@ -423,7 +435,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e66708079659fcb71e5d56a4c050b58dc9085c97d599d2cd867968b1a20babc"
+        configChecksum: "ecda597a26eaad8f7d1611096e736f0870b74b7c13e915deb99c16e5545cc99"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -509,7 +521,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0-b4
       annotations:
-        configChecksum: "e66708079659fcb71e5d56a4c050b58dc9085c97d599d2cd867968b1a20babc"
+        configChecksum: "ecda597a26eaad8f7d1611096e736f0870b74b7c13e915deb99c16e5545cc99"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -142,6 +142,18 @@ data:
       name: staging
     - id: production
       name: production
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   server.yaml: | 
     auth:
       appAuth:
@@ -377,6 +389,18 @@ data:
       passwordPath: /etc/db/pass.txt
       port: 5432
       username: flyteadmin
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   server.yaml: | 
     application:
       grpcMaxRecvMsgSizeMBs: 6
@@ -538,6 +562,18 @@ data:
         default-cpus: 100m
         default-env-vars: []
         default-memory: 100Mi
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   resource_manager.yaml: | 
     propeller:
       resourcemanager:
@@ -879,7 +915,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "391e8e126d669f751ac1a03de0b45fe7969a0fe58f3dfead9bb7be1b5d951ff"
+        configChecksum: "c26f85c2c14e2d92b7ffe4c931918a375a459870b142caad4f9b97947e467ad"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -1201,7 +1237,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b33f5d90f29b33dc6980bf47d7ac39d9955e0275fec16a356777fa864b90e7f"
+        configChecksum: "a296db3de9a904e87ff0f51ab5ac2f025193cdfb92ea5621af5d46a70699ac9"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -1305,7 +1341,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "391e8e126d669f751ac1a03de0b45fe7969a0fe58f3dfead9bb7be1b5d951ff"
+        configChecksum: "c26f85c2c14e2d92b7ffe4c931918a375a459870b142caad4f9b97947e467ad"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte
@@ -1404,7 +1440,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e66708079659fcb71e5d56a4c050b58dc9085c97d599d2cd867968b1a20babc"
+        configChecksum: "ecda597a26eaad8f7d1611096e736f0870b74b7c13e915deb99c16e5545cc99"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -1490,7 +1526,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0-b4
       annotations:
-        configChecksum: "e66708079659fcb71e5d56a4c050b58dc9085c97d599d2cd867968b1a20babc"
+        configChecksum: "ecda597a26eaad8f7d1611096e736f0870b74b7c13e915deb99c16e5545cc99"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -111,6 +111,18 @@ data:
       name: staging
     - id: production
       name: production
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   server.yaml: | 
     auth:
       appAuth:
@@ -356,6 +368,18 @@ data:
       passwordPath: /etc/db/pass.txt
       port: 5432
       username: flyteadmin
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   server.yaml: | 
     application:
       grpcMaxRecvMsgSizeMBs: 6
@@ -575,7 +599,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "20a517901c6b6f01f47e968fa15ca51f6d9522e728ecace8b48553eb428cde6"
+        configChecksum: "53737bc0cafe619900707912054d56dd8564533779ccd43728ce3c68d2bc7e9"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -897,7 +921,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4b8758ec18556294a51a4c08ad7b82e4311d52c1a58448d1caa9589682482cb"
+        configChecksum: "c752ecfbf2d41a20159a1ec417ace2b2a9a0a778966659c142e8e1479dd7ded"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -1001,7 +1025,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "20a517901c6b6f01f47e968fa15ca51f6d9522e728ecace8b48553eb428cde6"
+        configChecksum: "53737bc0cafe619900707912054d56dd8564533779ccd43728ce3c68d2bc7e9"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte

--- a/deployment/gcp/flyte_helm_dataplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_dataplane_generated.yaml
@@ -164,6 +164,18 @@ data:
         default-cpus: 100m
         default-env-vars: []
         default-memory: 100Mi
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   resource_manager.yaml: | 
     propeller:
       resourcemanager:
@@ -431,7 +443,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8b321446ff6486842c8d75e847b553d4dce5d8db837a464c52fbc7d79f6873b"
+        configChecksum: "f5c6c3ba4626fd2b81280a9c58f26da46d9a698fab839f2399302703b86e807"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -516,7 +528,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0-b4
       annotations:
-        configChecksum: "8b321446ff6486842c8d75e847b553d4dce5d8db837a464c52fbc7d79f6873b"
+        configChecksum: "f5c6c3ba4626fd2b81280a9c58f26da46d9a698fab839f2399302703b86e807"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -142,6 +142,18 @@ data:
       name: staging
     - id: production
       name: production
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   server.yaml: | 
     auth:
       appAuth:
@@ -387,6 +399,18 @@ data:
       passwordPath: /etc/db/pass.txt
       port: 5432
       username: flyteadmin
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   server.yaml: | 
     application:
       grpcMaxRecvMsgSizeMBs: 6
@@ -551,6 +575,18 @@ data:
         default-cpus: 100m
         default-env-vars: []
         default-memory: 100Mi
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   resource_manager.yaml: | 
     propeller:
       resourcemanager:
@@ -904,7 +940,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "20a517901c6b6f01f47e968fa15ca51f6d9522e728ecace8b48553eb428cde6"
+        configChecksum: "53737bc0cafe619900707912054d56dd8564533779ccd43728ce3c68d2bc7e9"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -1226,7 +1262,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4b8758ec18556294a51a4c08ad7b82e4311d52c1a58448d1caa9589682482cb"
+        configChecksum: "c752ecfbf2d41a20159a1ec417ace2b2a9a0a778966659c142e8e1479dd7ded"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -1330,7 +1366,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "20a517901c6b6f01f47e968fa15ca51f6d9522e728ecace8b48553eb428cde6"
+        configChecksum: "53737bc0cafe619900707912054d56dd8564533779ccd43728ce3c68d2bc7e9"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte
@@ -1429,7 +1465,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8b321446ff6486842c8d75e847b553d4dce5d8db837a464c52fbc7d79f6873b"
+        configChecksum: "f5c6c3ba4626fd2b81280a9c58f26da46d9a698fab839f2399302703b86e807"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -1514,7 +1550,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0-b4
       annotations:
-        configChecksum: "8b321446ff6486842c8d75e847b553d4dce5d8db837a464c52fbc7d79f6873b"
+        configChecksum: "f5c6c3ba4626fd2b81280a9c58f26da46d9a698fab839f2399302703b86e807"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -262,6 +262,18 @@ data:
     logger:
       level: 5
       show-source: true
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   server.yaml: | 
     auth:
       appAuth:
@@ -486,6 +498,18 @@ data:
       host: postgres
       port: 5432
       username: postgres
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   logger.yaml: | 
     logger:
       level: 5
@@ -668,6 +692,18 @@ data:
     logger:
       level: 5
       show-source: true
+  otel.yaml: | 
+    otel:
+      file: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
   resource_manager.yaml: | 
     propeller:
       resourcemanager:
@@ -6692,7 +6728,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f2d2bbea27b58cc5a73da30eb8aeb56fc41863f4eba2bfe407da2e97a6372e8"
+        configChecksum: "b435a59792537ee4fccc9614a73cfbb8a2317b49207afc89127127f397f5f4b"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -6996,7 +7032,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "09741ff6c767aced89645ffb4806eaa65224703f84ee03677062dc624664c1e"
+        configChecksum: "21632a41587831f93dc2408f0043104f06478b4574b4b8e140c2b084e375f84"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -7089,7 +7125,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f2d2bbea27b58cc5a73da30eb8aeb56fc41863f4eba2bfe407da2e97a6372e8"
+        configChecksum: "b435a59792537ee4fccc9614a73cfbb8a2317b49207afc89127127f397f5f4b"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte
@@ -7184,7 +7220,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "60d818299ae1c2f954ecdef8fe5b9f3dd78a02bf3b3d5bc57bcef42b9d00358"
+        configChecksum: "efedd45c01d7aea055d79df44724ba729e80872f7c1f324bb9dfe4a4fbd9ef1"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -7262,7 +7298,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0-b4
       annotations:
-        configChecksum: "60d818299ae1c2f954ecdef8fe5b9f3dd78a02bf3b3d5bc57bcef42b9d00358"
+        configChecksum: "efedd45c01d7aea055d79df44724ba729e80872f7c1f324bb9dfe4a4fbd9ef1"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: RVMxNzVuQnh4aHJ0Y3hNVg==
+  haSharedSecret: NEw2VVNMT2VXdEdYanVtcA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: f75b24367e90266031e255ddba64450a00364b2834b7a37c0611c77cb105bdf7
+        checksum/secret: 4bc204a05c221cd69a5cad0d838fa30886c2c776245ae55d937aec2e83126aba
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: b3B2eDlNUTZlWGlJeFZQbQ==
+  haSharedSecret: Umg4Tml4NGRCQVBrVTUwZw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: d735c8c3ad11a0400bb5c51e2f8f5c08ef262fcb17c1e40410d9a98ffd0a7215
+        checksum/secret: ff59d09e8df68ae751f1749231f3f24b9f5e66f0f4be92e7dd4c14037c2439ca
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: RTVvVEFYYlRUWnU4TGRUYQ==
+  haSharedSecret: WnMwekpCZ0Fmb2p6SW1Fcg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: af283975f133022af6b0fa9b099656108d0e3cefbd46adf0eaf3065f1b707ca3
+        checksum/secret: 9fa416e91f041fa2213c7819aa3317d7d252d4cf6c63fcb6e0440c5d1963f406
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/flytestdlib/otelutils/factory.go
+++ b/flytestdlib/otelutils/factory.go
@@ -35,12 +35,6 @@ const (
 var tracerProviders = make(map[string]*trace.TracerProvider)
 var noopTracerProvider = noop.NewTracerProvider()
 
-// Deprecated: RegisterTracerProvider registers a tracer provider for the given service name. It uses a default context if necessary.
-// Instead, use RegisterTracerProviderWithContext.
-func RegisterTracerProvider(serviceName string, config *Config) error {
-	return RegisterTracerProviderWithContext(context.Background(), serviceName, config)
-}
-
 // RegisterTracerProviderWithContext registers a tracer provider for the given service name.
 func RegisterTracerProviderWithContext(ctx context.Context, serviceName string, config *Config) error {
 	if config == nil {


### PR DESCRIPTION
## Tracking issue
Closes #6536 

## Why are the changes needed?
This makes is easy to understand where to configure OTEL in the flyte-core helm chart.

## What changes were proposed in this pull request?
Adds a config section for OTEL and plumbs it into the flyte config directory under `otel.yaml`. Adds examples and documentation.

## How was this patch tested?
Tested in production. 

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the Flyte core helm chart by adding OpenTelemetry (OTEL) configuration support, improving observability and security. It introduces a dedicated section in the `otel.yaml` file, updates deployment manifests, and modifies checksum values for better management and consistency. Additionally, deprecated functions related to tracer provider registration have been removed.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, making the review process relatively easy.
-->
</div>