### PR TITLE
Add HPA for datacatalog

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -149,6 +149,17 @@ helm install gateway bitnami/contour -n flyte
 | datacatalog.additionalVolumes | list | `[]` | Appends additional volumes to the deployment spec. May include template values. |
 | datacatalog.affinity | object | `{}` | affinity for Datacatalog deployment |
 | datacatalog.annotations | object | `{}` | Annotations for Datacatalog deployment |
+| datacatalog.autoscaling.enabled | bool | `false` |  |
+| datacatalog.autoscaling.maxReplicas | int | `10` |  |
+| datacatalog.autoscaling.metrics[0].resource.name | string | `"cpu"` |  |
+| datacatalog.autoscaling.metrics[0].resource.target.averageUtilization | int | `80` |  |
+| datacatalog.autoscaling.metrics[0].resource.target.type | string | `"Utilization"` |  |
+| datacatalog.autoscaling.metrics[0].type | string | `"Resource"` |  |
+| datacatalog.autoscaling.metrics[1].resource.name | string | `"memory"` |  |
+| datacatalog.autoscaling.metrics[1].resource.target.averageUtilization | int | `80` |  |
+| datacatalog.autoscaling.metrics[1].resource.target.type | string | `"Utilization"` |  |
+| datacatalog.autoscaling.metrics[1].type | string | `"Resource"` |  |
+| datacatalog.autoscaling.minReplicas | int | `1` |  |
 | datacatalog.configPath | string | `"/etc/datacatalog/config/*.yaml"` | Default regex string for searching configuration files |
 | datacatalog.enabled | bool | `true` |  |
 | datacatalog.extraArgs | object | `{}` | Appends extra command line arguments to the main command |

--- a/charts/flyte-core/templates/datacatalog/deployment.yaml
+++ b/charts/flyte-core/templates/datacatalog/deployment.yaml
@@ -12,7 +12,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+  {{- if not .Values.datacatalog.autoscaling.enabled }}
   replicas: {{ .Values.datacatalog.replicaCount }}
+  {{- end }}
   selector:
     matchLabels: {{ include "datacatalog.selectorLabels" . | nindent 6 }}
   {{- with .Values.datacatalog.strategy }}

--- a/charts/flyte-core/templates/datacatalog/hpa.yaml
+++ b/charts/flyte-core/templates/datacatalog/hpa.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.datacatalog.enabled .Values.datacatalog.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "datacatalog.name" . }}
+  namespace: {{ template "flyte.namespace" . }}
+  labels: {{ include "datacatalog.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "datacatalog.name" . }}
+  minReplicas: {{ .Values.datacatalog.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.datacatalog.autoscaling.maxReplicas }}
+  metrics:
+    {{ .Values.datacatalog.autoscaling.metrics | toYaml | nindent 4 }}
+{{- end }}

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -292,6 +292,24 @@ datacatalog:
       memory: 50Mi
   # Strategy for Datacatalog deployment
   strategy: {}
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 80
   # -- Default regex string for searching configuration files
   configPath: /etc/datacatalog/config/*.yaml
   # -- Service settings for Datacatalog

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: WVVIUFZkNjNtcXVCOHVGVA==
+  haSharedSecret: OGFidG9ENzFnVExIWjRaaQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 1c74b2a2841b6c2d6e8000fc2cb61f06d095a7b1380a4a04dd591d08077b871d
+        checksum/secret: 1db10551279483c20a6accc77042f7e7e586bda858a4366ede793cd661f88178
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: Uld4NXVCN2JwNExZaGl1cg==
+  haSharedSecret: OWtyVkdYYjhJNGxEeUZJMg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 8005ff2a5140f274fc227cb3fe06ee2f56cdff3c51fc7cfa70941aea0b25fbe2
+        checksum/secret: 7d349c9d0f096e1ee3e561ed7dfce29036ab0c303b6a2d8be93af05035f87fd7
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: aUlycXoxdUxEdVpSMTdTaw==
+  haSharedSecret: dVczakV5ZUVKWHZ3TGtwTA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: debfa0bb45235661403249fbce9b2e002ed2197c6e17550f7c3a3a7e6900c881
+        checksum/secret: 9fcd063887300794cd4b668194e47ca748fa7c14842246c51d953efb4b4f5bb2
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## Why are the changes needed?
Depending on the workflows being run by FlytePropeller data catalog load can be quite dynamic. It would be nice otherwise support horizontal pod autoscalers. 

## What changes were proposed in this pull request?
Adds support for horizontal pod autoscaler for data catalog.

## How was this patch tested?
Tested in our production environment. 

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request adds support for horizontal pod autoscalers (HPA) in the Flyte data catalog, enabling dynamic scaling based on workload. It includes a new HPA configuration in the Helm chart and updates several manifests with shared secrets to improve scalability and performance.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-defined, making the review process relatively quick.
-->
</div>