### PR TITLE
Implement async event recording to unblock reconciliation workers

### DIFF
--- a/flytepropeller/events/admin_eventsink.go
+++ b/flytepropeller/events/admin_eventsink.go
@@ -3,10 +3,12 @@ package events
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/golang/protobuf/proto"
 	grpcRetry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/propagation"
 	"golang.org/x/time/rate"
@@ -23,15 +25,50 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
+type queuedEvent struct {
+	message proto.Message
+	id      []byte
+}
+
+type asyncEventSinkMetrics struct {
+	eventsQueued      prometheus.Counter
+	eventsProcessed   prometheus.Counter
+	eventsFailed      prometheus.Counter
+	queueDepth        prometheus.Gauge
+	processingLatency prometheus.Histogram
+}
+
 type adminEventSink struct {
 	adminClient service.AdminServiceClient
 	filter      fastcheck.Filter
 	rateLimiter *rate.Limiter
 	cfg         *Config
+
+	eventQueue chan *queuedEvent
+	stopCh     chan struct{}
+	closed     chan struct{}
+	wg         sync.WaitGroup
+	metrics    *asyncEventSinkMetrics
+	inFlight   sync.Map
+}
+
+func newAsyncEventSinkMetrics(scope promutils.Scope) *asyncEventSinkMetrics {
+	return &asyncEventSinkMetrics{
+		eventsQueued: scope.MustNewCounter("events_queued",
+			"Total number of events queued for async processing"),
+		eventsProcessed: scope.MustNewCounter("events_processed",
+			"Total number of events successfully processed"),
+		eventsFailed: scope.MustNewCounter("events_failed",
+			"Total number of events that failed processing"),
+		queueDepth: scope.MustNewGauge("queue_depth",
+			"Current depth of the event queue"),
+		processingLatency: scope.MustNewHistogram("processing_latency_ms",
+			"Event processing latency in milliseconds"),
+	}
 }
 
 // Constructs a new EventSink that sends events to FlyteAdmin through gRPC
