### PR TITLE
Aborting forever and untriggerd on_failure node when aborting failure caused by UserError

### DIFF
--- a/flytepropeller/pkg/controller/handler.go
+++ b/flytepropeller/pkg/controller/handler.go
@@ -104,7 +104,9 @@ func (p *Propeller) TryMutateWorkflow(ctx context.Context, originalW *v1alpha1.F
 	ctx = contextutils.WithResourceVersion(ctx, mutableW.GetResourceVersion())
 
 	maxRetries := uint32(p.cfg.MaxWorkflowRetries) // #nosec G115
-	if !mutableW.GetDeletionTimestamp().IsZero() || mutableW.Status.FailedAttempts > maxRetries {
+	if !mutableW.GetDeletionTimestamp().IsZero() ||
+		(mutableW.Status.FailedAttempts > maxRetries &&
+			mutableW.GetExecutionStatus().GetPhase() != v1alpha1.WorkflowPhaseHandlingFailureNode) {
 		var err error
 		func() {
 			defer func() {

--- a/flytepropeller/pkg/controller/nodes/dynamic/handler.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/handler.go
@@ -98,7 +98,7 @@ func (d dynamicNodeTaskNodeHandler) produceDynamicWorkflow(ctx context.Context, 
 		if stdErrors.IsCausedBy(err, utils.ErrorCodeUser) {
 			return handler.DoTransition(handler.TransitionTypeEphemeral,
 				handler.PhaseInfoFailure(core.ExecutionError_USER, "DynamicWorkflowBuildFailed", err.Error(), nil),
-			), handler.DynamicNodeState{Phase: v1alpha1.DynamicNodePhaseFailing, Reason: err.Error()}, nil
+			), handler.DynamicNodeState{Phase: v1alpha1.DynamicNodePhaseFailing, Reason: err.Error(), IsFailurePermanent: true}, nil
 		}
 		return handler.Transition{}, handler.DynamicNodeState{}, err
 	}
@@ -125,7 +125,7 @@ func (d dynamicNodeTaskNodeHandler) handleDynamicSubNodes(ctx context.Context, n
 		if stdErrors.IsCausedBy(err, utils.ErrorCodeUser) {
 			return handler.DoTransition(handler.TransitionTypeEphemeral,
 				handler.PhaseInfoFailure(core.ExecutionError_USER, "DynamicWorkflowBuildFailed", err.Error(), nil),
-			), handler.DynamicNodeState{Phase: v1alpha1.DynamicNodePhaseFailing, Reason: err.Error()}, nil
+			), handler.DynamicNodeState{Phase: v1alpha1.DynamicNodePhaseFailing, Reason: err.Error(), IsFailurePermanent: true}, nil
 		}
 		// Mostly a system error or unknown
 		return handler.Transition{}, handler.DynamicNodeState{}, err

--- a/flytepropeller/pkg/controller/nodes/dynamic/handler.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/handler.go
@@ -96,9 +96,10 @@ func (d dynamicNodeTaskNodeHandler) produceDynamicWorkflow(ctx context.Context, 
 	dCtx, err := d.buildContextualDynamicWorkflow(ctx, nCtx)
 	if err != nil {
 		if stdErrors.IsCausedBy(err, utils.ErrorCodeUser) {
+			isPermanent := !stdErrors.IsCausedBy(err, utils.ErrorCodeSystem)
 			return handler.DoTransition(handler.TransitionTypeEphemeral,
 				handler.PhaseInfoFailure(core.ExecutionError_USER, "DynamicWorkflowBuildFailed", err.Error(), nil),
-			), handler.DynamicNodeState{Phase: v1alpha1.DynamicNodePhaseFailing, Reason: err.Error(), IsFailurePermanent: true}, nil
+			), handler.DynamicNodeState{Phase: v1alpha1.DynamicNodePhaseFailing, Reason: err.Error(), IsFailurePermanent: isPermanent}, nil
 		}
 		return handler.Transition{}, handler.DynamicNodeState{}, err
 	}
@@ -123,9 +124,10 @@ func (d dynamicNodeTaskNodeHandler) handleDynamicSubNodes(ctx context.Context, n
 	dCtx, err := d.buildContextualDynamicWorkflow(ctx, nCtx)
 	if err != nil {
 		if stdErrors.IsCausedBy(err, utils.ErrorCodeUser) {
+			isPermanent := !stdErrors.IsCausedBy(err, utils.ErrorCodeSystem)
 			return handler.DoTransition(handler.TransitionTypeEphemeral,
 				handler.PhaseInfoFailure(core.ExecutionError_USER, "DynamicWorkflowBuildFailed", err.Error(), nil),
-			), handler.DynamicNodeState{Phase: v1alpha1.DynamicNodePhaseFailing, Reason: err.Error(), IsFailurePermanent: true}, nil
+			), handler.DynamicNodeState{Phase: v1alpha1.DynamicNodePhaseFailing, Reason: err.Error(), IsFailurePermanent: isPermanent}, nil
 		}
 		// Mostly a system error or unknown
 		return handler.Transition{}, handler.DynamicNodeState{}, err

--- a/flytepropeller/pkg/controller/workflow/executor.go
+++ b/flytepropeller/pkg/controller/workflow/executor.go
@@ -499,17 +499,28 @@ func (c *workflowExecutor) HandleAbortedWorkflow(ctx context.Context, w *v1alpha
 		}
 
 		var status Status
-		if err != nil {
-			// This workflow failed, record that phase and corresponding error message.
-			status = StatusFailed(&core.ExecutionError{
-				Code:    "Workflow abort failed",
+		if w.GetDeletionTimestamp() != nil {
+			// Explicit deletion: abort without running failure node.
+			if err != nil {
+				status = StatusFailed(&core.ExecutionError{
+					Code:    "Workflow abort failed",
+					Message: err.Error(),
+					Kind:    core.ExecutionError_SYSTEM,
+				})
+			} else {
+				status = Status{TransitionToPhase: v1alpha1.WorkflowPhaseAborted}
+			}
+		} else {
+			// Max system retries exhausted: give on_failure a chance to run.
+			execErr := &core.ExecutionError{
+				Code:    errors.RuntimeExecutionError.String(),
 				Message: err.Error(),
 				Kind:    core.ExecutionError_SYSTEM,
-			})
-		} else {
-			// Otherwise, this workflow is aborted.
-			status = Status{
-				TransitionToPhase: v1alpha1.WorkflowPhaseAborted,
+			}
+			if failureNode := w.GetOnFailureNode(); failureNode != nil {
+				status = StatusFailureNode(execErr)
+			} else {
+				status = StatusFailed(execErr)
 			}
 		}
 		if err := c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, w.GetExecutionStatus(), status); err != nil {

--- a/flytepropeller/pkg/controller/workflow/executor.go
+++ b/flytepropeller/pkg/controller/workflow/executor.go
@@ -494,7 +494,10 @@ func (c *workflowExecutor) HandleAbortedWorkflow(ctx context.Context, w *v1alpha
 			return err
 		}
 
-		if w.Status.FailedAttempts > maxRetries {
+		if w.Status.FailedAttempts >= maxRetries {
+			if err != nil {
+				logger.Warningf(ctx, "Discarding cleanup error because system retries are exhausted: %v", err)
+			}
 			err = errors.Errorf(errors.RuntimeExecutionError, w.GetID(), "max number of system retry attempts [%d/%d] exhausted. Last known status message: %v", w.Status.FailedAttempts, maxRetries, w.Status.Message)
 		}
 


### PR DESCRIPTION
## Tracking issue
flyteorg/flyte#6695

## Why are the changes needed?
1. Solving Aborting forever when failure of aborting happens
2. Set on failure function in failing state node when aborting fails


## What changes were proposed in this pull request?

1. Node state transfer to failing when an user error happen in Aborting and finalizing steps.
2. Exceeding max retries make the workflow state failed in order to trigger on failure node.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
