### PR TITLE
Fix issue with assertions with time zones

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -3,6 +3,7 @@ package ray
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -1217,7 +1218,7 @@ func TestGetEventInfo_LogTemplates(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-namespace",
 					CreationTimestamp: metav1.Time{
-						Time: time.Date(2024, time.January, 1, 12, 0, 0, 0, time.UTC),
+						Time: time.Unix(0, 0),
 					},
 				},
 				Status: rayv1.RayJobStatus{
@@ -1231,7 +1232,7 @@ func TestGetEventInfo_LogTemplates(t *testing.T) {
 			expectedTaskLogs: []*core.TaskLog{
 				{
 					Name: "ray job ID",
-					Uri:  "http://test/2024-01-01T12:00:00Z/1704110400",
+					Uri:  fmt.Sprintf("http://test/%s/0", time.Unix(0, 0).Format(time.RFC3339)),
 				},
 			},
 		},


### PR DESCRIPTION
## Tracking issue
Closes #6772 

## Why are the changes needed?
The unit test uses a static assertion of a time format that includes local zone information which fails for non UTC machines.

## What changes were proposed in this pull request?
Update the unit test to dynamically create expected value.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