-func NewAdminEventSink(ctx context.Context, adminClient service.AdminServiceClient, config *Config, filter fastcheck.Filter) (EventSink, error) {
+func NewAdminEventSink(ctx context.Context, adminClient service.AdminServiceClient, config *Config, filter fastcheck.Filter, scope promutils.Scope) (EventSink, error) {
 	rateLimiter := rate.NewLimiter(rate.Limit(config.Rate), config.Capacity)
 
 	eventSink := &adminEventSink{
@@ -41,18 +78,24 @@ func NewAdminEventSink(ctx context.Context, adminClient service.AdminServiceClie
 		cfg:         config,
 	}
 
-	logger.Infof(ctx, "Created new AdminEventSink to Admin service")
+	eventSink.eventQueue = make(chan *queuedEvent, config.EventQueueSize)
+	eventSink.stopCh = make(chan struct{})
+	eventSink.closed = make(chan struct{})
+	eventSink.metrics = newAsyncEventSinkMetrics(scope.NewSubScope("async"))
+
+	eventSink.wg.Add(1)
+	go eventSink.worker()
+
+	logger.Infof(ctx, "Created new AdminEventSink to Admin service with async processing enabled")
 	return eventSink, nil
 }
 
-// Sends events to the FlyteAdmin service through gRPC
 func (s *adminEventSink) Sink(ctx context.Context, message proto.Message) error {
 	logger.Debugf(ctx, "AdminEventSink received a new event %s", message.String())
 
-	// Short-circuit if event has already been sent
 	id, err := IDFromMessage(message)
 	if err != nil {
-		return fmt.Errorf("Failed to parse message id [%v]", message.String())
+		return fmt.Errorf("failed to parse message id [%v]", message.String())
 	}
 
 	if s.filter.Contains(ctx, id) {
@@ -64,50 +107,139 @@ func (s *adminEventSink) Sink(ctx context.Context, message proto.Message) error 
 		}
 	}
 
-	// Validate submission with rate limiter and send admin event
-	if s.rateLimiter.Allow() {
-		switch eventMessage := message.(type) {
-		case *event.WorkflowExecutionEvent:
-			request := &admin.WorkflowExecutionEventRequest{
-				Event: eventMessage,
-			}
-
-			_, err := s.adminClient.CreateWorkflowEvent(ctx, request)
-			if err != nil {
-				return errors.WrapError(err)
-			}
-		case *event.NodeExecutionEvent:
-			request := &admin.NodeExecutionEventRequest{
-				Event: eventMessage,
-			}
-
-			_, err := s.adminClient.CreateNodeEvent(ctx, request)
-			if err != nil {
-				return errors.WrapError(err)
-			}
-		case *event.TaskExecutionEvent:
-			request := &admin.TaskExecutionEventRequest{
-				Event: eventMessage,
-			}
-
-			_, err := s.adminClient.CreateTaskEvent(ctx, request)
-			if err != nil {
-				return errors.WrapError(err)
-			}
-		default:
-			return fmt.Errorf("unknown event type [%s]", eventMessage.String())
+	// Check if event is currently in-flight to prevent duplicates in queue
+	idStr := string(id)
+	if _, exists := s.inFlight.LoadOrStore(idStr, true); exists {
+		logger.Debugf(ctx, "event '%s' is already queued for processing", idStr)
+		return &errors.EventError{
+			Code:    errors.AlreadyExists,
+			Cause:   fmt.Errorf("event is already queued"),
+			Message: "Event Already Queued",
 		}
-	} else {
-		return &errors.EventError{Code: errors.ResourceExhausted,
-			Cause: fmt.Errorf("Admin EventSink throttling admin traffic"), Message: "Resource Exhausted"}
 	}
 
-	s.filter.Add(ctx, id)
+	// Check if sink is closed before enqueueing
+	select {
+	case <-s.closed:
+		s.inFlight.Delete(idStr)
+		return fmt.Errorf("event sink is closed")
+	default:
+	}
+
+	qe := &queuedEvent{
+		message: message,
+		id:      id,
+	}
+
+	select {
+	case s.eventQueue <- qe:
+		s.metrics.eventsQueued.Inc()
+		s.metrics.queueDepth.Set(float64(len(s.eventQueue)))
+		return nil
+	case <-s.closed:
+		s.inFlight.Delete(idStr)
+		return fmt.Errorf("event sink is closed")
+	default:
+		s.inFlight.Delete(idStr)
+		logger.Warnf(ctx, "event queue is full (%d events), rejecting event '%s'", len(s.eventQueue), idStr)
+		return &errors.EventError{
+			Code:    errors.ResourceExhausted,
+			Cause:   fmt.Errorf("event queue is full"),
+			Message: "Event Queue Full",
+		}
+	}
+}
+
+func (s *adminEventSink) sendEvent(ctx context.Context, message proto.Message) error {
+	switch eventMessage := message.(type) {
+	case *event.WorkflowExecutionEvent:
+		request := &admin.WorkflowExecutionEventRequest{
+			Event: eventMessage,
+		}
+
+		_, err := s.adminClient.CreateWorkflowEvent(ctx, request)
+		if err != nil {
+			return errors.WrapError(err)
+		}
+	case *event.NodeExecutionEvent:
+		request := &admin.NodeExecutionEventRequest{
+			Event: eventMessage,
+		}
+
+		_, err := s.adminClient.CreateNodeEvent(ctx, request)
+		if err != nil {
+			return errors.WrapError(err)
+		}
+	case *event.TaskExecutionEvent:
+		request := &admin.TaskExecutionEventRequest{
+			Event: eventMessage,
+		}
+
+		_, err := s.adminClient.CreateTaskEvent(ctx, request)
+		if err != nil {
+			return errors.WrapError(err)
+		}
+	default:
+		return fmt.Errorf("unknown event type [%s]", eventMessage.String())
+	}
 	return nil
 }
 
-// Closes the gRPC client connection. This should be deferred on the client does shutdown cleanup.
+func (s *adminEventSink) worker() {
+	ctx := context.Background()
+	defer s.wg.Done()
+
+	for {
+		select {
+		case <-s.stopCh:
+			logger.Infof(ctx, "Draining event queue, %d events remaining", len(s.eventQueue))
+			for {
+				select {
+				case qe := <-s.eventQueue:
+					s.processEvent(ctx, qe, true)
+				default:
+					logger.Infof(ctx, "Event queue drained")
+					return
+				}
+			}
+		case qe := <-s.eventQueue:
+			s.processEvent(ctx, qe, false)
+		}
+	}
+}
+
+func (s *adminEventSink) processEvent(ctx context.Context, qe *queuedEvent, draining bool) {
+	startTime := time.Now()
+	s.metrics.queueDepth.Set(float64(len(s.eventQueue)))
+	idStr := string(qe.id)
+
+	defer s.inFlight.Delete(idStr)
+
+	if !draining {
+		if err := s.rateLimiter.Wait(ctx); err != nil {
+			logger.Warnf(ctx, "Rate limiter context cancelled: %v", err)
+			s.metrics.eventsFailed.Inc()
+			return
+		}
+	}
+
+	if err := s.sendEvent(ctx, qe.message); err != nil {
+		logger.Errorf(ctx, "Failed to send async event after retries: %v", err)
+		s.metrics.eventsFailed.Inc()
+	} else {
+		s.filter.Add(ctx, qe.id)
+		s.metrics.eventsProcessed.Inc()
+		latency := time.Since(startTime).Milliseconds()
+		s.metrics.processingLatency.Observe(float64(latency))
+	}
+}
+
 func (s *adminEventSink) Close() error {
+	logger.Info(context.Background(), "Shutting down async event sink")
+	close(s.closed)
+	close(s.stopCh)
+	s.wg.Wait()
+	logger.Info(context.Background(), "Async event sink shutdown complete")
 	return nil
 }
 
@@ -176,7 +308,7 @@ func ConstructEventSink(ctx context.Context, config *Config, scope promutils.Sco
 			return nil, err
 		}
 
-		return NewAdminEventSink(ctx, adminClient, config, filter)
+		return NewAdminEventSink(ctx, adminClient, config, filter, scope.NewSubScope("admin"))
 	default:
 		return NewStdoutSink()
 	}

--- a/flytepropeller/events/admin_eventsink_integration_test.go
+++ b/flytepropeller/events/admin_eventsink_integration_test.go
@@ -2,6 +2,7 @@
 // +build integration
 
 // Add this tag to your project settings if you want to pick it up.
+// Run with: go test -tags=integration -v
 
 package events
 
@@ -19,6 +20,8 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyte/flytestdlib/config"
+	"github.com/flyteorg/flyte/flytestdlib/fastcheck"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 var (
@@ -58,7 +61,13 @@ func TestAdminEventSinkTimeout(t *testing.T) {
 		Capacity: 1,
 	}
 
-	eventSink, err := NewAdminEventSink(ctx, adminClient, eventSinkConfig)
+	scope := promutils.NewTestScope()
+	filter, err := fastcheck.NewOppoBloomFilter(1000, scope.NewSubScope("integration_filter"))
+	assert.NoError(t, err)
+
+	eventSink, err := NewAdminEventSink(ctx, adminClient, eventSinkConfig, filter, scope)
+	assert.NoError(t, err)
+	defer eventSink.Close()
 
 	wfEvent := &event.WorkflowExecutionEvent{
 		Phase:      core.WorkflowExecution_RUNNING,
@@ -69,9 +78,72 @@ func TestAdminEventSinkTimeout(t *testing.T) {
 			Name:    "ikuy55mn0y",
 		},
 		ProducerId:   "testproducer",
-		OutputResult: &event.WorkflowExecutionEvent_OutputUri{"s3://blah/blah/blah"},
+		OutputResult: &event.WorkflowExecutionEvent_OutputUri{OutputUri: "s3://blah/blah/blah"},
 	}
 
 	err = eventSink.Sink(ctx, wfEvent)
 	assert.NoError(t, err)
+
+	// Wait for async processing
+	time.Sleep(2 * time.Second)
+}
+
+// TestAdminEventSinkAsyncIntegration tests async event processing against a real admin service
+// Requires admin to be running on localhost:8089
+// Run with: go test -tags=integration -v -run TestAdminEventSinkAsyncIntegration
+func TestAdminEventSinkAsyncIntegration(t *testing.T) {
+	ctx := context.Background()
+
+	adminClient := admin.InitializeAdminClient(ctx, adminServiceConfig)
+
+	eventSinkConfig := &Config{
+		Rate:     10, // 10 events per second
+		Capacity: 10,
+	}
+
+	scope := promutils.NewTestScope()
+	filter, err := fastcheck.NewOppoBloomFilter(1000, scope.NewSubScope("integration_filter"))
+	assert.NoError(t, err)
+
+	eventSink, err := NewAdminEventSink(ctx, adminClient, eventSinkConfig, filter, scope)
+	assert.NoError(t, err)
+	defer eventSink.Close()
+
+	// Send multiple events asynchronously
+	numEvents := 5
+	for i := 0; i < numEvents; i++ {
+		wfEvent := &event.WorkflowExecutionEvent{
+			Phase:      core.WorkflowExecution_RUNNING,
+			OccurredAt: ptypes.TimestampNow(),
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "flyteexamples",
+				Domain:  "development",
+				Name:    fmt.Sprintf("async-integration-test-%d", i),
+			},
+			ProducerId:   "integration-test",
+			OutputResult: &event.WorkflowExecutionEvent_OutputUri{OutputUri: "s3://test/output"},
+		}
+
+		err = eventSink.Sink(ctx, wfEvent)
+		assert.NoError(t, err, "Should enqueue event %d without blocking", i)
+	}
+
+	// Wait for all events to be processed
+	time.Sleep(3 * time.Second)
+
+	// Try to send duplicate - should be rejected as already sent
+	duplicateEvent := &event.WorkflowExecutionEvent{
+		Phase:      core.WorkflowExecution_RUNNING,
+		OccurredAt: ptypes.TimestampNow(),
+		ExecutionId: &core.WorkflowExecutionIdentifier{
+			Project: "flyteexamples",
+			Domain:  "development",
+			Name:    "async-integration-test-0",
+		},
+		ProducerId:   "integration-test",
+		OutputResult: &event.WorkflowExecutionEvent_OutputUri{OutputUri: "s3://test/output"},
+	}
+
+	err = eventSink.Sink(ctx, duplicateEvent)
+	assert.Error(t, err, "Should reject duplicate event")
 }

--- a/flytepropeller/events/admin_eventsink_test.go
+++ b/flytepropeller/events/admin_eventsink_test.go
@@ -2,15 +2,16 @@ package events
 
 import (
 	"context"
+	"fmt"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/flyteorg/flyte/flyteidl/clients/go/admin/mocks"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
@@ -18,6 +19,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyte/flytepropeller/events/errors"
 	fastcheckMocks "github.com/flyteorg/flyte/flytestdlib/fastcheck/mocks"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
 var (
@@ -72,7 +74,8 @@ var (
 func CreateMockAdminEventSink(t *testing.T, rate int64, capacity int) (EventSink, *mocks.AdminServiceClient, *fastcheckMocks.Filter) {
 	mockClient := &mocks.AdminServiceClient{}
 	filter := &fastcheckMocks.Filter{}
-	eventSink, _ := NewAdminEventSink(context.Background(), mockClient, &Config{Rate: rate, Capacity: capacity}, filter)
+	scope := promutils.NewTestScope()
+	eventSink, _ := NewAdminEventSink(context.Background(), mockClient, &Config{Rate: rate, Capacity: capacity, EventQueueSize: 1000}, filter, scope)
 	return eventSink, mockClient, filter
 }
 
@@ -128,53 +131,6 @@ func TestAdminTaskEvent(t *testing.T) {
 
 	err := adminEventSink.Sink(ctx, taskEvent)
 	assert.NoError(t, err)
-}
-
-func TestAdminAlreadyExistsError(t *testing.T) {
-	ctx := context.Background()
-	adminEventSink, adminClient, filter := CreateMockAdminEventSink(t, 100, 1000)
-	filter.EXPECT().Add(mock.Anything, mock.Anything).Return(true)
-	filter.EXPECT().Contains(mock.Anything, mock.Anything).Return(false)
-
-	alreadyExistErr := status.Error(codes.AlreadyExists, "Grpc AlreadyExists error")
-
-	adminClient.On(
-		"CreateTaskEvent",
-		ctx,
-		mock.MatchedBy(func(req *admin.TaskExecutionEventRequest) bool { return true }),
-	).Return(nil, alreadyExistErr)
-
-	err := adminEventSink.Sink(ctx, taskEvent)
-	assert.Error(t, err)
-	assert.True(t, errors.IsAlreadyExists(err))
-}
-
-func TestAdminRateLimitError(t *testing.T) {
-	ctx := context.Background()
-	adminEventSink, adminClient, filter := CreateMockAdminEventSink(t, 1, 1)
-	filter.EXPECT().Add(mock.Anything, mock.Anything).Return(true)
-	filter.EXPECT().Contains(mock.Anything, mock.Anything).Return(false)
-
-	adminClient.On(
-		"CreateTaskEvent",
-		ctx,
-		mock.MatchedBy(func(req *admin.TaskExecutionEventRequest) bool {
-			return req.GetEvent() == taskEvent
-		}),
-	).Return(&admin.TaskExecutionEventResponse{}, nil)
-
-	var rateLimitedErr error
-	for i := 0; i < 10; i++ {
-		err := adminEventSink.Sink(ctx, taskEvent)
-
-		if err != nil {
-			rateLimitedErr = err
-			break
-		}
-	}
-
-	assert.Error(t, rateLimitedErr)
-	assert.True(t, errors.IsResourceExhausted(rateLimitedErr))
 }
 
 func TestAdminFilterContains(t *testing.T) {
@@ -271,4 +227,820 @@ func TestIDFromMessage(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAsyncEventProcessing(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &mocks.AdminServiceClient{}
+	filter := &fastcheckMocks.Filter{}
+	cfg := &Config{
+		Rate:           500,
+		Capacity:       1000,
+		EventQueueSize: 1000,
+	}
+
+	scope := promutils.NewTestScope()
+	eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+	assert.NoError(t, err)
+	defer eventSink.Close()
+
+	filter.On("Add", mock.Anything, mock.Anything).Return(true)
+	filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+	wfEvent := &event.WorkflowExecutionEvent{
+		ExecutionId: &core.WorkflowExecutionIdentifier{
+			Project: "p",
+			Domain:  "d",
+			Name:    "n",
+		},
+		Phase:      core.WorkflowExecution_RUNNING,
+		OccurredAt: ptypes.TimestampNow(),
+	}
+
+	mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+		Return(&admin.WorkflowExecutionEventResponse{}, nil)
+
+	// Enqueue event
+	err = eventSink.Sink(ctx, wfEvent)
+	assert.NoError(t, err)
+
+	// Wait for worker to process
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify event was sent
+	mockClient.AssertExpectations(t)
+}
+
+func TestAsyncNoEventsDroppedUnderRateLimit(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &mocks.AdminServiceClient{}
+	filter := &fastcheckMocks.Filter{}
+
+	cfg := &Config{
+		Rate:           2,
+		Capacity:       2,
+		EventQueueSize: 1000,
+	}
+
+	scope := promutils.NewTestScope()
+	eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+	assert.NoError(t, err)
+	defer eventSink.Close()
+
+	filter.On("Add", mock.Anything, mock.Anything).Return(true)
+	filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+	mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+		Return(&admin.WorkflowExecutionEventResponse{}, nil)
+
+	// Send 10 UNIQUE events (different execution names) - this will hit rate limit
+	numEvents := 10
+	for i := 0; i < numEvents; i++ {
+		wfEvent := &event.WorkflowExecutionEvent{
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    fmt.Sprintf("execution-%d", i), // Unique execution name
+			},
+			Phase:      core.WorkflowExecution_RUNNING,
+			OccurredAt: ptypes.TimestampNow(),
+		}
+		err := eventSink.Sink(ctx, wfEvent)
+		assert.NoError(t, err, "Sink should never fail even under rate limiting")
+	}
+
+	// Wait for all events to be processed (at 2/sec, 10 events = 5 seconds)
+	time.Sleep(6 * time.Second)
+
+	// Critical assertion: ALL events must be processed, NONE dropped
+	mockClient.AssertNumberOfCalls(t, "CreateWorkflowEvent", numEvents)
+}
+
+func TestAsyncQueueBackpressure(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &mocks.AdminServiceClient{}
+	filter := &fastcheckMocks.Filter{}
+
+	cfg := &Config{
+		Rate:           1,
+		Capacity:       1,
+		EventQueueSize: 1000,
+	}
+
+	scope := promutils.NewTestScope()
+	eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+	assert.NoError(t, err)
+	defer eventSink.Close()
+
+	filter.On("Add", mock.Anything, mock.Anything).Return(true)
+	filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+	mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+		Return(&admin.WorkflowExecutionEventResponse{}, nil)
+
+	// Send UNIQUE events in goroutine to test backpressure
+	numEvents := 5
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numEvents; i++ {
+			wfEvent := &event.WorkflowExecutionEvent{
+				ExecutionId: &core.WorkflowExecutionIdentifier{
+					Project: "p",
+					Domain:  "d",
+					Name:    fmt.Sprintf("execution-%d", i), // Unique execution name
+				},
+				Phase:      core.WorkflowExecution_RUNNING,
+				OccurredAt: ptypes.TimestampNow(),
+			}
+			err := eventSink.Sink(ctx, wfEvent)
+			assert.NoError(t, err, "Sink should block but not error when queue is full")
+		}
+	}()
+
+	// Wait for all events to be enqueued and processed
+	wg.Wait()
+	time.Sleep(6 * time.Second)
+
+	// All events should be processed, none dropped
+	mockClient.AssertNumberOfCalls(t, "CreateWorkflowEvent", numEvents)
+}
+
+func TestAsyncGracefulShutdown(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &mocks.AdminServiceClient{}
+	filter := &fastcheckMocks.Filter{}
+	cfg := &Config{
+		Rate:           500,
+		Capacity:       1000,
+		EventQueueSize: 1000,
+	}
+
+	scope := promutils.NewTestScope()
+	eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+	assert.NoError(t, err)
+
+	filter.On("Add", mock.Anything, mock.Anything).Return(true)
+	filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+	mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+		Return(&admin.WorkflowExecutionEventResponse{}, nil)
+
+	// Enqueue multiple UNIQUE events
+	numEvents := 5
+	for i := 0; i < numEvents; i++ {
+		wfEvent := &event.WorkflowExecutionEvent{
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    fmt.Sprintf("execution-%d", i), // Unique execution name
+			},
+			Phase:      core.WorkflowExecution_RUNNING,
+			OccurredAt: ptypes.TimestampNow(),
+		}
+		err := eventSink.Sink(ctx, wfEvent)
+		assert.NoError(t, err)
+	}
+
+	// Close immediately - should drain queue
+	err = eventSink.Close()
+	assert.NoError(t, err)
+
+	// All events should have been processed before shutdown
+	mockClient.AssertNumberOfCalls(t, "CreateWorkflowEvent", numEvents)
+}
+
+func TestAsyncMultipleEventTypes(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &mocks.AdminServiceClient{}
+	filter := &fastcheckMocks.Filter{}
+	cfg := &Config{
+		Rate:           500,
+		Capacity:       1000,
+		EventQueueSize: 1000,
+	}
+
+	scope := promutils.NewTestScope()
+	eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+	assert.NoError(t, err)
+	defer eventSink.Close()
+
+	filter.On("Add", mock.Anything, mock.Anything).Return(true)
+	filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+	// Workflow event
+	wfEvent := &event.WorkflowExecutionEvent{
+		ExecutionId: &core.WorkflowExecutionIdentifier{
+			Project: "p",
+			Domain:  "d",
+			Name:    "n",
+		},
+		Phase:      core.WorkflowExecution_RUNNING,
+		OccurredAt: ptypes.TimestampNow(),
+	}
+
+	// Node event
+	nodeEvent := &event.NodeExecutionEvent{
+		Id: &core.NodeExecutionIdentifier{
+			NodeId: "node1",
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    "n",
+			},
+		},
+		Phase:      core.NodeExecution_RUNNING,
+		OccurredAt: ptypes.TimestampNow(),
+	}
+
+	// Task event
+	taskEvent := &event.TaskExecutionEvent{
+		TaskId: &core.Identifier{
+			ResourceType: core.ResourceType_TASK,
+			Name:         "task1",
+		},
+		ParentNodeExecutionId: &core.NodeExecutionIdentifier{
+			NodeId: "node1",
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    "n",
+			},
+		},
+		Phase:      core.TaskExecution_RUNNING,
+		OccurredAt: ptypes.TimestampNow(),
+	}
+
+	mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+		Return(&admin.WorkflowExecutionEventResponse{}, nil)
+	mockClient.On("CreateNodeEvent", mock.Anything, mock.Anything).
+		Return(&admin.NodeExecutionEventResponse{}, nil)
+	mockClient.On("CreateTaskEvent", mock.Anything, mock.Anything).
+		Return(&admin.TaskExecutionEventResponse{}, nil)
+
+	// Send all three event types
+	assert.NoError(t, eventSink.Sink(ctx, wfEvent))
+	assert.NoError(t, eventSink.Sink(ctx, nodeEvent))
+	assert.NoError(t, eventSink.Sink(ctx, taskEvent))
+
+	// Wait for processing
+	time.Sleep(500 * time.Millisecond)
+
+	// All should be processed
+	mockClient.AssertExpectations(t)
+}
+
+func TestAsyncHighVolume(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &mocks.AdminServiceClient{}
+	filter := &fastcheckMocks.Filter{}
+
+	cfg := &Config{
+		Rate:           100,
+		Capacity:       100,
+		EventQueueSize: 1000,
+	}
+
+	scope := promutils.NewTestScope()
+	eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+	assert.NoError(t, err)
+	defer eventSink.Close()
+
+	filter.On("Add", mock.Anything, mock.Anything).Return(true)
+	filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+	mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+		Return(&admin.WorkflowExecutionEventResponse{}, nil)
+
+	numEvents := 1000
+	var wg sync.WaitGroup
+
+	numWorkers := 10
+	eventsPerWorker := numEvents / numWorkers
+
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		workerID := w
+		go func() {
+			defer wg.Done()
+			for i := 0; i < eventsPerWorker; i++ {
+				wfEvent := &event.WorkflowExecutionEvent{
+					ExecutionId: &core.WorkflowExecutionIdentifier{
+						Project: "stress-test",
+						Domain:  "production",
+						Name:    fmt.Sprintf("worker-%d-execution-%d", workerID, i),
+					},
+					Phase:      core.WorkflowExecution_RUNNING,
+					OccurredAt: ptypes.TimestampNow(),
+				}
+				err := eventSink.Sink(ctx, wfEvent)
+				assert.NoError(t, err, "Sink should never fail under high load")
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	time.Sleep(12 * time.Second)
+
+	mockClient.AssertNumberOfCalls(t, "CreateWorkflowEvent", numEvents)
+}
+
+func TestAsyncEventFailureRetry(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &mocks.AdminServiceClient{}
+	filter := &fastcheckMocks.Filter{}
+	cfg := &Config{
+		Rate:           50,
+		Capacity:       100,
+		EventQueueSize: 1000,
+	}
+
+	scope := promutils.NewTestScope()
+	eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+	assert.NoError(t, err)
+	defer eventSink.Close()
+
+	filter.On("Add", mock.Anything, mock.Anything).Return(true)
+	filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+	wfEvent := &event.WorkflowExecutionEvent{
+		ExecutionId: &core.WorkflowExecutionIdentifier{
+			Project: "p",
+			Domain:  "d",
+			Name:    "retry-test",
+		},
+		Phase:      core.WorkflowExecution_RUNNING,
+		OccurredAt: ptypes.TimestampNow(),
+	}
+
+	// First call fails
+	mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+		Return(nil, fmt.Errorf("network error - simulated failure")).
+		Once()
+
+	// Second call succeeds
+	mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+		Return(&admin.WorkflowExecutionEventResponse{}, nil).
+		Once()
+
+	// First attempt - enqueue event
+	err = eventSink.Sink(ctx, wfEvent)
+	assert.NoError(t, err)
+
+	// Wait for processing (will fail)
+	time.Sleep(200 * time.Millisecond)
+
+	// Second attempt - should be allowed to retry since first failed
+	err = eventSink.Sink(ctx, wfEvent)
+	assert.NoError(t, err, "Should allow retry after failure")
+
+	// Wait for second processing (should succeed)
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify both attempts were made (failure + success)
+	mockClient.AssertExpectations(t)
+}
+
+func TestAsyncInFlightDuplicate(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &mocks.AdminServiceClient{}
+	filter := &fastcheckMocks.Filter{}
+
+	cfg := &Config{
+		Rate:           1,
+		Capacity:       1,
+		EventQueueSize: 1000,
+	}
+
+	scope := promutils.NewTestScope()
+	eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+	assert.NoError(t, err)
+	defer eventSink.Close()
+
+	filter.On("Add", mock.Anything, mock.Anything).Return(true)
+	filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+	wfEvent := &event.WorkflowExecutionEvent{
+		ExecutionId: &core.WorkflowExecutionIdentifier{
+			Project: "p",
+			Domain:  "d",
+			Name:    "in-flight-duplicate-test",
+		},
+		Phase:      core.WorkflowExecution_RUNNING,
+		OccurredAt: ptypes.TimestampNow(),
+	}
+
+	// Mock should only be called once (for the first event)
+	mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+		Return(&admin.WorkflowExecutionEventResponse{}, nil).
+		Once()
+
+	// First submission - should succeed and start processing
+	err = eventSink.Sink(ctx, wfEvent)
+	assert.NoError(t, err, "First submission should succeed")
+
+	// Immediately submit same event again while first is still in-flight
+	// This should be rejected because the event is already queued for processing
+	err = eventSink.Sink(ctx, wfEvent)
+	assert.Error(t, err, "Second submission should fail - event already in-flight")
+	assert.True(t, errors.IsAlreadyExists(err), "Error should be AlreadyExists")
+
+	// Wait for the first event to finish processing
+	time.Sleep(2 * time.Second)
+
+	// Verify only one call was made to admin client (no duplicate sent)
+	mockClient.AssertExpectations(t)
+	mockClient.AssertNumberOfCalls(t, "CreateWorkflowEvent", 1)
+}
+
+func TestAsyncNetworkFailures(t *testing.T) {
+	t.Run("NetworkTimeout", func(t *testing.T) {
+		ctx := context.Background()
+		mockClient := &mocks.AdminServiceClient{}
+		filter := &fastcheckMocks.Filter{}
+		cfg := &Config{
+			Rate:           50,
+			Capacity:       100,
+			EventQueueSize: 1000,
+		}
+
+		scope := promutils.NewTestScope()
+		eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+		assert.NoError(t, err)
+		defer eventSink.Close()
+
+		filter.On("Add", mock.Anything, mock.Anything).Return(true)
+		filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+		wfEvent := &event.WorkflowExecutionEvent{
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    "network-timeout-test",
+			},
+			Phase:      core.WorkflowExecution_RUNNING,
+			OccurredAt: ptypes.TimestampNow(),
+		}
+
+		// Simulate network timeout
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("context deadline exceeded")).
+			Once()
+
+		// Retry should succeed
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+			Return(&admin.WorkflowExecutionEventResponse{}, nil).
+			Once()
+
+		// First attempt - will timeout
+		err = eventSink.Sink(ctx, wfEvent)
+		assert.NoError(t, err)
+		time.Sleep(200 * time.Millisecond)
+
+		// Second attempt - should be allowed to retry
+		err = eventSink.Sink(ctx, wfEvent)
+		assert.NoError(t, err)
+		time.Sleep(200 * time.Millisecond)
+
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("ConnectionRefused", func(t *testing.T) {
+		ctx := context.Background()
+		mockClient := &mocks.AdminServiceClient{}
+		filter := &fastcheckMocks.Filter{}
+		cfg := &Config{
+			Rate:           50,
+			Capacity:       100,
+			EventQueueSize: 1000,
+		}
+
+		scope := promutils.NewTestScope()
+		eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+		assert.NoError(t, err)
+		defer eventSink.Close()
+
+		filter.On("Add", mock.Anything, mock.Anything).Return(true)
+		filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+		wfEvent := &event.WorkflowExecutionEvent{
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    "connection-refused-test",
+			},
+			Phase:      core.WorkflowExecution_RUNNING,
+			OccurredAt: ptypes.TimestampNow(),
+		}
+
+		// Simulate connection refused
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("dial tcp 127.0.0.1:8089: connect: connection refused")).
+			Once()
+
+		// After admin restarts, retry should succeed
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+			Return(&admin.WorkflowExecutionEventResponse{}, nil).
+			Once()
+
+		// First attempt - connection refused
+		err = eventSink.Sink(ctx, wfEvent)
+		assert.NoError(t, err)
+		time.Sleep(200 * time.Millisecond)
+
+		// Second attempt after admin restart
+		err = eventSink.Sink(ctx, wfEvent)
+		assert.NoError(t, err)
+		time.Sleep(200 * time.Millisecond)
+
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("IntermittentFailures", func(t *testing.T) {
+		ctx := context.Background()
+		mockClient := &mocks.AdminServiceClient{}
+		filter := &fastcheckMocks.Filter{}
+		cfg := &Config{
+			Rate:           50,
+			Capacity:       100,
+			EventQueueSize: 1000,
+		}
+
+		scope := promutils.NewTestScope()
+		eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+		assert.NoError(t, err)
+		defer eventSink.Close()
+
+		filter.On("Add", mock.Anything, mock.Anything).Return(true)
+		filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+		wfEvent := &event.WorkflowExecutionEvent{
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    "intermittent-test",
+			},
+			Phase:      core.WorkflowExecution_RUNNING,
+			OccurredAt: ptypes.TimestampNow(),
+		}
+
+		// Multiple intermittent failures before success
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("temporary network error")).
+			Once()
+
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("service unavailable")).
+			Once()
+
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+			Return(&admin.WorkflowExecutionEventResponse{}, nil).
+			Once()
+
+		// Three attempts, last one succeeds
+		for i := 0; i < 3; i++ {
+			err = eventSink.Sink(ctx, wfEvent)
+			assert.NoError(t, err, "Sink should allow retry attempt %d", i)
+			time.Sleep(200 * time.Millisecond)
+		}
+
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("PartialBatchFailure", func(t *testing.T) {
+		ctx := context.Background()
+		mockClient := &mocks.AdminServiceClient{}
+		filter := &fastcheckMocks.Filter{}
+		cfg := &Config{
+			Rate:           50,
+			Capacity:       100,
+			EventQueueSize: 1000,
+		}
+
+		scope := promutils.NewTestScope()
+		eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+		assert.NoError(t, err)
+		defer eventSink.Close()
+
+		filter.On("Add", mock.Anything, mock.Anything).Return(true)
+		filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+		// Event 0: success
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.MatchedBy(func(req *admin.WorkflowExecutionEventRequest) bool {
+			return req.GetEvent().GetExecutionId().GetName() == "batch-event-0"
+		})).Return(&admin.WorkflowExecutionEventResponse{}, nil).Once()
+
+		// Event 1: fail first time, then succeed on retry
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.MatchedBy(func(req *admin.WorkflowExecutionEventRequest) bool {
+			return req.GetEvent().GetExecutionId().GetName() == "batch-event-1"
+		})).Return(nil, fmt.Errorf("network error for event 1")).Once()
+
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.MatchedBy(func(req *admin.WorkflowExecutionEventRequest) bool {
+			return req.GetEvent().GetExecutionId().GetName() == "batch-event-1"
+		})).Return(&admin.WorkflowExecutionEventResponse{}, nil).Once()
+
+		// Event 2: success
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.MatchedBy(func(req *admin.WorkflowExecutionEventRequest) bool {
+			return req.GetEvent().GetExecutionId().GetName() == "batch-event-2"
+		})).Return(&admin.WorkflowExecutionEventResponse{}, nil).Once()
+
+		// Event 3: fail first time, then succeed on retry
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.MatchedBy(func(req *admin.WorkflowExecutionEventRequest) bool {
+			return req.GetEvent().GetExecutionId().GetName() == "batch-event-3"
+		})).Return(nil, fmt.Errorf("network error for event 3")).Once()
+
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.MatchedBy(func(req *admin.WorkflowExecutionEventRequest) bool {
+			return req.GetEvent().GetExecutionId().GetName() == "batch-event-3"
+		})).Return(&admin.WorkflowExecutionEventResponse{}, nil).Once()
+
+		// Event 4: success
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.MatchedBy(func(req *admin.WorkflowExecutionEventRequest) bool {
+			return req.GetEvent().GetExecutionId().GetName() == "batch-event-4"
+		})).Return(&admin.WorkflowExecutionEventResponse{}, nil).Once()
+
+		// Send 5 events - events 1 and 3 will fail initially
+		for i := 0; i < 5; i++ {
+			wfEvent := &event.WorkflowExecutionEvent{
+				ExecutionId: &core.WorkflowExecutionIdentifier{
+					Project: "p",
+					Domain:  "d",
+					Name:    fmt.Sprintf("batch-event-%d", i),
+				},
+				Phase:      core.WorkflowExecution_RUNNING,
+				OccurredAt: ptypes.TimestampNow(),
+			}
+			err = eventSink.Sink(ctx, wfEvent)
+			assert.NoError(t, err)
+		}
+
+		time.Sleep(500 * time.Millisecond)
+
+		// Retry failed events - they should be allowed
+		for i := 1; i <= 3; i += 2 {
+			wfEvent := &event.WorkflowExecutionEvent{
+				ExecutionId: &core.WorkflowExecutionIdentifier{
+					Project: "p",
+					Domain:  "d",
+					Name:    fmt.Sprintf("batch-event-%d", i),
+				},
+				Phase:      core.WorkflowExecution_RUNNING,
+				OccurredAt: ptypes.TimestampNow(),
+			}
+			err = eventSink.Sink(ctx, wfEvent)
+			assert.NoError(t, err, "Should allow retry for failed event")
+		}
+
+		time.Sleep(500 * time.Millisecond)
+
+		// All events should eventually succeed
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("ContextCancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		mockClient := &mocks.AdminServiceClient{}
+		filter := &fastcheckMocks.Filter{}
+		cfg := &Config{
+			Rate:           1,
+			Capacity:       1,
+			EventQueueSize: 1000,
+		}
+
+		scope := promutils.NewTestScope()
+		eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+		assert.NoError(t, err)
+		defer eventSink.Close()
+
+		filter.On("Add", mock.Anything, mock.Anything).Return(true)
+		filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+		mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+			Return(&admin.WorkflowExecutionEventResponse{}, nil)
+
+		wfEvent := &event.WorkflowExecutionEvent{
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    "context-cancel-test",
+			},
+			Phase:      core.WorkflowExecution_RUNNING,
+			OccurredAt: ptypes.TimestampNow(),
+		}
+
+		// Enqueue event
+		err = eventSink.Sink(ctx, wfEvent)
+		assert.NoError(t, err)
+
+		// Cancel context while processing
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+
+		// Should handle cancellation gracefully
+		time.Sleep(200 * time.Millisecond)
+	})
+}
+
+func TestSinkAfterClose(t *testing.T) {
+	ctx := context.Background()
+	adminEventSink, _, filter := CreateMockAdminEventSink(t, 100, 1000)
+	filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+
+	err := adminEventSink.Close()
+	assert.NoError(t, err)
+
+	testEvent := &event.WorkflowExecutionEvent{
+		ExecutionId: &core.WorkflowExecutionIdentifier{
+			Project: "p",
+			Domain:  "d",
+			Name:    "close-test",
+		},
+		Phase:      core.WorkflowExecution_RUNNING,
+		OccurredAt: ptypes.TimestampNow(),
+	}
+
+	err = adminEventSink.Sink(ctx, testEvent)
+	assert.Error(t, err, "Sink should fail after Close()")
+	assert.Contains(t, err.Error(), "closed", "Error should mention sink is closed")
+}
+
+func TestQueueFullNonBlocking(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &mocks.AdminServiceClient{}
+	filter := &fastcheckMocks.Filter{}
+
+	cfg := &Config{
+		Rate:           100,
+		Capacity:       100,
+		EventQueueSize: 2,
+	}
+
+	scope := promutils.NewTestScope()
+	eventSink, err := NewAdminEventSink(ctx, mockClient, cfg, filter, scope)
+	assert.NoError(t, err)
+
+	filter.On("Contains", mock.Anything, mock.Anything).Return(false)
+	filter.On("Add", mock.Anything, mock.Anything).Return(true)
+
+	blockProcessing := make(chan struct{})
+	processingStarted := make(chan bool, 10)
+	processedCount := make(chan int, 10)
+	var count int
+
+	mockClient.On("CreateWorkflowEvent", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			processingStarted <- true
+			<-blockProcessing
+			count++
+			processedCount <- count
+		}).
+		Return(&admin.WorkflowExecutionEventResponse{}, nil)
+
+	// Enqueue 3 events - queue capacity is 2, so one is being processed and 2 are queued
+	for i := 0; i < 3; i++ {
+		wfEvent := &event.WorkflowExecutionEvent{
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    fmt.Sprintf("fill-%d", i),
+			},
+			Phase:      core.WorkflowExecution_RUNNING,
+			OccurredAt: ptypes.TimestampNow(),
+		}
+		err := eventSink.Sink(ctx, wfEvent)
+		assert.NoError(t, err)
+	}
+
+	// Wait for worker to start processing first event
+	<-processingStarted
+	time.Sleep(50 * time.Millisecond)
+
+	// Now the queue should be full: 1 being processed + 2 in queue
+	wfEvent4 := &event.WorkflowExecutionEvent{
+		ExecutionId: &core.WorkflowExecutionIdentifier{
+			Project: "p",
+			Domain:  "d",
+			Name:    "overflow",
+		},
+		Phase:      core.WorkflowExecution_RUNNING,
+		OccurredAt: ptypes.TimestampNow(),
+	}
+
+	err = eventSink.Sink(ctx, wfEvent4)
+	assert.Error(t, err, "Should reject event when queue is full")
+	assert.True(t, errors.IsResourceExhausted(err), "Should return ResourceExhausted error")
+
+	// Unblock processing and wait for all 3 events to complete
+	close(blockProcessing)
+	for i := 0; i < 3; i++ {
+		<-processedCount
+	}
+
+	// Now close gracefully
+	err = eventSink.Close()
+	assert.NoError(t, err)
+
+	// Verify exactly 3 events were processed
+	mockClient.AssertNumberOfCalls(t, "CreateWorkflowEvent", 3)
 }

