### PR TITLE
Remove use of deprecated pod phase

### DIFF
--- a/flyteplugins/go/tasks/plugins/array/k8s/integration_test.go
+++ b/flyteplugins/go/tasks/plugins/array/k8s/integration_test.go
@@ -135,8 +135,6 @@ func advancePodPhases(ctx context.Context, store *storage.DataStore, outputWrite
 
 func nextHappyPodPhase(phase v1.PodPhase) v1.PodPhase {
 	switch phase {
-	case v1.PodUnknown:
-		fallthrough
 	case v1.PodPending:
 		fallthrough
 	case "":
@@ -147,5 +145,5 @@ func nextHappyPodPhase(phase v1.PodPhase) v1.PodPhase {
 		return v1.PodSucceeded
 	}
 
-	return v1.PodUnknown
+	return ""
 }

--- a/flyteplugins/go/tasks/plugins/k8s/pod/plugin.go
+++ b/flyteplugins/go/tasks/plugins/k8s/pod/plugin.go
@@ -172,13 +172,11 @@ func (plugin) GetTaskPhaseWithLogs(ctx context.Context, pluginContext k8s.Plugin
 	}
 
 	taskExecID := pluginContext.TaskExecutionMetadata().GetTaskExecutionID()
-	if pod.Status.Phase != v1.PodUnknown {
-		taskLogs, err := logs.GetLogsForContainerInPod(ctx, logPlugin, taskExecID, pod, 0, logSuffix, extraLogTemplateVarsByScheme, taskTemplate)
-		if err != nil {
-			return pluginsCore.PhaseInfoUndefined, err
-		}
-		info.Logs = taskLogs
+	taskLogs, err := logs.GetLogsForContainerInPod(ctx, logPlugin, taskExecID, pod, 0, logSuffix, extraLogTemplateVarsByScheme, taskTemplate)
+	if err != nil {
+		return pluginsCore.PhaseInfoUndefined, err
 	}
+	info.Logs = taskLogs
 
 	phaseInfo, err := DemystifyPodStatus(ctx, pod, info)
 	if err != nil {
@@ -203,8 +201,6 @@ func DemystifyPodStatus(ctx context.Context, pod *v1.Pod, info pluginsCore.TaskI
 		phaseInfo, err = flytek8s.DemystifyPending(pod.Status, info)
 	case v1.PodReasonUnschedulable:
 		phaseInfo = pluginsCore.PhaseInfoQueuedWithTaskInfo(pluginsCore.DefaultPhaseVersion, "pod unschedulable", &info)
-	case v1.PodUnknown:
-		// DO NOTHING
 	default:
 		if !primaryContainerExists {
 			// if all of the containers and sidecars in the Pod are complete, as an optimization, we can declare the task as

--- a/flyteplugins/go/tasks/plugins/k8s/pod/sidecar_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/pod/sidecar_test.go
@@ -751,7 +751,6 @@ func TestGetTaskSidecarStatus(t *testing.T) {
 		v1.PodSucceeded:           pluginsCore.PhaseSuccess,
 		v1.PodFailed:              pluginsCore.PhaseRetryableFailure,
 		v1.PodReasonUnschedulable: pluginsCore.PhaseQueued,
-		v1.PodUnknown:             pluginsCore.PhaseUndefined,
 	}
 
 	for podPhase, expectedTaskPhase := range testCases {


### PR DESCRIPTION
## Why are the changes needed?
`v1.PodUnknown` has been deprecated and unused since 2015. My IDE has warning messages and I figured it should be safe to just cleanup this part of the code.

See: https://pkg.go.dev/k8s.io/api/core/v1@v0.28.2#PodUnknown

## What changes were proposed in this pull request?
Removes all references to `v1.PodUnknown` pod phase.

## How was this patch tested?
Unit tests

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request removes all references to the deprecated pod phase `v1.PodUnknown`, which has been unused since 2015. The updates across multiple files enhance code cleanliness and maintain functionality. Unit tests were added to ensure existing features remain intact.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>