### PR TITLE
Fix: add composite index on DatasetUUID and ArtifactID in tags model …

### DIFF
--- a/datacatalog/pkg/repositories/models/tag.go
+++ b/datacatalog/pkg/repositories/models/tag.go
@@ -11,7 +11,7 @@ type TagKey struct {
 type Tag struct {
 	BaseModel
 	TagKey
-	ArtifactID  string   `gorm:"index:tags_dataset_uuid_artifact_id_idx,priority:2`
+	ArtifactID  string   `gorm:"index:tags_dataset_uuid_artifact_id_idx,priority:2"`
 	DatasetUUID string   `gorm:"type:uuid;index:tags_dataset_uuid_idx;index:tags_dataset_uuid_artifact_id_idx,priority:1"`
 	Artifact    Artifact `gorm:"references:DatasetProject,DatasetName,DatasetDomain,DatasetVersion,ArtifactID;foreignkey:DatasetProject,DatasetName,DatasetDomain,DatasetVersion,ArtifactID"`
 }


### PR DESCRIPTION
## Tracking issue
Closes #4583 

## Why are the changes needed?
The Flyte tags table lacked a composite index on the DatasetUUID and ArtifactID columns.
As a result, queries filtering by both fields (for example, fetching tags associated with a specific dataset and artifact) were less efficient, leading to unnecessary full-table scans in some cases.

This change adds a composite index to improve query performance and reduce latency in database lookups involving both columns.

## What changes were proposed in this pull request?
This PR adds a composite GORM index on the DatasetUUID and ArtifactID fields in the tags model.

```diff
- ArtifactID  string
- DatasetUUID string   `gorm:"type:uuid;index:tags_dataset_uuid_idx"`
+ ArtifactID  string   `gorm:"index:tags_dataset_uuid_artifact_id_idx,priority:2"`
+ DatasetUUID string   `gorm:"type:uuid;index:tags_dataset_uuid_idx;index:tags_dataset_uuid_artifact_id_idx,priority:1"`
```

### How this fixes the issue:
- Introduces a composite index named `tags_dataset_uuid_artifact_id_idx`.
- Sets index priority for `DatasetUUID` (1) and `ArtifactID` (2) to ensure optimal ordering for typical query patterns.
- Addresses [#4583](https://github.com/flyteorg/flyte/issues/4583) by improving query efficiency without changing existing schema behavior.

## How was this patch tested?

### Labels
- **changed**: For changes in existing functionality.
- **fixed**: For any bug fixed.

This is important to improve the readability of release notes.

### Setup process
No special setup required. Run database migrations after updating Flyte to apply the new index.

### Screenshots
N/A — schema-level optimization.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs
N/A

## Docs link
N/A — this change affects backend model definitions only and does not modify public APIs or user-facing documentation. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces a composite index on the DatasetUUID and ArtifactID fields in the tags model, significantly enhancing query performance and addressing inefficiencies in database lookups. The changes aim to optimize query execution and reduce latency in database operations.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>