### PR TITLE
[fix] Support typing.Union in flytecopilot

### DIFF
--- a/flytecopilot/data/download.go
+++ b/flytecopilot/data/download.go
@@ -394,7 +394,8 @@ func (d Downloader) handleScalar(ctx context.Context, scalar *core.Scalar, toFil
 		return i, scalar, err
 	case *core.Scalar_Union:
 		b := scalar.GetUnion()
-		return d.handleScalar(ctx, b.Value.GetScalar(), toFilePath, writeToFile)
+		i, lit, err := d.handleLiteral(ctx, b.GetValue(), toFilePath, writeToFile)
+		return i, &core.Scalar{Value: &core.Scalar_Union{Union: &core.Union{Type: b.GetType(), Value: lit}}}, err
 	case *core.Scalar_NoneType:
 		if writeToFile {
 			return nil, scalar, os.WriteFile(toFilePath, []byte("null"), os.ModePerm) // #nosec G306


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/6662

## Why are the changes needed?

An error happens when running a ContainerTask task remote execution with `typing.Union` inputs with flyte copilot.

```
{"level":"error","msg":"Failed to persist [spec], err unsupported scalar type [*core.Scalar_Union]",...}
{"level":"info","msg":"Exited downloading inputs from [.../inputs.pb]",...}
{"level":"error","msg":"Downloading failed, err failed to download input variable from remote store: variable [spec] download/store failed: unsupported scalar type [*core.Scalar_Union]",...}
```

Context: Support for Union types in the Flyte IDL was added in https://github.com/flyteorg/flyte/issues/1349, but there is still a small missing piece in flytecopilot to support downloading Union-type scalars for ContainerTask flyte tasks. This PR adds this small missing piece.

## What changes were proposed in this pull request?

Add a logical path to flytecopilot for `typing.Union` types.

## How was this patch tested?

Tested in my flyte deployment, and confirmed that `typing.Union` inputs now are correctly downloaded by the flytecopilot init container.

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances flytecopilot by adding support for `typing.Union` types, improving the handling of inputs for ContainerTask tasks. It includes logic for processing Union scalar types and introduces new test cases to ensure functionality across various input scenarios.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>