--- a/flytepropeller/events/config.go
+++ b/flytepropeller/events/config.go
@@ -22,23 +22,25 @@ const (
 )
 
 type Config struct {
-	Type          EventReportingType `json:"type" pflag:",Sets the type of EventSink to configure [log/admin/file]."`
-	FilePath      string             `json:"file-path" pflag:",For file types, specify where the file should be located."`
-	Rate          int64              `json:"rate" pflag:",Max rate at which events can be recorded per second."`
-	Capacity      int                `json:"capacity" pflag:",The max bucket size for event recording tokens."`
-	MaxRetries    int                `json:"max-retries" pflag:",The max number of retries for event recording."`
-	BackoffScalar int                `json:"base-scalar" pflag:",The base/scalar backoff duration in milliseconds for event recording retries."`
-	BackoffJitter string             `json:"backoff-jitter" pflag:",A string representation of a floating point number between 0 and 1 specifying the jitter factor for event recording retries."`
+	Type           EventReportingType `json:"type" pflag:",Sets the type of EventSink to configure [log/admin/file]."`
+	FilePath       string             `json:"file-path" pflag:",For file types, specify where the file should be located."`
+	Rate           int64              `json:"rate" pflag:",Max rate at which events can be recorded per second."`
+	Capacity       int                `json:"capacity" pflag:",The max bucket size for event recording tokens."`
+	EventQueueSize int                `json:"event-queue-size" pflag:",The size of the async event queue buffer."`
+	MaxRetries     int                `json:"max-retries" pflag:",The max number of retries for event recording."`
+	BackoffScalar  int                `json:"base-scalar" pflag:",The base/scalar backoff duration in milliseconds for event recording retries."`
+	BackoffJitter  string             `json:"backoff-jitter" pflag:",A string representation of a floating point number between 0 and 1 specifying the jitter factor for event recording retries."`
 }
 
 var (
 	defaultConfig = Config{
-		Rate:          int64(500),
-		Capacity:      1000,
-		Type:          EventSinkAdmin,
-		MaxRetries:    5,
-		BackoffScalar: 100,
-		BackoffJitter: "0.1",
+		Rate:           int64(500),
+		Capacity:       1000,
+		EventQueueSize: 1000,
+		Type:           EventSinkAdmin,
+		MaxRetries:     5,
+		BackoffScalar:  100,
+		BackoffJitter:  "0.1",
 	}
 
 	configSection = config.MustRegisterSectionWithUpdates(configSectionKey, &defaultConfig, func(ctx context.Context, newValue config.Config) {

--- a/flytepropeller/events/config_flags.go
+++ b/flytepropeller/events/config_flags.go
@@ -54,6 +54,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "file-path"), defaultConfig.FilePath, "For file types,  specify where the file should be located.")
 	cmdFlags.Int64(fmt.Sprintf("%v%v", prefix, "rate"), defaultConfig.Rate, "Max rate at which events can be recorded per second.")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "capacity"), defaultConfig.Capacity, "The max bucket size for event recording tokens.")
