### PR TITLE
Remove projectcontour annotations from helm charts by default

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -156,7 +156,7 @@ helm install gateway bitnami/contour -n flyte
 | datacatalog.replicaCount | int | `1` | Replicas count for Datacatalog deployment |
 | datacatalog.resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Datacatalog deployment |
 | datacatalog.securityContext | object | `{"fsGroup":1001,"fsGroupChangePolicy":"OnRootMismatch","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for datacatalog pod(s). |
-| datacatalog.service | object | `{"additionalPorts":[],"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"type":"NodePort"}` | Service settings for Datacatalog |
+| datacatalog.service | object | `{"additionalPorts":[],"annotations":{},"type":"NodePort"}` | Service settings for Datacatalog |
 | datacatalog.service.additionalPorts | list | `[]` | Appends additional ports to the service spec. |
 | datacatalog.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[]}` | Configuration for service accounts for Datacatalog |
 | datacatalog.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to Datacatalog pods |
@@ -198,7 +198,7 @@ helm install gateway bitnami/contour -n flyte
 | flyteadmin.resources | object | `{"limits":{"cpu":"250m","ephemeral-storage":"100Mi","memory":"500Mi"},"requests":{"cpu":"10m","ephemeral-storage":"50Mi","memory":"50Mi"}}` | Default resources requests and limits for Flyteadmin deployment |
 | flyteadmin.secrets | object | `{}` |  |
 | flyteadmin.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for flyteadmin pod(s). |
-| flyteadmin.service | object | `{"additionalPorts":[],"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"appProtocols":{"enabled":false},"loadBalancerSourceRanges":[],"type":"ClusterIP"}` | Service settings for Flyteadmin |
+| flyteadmin.service | object | `{"additionalPorts":[],"annotations":{},"appProtocols":{"enabled":false},"loadBalancerSourceRanges":[],"type":"ClusterIP"}` | Service settings for Flyteadmin |
 | flyteadmin.service.additionalPorts | list | `[]` | Appends additional ports to the service spec. |
 | flyteadmin.serviceAccount | object | `{"alwaysCreate":false,"annotations":{},"clusterRole":null,"create":true,"createClusterRole":null,"imagePullSecrets":[],"rbac":true,"rbacRules":{"apiGroups":["","flyte.lyft.com","rbac.authorization.k8s.io"],"resources":["configmaps","flyteworkflows","namespaces","pods","resourcequotas","roles","rolebindings","secrets","services","serviceaccounts","spark-role","limitranges"],"verbs":["*"]},"rbacScope":"cluster"}` | Configuration for service accounts for FlyteAdmin |
 | flyteadmin.serviceAccount.alwaysCreate | bool | `false` | Should a service account always be created for flyteadmin even without an actual flyteadmin deployment running (e.g. for multi-cluster setups) |
@@ -364,7 +364,7 @@ helm install gateway bitnami/contour -n flyte
 | webhook.resources.requests.ephemeral-storage | string | `"500Mi"` |  |
 | webhook.resources.requests.memory | string | `"500Mi"` |  |
 | webhook.securityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"Always","runAsNonRoot":true,"runAsUser":1001,"seLinuxOptions":{"type":"spc_t"}}` | Sets securityContext for webhook pod(s). |
-| webhook.service | object | `{"annotations":{"projectcontour.io/upstream-protocol.h2c":"grpc"},"type":"ClusterIP"}` | Service settings for the webhook |
+| webhook.service | object | `{"annotations":{},"type":"ClusterIP"}` | Service settings for the webhook |
 | webhook.serviceAccount | object | `{"annotations":{},"create":true,"imagePullSecrets":[],"rbacRules":[{"apiGroups":["*"],"resources":["mutatingwebhookconfigurations","secrets","pods","replicasets/finalizers"],"verbs":["get","create","update","patch"]}],"rbacScope":"cluster"}` | Configuration for service accounts for the webhook |
 | webhook.serviceAccount.annotations | object | `{}` | Annotations for ServiceAccount attached to the webhook |
 | webhook.serviceAccount.create | bool | `true` | Should a service account be created for the webhook |

--- a/charts/flyte-core/values-keycloak-idp-flyteclients-without-browser.yaml
+++ b/charts/flyte-core/values-keycloak-idp-flyteclients-without-browser.yaml
@@ -164,8 +164,6 @@ datacatalog:
   configPath: /etc/datacatalog/config/*.yaml
   # -- Service settings for Datacatalog
   service:
-    annotations:
-      projectcontour.io/upstream-protocol.h2c: grpc
     type: NodePort
   # -- Configuration for service accounts for Datacatalog
   serviceAccount:
@@ -323,8 +321,6 @@ webhook:
     imagePullSecrets: []
   # -- Service settings for the webhook
   service:
-    annotations:
-      projectcontour.io/upstream-protocol.h2c: grpc
     type: ClusterIP
 
 # ------------------------------------------------

--- a/charts/flyte-core/values-keycloak-idp-flyteclients-without-browser.yaml
+++ b/charts/flyte-core/values-keycloak-idp-flyteclients-without-browser.yaml
@@ -52,8 +52,7 @@ flyteadmin:
     - flyteexamples
   # -- Service settings for Flyteadmin
   service:
-    annotations:
-      projectcontour.io/upstream-protocol.h2c: grpc
+    annotations: {}
     type: ClusterIP
     loadBalancerSourceRanges: []
   # -- Configuration for service accounts for FlyteAdmin

--- a/charts/flyte-core/values-sandbox.yaml
+++ b/charts/flyte-core/values-sandbox.yaml
@@ -3,15 +3,13 @@ flyteadmin:
   serviceMonitor:
     enabled: false
   service:
-    annotations:
-      projectcontour.io/upstream-protocol.h2c: grpc
+    annotations: {}
     type: ClusterIP
     loadBalancerSourceRanges: []
 
 datacatalog:
   service:
-    annotations:
-      projectcontour.io/upstream-protocol.h2c: grpc
+    annotations: {}
     type: NodePort
 
 flyteconsole:

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -66,8 +66,7 @@ flyteadmin:
   service:
     appProtocols:
       enabled: false
-    annotations:
-      projectcontour.io/upstream-protocol.h2c: grpc
+    annotations: {}
     type: ClusterIP
     loadBalancerSourceRanges: []
     # -- Appends additional ports to the service spec.
@@ -260,8 +259,7 @@ datacatalog:
   configPath: /etc/datacatalog/config/*.yaml
   # -- Service settings for Datacatalog
   service:
-    annotations:
-      projectcontour.io/upstream-protocol.h2c: grpc
+    annotations: {}
     type: NodePort
     # -- Appends additional ports to the service spec.
     additionalPorts: []
@@ -631,8 +629,7 @@ webhook:
           - patch
   # -- Service settings for the webhook
   service:
-    annotations:
-      projectcontour.io/upstream-protocol.h2c: grpc
+    annotations: {}
     type: ClusterIP
   # -- Annotations for webhook deployment
   annotations: {}

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -741,8 +741,6 @@ metadata:
     app.kubernetes.io/instance: flyte
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: ClusterIP
   ports:
@@ -799,8 +797,6 @@ metadata:
     app.kubernetes.io/instance: flyte
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: NodePort
   ports:
@@ -823,8 +819,6 @@ kind: Service
 metadata:
   name: flyte-pod-webhook
   namespace: flyte
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   selector:
     app: flyte-pod-webhook

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -467,8 +467,6 @@ metadata:
     app.kubernetes.io/instance: flyte
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: ClusterIP
   ports:
@@ -525,8 +523,6 @@ metadata:
     app.kubernetes.io/instance: flyte
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: NodePort
   ports:

--- a/deployment/eks/flyte_helm_dataplane_generated.yaml
+++ b/deployment/eks/flyte_helm_dataplane_generated.yaml
@@ -394,8 +394,6 @@ kind: Service
 metadata:
   name: flyte-pod-webhook
   namespace: flyte
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   selector:
     app: flyte-pod-webhook

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -772,8 +772,6 @@ metadata:
     app.kubernetes.io/instance: flyte
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: ClusterIP
   ports:
@@ -830,8 +828,6 @@ metadata:
     app.kubernetes.io/instance: flyte
     helm.sh/chart: flyte-core-v0.1.10
     app.kubernetes.io/managed-by: Helm
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: NodePort
   ports:
@@ -854,8 +850,6 @@ kind: Service
 metadata:
   name: flyte-pod-webhook
   namespace: flyte
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   selector:
     app: flyte-pod-webhook

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -482,7 +482,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations: 
     cloud.google.com/app-protocols: '{"grpc":"HTTP2"}'
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: ClusterIP
   ports:
@@ -541,7 +540,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations: 
     cloud.google.com/app-protocols: '{"grpc":"HTTP2"}'
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: NodePort
   ports:

--- a/deployment/gcp/flyte_helm_dataplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_dataplane_generated.yaml
@@ -402,8 +402,6 @@ kind: Service
 metadata:
   name: flyte-pod-webhook
   namespace: flyte
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   selector:
     app: flyte-pod-webhook

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -795,7 +795,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations: 
     cloud.google.com/app-protocols: '{"grpc":"HTTP2"}'
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: ClusterIP
   ports:
@@ -854,7 +853,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations: 
     cloud.google.com/app-protocols: '{"grpc":"HTTP2"}'
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   type: NodePort
   ports:
@@ -877,8 +875,6 @@ kind: Service
 metadata:
   name: flyte-pod-webhook
   namespace: flyte
-  annotations: 
-    projectcontour.io/upstream-protocol.h2c: grpc
 spec:
   selector:
     app: flyte-pod-webhook

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: S3N6c1NmNlE1NWliSENPRw==
+  haSharedSecret: MEIwcmJJbVpYTzNvWUI4dw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: b6bf08c653c0a05ba21b3e2bc037bfef49a3dbd9d79dbd7e2a88b85564a3b549
+        checksum/secret: 4e912644ecb5b5e11780d728f1c9ff35eb897c6b627f08ff9dce046510be34cd
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: N01RcDB0TDJrMkJEV2RQWQ==
+  haSharedSecret: S3N6c1NmNlE1NWliSENPRw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 31ce64359d95db6a01fdbacfb8c31c9662b81a9073c011f70d831a3912581a90
+        checksum/secret: b6bf08c653c0a05ba21b3e2bc037bfef49a3dbd9d79dbd7e2a88b85564a3b549
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: VUZKQkkyRkdvSE85NW9ldg==
+  haSharedSecret: anFpa0hhU2FQNFFCMDVQcQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 78c2079a8d620506127aaf57a932d81c34ae3132ccdef90f9e48fdb29e5026ec
+        checksum/secret: 8233e23559018ae9d4bc6ddb3ba9091d15e9c5f5eb9ae43bb65294c0d7b88548
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: cHcweTZ3RjJwMWx1eURYRg==
+  haSharedSecret: VUZKQkkyRkdvSE85NW9ldg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: f9b3ea8798640b8fc46d01b0efef84b90e0c50575a420cf44360e3d119c06e23
+        checksum/secret: 78c2079a8d620506127aaf57a932d81c34ae3132ccdef90f9e48fdb29e5026ec
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: anVuVXJ6S28zZnI0UFQzeQ==
+  haSharedSecret: aXdvSXhMaExjRW92QjFZUA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 995e4e6344b4babb5aec8313190c84878cf2b7366118c1e93073cb9d670fdcee
+        checksum/secret: b0630c355df79e5d455fbc7c21ddce30fba4a1eca1b41d1801882c51d020cc1b
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: aXdvSXhMaExjRW92QjFZUA==
+  haSharedSecret: Y1J0V2gyVEY0ZU1UbmNzRw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: b0630c355df79e5d455fbc7c21ddce30fba4a1eca1b41d1801882c51d020cc1b
+        checksum/secret: 8c6d550b5c3b9292aadd1b4ffbea2d1713264ff0d28abe98efc389797a077c75
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## Tracking issue
Closes #6562 

## Why are the changes needed?
Helm charts shouldn't have references to implementation specific ingress annotations, especially ones not even used by Flyte. This should help reduce confusion when folks see the annotations in their Kubernetes resources. 

Note: this may be a breaking change for the rare folks using project contours and relying on the default annotations.

## What changes were proposed in this pull request?
Eliminating projectcontour annotations from the flute-core helm chart

## How was this patch tested?
See unit tests

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the Flyte helm charts by removing unused projectcontour annotations, reducing user confusion. It also updates several secrets across manifest files for improved consistency and security. While this may be a breaking change for some users, it streamlines configurations for the majority.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>