### PR TITLE
Allow `.tpl` of database secret names and image repository and tag

### DIFF
--- a/.github/workflows/validate-helm-charts.yaml
+++ b/.github/workflows/validate-helm-charts.yaml
@@ -21,7 +21,9 @@ jobs:
           sparse-checkout: charts
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v4.3.1
+        with:
+          version: v3.19.0
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -53,7 +55,7 @@ jobs:
             --chart-repos spark-operator=https://kubeflow.github.io/spark-operator \
             --chart-repos dask=https://helm.dask.org \
             --chart-repos bitnami=https://charts.bitnami.com/bitnami \
-            --chart-repos twuni=https://helm.twun.io \
+            --chart-repos twuni=https://twuni.github.io/docker-registry.helm \
             --chart-repos kubernetes-dashboard=https://kubernetes.github.io/dashboard
 
   validate-manifests:
@@ -76,7 +78,9 @@ jobs:
             docker/sandbox-bundled/manifests
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v4.3.1
+        with:
+          version: v3.19.0
 
       - name: Install kubeconform
         run: |

--- a/charts/flyte-core/templates/_helpers.tpl
+++ b/charts/flyte-core/templates/_helpers.tpl
@@ -176,7 +176,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 {{- define "databaseSecret.volume" -}}
 {{- $secretName := tpl (.Values.common.databaseSecret.name | default "") . -}}
-{{- if $secretName }}
+{{- if $secretName -}}
 - name: {{ $secretName }}
   secret:
     secretName: {{ $secretName }}
@@ -185,7 +185,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 {{- define "databaseSecret.volumeMount" -}}
 {{- $secretName := tpl (.Values.common.databaseSecret.name | default "") . -}}
-{{- if $secretName }}
+{{- if $secretName -}}
 - mountPath: /etc/db
   name: {{ $secretName }}
 {{- end }}

--- a/charts/flyte-core/templates/_helpers.tpl
+++ b/charts/flyte-core/templates/_helpers.tpl
@@ -175,17 +175,19 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 # Optional blocks for secret mount
 
 {{- define "databaseSecret.volume" -}}
-{{- with .Values.common.databaseSecret.name -}}
-- name: {{ . }}
+{{- $secretName := tpl (.Values.common.databaseSecret.name | default "") . -}}
+{{- if $secretName }}
+- name: {{ $secretName }}
   secret:
-    secretName: {{ . }}
+    secretName: {{ $secretName }}
 {{- end }}
 {{- end }}
 
 {{- define "databaseSecret.volumeMount" -}}
-{{- with .Values.common.databaseSecret.name -}}
+{{- $secretName := tpl (.Values.common.databaseSecret.name | default "") . -}}
+{{- if $secretName }}
 - mountPath: /etc/db
-  name: {{ . }}
+  name: {{ $secretName }}
 {{- end }}
 {{- end }}
 

--- a/charts/flyte-core/templates/admin/deployment.yaml
+++ b/charts/flyte-core/templates/admin/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           - {{ .Values.flyteadmin.configPath }}
           - migrate
           - run
-          image: "{{ .Values.flyteadmin.image.repository }}:{{ .Values.flyteadmin.image.tag }}"
+          image: "{{ tpl .Values.flyteadmin.image.repository . }}:{{ tpl .Values.flyteadmin.image.tag . }}"
           imagePullPolicy: "{{ .Values.flyteadmin.image.pullPolicy }}"
           name: run-migrations
           securityContext:
@@ -74,7 +74,7 @@ spec:
           {{- range .Values.flyteadmin.initialProjects }}
           - {{ . }}
           {{- end }}
-          image: "{{ .Values.flyteadmin.image.repository }}:{{ .Values.flyteadmin.image.tag }}"
+          image: "{{ tpl .Values.flyteadmin.image.repository . }}:{{ tpl .Values.flyteadmin.image.tag . }}"
           imagePullPolicy: "{{ .Values.flyteadmin.image.pullPolicy }}"
           name: seed-projects
           securityContext:
