### PR TITLE
Allow data catalog to be configured as headless service

### DIFF
--- a/charts/flyte-core/templates/datacatalog/service.yaml
+++ b/charts/flyte-core/templates/datacatalog/service.yaml
@@ -12,6 +12,9 @@ spec:
   {{- with .Values.datacatalog.service.type}}
   type: {{ . }}
   {{- end }}
+  {{- with .Values.datacatalog.service.clusterIP}}
+  clusterIP: {{ . }}
+  {{- end }}
   ports:
   - name: http
     port: 88


### PR DESCRIPTION
## Tracking issue
Closes #6563 

## Why are the changes needed?
This allows users to configure data catalog as a headless service and use gRPC client side load balancing.

## What changes were proposed in this pull request?
I am proposing a way to make the `ClusterIP` configurable so that it can be set to `None` as required for a headless service.

## How was this patch tested?
Tested in production

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the data catalog by allowing it to be configured as a headless service. Users can now set the ClusterIP to None, facilitating gRPC client-side load balancing and improving service configuration flexibility.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>