### PR TITLE
Disable strict mode in flytectl

### DIFF
--- a/flytectl/cmd/root.go
+++ b/flytectl/cmd/root.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	cfgFile        string
-	configAccessor = viper.NewAccessor(stdConfig.Options{StrictMode: true})
+	configAccessor = viper.NewAccessor(stdConfig.Options{StrictMode: false})
 )
 
 const (
@@ -116,7 +116,7 @@ func initConfig(cmd *cobra.Command, _ []string) error {
 	}
 
 	configAccessor = viper.NewAccessor(stdConfig.Options{
-		StrictMode:  true,
+		StrictMode:  false,
 		SearchPaths: []string{configFile},
 	})
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Allow users to have some other config in the flytectl config.

## What changes were proposed in this pull request?
Disable strict mode in flytectl

## How was this patch tested?
flytectl get project


### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances usability by disabling strict mode in the flytectl configuration, allowing users greater flexibility in their settings. The modification accommodates various user configurations for improved user experience.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>