@@ -98,7 +98,7 @@ spec:
           - {{ .Values.flyteadmin.configPath }}
           - clusterresource
           - sync
-          image: "{{ .Values.flyteadmin.image.repository }}:{{ .Values.flyteadmin.image.tag }}"
+          image: "{{ tpl .Values.flyteadmin.image.repository . }}:{{ tpl .Values.flyteadmin.image.tag . }}"
           imagePullPolicy: "{{ .Values.flyteadmin.image.pullPolicy }}"
           name: sync-cluster-resources
           securityContext:
@@ -125,7 +125,7 @@ spec:
             {{- end }}
         {{- end }}
         - name: generate-secrets
-          image: "{{ .Values.flyteadmin.image.repository }}:{{ .Values.flyteadmin.image.tag }}"
+          image: "{{ tpl .Values.flyteadmin.image.repository . }}:{{ tpl .Values.flyteadmin.image.tag . }}"
           imagePullPolicy: "{{ .Values.flyteadmin.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
           args:
@@ -164,7 +164,7 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         {{- end }}
-        image: "{{ .Values.flyteadmin.image.repository }}:{{ .Values.flyteadmin.image.tag }}"
+        image: "{{ tpl .Values.flyteadmin.image.repository . }}:{{ tpl .Values.flyteadmin.image.tag . }}"
         imagePullPolicy: "{{ .Values.flyteadmin.image.pullPolicy }}"
         name: flyteadmin
         ports:

--- a/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
+++ b/charts/flyte-core/templates/clusterresourcesync/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             {{- toYaml . | nindent 10 }}
             {{- end }}
           {{- end }}
-          image: "{{ .Values.flyteadmin.image.repository }}:{{ .Values.flyteadmin.image.tag }}"
+          image: "{{ tpl .Values.flyteadmin.image.repository . }}:{{ tpl .Values.flyteadmin.image.tag . }}"
           imagePullPolicy: "{{ .Values.flyteadmin.image.pullPolicy }}"
           name: sync-cluster-resources
           {{- with .Values.cluster_resource_manager.resources }}

--- a/charts/flyte-core/templates/console/deployment.yaml
+++ b/charts/flyte-core/templates/console/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       priorityClassName: {{ .Values.flyteconsole.priorityClassName }}
       {{- end }}
       containers:
-      - image: "{{ .Values.flyteconsole.image.repository }}:{{ .Values.flyteconsole.image.tag }}"
+      - image: "{{ tpl .Values.flyteconsole.image.repository . }}:{{ tpl .Values.flyteconsole.image.tag . }}"
         imagePullPolicy: "{{ .Values.flyteconsole.image.pullPolicy }}"
         name: flyteconsole
         envFrom:

--- a/charts/flyte-core/templates/datacatalog/deployment.yaml
+++ b/charts/flyte-core/templates/datacatalog/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - {{ .Values.datacatalog.configPath }}
         - migrate
         - run
-        image: "{{ .Values.datacatalog.image.repository }}:{{ .Values.datacatalog.image.tag }}"
+        image: "{{ tpl .Values.datacatalog.image.repository . }}:{{ tpl .Values.datacatalog.image.tag . }}"
         imagePullPolicy: "{{ .Values.datacatalog.image.pullPolicy }}"
         name: run-migrations
         volumeMounts: {{- include "databaseSecret.volumeMount" . | nindent 8 }}
@@ -73,7 +73,7 @@ spec:
           {{- toYaml . | nindent 8 }}
           {{- end }}
         {{- end }}
-        image: "{{ .Values.datacatalog.image.repository }}:{{ .Values.datacatalog.image.tag }}"
+        image: "{{ tpl .Values.datacatalog.image.repository . }}:{{ tpl .Values.datacatalog.image.tag . }}"
         imagePullPolicy: "{{ .Values.datacatalog.image.pullPolicy }}"
         name: datacatalog
         ports:

