### PR TITLE
default otel file should be a map

### DIFF
--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -888,7 +888,8 @@ configmap:
       # -- The type of exporter to use
       type: noop
       # -- Configuration for the file exporter type
-      file: "/tmp/trace.txt"
+      file:
+        path: "/tmp/trace.txt"
       # -- Configuration for the jaeger exporter type
       jaeger:
         endpoint: "http://localhost:14268/api/traces"


### PR DESCRIPTION
## Tracking issue

Closes 6636

## Why are the changes needed?

defaults are not working 

 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request modifies the default configuration for the OpenTelemetry file exporter to correctly utilize a map structure, addressing a tracking issue identified in PR #6636.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>