+	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "event-queue-size"), defaultConfig.EventQueueSize, "The size of the async event queue buffer.")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "max-retries"), defaultConfig.MaxRetries, "The max number of retries for event recording.")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "base-scalar"), defaultConfig.BackoffScalar, "The base/scalar backoff duration in milliseconds for event recording retries.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "backoff-jitter"), defaultConfig.BackoffJitter, "A string representation of a floating point number between 0 and 1 specifying the jitter factor for event recording retries.")

--- a/flytepropeller/events/config_flags_test.go
+++ b/flytepropeller/events/config_flags_test.go
@@ -155,6 +155,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_event-queue-size", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("event-queue-size", testValue)
+			if vInt, err := cmdFlags.GetInt("event-queue-size"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt), &actual.EventQueueSize)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_max-retries", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/6682

## Why are the changes needed?

Root Cause: Cross-region traffic between FlyteAdmin and its database adds significant latency (300ms-1s) to each event write. Since event recording happened synchronously in the reconciliation loop (admin_eventsink.go:93-150), each reconciliation worker thread blocks waiting for the database transaction to complete across regions.

When FlyteAdmin experiences latency (300ms-1s per event), synchronous event recording blocks reconciliation workers. 

With hundreds or thousands of workflows, this causes:
  - 10x slowdown in reconciliation times
  - Cascading delays as workers wait for event responses
  - Potential DDOS of FlyteAdmin under high load
  - Degraded overall system performance


