### PR TITLE
Bump flyteidl 1 to python 3.13

### DIFF
--- a/flyteidl/pyproject.toml
+++ b/flyteidl/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development",


### PR DESCRIPTION
## Why are the changes needed?
There's no reason why we shouldn't be able to install flyteidl on 3.13.

## What changes were proposed in this pull request?
Bump project limit.

## How was this patch tested?
Tested locally by installing.


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Updates the Python version requirement for the Flyte IDL project to allow installation on Python 3.13.</li>

<li>Modifications to the dependencies and classifiers in the pyproject.toml file ensure compatibility with the newer Python version.</li>

<li>Aims to broaden the usability of the Flyte IDL library.</li>

<li>Overall summary: updates Python version requirements and dependencies in pyproject.toml, broadening usability.</li>

</ul>

</div>