### PR TITLE
Add option to configure service monitor for flyte scheduler

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -313,10 +313,17 @@ helm install gateway bitnami/contour -n flyte
 | flytescheduler.runPrecheck | bool | `true` | Whether to inject an init container which waits on flyteadmin |
 | flytescheduler.secrets | object | `{}` |  |
 | flytescheduler.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for flytescheduler pod(s). |
+| flytescheduler.service | object | `{"enabled":false}` | Settings for flytescheduler service |
+| flytescheduler.service.enabled | bool | `false` | If enabled create the flytescheduler service |
 | flytescheduler.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for Flytescheduler |
 | flytescheduler.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Flytescheduler pods |
 | flytescheduler.serviceAccount.create | bool | `true` | Should a service account be created for Flytescheduler |
 | flytescheduler.serviceAccount.imagePullSecrets | list | `[]` | ImagePullSecrets to automatically assign to the service account |
+| flytescheduler.serviceMonitor | object | `{"enabled":false,"interval":"60s","labels":{},"scrapeTimeout":"30s"}` | Settings for flytescheduler service monitor |
+| flytescheduler.serviceMonitor.enabled | bool | `false` | If enabled create the flytescheduler service monitor |
+| flytescheduler.serviceMonitor.interval | string | `"60s"` | Sets the interval at which metrics will be scraped by prometheus |
+| flytescheduler.serviceMonitor.labels | object | `{}` | Sets the labels for the service monitor which are required by the prometheus to auto-detect the service monitor and start scrapping the metrics |
+| flytescheduler.serviceMonitor.scrapeTimeout | string | `"30s"` | Sets the timeout after which request to scrape metrics will time out |
 | flytescheduler.strategy | object | `{}` |  |
 | flytescheduler.tolerations | list | `[]` | tolerations for Flytescheduler deployment |
 | secrets.adminOauthClientCredentials.clientId | string | `"flytepropeller"` |  |

--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -313,7 +313,7 @@ helm install gateway bitnami/contour -n flyte
 | flytescheduler.runPrecheck | bool | `true` | Whether to inject an init container which waits on flyteadmin |
 | flytescheduler.secrets | object | `{}` |  |
 | flytescheduler.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for flytescheduler pod(s). |
-| flytescheduler.service | object | `{"enabled":false}` | Settings for flytescheduler service |
+| flytescheduler.service | object | `{"enabled":false,"type":"ClusterIP"}` | Settings for flytescheduler service |
 | flytescheduler.service.enabled | bool | `false` | If enabled create the flytescheduler service |
 | flytescheduler.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for Flytescheduler |
 | flytescheduler.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Flytescheduler pods |
@@ -322,7 +322,7 @@ helm install gateway bitnami/contour -n flyte
 | flytescheduler.serviceMonitor | object | `{"enabled":false,"interval":"60s","labels":{},"scrapeTimeout":"30s"}` | Settings for flytescheduler service monitor |
 | flytescheduler.serviceMonitor.enabled | bool | `false` | If enabled create the flytescheduler service monitor |
 | flytescheduler.serviceMonitor.interval | string | `"60s"` | Sets the interval at which metrics will be scraped by prometheus |
-| flytescheduler.serviceMonitor.labels | object | `{}` | Sets the labels for the service monitor which are required by the prometheus to auto-detect the service monitor and start scrapping the metrics |
+| flytescheduler.serviceMonitor.labels | object | `{}` | Sets the labels for the service monitor which are required by the prometheus to auto-detect the service monitor and start scraping the metrics |
 | flytescheduler.serviceMonitor.scrapeTimeout | string | `"30s"` | Sets the timeout after which request to scrape metrics will time out |
 | flytescheduler.strategy | object | `{}` |  |
 | flytescheduler.tolerations | list | `[]` | tolerations for Flytescheduler deployment |

