### PR TITLE
Update Flyte CI to use bitnami legacy repo for older pinned Bitnami docker images

### DIFF
--- a/docker/sandbox-bundled/images/manifest.txt
+++ b/docker/sandbox-bundled/images/manifest.txt
@@ -1,6 +1,6 @@
-docker.io/bitnami/os-shell:sandbox=bitnami/os-shell:11-debian-11
-docker.io/bitnami/minio:sandbox=bitnami/minio:2023.1.25-debian-11-r0
-docker.io/bitnami/postgresql:sandbox=bitnami/postgresql:15.1.0-debian-11-r20
+docker.io/bitnami/os-shell:sandbox=bitnamilegacy/os-shell:11-debian-11
+docker.io/bitnami/minio:sandbox=bitnamilegacy/minio:2023.1.25-debian-11-r0
+docker.io/bitnami/postgresql:sandbox=bitnamilegacy/postgresql:15.1.0-debian-11-r20
 docker.io/envoyproxy/envoy:sandbox=envoyproxy/envoy:v1.23-latest
 docker.io/kubernetesui/dashboard:sandbox=kubernetesui/dashboard:v2.7.0
 docker.io/library/registry:sandbox=registry:2.8.1


### PR DESCRIPTION
## Tracking issue
Closes #6630 

## Why are the changes needed?
See: https://github.com/bitnami/charts/issues/35164
tl;dr: bitnami is moving old docker images to bitnami-legacy, to encourage folks to make the switch they are doing intentional brownouts every week.

## What changes were proposed in this pull request?
Use the Bitnami-legacy image repository for old pinned images

## How was this patch tested?
With CI

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request updates the CI configuration to use the Bitnami legacy repository for older pinned Docker images, ensuring the CI pipeline functions correctly with these images following Bitnami's transition.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve configuration updates, making the review process relatively simple.
-->
</div>