### PR TITLE
[BUG] invalid cron date schedule creates infinite loop in flytescheduler

### DIFF
--- a/flyteadmin/scheduler/core/gocron_scheduler.go
+++ b/flyteadmin/scheduler/core/gocron_scheduler.go
@@ -257,7 +257,7 @@ func getCronScheduledTime(cronString string, fromTime time.Time) (time.Time, err
 	// which can cause infinite while loops. This is a known library issue that should be fixed
 	// by modifying the ParseStandard method in the future.
 	if nextTime.IsZero() {
-		return time.Time{}, fmt.Errorf("invalid crontab configuration")
+		return time.Time{}, fmt.Errorf("invalid crontab string configuration: %s", cronString)
 	}
 	return nextTime, nil
 }

--- a/flyteadmin/scheduler/core/gocron_scheduler.go
+++ b/flyteadmin/scheduler/core/gocron_scheduler.go
@@ -189,6 +189,7 @@ func (g *GoCronScheduler) CatchupAll(ctx context.Context, until time.Time) bool 
 			err := g.CatchUpSingleSchedule(ctx, job.schedule, *fromTime, until)
 			if err != nil {
 				// stop the iteration since one of the catchups failed
+				logger.Errorf(ctx, "catching up schedule failed with error: %v", err)
 				failed = true
 				return false
 			}

--- a/flyteadmin/scheduler/core/gocron_scheduler.go
+++ b/flyteadmin/scheduler/core/gocron_scheduler.go
@@ -252,7 +252,7 @@ func getCronScheduledTime(cronString string, fromTime time.Time) (time.Time, err
 		return time.Time{}, err
 	}
 	nextTime := sched.Next(fromTime)
-	// Todo: nextTime.IsZero() check is needed because cron.ParseStandard library
+	// TODO: nextTime.IsZero() check is needed because cron.ParseStandard library
 	// incorrectly returns January 1st, year 1 for certain invalid cron schedules (e.g. 0 0 31 2 *),
 	// which can cause infinite while loops. This is a known library issue that should be fixed
 	// by modifying the ParseStandard method in the future.

--- a/flyteadmin/scheduler/core/gocron_scheduler.go
+++ b/flyteadmin/scheduler/core/gocron_scheduler.go
@@ -232,6 +232,14 @@ func GetCatchUpTimes(s models.SchedulableEntity, from time.Time, to time.Time) (
 		if scheduledTime.After(to) {
 			break
 		}
+		// Todo: scheduledTime.Before(from) check is needed because cron.ParseStandard library
+		// incorrectly returns January 1st, year 1 for certain invalid cron schedules (e.g. 0 0 31 2 *),
+		// which can cause infinite while loops. This is a known library issue that should be fixed
+		// by modifying the ParseStandard method in the future.
+		if scheduledTime.Before(from) {
+			return nil, fmt.Errorf("invalid crontab configuration")
+		}
+
 		scheduledTimes = append(scheduledTimes, scheduledTime)
 		currFrom = scheduledTime
 	}

--- a/flyteadmin/scheduler/core/gocron_scheduler_test.go
+++ b/flyteadmin/scheduler/core/gocron_scheduler_test.go
@@ -217,14 +217,14 @@ func TestGetCronScheduledTime(t *testing.T) {
 			cronExpression: "0 0 31 2 *", // February 31st - invalid
 			fromTime:       time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC),
 			expectError:    true,
-			errorContains:  "invalid crontab configuration",
+			errorContains:  "invalid crontab string configuration",
 		},
 		{
 			name:           "invalid cron expression with April 31st should return error",
 			cronExpression: "0 0 31 4 *", // April 31st - invalid
 			fromTime:       time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC),
 			expectError:    true,
-			errorContains:  "invalid crontab configuration",
+			errorContains:  "invalid crontab string configuration",
 		},
 		{
 			name:           "invalid cron expression with malformed syntax should return error",
@@ -244,7 +244,6 @@ func TestGetCronScheduledTime(t *testing.T) {
 					assert.Contains(t, err.Error(), tt.errorContains)
 				}
 				assert.True(t, nextTime.IsZero())
-				t.Logf("Got expected error: %v", err)
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, tt.expectedTime, nextTime)
@@ -253,7 +252,7 @@ func TestGetCronScheduledTime(t *testing.T) {
 	}
 }
 
