### PR TITLE
Add start- and end-time log link template vars to Ray plugin

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -1211,6 +1211,30 @@ func TestGetEventInfo_LogTemplates(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "ray job start time",
+			rayJob: rayv1.RayJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-namespace",
+					CreationTimestamp: metav1.Time{
+						Time: time.Date(2024, time.January, 1, 12, 0, 0, 0, time.UTC),
+					},
+				},
+				Status: rayv1.RayJobStatus{
+					JobId: "ray-job-1",
+				},
+			},
+			logPlugin: tasklog.TemplateLogPlugin{
+				DisplayName:  "ray job ID",
+				TemplateURIs: []tasklog.TemplateURI{"http://test/{{ .PodRFC3339StartTime }}/{{ .PodUnixStartTime }}"},
+			},
+			expectedTaskLogs: []*core.TaskLog{
+				{
+					Name: "ray job ID",
+					Uri:  "http://test/2024-01-01T12:00:00Z/1704110400",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Why are the changes needed?

In the Ray plugin log link configuration one currently cannot use the start time of the job as a template variable as is the case in other plugins like e.g. the [pod plugin](https://github.com/flyteorg/flyteplugins/pull/360) or the [kubeflow training jobs plugin](https://github.com/flyteorg/flyteplugins/pull/362).

This is quite useful for configuring the correct time range in services like GCP stackdriver logging so that users immediately see the relevant logs without first having to manually specify the right time range.

In this PR I'm adding the same template vars to the Ray plugin.

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request adds start and end time log link template variables to the Ray plugin, allowing users to configure time ranges for logging services more effectively.</li>

<li>The changes ensure that the Ray plugin aligns with similar functionalities in other plugins, improving usability.</li>

<li>Tests have been added to verify the new features, ensuring that all existing functionalities remain intact.</li>

<li>Overall, the pull request introduces enhancements to the Ray plugin's logging capabilities and adds relevant tests.</li>

</ul>

</div>