### PR TITLE
Fix: Immediately fail if plugin.BuildResource fails instead of retrying until system retry budget is exhausted

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -211,7 +211,11 @@ func (e *PluginManager) launchResource(ctx context.Context, tCtx pluginsCore.Tas
 
 	o, err := e.plugin.BuildResource(ctx, k8sTaskCtx)
 	if err != nil {
-		return pluginsCore.UnknownTransition, err
+		// If the resource cannot be constructed then permanently fail because this does not
+		// depend on any external system so this is not a transient error. Notify the user
+		// immediately so they can fix the task definition.
+		return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("FailedToBuildResource",
+			fmt.Sprintf("could not build resource for task: %v", err.Error()), nil)), nil
 	}
 
 	taskTemplate, err := tCtx.TaskReader().Read(ctx)


### PR DESCRIPTION
## Why are the changes needed?

One of our engineers launched a Ray task with an invalid custom pod spec and had to wait ~1.5 hours before he was notified of the mistake because the error, while fatal, was classified as a transient system error that can be retried with exponential backoff.

Details:

In this case, a Ray task with a custom pod spec was registered that specified `"4GB"` as a resource request instead of `"4G"` or `"4Gi"`. In the Ray plugin, [here](https://github.com/flyteorg/flyte/blob/cc49cad0a47e596a4c6f2e99098c875a00f4e84f/flyteplugins/go/tasks/plugins/k8s/ray/ray.go#L527), the `k8sPod.GetPodSpec()` could not be unmarshaled into a `v1.PodSpec` because the `"GB"` violated `Err: [quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$']`.

As a consequence, [`plugin.BuildResource(...)`  ](https://github.com/flyteorg/flyte/blob/cc49cad0a47e596a4c6f2e99098c875a00f4e84f/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go#L212) in the plugin manager failed with an error.

However, we currently treat errors in `plugin.BuildResource()` with:

```go
	if err != nil {
		return pluginsCore.UnknownTransition, err
	}
```

The consequence is that this will be retried until the system retry budget is exhausted (including time wasted on backoff):

```console
RuntimeExecutionError: max number of system retry attempts [51/50] exhausted. Last known status message: failed at Node[dn0]. RuntimeExecutionError: failed during plugin execution, caused by: failed to execute handle for plugin [ray]: [BadTaskSpecification] Unable to unmarshal pod ... Err: [quantities must match the regular expression
```

`BuildResource` constructs the Kubernetes manifest that the plugin manager will then apply to the cluster but `BuildResource` itself is not calling any external systems. Therefore, I would argue that this is not a transient error that we would expect to eventually work.

I would argue that when the K8s manifest cannot be constructed by `BuildResource` we want to fail immediately so that the user has a chance to fix the task definition instead of being mislead for ~1.5h that the task will eventually run.



## What changes were proposed in this pull request?

If `e.plugin.BuildResource(ctx, k8sTaskCtx)` fails in the plugin manager, return an error that is not retryable.

## How was this patch tested?

Ran a flytepropeller locally with a debugger attached. Made sure that with this change, in the scenario above, the user is directly shown the error.
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request fixes a critical issue where errors in the resource construction process were treated as transient, leading to unnecessary retries and delays.</li>

<li>The changes ensure that if the `plugin.BuildResource` function fails, the system will immediately return an error instead of retrying.</li>

<li>This fix allows users to correct their task definitions without prolonged waiting.</li>

<li>Overall, this update addresses the resource construction process in the `plugin.BuildResource` function and improves user feedback on fatal errors.</li>

</ul>

</div>