## What changes were proposed in this pull request?
  Implemented asynchronous event recording to decouple event sending from reconciliation, eliminating cross-region latency from the critical path:

  Key changes:
  - Events go into a buffered channel (1000 capacity by default), processed by a background worker
  - Sink() returns in ~1ms instead of blocking for cross-region latency
  - Rate limiting on the worker side to avoid overwhelming admin/database
  - In-flight tracking with sync.Map to prevent duplicate queuing
  - Graceful shutdown drains the queue
  - Added prometheus metrics: events_queued, events_processed, events_failed, queue_depth, processing_latency_ms

  Config addition:
  - EventQueueSize parameter (default: 1000)


## How was this patch tested?

 Added comprehensive tests for async processing, rate limiting, backpressure, graceful shutdown, network failures, retries, and high volume scenarios. Also tested in a staging server triggering 1000 executions at the time.
 
### Labels

Please add one or more of the following labels to categorize your PR:
- **changed**: For changes in existing functionality.
- **fixed**: For any bug fixed.

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request implements asynchronous event recording in the AdminEventSink to enhance the performance of reconciliation workers by decoupling event sending from the reconciliation process. Key features include a buffered channel for event processing, rate limiting, in-flight tracking to prevent duplicates, and new Prometheus metrics for monitoring. Comprehensive tests have been added to ensure reliability under high load conditions.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are well-defined and the addition of comprehensive tests suggests a high quality of implementation, making the review process straightforward.
-->
</div>