### PR TITLE
Pin neoeinstein-prost to v0.4.0

### DIFF
--- a/flyteidl/buf.gen.yaml
+++ b/flyteidl/buf.gen.yaml
@@ -8,7 +8,7 @@ plugins:
     out: gen/pb_python
   - plugin: buf.build/protocolbuffers/pyi:v22.2
     out: gen/pb_python
-  - plugin: buf.build/community/neoeinstein-prost
+  - plugin: buf.build/community/neoeinstein-prost:v0.4.0
     out: gen/pb_rust
   - plugin: buf.build/community/neoeinstein-tonic:v0.4.0
     out: gen/pb_rust


### PR DESCRIPTION
## Why are the changes needed?

We use the an unpinned `neoeinstein-prost` which now generates incompatible changes for `neoeinstein-tonic`. This pins the version to the one that was previously being used so we have more reproducible builds.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Tested locally

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Pins the version of the neoeinstein-prost dependency to v0.4.0 in the buf.gen.yaml file to avoid incompatible changes from the unpinned version.</li>

<li>Ensures more reproducible builds by locking the dependency version.</li>

<li>Enhances stability in the build process by preventing potential issues from version changes.</li>

<li>Overall summary: updates the neoeinstein-prost dependency in buf.gen.yaml, introducing stability improvements.</li>

</ul>

</div>