-func TestGetCatchUpTimesWithInvalidCronExpression(t *testing.T) {
+func TestGetCatchUpTimesWithCronExpression(t *testing.T) {
 	tests := []struct {
 		name           string
 		cronExpression string
@@ -261,7 +260,6 @@ func TestGetCatchUpTimesWithInvalidCronExpression(t *testing.T) {
 		toTime         time.Time
 		expectError    bool
 		errorContains  string
-		expectCatchup  bool
 	}{
 		{
 			name:           "invalid cron expression with February 31st should return error",
@@ -269,8 +267,7 @@ func TestGetCatchUpTimesWithInvalidCronExpression(t *testing.T) {
 			fromTime:       time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC),
 			toTime:         time.Date(2023, time.December, 31, 23, 59, 59, 0, time.UTC),
 			expectError:    true,
-			errorContains:  "invalid crontab configuration",
-			expectCatchup:  false,
+			errorContains:  "invalid crontab string configuration",
 		},
 		{
 			name:           "invalid cron expression with April 31st should return error",
@@ -278,8 +275,7 @@ func TestGetCatchUpTimesWithInvalidCronExpression(t *testing.T) {
 			fromTime:       time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC),
 			toTime:         time.Date(2023, time.December, 31, 23, 59, 59, 0, time.UTC),
 			expectError:    true,
-			errorContains:  "invalid crontab configuration",
-			expectCatchup:  false,
+			errorContains:  "invalid crontab string configuration",
 		},
 		{
 			name:           "valid cron expression should work normally",
@@ -287,7 +283,6 @@ func TestGetCatchUpTimesWithInvalidCronExpression(t *testing.T) {
 			fromTime:       time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC),
 			toTime:         time.Date(2023, time.December, 31, 23, 59, 59, 0, time.UTC),
 			expectError:    false,
-			expectCatchup:  true,
 		},
 	}
 
@@ -305,15 +300,9 @@ func TestGetCatchUpTimesWithInvalidCronExpression(t *testing.T) {
 					assert.Contains(t, err.Error(), tt.errorContains)
 				}
 				assert.Nil(t, catchupTimes)
-				t.Logf("Got expected error: %v", err)
 			} else {
 				assert.Nil(t, err)
-				if tt.expectCatchup {
-					assert.True(t, len(catchupTimes) > 0, "Should get valid catchup times")
-					t.Logf("Got %d valid catchup times", len(catchupTimes))
-				} else {
-					assert.Nil(t, catchupTimes)
-				}
+				assert.True(t, len(catchupTimes) > 0, "Should get valid catchup times")
 			}
 		})
 	}


### PR DESCRIPTION
## Tracking issue

Related to #6470 
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?
Fix issue where Flyte scheduler enters infinite loop and OOM when given an invalid cron expression like `0 0 31 2 *`. The [cron parser library](https://github.com/unionai/cron/blob/master/parser.go#L88-L153) returns the default date (0001-01-01) for such expressions, which leads to an infinite scheduling loop.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
This PR introduces a hotfix to break the while loop and return an error when the Flyte scheduler encounters an invalid cron expression during schedule time calculation. However, the underlying cron parser library should be properly updated to handle invalid cron expressions correctly.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Test workflow:
```
from datetime import datetime

from flytekit import task, workflow, CronSchedule, LaunchPlan


@task
def task_1(message: str) -> str:
    return message


@workflow
def date_formatter_wf2() -> str:
    return task_1("hello")

cron_lp = LaunchPlan.get_or_create(
    name="cron_scheduled_lp",
    workflow=date_formatter_wf2,
    schedule=CronSchedule(
        schedule="0 0 31 2 *",
    ),
)
```
Log output:
<img width="598" height="310" alt="截圖 2025-08-10 下午4 13 23" src="https://github.com/user-attachments/assets/16913b7f-3a1e-4436-804d-da5d625b80ea" />


The error was raised as expected

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **fixed**: For any bug fixed.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] All new and existing tests passed.
- [X] All commits are signed-off. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a critical bug in the Flyte scheduler that caused infinite loops and out-of-memory errors due to invalid cron expressions. It introduces validation checks and improved error handling and logging, implements a hotfix to terminate the scheduling loop upon detection of such errors, and includes a TODO for future enhancements to the cron parser library.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>