### PR TITLE
handle azure Gen2 storage path when parsing ref (#841)

### DIFF
--- a/flytestdlib/storage/storage.go
+++ b/flytestdlib/storage/storage.go
@@ -170,7 +170,16 @@ func (r DataReference) Split() (scheme, container, key string, err error) {
 		return "", "", "", err
 	}
 
-	return u.Scheme, u.Host, strings.Trim(u.Path, "/"), nil
+	// Handle storage URLs that use @ to separate container/bucket name from the storage endpoint.
+	// When url.Parse encounters the @ symbol, it treats the part before @ as User and the part after as Host.
+	// Example: Azure ADLS Gen2 uses abfs://container@storageaccount.dfs.core.windows.net/path format.
+	if u.User != nil && u.User.Username() != "" {
+		container = u.User.Username()
+	} else {
+		container = u.Host
+	}
+
+	return u.Scheme, container, strings.Trim(u.Path, "/"), nil
 }
 
 func (r DataReference) String() string {

--- a/flytestdlib/storage/storage_test.go
+++ b/flytestdlib/storage/storage_test.go
@@ -20,13 +20,45 @@ func TestDataReference_New(t *testing.T) {
 }
 
 func TestDataReference_Split(t *testing.T) {
-	input := DataReference("s3://container/path/to/file")
-	scheme, container, key, err := input.Split()
+	t.Run("S3 URL", func(t *testing.T) {
+		input := DataReference("s3://container/path/to/file")
+		scheme, container, key, err := input.Split()
 
-	assert.NoError(t, err)
-	assert.Equal(t, "s3", scheme)
-	assert.Equal(t, "container", container)
-	assert.Equal(t, "path/to/file", key)
+		assert.NoError(t, err)
+		assert.Equal(t, "s3", scheme)
+		assert.Equal(t, "container", container)
+		assert.Equal(t, "path/to/file", key)
+	})
+
+	t.Run("Azure ADLS Gen2 URL with storage account", func(t *testing.T) {
+		input := DataReference("abfs://mycontainer@mystorageaccount.dfs.core.windows.net/path/to/file")
+		scheme, container, key, err := input.Split()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "abfs", scheme)
+		assert.Equal(t, "mycontainer", container)
+		assert.Equal(t, "path/to/file", key)
+	})
+
+	t.Run("Azure ADLS Gen2 URL without path", func(t *testing.T) {
+		input := DataReference("abfs://mycontainer@mystorageaccount.dfs.core.windows.net")
+		scheme, container, key, err := input.Split()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "abfs", scheme)
+		assert.Equal(t, "mycontainer", container)
+		assert.Equal(t, "", key)
+	})
+
+	t.Run("GCS URL", func(t *testing.T) {
+		input := DataReference("gs://bucket/path/to/object")
+		scheme, container, key, err := input.Split()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "gs", scheme)
+		assert.Equal(t, "bucket", container)
+		assert.Equal(t, "path/to/object", key)
+	})
 }
 
 func ExampleNewDataStore() {


### PR DESCRIPTION
## Why are the changes needed?
Gen2 path that separates the storage account and container w/ an @

## What changes were proposed in this pull request?
Update the parsing of the storage location to account for this.

## How was this patch tested?
has been running in Union azure clusters

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
