### PR TITLE
[Bug] support download old version of flytectl by install.sh

### DIFF
--- a/flytectl/install.sh
+++ b/flytectl/install.sh
@@ -96,7 +96,7 @@ tag_to_version() {
     TAG="$REALTAG"
     VERSION=${TAG#v}
   elif [ "$STATUS_CODE" -eq 200 ]; then
-    log_crit "Tag '${TAG}' does not exist on GitHub. Check available releases at https://github.com/${OWNER}/${REPO}/releases"
+    TAG="flytectl/$TAG"
     VERSION=${TAG#v}
   else
     log_crit "unable to find '${TAG}' - use 'latest' or see https://github.com/${PREFIX}/releases for details"


### PR DESCRIPTION
## Tracking issue
Related to #6657 

## Why are the changes needed?

check when the old version of flytectl may not be listed in the response from api.github.com. 
## What changes were proposed in this pull request?

1. Check https://api.github.com/repos/${OWNER}/${REPO}/releases/tags/flytectl/${TAG}
2. download if the url is work

## How was this patch tested?
```
bash ./install.sh v0.8.19 # download v0.8.19
./bin/flytectl version
bash ./install.sh # download latest one
./bin/flytectl version
```

### Labels

- **fixed**

This is important to improve the readability of release notes.

### Setup process

### Screenshots
<img width="699" height="465" alt="image" src="https://github.com/user-attachments/assets/600eefaf-3f2f-491b-a841-ccdcbf8359fd" />

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the installation script for flytectl by adding checks for downloading older versions not listed in the GitHub API response. It introduces a new URL check to ensure specified versions can be retrieved, improving the robustness and user experience of version management.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>