### PR TITLE
[charts] Flyte-Binary: Add preInitContainers value

### DIFF
--- a/charts/flyte-binary/README.md
+++ b/charts/flyte-binary/README.md
@@ -106,6 +106,7 @@ Chart for basic single Flyte executable deployment
 | deployment.podSecurityContext.fsGroup | int | `65534` |  |
 | deployment.podSecurityContext.runAsGroup | int | `65534` |  |
 | deployment.podSecurityContext.runAsUser | int | `65534` |  |
+| deployment.preInitContainers | list | `[]` |  |
 | deployment.readinessProbe | object | `{}` |  |
 | deployment.securityContext | object | `{}` |  |
 | deployment.sidecars | list | `[]` |  |

--- a/charts/flyte-binary/templates/deployment.yaml
+++ b/charts/flyte-binary/templates/deployment.yaml
@@ -63,6 +63,9 @@ spec:
       {{- if or .Values.deployment.initContainers (not (include "flyte-binary.configuration.externalConfiguration" .)) }}
       initContainers:
         {{- if not (include "flyte-binary.configuration.externalConfiguration" .) }}
+        {{- if .Values.deployment.preInitContainers }}
+        {{- tpl ( .Values.deployment.preInitContainers | toYaml ) . | nindent 8 }}
+        {{- end }}
         - name: wait-for-db
           {{- with .Values.deployment.waitForDB.image }}
           image: {{ printf "%s:%s" .repository .tag | quote }}

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -302,6 +302,8 @@ deployment:
   sidecars: []
   # initContainers Specify additional init containers for Flyte pod
   initContainers: []
+  # preInitContainers Specify additional pre-init containers for Flyte pod that run before the wait-for-db init container
+  preInitContainers: []
   # extraPodSpec Specify additional configuration for Flyte pod
   # This can be used for adding affinity, tolerations, hostNetwork, etc.
   extraPodSpec: {}


### PR DESCRIPTION
## Tracking issue

There does not seem to be existing Github issues for this.

## Why are the changes needed?

`deployment.initContainers` are inserted after the `wait-for-db` init container, making it wait forever if the database connection is also provided by an init container.

## What changes were proposed in this pull request?

Adds `deployment.preInitContainers` value that inserts its contents before any other init container in the deployment.

Example values configuration snippet for cloud-sql-proxy: 

```
deployment:
  (...)
  preInitContainers:
    - name: cloud-sql-proxy
      restartPolicy: Always
      image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
      args:
        - "--private-ip"
        - "--auto-iam-authn"
        - "--structured-logs"
        - "--port=5433"
        - "<Cloud SQL connection name>"
```

## How was this patch tested?

Deployed the chart including the new value and ran a test execution with the deployed chart.

### Labels

- **added**: New `deployment.preInitContainers` value for `flyte-binary` Helm chart

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Docs link

No new docs, beside the Helm-docs generated README for the new value. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request adds a new configuration option, preInitContainers, to the Flyte-Binary Helm chart, enabling users to specify additional init containers. This enhancement aims to prevent deployment hangs related to database connection issues by modifying the deployment template and values configuration file.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>