### PR TITLE
Handle child node timeout in branch nodes

### DIFF
--- a/flytepropeller/pkg/controller/nodes/branch/handler.go
+++ b/flytepropeller/pkg/controller/nodes/branch/handler.go
@@ -172,7 +172,7 @@ func (b *branchHandler) recurseDownstream(ctx context.Context, nCtx interfaces.N
 		return handler.DoTransition(handler.TransitionTypeEphemeral, phase), nil
 	}
 
-	if downstreamStatus.HasFailed() {
+	if downstreamStatus.HasFailed() || downstreamStatus.HasTimedOut() {
 		return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoFailureErr(downstreamStatus.Err, nil)), nil
 	}
 

--- a/flytepropeller/pkg/controller/nodes/branch/handler_test.go
+++ b/flytepropeller/pkg/controller/nodes/branch/handler_test.go
@@ -181,6 +181,8 @@ func TestBranchHandler_RecurseDownstream(t *testing.T) {
 			bn, false, handler.EPhaseRunning, v1alpha1.NodePhaseRunning, true, ""},
 		{"childFailure", interfaces.NodeStatusFailed(expectedError), nil,
 			bn, false, handler.EPhaseFailed, v1alpha1.NodePhaseFailed, true, ""},
+		{"childTimedOut", interfaces.NodeStatusTimedOut, nil,
+			bn, false, handler.EPhaseFailed, v1alpha1.NodePhaseTimedOut, true, ""},
 		{"childComplete", interfaces.NodeStatusComplete, nil,
 			bn, false, handler.EPhaseSuccess, v1alpha1.NodePhaseSucceeded, true, ""},
 		{"childCompleteNoOutputs", interfaces.NodeStatusComplete, nil,


### PR DESCRIPTION
## Tracking issue
Closes #6677 

## Why are the changes needed?
Branch nodes with child node timeouts result in zombie workflows stuck in a running state.

## What changes were proposed in this pull request?
Update the branch node handling logic to correctly fail the branch node when a child node times out.

## How was this patch tested?
Unit tests

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request improves branch node handling by updating the logic to fail the branch node when a child node times out, preventing zombie workflows. A new test case has been added to validate this functionality.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, making the review process relatively quick.
-->
</div>