### PR TITLE
correctly cast timeout for grace period seconds (#850)

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -274,7 +274,8 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 			// Let the sidecar container start before the downloader; it will ensure the signal watcher is started before the main container finishes.
 			coPilotPod.InitContainers = append([]v1.Container{sidecar}, coPilotPod.InitContainers...)
 
-			coPilotPod.TerminationGracePeriodSeconds = (*int64)(&cfg.Timeout.Duration)
+			timeoutSeconds := int64(cfg.Timeout.Duration.Seconds())
+			coPilotPod.TerminationGracePeriodSeconds = &timeoutSeconds
 		}
 	}
 


### PR DESCRIPTION
## Why are the changes needed?
pods can get stuck in terminating essentially indefinitely due to terminationGracePeriodSeconds getting incorrectly cast from the config value

## What changes were proposed in this pull request?
correctly cast config value for terminationGracePeriodSeconds

## How was this patch tested?
has been running in Union clusters for a while

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
