### PR TITLE
Fix: Avoid merging pod template twice if template container name matches task container name

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -815,7 +815,8 @@ func MergeBasePodSpecOntoTemplate(templatePodSpec *v1.PodSpec, basePodSpec *v1.P
 
 		// Check for any name matching template containers
 		for _, templateInitContainer := range templatePodSpec.InitContainers {
-			if templateInitContainer.Name != initContainer.Name {
+			// skip default and primary template init containers as they are handled above
+			if initContainer.Name == primaryInitContainerName || initContainer.Name == defaultInitContainerTemplateName || templateInitContainer.Name != initContainer.Name {
 				continue
 			}
 

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -2341,12 +2341,25 @@ func TestMergeBasePodSpecsOntoTemplate(t *testing.T) {
 						Env:   []v1.EnvVar{{Name: "FOO", Value: "BAR"}},
 					},
 				},
+				InitContainers: []v1.Container{
+					{
+						Name:  "default-init",
+						Image: "default-task-init-image",
+						Env:   []v1.EnvVar{{Name: "INIT_FOO", Value: "INIT_BAR"}},
+					},
+				},
 			},
 			basePodSpec: &v1.PodSpec{
 				Containers: []v1.Container{
 					{
 						Name:  "default",
 						Image: "task-image",
+					},
+				},
+				InitContainers: []v1.Container{
+					{
+						Name:  "default-init",
+						Image: "task-init-image",
 					},
 				},
 			},
@@ -2360,8 +2373,18 @@ func TestMergeBasePodSpecsOntoTemplate(t *testing.T) {
 						},
 					},
 				},
+				InitContainers: []v1.Container{
+					{
+						Name:  "default-init",
+						Image: "task-init-image",
+						Env: []v1.EnvVar{
+							{Name: "INIT_FOO", Value: "INIT_BAR"},
+						},
+					},
+				},
 			},
-			primaryContainerName: "primary",
+			primaryContainerName:     "primary",
+			primaryInitContainerName: "primary-init",
 		},
 		{
 			name: "template with primary container with env vars, base with primary container",
@@ -2373,12 +2396,25 @@ func TestMergeBasePodSpecsOntoTemplate(t *testing.T) {
 						Env:   []v1.EnvVar{{Name: "FOO", Value: "BAR"}},
 					},
 				},
+				InitContainers: []v1.Container{
+					{
+						Name:  "primary-init",
+						Image: "default-task-init-image",
+						Env:   []v1.EnvVar{{Name: "INIT_FOO", Value: "INIT_BAR"}},
+					},
+				},
 			},
 			basePodSpec: &v1.PodSpec{
 				Containers: []v1.Container{
 					{
 						Name:  "primary",
 						Image: "task-image",
+					},
+				},
+				InitContainers: []v1.Container{
+					{
+						Name:  "primary-init",
+						Image: "task-init-image",
 					},
 				},
 			},
@@ -2392,8 +2428,18 @@ func TestMergeBasePodSpecsOntoTemplate(t *testing.T) {
 						},
 					},
 				},
+				InitContainers: []v1.Container{
+					{
+						Name:  "primary-init",
+						Image: "task-init-image",
+						Env: []v1.EnvVar{
+							{Name: "INIT_FOO", Value: "INIT_BAR"},
+						},
+					},
+				},
 			},
-			primaryContainerName: "primary",
+			primaryContainerName:     "primary",
+			primaryInitContainerName: "primary-init",
 		},
 	}
 


### PR DESCRIPTION
## Why are the changes needed?

Users can configure [pod templates ](https://www.union.ai/docs/v1/flyte/deployment/flyte-configuration/configuring-podtemplates/#create-a-podtemplate-resource) that are applied to all task pods.
Currently, if the pod template has a container called `"primary"` or `"default"` and the task container uses the same name, the merging occurs twice leading to environment variables being duplicated.

This PR fixes this.

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Enhances the merging logic for pod templates to prevent duplication of environment variables when container names match, specifically for 'primary' or 'default'.</li>

<li>Addresses an issue where merging could occur multiple times under these conditions.</li>

<li>New tests have been introduced to ensure the correct behavior of the merging process, thereby improving the overall reliability of pod template handling.</li>

<li>Overall, this pull request touches on the merging logic for pod templates and introduces new tests to ensure reliability.</li>

</ul>

</div>