### PR TITLE
[V2][Fix] pin openapiv2 version to prevent panic

### DIFF
--- a/buf.gen.go.yaml
+++ b/buf.gen.go.yaml
@@ -33,7 +33,7 @@ plugins:
       - module=github.com/flyteorg/flyte/v2/gen/go
       - standalone=true
       - allow_delete_body=true
-  - remote: buf.build/grpc-ecosystem/openapiv2
+  - remote: buf.build/grpc-ecosystem/openapiv2:v2.27.4
     out: gen/go/gateway
     opt:
       - json_names_for_fields=false


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

Getting following error when using `make gen`

```sh
buf generate --clean --template buf.gen.go.yaml --exclude-path flytestdlib/
Failure: invalid_argument: plugin "buf.build/grpc-ecosystem/openapiv2:v2.27.5" exited with non-zero status 2: panic: can't resolve OpenAPI ref from typename ".flyteidl2.task.Inputs"

goroutine 1 [running]:
github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopenapi.schemaOfFieldBase(_, _, _)
        github.com/grpc-ecosystem/grpc-gateway/v2@v2.27.5/protoc-gen-openapiv2/internal/genopenapi/template.go:857 +0x885
github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopenapi.schemaOfField(_, _, _)
        github.com/grpc-ecosystem/grpc-gateway/v2@v2.27.5/protoc-gen-openapiv2/internal/genopenapi/template.go:911 +0x58
github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopenapi.renderFieldAsDefinition(_, _, _, {_, _, _})
        github.com/grpc-ecosystem/grpc-gateway/v2@v2.27.5/protoc-gen-openapiv2/internal/genopenapi/template.go:694 +0x42f
github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopenapi.renderMessageAsDefinition(_, _, _, {_, _, _})
        github.com/grpc-ecosystem/grpc-gateway/v2@v2.27.5/protoc-gen-openapiv2/internal/genopenapi/template.go:608 +0xec8
github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopenapi.renderServices({0xc0017828e0, 0x2, 0x0?}, 0xc000178eb8, 0xc000166ea0, 0xc0008fb068, 0xc0008faf70, {0x0, 0x0, 0x0}, ...)
        github.com/grpc-ecosystem/grpc-gateway/v2@v2.27.5/protoc-gen-openapiv2/internal/genopenapi/template.go:1559 +0x7b1
github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopenapi.applyTemplate({0xc001716ab0, 0xc000166ea0})
        github.com/grpc-ecosystem/grpc-gateway/v2@v2.27.5/protoc-gen-openapiv2/internal/genopenapi/template.go:2100 +0x315
github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopenapi.(*generator).Generate(0xc0008fbd50, {0xc000eef688?, 0x2b?, 0xc000609e70?})
        github.com/grpc-ecosystem/grpc-gateway/v2@v2.27.5/protoc-gen-openapiv2/internal/genopenapi/generator.go:403 +0x1b7
main.main()
        github.com/grpc-ecosystem/grpc-gateway/v2@v2.27.5/protoc-gen-openapiv2/main.go:236 +0x11e5
```

## What changes were proposed in this pull request?

The error is related to an open issue in `grpc-gateway` repo: https://github.com/grpc-ecosystem/grpc-gateway/issues/6274. Pin the version of `buf.build/grpc-ecosystem/openapiv2` to `v2.27.4` (the previous version) for now to prevent the error

## How was this patch tested?

Ensure `make gen` pass

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
