### PR TITLE
don't overwrite existing err when closing reader (#719)

### DIFF
--- a/flytestdlib/storage/protobuf_store.go
+++ b/flytestdlib/storage/protobuf_store.go
@@ -44,8 +44,8 @@ func (s DefaultProtobufStore) ReadProtobuf(ctx context.Context, reference DataRe
 	}
 
 	defer func() {
-		err = rc.Close()
-		if err != nil {
+		cErr := rc.Close()
+		if cErr != nil {
 			logger.Warnf(ctx, "Failed to close reference [%v]. Error: %v", reference, err)
 		}
 	}()


### PR DESCRIPTION
## Why are the changes needed?
Error on failed un-marshaling of an outputs file gets overwritten by deferred closing of the reader + swallow errors closing reader

## What changes were proposed in this pull request?
don't overwrite err

## How was this patch tested?
running in Union clusters for a while

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