--- a/charts/flyte-core/templates/flytescheduler/deployment.yaml
+++ b/charts/flyte-core/templates/flytescheduler/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           {{- toYaml . | nindent 8 }}
           {{- end }}
         {{- end }}
-        image: "{{ .Values.flytescheduler.image.repository }}:{{ .Values.flytescheduler.image.tag }}"
+        image: "{{ tpl .Values.flytescheduler.image.repository . }}:{{ tpl .Values.flytescheduler.image.tag . }}"
         imagePullPolicy: "{{ .Values.flytescheduler.image.pullPolicy }}"
         name: flytescheduler-check
         securityContext:
@@ -74,7 +74,7 @@ spec:
           {{- toYaml . | nindent 8 }}
           {{- end }}
         {{- end }}
-        image: "{{ .Values.flytescheduler.image.repository }}:{{ .Values.flytescheduler.image.tag }}"
+        image: "{{ tpl .Values.flytescheduler.image.repository . }}:{{ tpl .Values.flytescheduler.image.tag . }}"
         imagePullPolicy: "{{ .Values.flytescheduler.image.pullPolicy }}"
         name: flytescheduler
         ports:

--- a/charts/flyte-core/templates/propeller/deployment.yaml
+++ b/charts/flyte-core/templates/propeller/deployment.yaml
@@ -83,7 +83,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- end }}
-        image: "{{ .Values.flytepropeller.image.repository }}:{{ .Values.flytepropeller.image.tag }}"
+        image: "{{ tpl .Values.flytepropeller.image.repository . }}:{{ tpl .Values.flytepropeller.image.tag . }}"
         imagePullPolicy: "{{ .Values.flytepropeller.image.pullPolicy }}"
         {{- if .Values.flytepropeller.manager }}
         name: flytepropeller-manager

--- a/charts/flyte-core/templates/propeller/manager.yaml
+++ b/charts/flyte-core/templates/propeller/manager.yaml
@@ -34,7 +34,7 @@ template:
         valueFrom:
           fieldRef:
             fieldPath: metadata.name
-      image: "{{ .Values.flytepropeller.image.repository }}:{{ .Values.flytepropeller.image.tag }}"
+      image: "{{ tpl .Values.flytepropeller.image.repository . }}:{{ tpl .Values.flytepropeller.image.tag . }}"
       imagePullPolicy: "{{ .Values.flytepropeller.image.pullPolicy }}"
       name: {{ index .Values.configmap.core.manager "pod-template-container-name" }}
       ports:

--- a/charts/flyte-core/templates/propeller/webhook.yaml
+++ b/charts/flyte-core/templates/propeller/webhook.yaml
@@ -42,7 +42,7 @@ spec:
       labels:
         app: {{ template "flyte-pod-webhook.name" . }}
         app.kubernetes.io/name: {{ template "flyte-pod-webhook.name" . }}
