### PR TITLE
[FlyteCTL] only get v1 sandbox image

### DIFF
--- a/flytectl/pkg/github/githubutil.go
+++ b/flytectl/pkg/github/githubutil.go
@@ -25,6 +25,7 @@ const (
 	flyte                   = "flyte"
 	flytectl                = "flytectl"
 	sandboxSupportedVersion = "v0.10.0"
+	sandboxMaxVersion       = "v2.0.0"
 	flytectlRepository      = "github.com/flyteorg/flyte"
 	commonMessage           = "\n A new release of flytectl is available: %s → %s \n"
 	brewMessage             = "To upgrade, run: brew update && brew upgrade flytectl \n"
@@ -129,6 +130,17 @@ func GetSandboxImageSha(tag string, pre bool, g GHRepoService) (string, string, 
 			return "", release.GetTagName(), err
 		}
 		for _, v := range releases {
+			tagName := v.GetTagName()
+
+			// Skip versions >= sandboxMaxVersion (v2.x and above)
+			// flytectl only supports flyte v1
+			isLessThan, err := util.IsVersionGreaterThan(sandboxMaxVersion, tagName)
+			if err == nil && !isLessThan {
+				// tagName >= sandboxMaxVersion, skip it
+				logger.Debugf(context.Background(), "skipping release %s (>= %s)", tagName, sandboxMaxVersion)
+				continue
+			}
+
 			// When pre-releases are allowed, simply choose the latest release
 			if pre {
 				release = v


### PR DESCRIPTION
## Tracking issue
Closes #6814

## Why are the changes needed?

Flyte recently released v2.0.0, however, flytectl is only for flyte v1. We should prevent it getting v2 image when building sandbox with `flytectl demo start`

## What changes were proposed in this pull request?

Skip release for flyte version >= v2.x.x

## How was this patch tested?

build flytectl and run locally

<img width="2356" height="954" alt="image" src="https://github.com/user-attachments/assets/ecc5f741-a513-4cb2-bd0d-641b1b4f14cf" />


### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