--- a/charts/flyte-core/templates/flytescheduler/service-monitor.yaml
+++ b/charts/flyte-core/templates/flytescheduler/service-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.workflow_scheduler.enabled (eq .Values.workflow_scheduler.type "native") .Values.flytescheduler.service.enabled .Values.flytescheduler.serviceMonitor.enabled}}
+{{- if and .Values.workflow_scheduler.enabled (eq .Values.workflow_scheduler.type "native") .Values.flytescheduler.service.enabled .Values.flytescheduler.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/flyte-core/templates/flytescheduler/service-monitor.yaml
+++ b/charts/flyte-core/templates/flytescheduler/service-monitor.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.workflow_scheduler.enabled (eq .Values.workflow_scheduler.type "native") .Values.flytescheduler.service.enabled .Values.flytescheduler.serviceMonitor.enabled}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  namespace: {{ template "flyte.namespace" . }}
+  name: {{ template "flytescheduler.name" . }}
+  labels:
+  {{- with .Values.flytescheduler.serviceMonitor.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - interval: {{ .Values.flytescheduler.serviceMonitor.interval }}
+      port: http-metrics
+      path: /metrics
+      scrapeTimeout: {{ .Values.flytescheduler.serviceMonitor.scrapeTimeout }}
+  selector:
+    matchLabels: {{ include "flytescheduler.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/flyte-core/templates/flytescheduler/service.yaml
+++ b/charts/flyte-core/templates/flytescheduler/service.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.workflow_scheduler.enabled (eq .Values.workflow_scheduler.type "native") .Values.flytescheduler.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ template "flyte.namespace" . }}
+  name: {{ template "flytescheduler.name" . }}
+  labels: {{ include "flytescheduler.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-metrics
+      protocol: TCP
+      port: {{ .Values.configmap.schedulerConfig.scheduler.profilerPort }}
+  selector: {{ include "flytescheduler.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/flyte-core/templates/flytescheduler/service.yaml
+++ b/charts/flyte-core/templates/flytescheduler/service.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ template "flytescheduler.name" . }}
   labels: {{ include "flytescheduler.labels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  {{- with .Values.flytescheduler.service.type}}
+  type: {{ . }}
+  {{- end }}
   ports:
     - name: http-metrics
       protocol: TCP

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -228,6 +228,23 @@ flytescheduler:
     seLinuxOptions:
       type: spc_t
 
+  # -- Settings for flytescheduler service
+  service:
+    # -- If enabled create the flytescheduler service
+    enabled: false
+
+  # -- Settings for flytescheduler service monitor
+  serviceMonitor:
+    # -- If enabled create the flytescheduler service monitor
+    enabled: false
+    # -- Sets the labels for the service monitor which are required by the
+    # prometheus to auto-detect the service monitor and start scrapping the metrics
+    labels: {}
+    # -- Sets the interval at which metrics will be scraped by prometheus
+    interval: 60s
+    # -- Sets the timeout after which request to scrape metrics will time out
+    scrapeTimeout: 30s
+
 #
 # DATACATALOG SETTINGS
 #

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -238,7 +238,7 @@ flytescheduler:
     # -- If enabled create the flytescheduler service monitor
     enabled: false
     # -- Sets the labels for the service monitor which are required by the
-    # prometheus to auto-detect the service monitor and start scrapping the metrics
+    # prometheus to auto-detect the service monitor and start scraping the metrics
     labels: {}
     # -- Sets the interval at which metrics will be scraped by prometheus
     interval: 60s

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -232,6 +232,7 @@ flytescheduler:
   service:
     # -- If enabled create the flytescheduler service
     enabled: false
+    type: ClusterIP
 
   # -- Settings for flytescheduler service monitor
   serviceMonitor:

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: MEIwcmJJbVpYTzNvWUI4dw==
+  haSharedSecret: MFhtV2t0MDdXNUZ2RmtlTA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 4e912644ecb5b5e11780d728f1c9ff35eb897c6b627f08ff9dce046510be34cd
+        checksum/secret: 08e1773956eee4a561d19e5bac8e0b26c45157abf174d7a913942f411d056a3d
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: MFhtV2t0MDdXNUZ2RmtlTA==
+  haSharedSecret: RVMxNzVuQnh4aHJ0Y3hNVg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 08e1773956eee4a561d19e5bac8e0b26c45157abf174d7a913942f411d056a3d
+        checksum/secret: f75b24367e90266031e255ddba64450a00364b2834b7a37c0611c77cb105bdf7
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: Q2NQNFU1T1l5aWE0azVqOA==
+  haSharedSecret: b3B2eDlNUTZlWGlJeFZQbQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: eaabfff42714602482f15122a64169d5418919d9f97529714590bcbd67d741bf
+        checksum/secret: d735c8c3ad11a0400bb5c51e2f8f5c08ef262fcb17c1e40410d9a98ffd0a7215
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: anFpa0hhU2FQNFFCMDVQcQ==
+  haSharedSecret: Q2NQNFU1T1l5aWE0azVqOA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 8233e23559018ae9d4bc6ddb3ba9091d15e9c5f5eb9ae43bb65294c0d7b88548
+        checksum/secret: eaabfff42714602482f15122a64169d5418919d9f97529714590bcbd67d741bf
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: Y1J0V2gyVEY0ZU1UbmNzRw==
+  haSharedSecret: aHZ6MGJCWFJPTkl1YURkQw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 8c6d550b5c3b9292aadd1b4ffbea2d1713264ff0d28abe98efc389797a077c75
+        checksum/secret: 635ed31b426ec94eecb58dc1d2e85ada1ffd93443689cd40e682db52de968133
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: aHZ6MGJCWFJPTkl1YURkQw==
+  haSharedSecret: RTVvVEFYYlRUWnU4TGRUYQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 635ed31b426ec94eecb58dc1d2e85ada1ffd93443689cd40e682db52de968133
+        checksum/secret: af283975f133022af6b0fa9b099656108d0e3cefbd46adf0eaf3065f1b707ca3
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## Tracking issue
Closes #6557 

## Why are the changes needed?
It is helpful to have service monitors so that prometheus metrics can be scraped and used in dashboards for observability.

## What changes were proposed in this pull request?
Adds the option to render a service monitor for flyte scheduler

## How was this patch tested?
Tested in our production environment

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces a new feature for configuring a service monitor for the Flyte scheduler, enhancing observability through Prometheus metrics. It includes a ServiceMonitor and service definition in the Helm chart, along with updates to shared secrets in manifest files for improved security.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-defined, making the review process relatively simple.
-->
</div>