-        app.kubernetes.io/version: {{ .Values.flytepropeller.image.tag }}
+        app.kubernetes.io/version: {{ tpl .Values.flytepropeller.image.tag . }}
         {{- with .Values.webhook.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -67,7 +67,7 @@ spec:
 {{- if .Values.webhook.enabled }}
       initContainers:
       - name: generate-secrets
-        image: "{{ .Values.flytepropeller.image.repository }}:{{ .Values.flytepropeller.image.tag }}"
+        image: "{{ tpl .Values.flytepropeller.image.repository . }}:{{ tpl .Values.flytepropeller.image.tag . }}"
         imagePullPolicy: "{{ .Values.flytepropeller.image.pullPolicy }}"
         command:
           - flytepropeller
@@ -100,7 +100,7 @@ spec:
 {{- end }}
       containers:
         - name: webhook
-          image: "{{ .Values.flytepropeller.image.repository }}:{{ .Values.flytepropeller.image.tag }}"
+          image: "{{ tpl .Values.flytepropeller.image.repository . }}:{{ tpl .Values.flytepropeller.image.tag . }}"
           imagePullPolicy: "{{ .Values.flytepropeller.image.pullPolicy }}"
           command:
             - flytepropeller

--- a/charts/flyte-sandbox/Chart.lock
+++ b/charts/flyte-sandbox/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: docker-registry
-  repository: https://helm.twun.io/
+  repository: https://twuni.github.io/docker-registry.helm
   version: 2.2.2
 - name: flyte-binary
   repository: file://../flyte-binary
@@ -14,5 +14,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 12.8.1
-digest: sha256:f63a6ba148c681162253c24f0ba200ab7d5b7934a398824cb7b4f35d8f9166de
-generated: "2024-02-13T17:51:58.270175-08:00"
+digest: sha256:91238033c75676f44125aa05e1566231b0fa852fe03fe77e694723af7c0123ee
+generated: "2025-11-05T04:39:21.106275+11:00"

--- a/charts/flyte-sandbox/Chart.yaml
+++ b/charts/flyte-sandbox/Chart.yaml
@@ -26,7 +26,7 @@ appVersion: "1.16.1"
 dependencies:
   - name: docker-registry
     version: 2.2.2
-    repository: https://helm.twun.io/
+    repository: https://twuni.github.io/docker-registry.helm
     condition: docker-registry.enabled
   - name: flyte-binary
     version: v0.1.10

--- a/charts/flyte-sandbox/README.md
+++ b/charts/flyte-sandbox/README.md
@@ -11,8 +11,8 @@ A Helm chart for the Flyte local sandbox
 | file://../flyte-binary | flyte-binary | v0.1.10 |
 | https://charts.bitnami.com/bitnami | minio | 12.6.7 |
 | https://charts.bitnami.com/bitnami | postgresql | 12.8.1 |
-| https://helm.twun.io/ | docker-registry | 2.2.2 |
 | https://kubernetes.github.io/dashboard/ | kubernetes-dashboard | 6.0.0 |
+| https://twuni.github.io/docker-registry.helm | docker-registry | 2.2.2 |
 
 ## Values
 

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -710,6 +710,7 @@ data:
   resource_manager.yaml: | 
     propeller:
       resourcemanager:
+        redis: null
         type: noop
   storage.yaml: | 
     storage:
@@ -7222,7 +7223,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "671959f1f31dcfd1a93c1a484be7c7264f05b66de43df1a770f331d389787a4"
+        configChecksum: "ea603a73ffb9754ac5c6d9bab9a8e868050e0e7b118399be9c8b1cd4ce86cf1"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -7300,7 +7301,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.0
       annotations:
-        configChecksum: "671959f1f31dcfd1a93c1a484be7c7264f05b66de43df1a770f331d389787a4"
+        configChecksum: "ea603a73ffb9754ac5c6d9bab9a8e868050e0e7b118399be9c8b1cd4ce86cf1"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: NUFZSjlMb000dURTeFRHcA==
+  haSharedSecret: eXcwMTZmNEdwUFE2ZFV0dg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 70ab3a722bbba034ed7344ef07a16053252026dfe34e71c2448c980ff47a6181
+        checksum/secret: 4a4cc03af4e02059cc3187d1e7fca3ee9b7bf2af97cee7af58839c5f56ca77a5
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete-connector.yaml
+++ b/docker/sandbox-bundled/manifests/complete-connector.yaml
@@ -822,7 +822,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: eXcwMTZmNEdwUFE2ZFV0dg==
+  haSharedSecret: ZW5BRjNYM0F5ZmRSVlNmRw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1419,7 +1419,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 4a4cc03af4e02059cc3187d1e7fca3ee9b7bf2af97cee7af58839c5f56ca77a5
+        checksum/secret: 22b56dd6207e84d808d666cdca85aaad5281c0bb0ea3a4eebca4aed0f919142c
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: dW42d21uWXJEVkJCR2cxYw==
+  haSharedSecret: MWpnV2NMMVJIeFZGeXo2bg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 6aab2e353f8ad57a90248ccde71cbb99db910f4d81ce714f6e67a8bd2d4177e9
+        checksum/secret: decd96ac28abcc906850740c5562f0abcb474a37b9c4b8add7bb014228792ead
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -803,7 +803,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  haSharedSecret: UUltSk9iWTdxVzlNTGZPaQ==
+  haSharedSecret: dW42d21uWXJEVkJCR2cxYw==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -1367,7 +1367,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 809f2778eadd51c6c0289457a88bedac6de365127677a48c24dba5611799c3b2
+        checksum/secret: 6aab2e353f8ad57a90248ccde71cbb99db910f4d81ce714f6e67a8bd2d4177e9
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: cndyM3FFQWVkNFRGYlBOZg==
+  haSharedSecret: NzRPZzlMb1NBTVNaUW9vWg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: c5165688a8414b8e4b999b8074b1ee040e9da539445b6a38ba7d25def1d6d3ea
+        checksum/secret: 94c95e30f8dfc0685be30dde71d8241dd61ee352c706c92158fbed7876a04301
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -499,7 +499,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  haSharedSecret: aHlIMkgzdHluSUU0T2t2bA==
+  haSharedSecret: cndyM3FFQWVkNFRGYlBOZg==
   proxyPassword: ""
   proxyUsername: ""
 kind: Secret
@@ -934,7 +934,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8f50e768255a87f078ba8b9879a0c174c3e045ffb46ac8723d2eedbe293c8d81
-        checksum/secret: 5f9abc8cd74e0ef31cadbf5c8d52979e5fa091a0361f51dd898422abaeca6ed6
+        checksum/secret: c5165688a8414b8e4b999b8074b1ee040e9da539445b6a38ba7d25def1d6d3ea
       labels:
         app: docker-registry
         release: flyte-sandbox

--- a/script/generate_helm.sh
+++ b/script/generate_helm.sh
@@ -10,7 +10,7 @@ export HELM_INSTALL_DIR=${TMPDIR}
 
 if [ "${HELM_SKIP_INSTALL}" != "true" ]; then
 	# See https://github.com/helm/helm/issues/13324 for a breaking change in latest version of helm
-	curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | DESIRED_VERSION=v3.15.4 HELM_INSTALL_DIR=$HELM_INSTALL_DIR bash
+	curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | DESIRED_VERSION=v3.19.0 HELM_INSTALL_DIR=$HELM_INSTALL_DIR bash
 fi
 
 export PATH=$HELM_INSTALL_DIR:$PATH


### PR DESCRIPTION
Context: Union uses flyte-core as a subchart. This pattern is likely applicable for other organizations as well.

This PR makes it so `.Values.flyte.common.databaseSecret.name`, `*.image.repository`, `*.image.tag` respects Helm template values through the `tpl` function.

Additionally, we are updating Helm version to 3.19 as it is more up to date with latest release.

<ul>

<li>This pull request enhances the handling of database secrets in Helm templates by enabling dynamic referencing of the database secret name.</li>

<li>It modifies various deployment configurations to allow the use of templated values for image references and database secret names.</li>

<li>This improvement increases flexibility and configurability in secret management for deployments, allowing the secret name to be set using Helm template values.</li>

<li>Overall, the changes touch on YAML configuration files and deployment configurations, introducing risks related to secret management.</li>

</ul>

</div> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request enhances the handling of database secrets in Helm templates by enabling dynamic referencing of the database secret name.</li>

<li>It updates various deployment configurations to allow the use of templated values for image references and database secret names.</li>

<li>The Helm version is upgraded to 3.19.0, ensuring compatibility with the latest features.</li>

<li>Overall, these changes improve flexibility and configurability in secret management for deployments.</li>

</ul>

</div>