### PR TITLE
Fix OTEL helm chart config map

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -123,8 +123,8 @@ helm install gateway bitnami/contour -n flyte
 | configmap.enabled_plugins.tasks.task-plugins.enabled-plugins | list | `["container","sidecar","k8s-array","connector-service","echo"]` | [Enabled Plugins](https://pkg.go.dev/github.com/lyft/flyteplugins/go/tasks/config#Config). Enable sagemaker*, athena if you install the backend plugins |
 | configmap.k8s | object | `{"plugins":{"k8s":{"default-cpus":"100m","default-env-vars":[],"default-memory":"100Mi"}}}` | Kubernetes specific Flyte configuration |
 | configmap.k8s.plugins.k8s | object | `{"default-cpus":"100m","default-env-vars":[],"default-memory":"100Mi"}` | Configuration section for all K8s specific plugins [Configuration structure](https://pkg.go.dev/github.com/lyft/flyteplugins/go/tasks/pluginmachinery/flytek8s/config) |
-| configmap.otel | object | `{"otel":{"file":"/tmp/trace.txt","jaeger":{"endpoint":"http://localhost:14268/api/traces"},"otlpgrpc":{"endpoint":"http://localhost:4317"},"otlphttp":{"endpoint":"http://localhost:4318/v1/traces"},"sampler":{"parentSampler":"always"},"type":"noop"}}` | Open Telemetry Configuration |
-| configmap.otel.otel.file | string | `"/tmp/trace.txt"` | Configuration for the file exporter type |
+| configmap.otel | object | `{"otel":{"file":{"filename":"/tmp/trace.txt"},"jaeger":{"endpoint":"http://localhost:14268/api/traces"},"otlpgrpc":{"endpoint":"http://localhost:4317"},"otlphttp":{"endpoint":"http://localhost:4318/v1/traces"},"sampler":{"parentSampler":"always"},"type":"noop"}}` | Open Telemetry Configuration |
+| configmap.otel.otel.file | object | `{"filename":"/tmp/trace.txt"}` | Configuration for the file exporter type |
 | configmap.otel.otel.jaeger | object | `{"endpoint":"http://localhost:14268/api/traces"}` | Configuration for the jaeger exporter type |
 | configmap.otel.otel.otlphttp | object | `{"endpoint":"http://localhost:4318/v1/traces"}` | Configuration for the otlp exporter type |
 | configmap.otel.otel.sampler | object | `{"parentSampler":"always"}` | Configuration for sampling of traces |

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -906,7 +906,8 @@ configmap:
       # -- The type of exporter to use
       type: noop
       # -- Configuration for the file exporter type
-      file: "/tmp/trace.txt"
+      file:
+        filename: "/tmp/trace.txt"
       # -- Configuration for the jaeger exporter type
       jaeger:
         endpoint: "http://localhost:14268/api/traces"

--- a/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
+++ b/deployment/eks/flyte_aws_scheduler_helm_generated.yaml
@@ -132,7 +132,8 @@ data:
       name: production
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -394,7 +395,8 @@ data:
       username: flyteadmin
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -533,7 +535,8 @@ data:
         default-memory: 100Mi
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -883,7 +886,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1a3b03ce2201b7f44bd9e8d17d00e1ef9d227362fc9b4e45f3d08b56f7e1530"
+        configChecksum: "6fd4bb5460f260b492db7ddd34b6011581292e88b28c2e4514b7da75673cd4d"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -1205,7 +1208,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "43fd7fbb0370b3be922e40062b2903cb185d2436b4507c4e357a7c18dee71a1"
+        configChecksum: "1150f42645741b09ff07a85129828e62314df0b4dea984225c9b728a88bf1e2"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -1309,7 +1312,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "36a92fbbe19cb32e78a045f395c5c42a222d74491aecac870cf277fa9353acd"
+        configChecksum: "1cea68e6ccfdf4838847710d41b88bee0b9b3e15bb827d1be4332cfca17885c"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -1395,7 +1398,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0
       annotations:
-        configChecksum: "36a92fbbe19cb32e78a045f395c5c42a222d74491aecac870cf277fa9353acd"
+        configChecksum: "1cea68e6ccfdf4838847710d41b88bee0b9b3e15bb827d1be4332cfca17885c"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/deployment/eks/flyte_helm_controlplane_generated.yaml
+++ b/deployment/eks/flyte_helm_controlplane_generated.yaml
@@ -113,7 +113,8 @@ data:
       name: production
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -360,7 +361,8 @@ data:
       username: flyteadmin
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -581,7 +583,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c26f85c2c14e2d92b7ffe4c931918a375a459870b142caad4f9b97947e467ad"
+        configChecksum: "b1a6f6afb902bd1384515a97c5bad38985c0799ca8173efb0e664bda8eb9ca1"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -903,7 +905,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "43fd7fbb0370b3be922e40062b2903cb185d2436b4507c4e357a7c18dee71a1"
+        configChecksum: "1150f42645741b09ff07a85129828e62314df0b4dea984225c9b728a88bf1e2"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -1007,7 +1009,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c26f85c2c14e2d92b7ffe4c931918a375a459870b142caad4f9b97947e467ad"
+        configChecksum: "b1a6f6afb902bd1384515a97c5bad38985c0799ca8173efb0e664bda8eb9ca1"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte

--- a/deployment/eks/flyte_helm_dataplane_generated.yaml
+++ b/deployment/eks/flyte_helm_dataplane_generated.yaml
@@ -166,7 +166,8 @@ data:
         default-memory: 100Mi
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -435,7 +436,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "36a92fbbe19cb32e78a045f395c5c42a222d74491aecac870cf277fa9353acd"
+        configChecksum: "1cea68e6ccfdf4838847710d41b88bee0b9b3e15bb827d1be4332cfca17885c"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -521,7 +522,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0
       annotations:
-        configChecksum: "36a92fbbe19cb32e78a045f395c5c42a222d74491aecac870cf277fa9353acd"
+        configChecksum: "1cea68e6ccfdf4838847710d41b88bee0b9b3e15bb827d1be4332cfca17885c"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/deployment/eks/flyte_helm_generated.yaml
+++ b/deployment/eks/flyte_helm_generated.yaml
@@ -144,7 +144,8 @@ data:
       name: production
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -391,7 +392,8 @@ data:
       username: flyteadmin
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -564,7 +566,8 @@ data:
         default-memory: 100Mi
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -914,7 +917,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c26f85c2c14e2d92b7ffe4c931918a375a459870b142caad4f9b97947e467ad"
+        configChecksum: "b1a6f6afb902bd1384515a97c5bad38985c0799ca8173efb0e664bda8eb9ca1"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -1236,7 +1239,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "43fd7fbb0370b3be922e40062b2903cb185d2436b4507c4e357a7c18dee71a1"
+        configChecksum: "1150f42645741b09ff07a85129828e62314df0b4dea984225c9b728a88bf1e2"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -1340,7 +1343,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c26f85c2c14e2d92b7ffe4c931918a375a459870b142caad4f9b97947e467ad"
+        configChecksum: "b1a6f6afb902bd1384515a97c5bad38985c0799ca8173efb0e664bda8eb9ca1"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte
@@ -1439,7 +1442,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "36a92fbbe19cb32e78a045f395c5c42a222d74491aecac870cf277fa9353acd"
+        configChecksum: "1cea68e6ccfdf4838847710d41b88bee0b9b3e15bb827d1be4332cfca17885c"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -1525,7 +1528,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0
       annotations:
-        configChecksum: "36a92fbbe19cb32e78a045f395c5c42a222d74491aecac870cf277fa9353acd"
+        configChecksum: "1cea68e6ccfdf4838847710d41b88bee0b9b3e15bb827d1be4332cfca17885c"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/deployment/gcp/flyte_helm_controlplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_controlplane_generated.yaml
@@ -113,7 +113,8 @@ data:
       name: production
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -370,7 +371,8 @@ data:
       username: flyteadmin
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -598,7 +600,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "53737bc0cafe619900707912054d56dd8564533779ccd43728ce3c68d2bc7e9"
+        configChecksum: "e952d320a403549f597a6e5c264a4284fb2ae2e33b57c54e70975bf4f0f4f9a"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -920,7 +922,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d4f1d43ff19c2b948dd70af745e8407481bf9d05ae675a57c7884a2c55356f4"
+        configChecksum: "d1e2045469ac51c89c0d4b1074dab66d88bc3e03f9d6429d5726d27f2cb0bab"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -1024,7 +1026,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "53737bc0cafe619900707912054d56dd8564533779ccd43728ce3c68d2bc7e9"
+        configChecksum: "e952d320a403549f597a6e5c264a4284fb2ae2e33b57c54e70975bf4f0f4f9a"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte

--- a/deployment/gcp/flyte_helm_dataplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_dataplane_generated.yaml
@@ -166,7 +166,8 @@ data:
         default-memory: 100Mi
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -443,7 +444,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ec8130738ac1c879ccfd872066f7a4c307fec4329ea1f0d1eb9be9861dc1e5a"
+        configChecksum: "cb02c63751dd0ea8f2d6978c9902e8ee0504d1add320b4defc2514e702fb7d1"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -528,7 +529,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0
       annotations:
-        configChecksum: "ec8130738ac1c879ccfd872066f7a4c307fec4329ea1f0d1eb9be9861dc1e5a"
+        configChecksum: "cb02c63751dd0ea8f2d6978c9902e8ee0504d1add320b4defc2514e702fb7d1"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/deployment/gcp/flyte_helm_generated.yaml
+++ b/deployment/gcp/flyte_helm_generated.yaml
@@ -144,7 +144,8 @@ data:
       name: production
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -401,7 +402,8 @@ data:
       username: flyteadmin
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -577,7 +579,8 @@ data:
         default-memory: 100Mi
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -939,7 +942,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "53737bc0cafe619900707912054d56dd8564533779ccd43728ce3c68d2bc7e9"
+        configChecksum: "e952d320a403549f597a6e5c264a4284fb2ae2e33b57c54e70975bf4f0f4f9a"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -1261,7 +1264,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d4f1d43ff19c2b948dd70af745e8407481bf9d05ae675a57c7884a2c55356f4"
+        configChecksum: "d1e2045469ac51c89c0d4b1074dab66d88bc3e03f9d6429d5726d27f2cb0bab"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -1365,7 +1368,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "53737bc0cafe619900707912054d56dd8564533779ccd43728ce3c68d2bc7e9"
+        configChecksum: "e952d320a403549f597a6e5c264a4284fb2ae2e33b57c54e70975bf4f0f4f9a"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte
@@ -1464,7 +1467,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ec8130738ac1c879ccfd872066f7a4c307fec4329ea1f0d1eb9be9861dc1e5a"
+        configChecksum: "cb02c63751dd0ea8f2d6978c9902e8ee0504d1add320b4defc2514e702fb7d1"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -1549,7 +1552,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0
       annotations:
-        configChecksum: "ec8130738ac1c879ccfd872066f7a4c307fec4329ea1f0d1eb9be9861dc1e5a"
+        configChecksum: "cb02c63751dd0ea8f2d6978c9902e8ee0504d1add320b4defc2514e702fb7d1"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -264,7 +264,8 @@ data:
       show-source: true
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -500,7 +501,8 @@ data:
       username: postgres
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -694,7 +696,8 @@ data:
       show-source: true
   otel.yaml: | 
     otel:
-      file: /tmp/trace.txt
+      file:
+        filename: /tmp/trace.txt
       jaeger:
         endpoint: http://localhost:14268/api/traces
       otlpgrpc:
@@ -6727,7 +6730,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b435a59792537ee4fccc9614a73cfbb8a2317b49207afc89127127f397f5f4b"
+        configChecksum: "29b249082ba3f15e213daf85d53d386f968925a8aeab291c585078d59680378"
       labels: 
         app.kubernetes.io/name: flyteadmin
         app.kubernetes.io/instance: flyte
@@ -7031,7 +7034,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "21632a41587831f93dc2408f0043104f06478b4574b4b8e140c2b084e375f84"
+        configChecksum: "020bddf381d4d3384f1cd3abdc98315ad1926c0021415300d9f6264851d03d2"
       labels: 
         app.kubernetes.io/name: datacatalog
         app.kubernetes.io/instance: flyte
@@ -7124,7 +7127,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b435a59792537ee4fccc9614a73cfbb8a2317b49207afc89127127f397f5f4b"
+        configChecksum: "29b249082ba3f15e213daf85d53d386f968925a8aeab291c585078d59680378"
       labels: 
         app.kubernetes.io/name: flytescheduler
         app.kubernetes.io/instance: flyte
@@ -7219,7 +7222,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4af8c72e95b904104c840a151865d35982bfa679d80de4edef847c9930bb604"
+        configChecksum: "671959f1f31dcfd1a93c1a484be7c7264f05b66de43df1a770f331d389787a4"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -7297,7 +7300,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0
       annotations:
-        configChecksum: "4af8c72e95b904104c840a151865d35982bfa679d80de4edef847c9930bb604"
+        configChecksum: "671959f1f31dcfd1a93c1a484be7c7264f05b66de43df1a770f331d389787a4"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: OGFidG9ENzFnVExIWjRaaQ==
+  haSharedSecret: QUVqQmx5bGJySWhjSjF0bw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 1db10551279483c20a6accc77042f7e7e586bda858a4366ede793cd661f88178
+        checksum/secret: 798c87369386469c6c2311656622a0eb1482625653ad1de361695e01151c57fd
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: OWtyVkdYYjhJNGxEeUZJMg==
+  haSharedSecret: a1doU0xtWUlud0xsSTM5VQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 7d349c9d0f096e1ee3e561ed7dfce29036ab0c303b6a2d8be93af05035f87fd7
+        checksum/secret: 855c4f6fc84fb7a055427bcd712eac03e376383ba1d04ac1ab74bab9c5117879
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: dVczakV5ZUVKWHZ3TGtwTA==
+  haSharedSecret: ajRmNnZOcWZQTHlGa2c1eQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 9fcd063887300794cd4b668194e47ca748fa7c14842246c51d953efb4b4f5bb2
+        checksum/secret: 907c158b3cdfe55efc0894dbd4ba0762233336309d2584d3bd1167ca43564419
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## Why are the changes needed?
Fixes the rendered config map to match the go structs: https://github.com/flyteorg/flyte/blob/master/flytestdlib/otelutils/config.go#L35-L37

## What changes were proposed in this pull request?
Refactor otel config map output to match go struct

## How was this patch tested?
Tested by user: https://flyte-org.slack.com/archives/CP2HDHKE1/p1757966141336589

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the OTEL helm chart configuration by refactoring the output to align with Go structs, updating YAML files for consistency across deployments, and modifying checksums for improved security and integrity. These changes aim to clarify and ensure the correctness of the configuration essential for OTEL integration.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>