### PR TITLE
Add HPA to flyte console

### DIFF
--- a/charts/flyte-core/README.md
+++ b/charts/flyte-core/README.md
@@ -262,6 +262,17 @@ helm install gateway bitnami/contour -n flyte
 | flyteconnector.podLabels | object | `{}` | Labels for flyteconnector pods |
 | flyteconsole.affinity | object | `{}` | affinity for Flyteconsole deployment |
 | flyteconsole.annotations | object | `{}` | Annotations for Flyteconsole deployment |
+| flyteconsole.autoscaling.enabled | bool | `false` |  |
+| flyteconsole.autoscaling.maxReplicas | int | `10` |  |
+| flyteconsole.autoscaling.metrics[0].resource.name | string | `"cpu"` |  |
+| flyteconsole.autoscaling.metrics[0].resource.target.averageUtilization | int | `80` |  |
+| flyteconsole.autoscaling.metrics[0].resource.target.type | string | `"Utilization"` |  |
+| flyteconsole.autoscaling.metrics[0].type | string | `"Resource"` |  |
+| flyteconsole.autoscaling.metrics[1].resource.name | string | `"memory"` |  |
+| flyteconsole.autoscaling.metrics[1].resource.target.averageUtilization | int | `80` |  |
+| flyteconsole.autoscaling.metrics[1].resource.target.type | string | `"Utilization"` |  |
+| flyteconsole.autoscaling.metrics[1].type | string | `"Resource"` |  |
+| flyteconsole.autoscaling.minReplicas | int | `1` |  |
 | flyteconsole.enabled | bool | `true` |  |
 | flyteconsole.ga.enabled | bool | `false` |  |
 | flyteconsole.ga.tracking_id | string | `"G-0QW4DJWJ20"` |  |

--- a/charts/flyte-core/templates/console/deployment.yaml
+++ b/charts/flyte-core/templates/console/deployment.yaml
@@ -12,7 +12,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+  {{- if not .Values.flyteconsole.autoscaling.enabled }}
   replicas: {{ .Values.flyteconsole.replicaCount }}
+  {{- end }}
   selector:
     matchLabels: {{ include "flyteconsole.selectorLabels" . | nindent 6 }}
   {{- with .Values.flyteconsole.strategy }}

--- a/charts/flyte-core/templates/console/hpa.yaml
+++ b/charts/flyte-core/templates/console/hpa.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.flyteconsole.enabled .Values.flyteconsole.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "flyteconsole.name" . }}
+  namespace: {{ template "flyte.namespace" . }}
+  labels: {{ include "flyteconsole.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "flyteconsole.name" . }}
+  minReplicas: {{ .Values.flyteconsole.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.flyteconsole.autoscaling.maxReplicas }}
+  metrics:
+    {{ .Values.flyteconsole.autoscaling.metrics | toYaml | nindent 4 }}
+{{- end }}

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -586,6 +586,24 @@ flyteconsole:
       memory: 50Mi
   # Strategy for Flyteconsole deployment
   strategy: {}
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 80
   # -- Service settings for Flyteconsole
   service:
     appProtocols:

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: QUVqQmx5bGJySWhjSjF0bw==
+  haSharedSecret: NUFZSjlMb000dURTeFRHcA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 798c87369386469c6c2311656622a0eb1482625653ad1de361695e01151c57fd
+        checksum/secret: 70ab3a722bbba034ed7344ef07a16053252026dfe34e71c2448c980ff47a6181
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: a1doU0xtWUlud0xsSTM5VQ==
+  haSharedSecret: UUltSk9iWTdxVzlNTGZPaQ==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 855c4f6fc84fb7a055427bcd712eac03e376383ba1d04ac1ab74bab9c5117879
+        checksum/secret: 809f2778eadd51c6c0289457a88bedac6de365127677a48c24dba5611799c3b2
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: ajRmNnZOcWZQTHlGa2c1eQ==
+  haSharedSecret: aHlIMkgzdHluSUU0T2t2bA==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 907c158b3cdfe55efc0894dbd4ba0762233336309d2584d3bd1167ca43564419
+        checksum/secret: 5f9abc8cd74e0ef31cadbf5c8d52979e5fa091a0361f51dd898422abaeca6ed6
       labels:
         app: docker-registry
         release: flyte-sandbox


### PR DESCRIPTION
## Why are the changes needed?
Adds horizontal pod autoscaling to flyte console so that it can scale up in response to demand.

## What changes were proposed in this pull request?
Updated flyte-core to render a horizontal pod autoscaler for flyte console when enabled. 

## How was this patch tested?
Tested in our production environment

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request implements a Horizontal Pod Autoscaler (HPA) for the Flyte console, enabling dynamic scaling based on demand. It includes updates to deployment configurations, HPA specifications, and modifications to the values file for autoscaling. Additionally, shared secrets in the connector and manifest files have been updated for enhanced security.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>