### PR TITLE
Only return connector/agent plugins if enabled

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/handler.go
+++ b/flytepropeller/pkg/controller/nodes/task/handler.go
@@ -408,12 +408,12 @@ func (t Handler) ResolvePlugin(ctx context.Context, ttype string, executionConfi
 		return p, nil
 	}
 
-	if t.connectorService != nil && t.connectorService.ContainTaskType(ttype) {
+	if t.connectorService != nil && t.connectorService.CorePlugin != nil && t.connectorService.ContainTaskType(ttype) {
 		return t.connectorService.CorePlugin, nil
 	}
 
 	// The agent service plugin is deprecated and will be removed in the future
-	if t.agentService != nil && t.agentService.ContainTaskType(ttype) {
+	if t.agentService != nil && t.agentService.CorePlugin != nil && t.agentService.ContainTaskType(ttype) {
 		return t.agentService.CorePlugin, nil
 	}
 


### PR DESCRIPTION
## Tracking issue
Closes #6643

## Why are the changes needed?
The plugin resolution code will return a nil plugin if the task type matches the connector service or agent service but those plugins haven't been enabled and assigned a core plugin.

## What changes were proposed in this pull request?
Add additional nil checks before returning core plugins

## How was this patch tested?
No tests, as there are no tests for the new connector service code.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the plugin resolution logic by adding nil checks before returning core plugins for the connector and agent services. These changes improve robustness by ensuring that a nil plugin is returned if the corresponding services are not enabled, preventing potential errors in plugin resolution.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>