### PR TITLE
Fix Grafana dashboard queries for dynamic workflow metrics

### DIFF
--- a/deployment/stats/prometheus/flytepropeller-dashboard.json
+++ b/deployment/stats/prometheus/flytepropeller-dashboard.json
@@ -4406,7 +4406,7 @@
           "targets": [
             {
               "datasource": null,
-              "expr": "sum(flyte:propeller:all:node:build_dynamic_workflow_us) by (quantile, wf) / 1000",
+              "expr": "sum(flyte:propeller:all:build_dynamic_workflow_us) by (quantile, wf) / 1000",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4414,7 +4414,7 @@
               "intervalFactor": 2,
               "legendFormat": "",
               "metric": "",
-              "query": "sum(flyte:propeller:all:node:build_dynamic_workflow_us) by (quantile, wf) / 1000",
+              "query": "sum(flyte:propeller:all:build_dynamic_workflow_us) by (quantile, wf) / 1000",
               "refId": "A",
               "step": 10,
               "target": ""
@@ -4533,7 +4533,7 @@
           "targets": [
             {
               "datasource": null,
-              "expr": "sum(rate(flyte:propeller:all:node:build_dynamic_workflow_us_count[5m])) by (wf)",
+              "expr": "sum(rate(flyte:propeller:all:build_dynamic_workflow_us_count[5m])) by (wf)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4541,7 +4541,7 @@
               "intervalFactor": 2,
               "legendFormat": "",
               "metric": "",
-              "query": "sum(rate(flyte:propeller:all:node:build_dynamic_workflow_us_count[5m])) by (wf)",
+              "query": "sum(rate(flyte:propeller:all:build_dynamic_workflow_us_count[5m])) by (wf)",
               "refId": "A",
               "step": 10,
               "target": ""

--- a/stats/flytepropeller.dashboard.py
+++ b/stats/flytepropeller.dashboard.py
@@ -438,7 +438,7 @@ class FlytePropeller(object):
                 dataSource=DATASOURCE,
                 targets=[
                     Target(
-                        expr=f"sum(flyte:propeller:all:node:build_dynamic_workflow_us) by (quantile, wf) / 1000",
+                        expr=f"sum(flyte:propeller:all:build_dynamic_workflow_us) by (quantile, wf) / 1000",
                         refId="A",
                     ),
                 ],
@@ -449,7 +449,7 @@ class FlytePropeller(object):
                 dataSource=DATASOURCE,
                 targets=[
                     Target(
-                        expr=f"sum(rate(flyte:propeller:all:node:build_dynamic_workflow_us_count[5m])) by (wf)",
+                        expr=f"sum(rate(flyte:propeller:all:build_dynamic_workflow_us_count[5m])) by (wf)",
                         refId="A",
                     ),
                 ],


### PR DESCRIPTION
## Tracking issue
Closes #6545 

## Why are the changes needed?
These dashboard queries were incorrect

## What changes were proposed in this pull request?
Fixes the dashboard query

## How was this patch tested?
Tested in production

### Screenshots

Before
<img width="3105" height="1213" alt="Screenshot 2025-07-29 at 8 59 03 AM" src="https://github.com/user-attachments/assets/6f8cf12b-1b5a-4fe7-9e41-6349f5c18b40" />

After (wfs obfuscated)
<img width="3090" height="1156" alt="Screenshot 2025-07-29 at 8 59 33 AM" src="https://github.com/user-attachments/assets/980d6d96-d1cc-4fed-a574-4c085e8172e6" />


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request corrects the Grafana dashboard queries for dynamic workflow metrics, ensuring accurate data representation. The modifications have been tested in production to validate their effectiveness.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>