### PR TITLE
refactor: centralize mockery definitions in .mockery.yaml

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,0 +1,404 @@
+log-level: warn
+resolve-type-alias: False
+disable-version-string: True
+issue-845-fix: True
+structname: ""
+mockname: "{{.InterfaceName}}"
+filename: "{{.InterfaceName | snakecase}}.go"
+inpackage: false
+outpkg: "mocks"
+with-expecter: true
+packages:
+  # ============================================================================
+  # datacatalog
+  # ============================================================================
+  github.com/flyteorg/flyte/datacatalog/pkg/repositories/interfaces:
+    config:
+      all: false
+      dir: 'datacatalog/pkg/repositories/mocks'
+    interfaces:
+      ArtifactRepo:
+      TagRepo:
+      PartitionRepo:
+      ReservationRepo:
+      DatasetRepo:
+
+  github.com/flyteorg/flyte/datacatalog/pkg/manager/interfaces:
+    config:
+      all: false
+      dir: 'datacatalog/pkg/manager/mocks'
+    interfaces:
+      ArtifactManager:
+
+  # ============================================================================
+  # flytectl
+  # ============================================================================
+  github.com/flyteorg/flyte/flytectl/pkg/github:
+    config:
+      all: false
+      dir: 'flytectl/pkg/github/mocks'
+    interfaces:
+      GHRepoService:
+
+  github.com/flyteorg/flyte/flytectl/pkg/visualize:
+    config:
+      all: true
+      dir: 'flytectl/pkg/visualize/mocks'
+
+  github.com/flyteorg/flyte/flytectl/pkg/ext:
+    config:
+      all: true
+      dir: 'flytectl/pkg/ext/mocks'
+
+  github.com/flyteorg/flyte/flytectl/pkg/k8s:
+    config:
+      all: false
+      dir: 'flytectl/pkg/k8s/mocks'
+    interfaces:
+      ContextOps:
+
+  github.com/flyteorg/flyte/flytectl/pkg/docker:
+    config:
+      all: true
+      dir: 'flytectl/pkg/docker/mocks'
+
+  github.com/flyteorg/flyte/flytectl/cmd/update/interfaces:
+    config:
+      all: false
+      dir: 'flytectl/cmd/update/interfaces/mocks'
+    interfaces:
+      Updater:
+
+  # ============================================================================
+  # flytepropeller
+  # ============================================================================
+  github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common:
+    config:
+      all: true
+      dir: 'flytepropeller/pkg/compiler/common/mocks'
+
+  github.com/flyteorg/flyte/flytepropeller/events:
+    config:
+      all: true
+      dir: 'flytepropeller/events/mocks'
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/controller/interfaces:
+    config:
+      all: false
+      dir: 'flytepropeller/pkg/controller/mocks'
+      filename: "{{.InterfaceName | snakecase}}.go"
+    interfaces:
+      Limiter:
+      Reservation:
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors:
+    config:
+      all: true
+      dir: 'flytepropeller/pkg/controller/executors/mocks'
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces:
+    config:
+      all: true
+      dir: 'flytepropeller/pkg/controller/nodes/interfaces/mocks'
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/dynamic:
+    config:
+      all: true
+      dir: 'flytepropeller/pkg/controller/nodes/dynamic/mocks'
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/resourcemanager:
+    config:
+      all: false
+      dir: 'flytepropeller/pkg/controller/nodes/task/resourcemanager/mocks'
+    interfaces:
+      RedisClient:
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/gate:
+    config:
+      all: true
+      dir: 'flytepropeller/pkg/controller/nodes/gate/mocks'
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/recovery:
+    config:
+      all: false
+      dir: 'flytepropeller/pkg/controller/nodes/recovery/mocks'
+    interfaces:
+      Client:
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes:
+    config:
+      all: false
+      dir: 'flytepropeller/pkg/controller/nodes/mocks'
+    interfaces:
+      OutputResolver:
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/array:
+    config:
+      all: true
+      dir: 'flytepropeller/pkg/controller/nodes/array/mocks'
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/subworkflow/launchplan:
+    config:
+      all: true
+      dir: 'flytepropeller/pkg/controller/nodes/subworkflow/launchplan/mocks'
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/controller/workflowstore:
+    config:
+      all: true
+      dir: 'flytepropeller/pkg/controller/workflowstore/mocks'
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1:
+    config:
+      all: true
+      dir: 'flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks'
+
+  github.com/flyteorg/flyte/flytepropeller/pkg/webhook:
+    config:
+      all: true
+      dir: 'flytepropeller/pkg/webhook/mocks'
+
+  github.com/flyteorg/flyte/flytepropeller/manager/shardstrategy:
+    config:
+      all: false
+      dir: 'flytepropeller/manager/shardstrategy/mocks'
+    interfaces:
+      ShardStrategy:
+
+  # ============================================================================
+  # flytestdlib
+  # ============================================================================
+  github.com/flyteorg/flyte/flytestdlib/random:
+    config:
+      all: true
+      dir: 'flytestdlib/random/mocks'
+
+  github.com/flyteorg/flyte/flytestdlib/storage:
+    config:
+      all: false
+      dir: 'flytestdlib/storage/mocks'
+    interfaces:
+      RawStore:
+      ReferenceConstructor:
+      ComposedProtobufStore:
+
+  github.com/flyteorg/flyte/flytestdlib/fastcheck:
+    config:
+      all: false
+      dir: 'flytestdlib/fastcheck/mocks'
+    interfaces:
+      Filter:
+
+  github.com/flyteorg/flyte/flytestdlib/utils:
+    config:
+      all: true
+      dir: 'flytestdlib/utils/mocks'
+
+  github.com/flyteorg/flyte/flytestdlib/cache:
+    config:
+      all: true
+      dir: 'flytestdlib/cache/mocks'
+
+  # ============================================================================
+  # flyteplugins
+  # ============================================================================
+  github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/webapi:
+    config:
+      all: true
+      dir: 'flyteplugins/go/tasks/pluginmachinery/webapi/mocks'
+
+  github.com/flyteorg/flyte/flyteplugins/go/tasks/plugins/array/awsbatch:
+    config:
+      all: true
+      dir: 'flyteplugins/go/tasks/plugins/array/awsbatch/mocks'
+
+  github.com/flyteorg/flyte/flyteplugins/go/tasks/plugins/array/core:
+    config:
+      all: true
+      dir: 'flyteplugins/go/tasks/plugins/array/core/mocks'
+
+  github.com/flyteorg/flyte/flyteplugins/go/tasks/plugins/presto/client:
+    config:
+      all: true
+      dir: 'flyteplugins/go/tasks/plugins/presto/client/mocks'
+      filename: "{{.InterfaceName | snakecase}}.go"
+
+  github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io:
+    config:
+      all: true
+      dir: 'flyteplugins/go/tasks/pluginmachinery/io/mocks'
+
+  github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/internal/webapi:
+    config:
+      all: true
+      dir: 'flyteplugins/go/tasks/pluginmachinery/internal/webapi/mocks'
+
+  github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/k8s:
+    config:
+      all: true
+      dir: 'flyteplugins/go/tasks/pluginmachinery/k8s/mocks'
+
+  github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog:
+    config:
+      all: true
+      dir: 'flyteplugins/go/tasks/pluginmachinery/catalog/mocks'
+
+  github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/workqueue:
+    config:
+      all: true
+      dir: 'flyteplugins/go/tasks/pluginmachinery/workqueue/mocks'
+
+  github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core:
+    config:
+      all: true
+      dir: 'flyteplugins/go/tasks/pluginmachinery/core/mocks'
+
+  # ============================================================================
+  # flyteadmin
+  # ============================================================================
+  github.com/flyteorg/flyte/flyteadmin/pkg/data/interfaces:
+    config:
+      all: false
+      dir: 'flyteadmin/pkg/data/mocks'
+    interfaces:
+      RemoteURLInterface:
+
+  github.com/flyteorg/flyte/flyteadmin/pkg/executioncluster/interfaces:
+    config:
+      all: true
+      dir: 'flyteadmin/pkg/executioncluster/mocks'
+
+  github.com/flyteorg/flyte/flyteadmin/pkg/workflowengine/interfaces:
+    config:
+      all: false
+      dir: 'flyteadmin/pkg/workflowengine/mocks'
+    interfaces:
+      WorkflowExecutor:
+      FlyteWorkflowBuilder:
+
+  github.com/flyteorg/flyte/flyteadmin/pkg/manager/interfaces:
+    config:
+      all: false
+      dir: 'flyteadmin/pkg/manager/mocks'
+    interfaces:
+      TaskInterface:
+      WorkflowInterface:
+      NamedEntityInterface:
+      LaunchPlanInterface:
+      TaskExecutionInterface:
+      ResourceInterface:
+      MetricsInterface:
+      VersionInterface:
+      ExecutionInterface:
+      ProjectInterface:
+      NodeExecutionInterface:
+      SignalInterface:
+
+  github.com/flyteorg/flyte/flyteadmin/pkg/repositories/interfaces:
+    config:
+      all: false
+      dir: 'flyteadmin/pkg/repositories/mocks'
+    interfaces:
+      NamedEntityRepoInterface:
+      ExecutionEventRepoInterface:
+      DescriptionEntityRepoInterface:
+      NodeExecutionEventRepoInterface:
+      SignalRepoInterface:
+
+  github.com/flyteorg/flyte/flyteadmin/pkg/async/cloudevent/interfaces:
+    config:
+      all: false
+      dir: 'flyteadmin/pkg/async/cloudevent/mocks'
+    interfaces:
+      Publisher:
+      Sender:
+
+  github.com/flyteorg/flyte/flyteadmin/pkg/async/notifications/interfaces:
+    config:
+      all: false
+      dir: 'flyteadmin/pkg/async/notifications/mocks'
+    interfaces:
+      Publisher:
+      SMTPClient:
+      Emailer:
+      Processor:
+
+  github.com/flyteorg/flyte/flyteadmin/pkg/async/notifications/implementations:
+    config:
+      all: true
+      dir: 'flyteadmin/pkg/async/notifications/mocks'
+
+  github.com/flyteorg/flyte/flyteadmin/pkg/async/events/interfaces:
+    config:
+      all: false
+      dir: 'flyteadmin/pkg/async/events/mocks'
+    interfaces:
+      NodeExecutionEventWriter:
+      WorkflowExecutionEventWriter:
+
+  github.com/flyteorg/flyte/flyteadmin/pkg/async/schedule/interfaces:
+    config:
+      all: false
+      dir: 'flyteadmin/pkg/async/schedule/mocks'
+    interfaces:
+      WorkflowExecutor:
+      EventScheduler:
+
+  github.com/flyteorg/flyte/flyteadmin/pkg/runtime/interfaces:
+    config:
+      all: false
+      dir: 'flyteadmin/pkg/runtime/mocks'
+    interfaces:
+      QualityOfServiceConfiguration:
+      WhitelistConfiguration:
+      ClusterConfiguration:
+      NamespaceMappingConfiguration:
+      ClusterPoolAssignmentConfiguration:
+
+  github.com/flyteorg/flyte/flyteadmin/pkg/clusterresource/interfaces:
+    config:
+      all: false
+      dir: 'flyteadmin/pkg/clusterresource/mocks'
+    interfaces:
+      FlyteAdminDataProvider:
+
+  github.com/flyteorg/flyte/flyteadmin/scheduler/executor:
+    config:
+      all: false
+      dir: 'flyteadmin/scheduler/executor/mocks'
+    interfaces:
+      Executor:
+
+  github.com/flyteorg/flyte/flyteadmin/scheduler/repositories/interfaces:
+    config:
+      all: false
+      dir: 'flyteadmin/scheduler/repositories/mocks'
+    interfaces:
+      ScheduleEntitiesSnapShotRepoInterface:
+      SchedulableEntityRepoInterface:
+
+  github.com/flyteorg/flyte/flyteadmin/auth/interfaces:
+    config:
+      all: true
+      dir: 'flyteadmin/auth/interfaces/mocks'
+
+  # ============================================================================
+  # flyteidl
+  # ============================================================================
+  github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service:
+    config:
+      all: false
+      dir: 'flyteidl/clients/go/admin/mocks'
+    interfaces:
+      AdminServiceClient:
+
+  github.com/flyteorg/flyte/flyteidl/clients/go/admin:
+    config:
+      all: false
+      dir: 'flyteidl/clients/go/admin/mocks'
+    interfaces:
+      TokenSource:
+
+  github.com/flyteorg/flyte/flyteidl/clients/go/admin/cache:
+    config:
+      all: true
+      dir: 'flyteidl/clients/go/admin/cache/mocks'

--- a/datacatalog/pkg/manager/interfaces/artifact.go
+++ b/datacatalog/pkg/manager/interfaces/artifact.go
@@ -6,7 +6,6 @@ import (
 	idl_datacatalog "github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/datacatalog"
 )
 
-//go:generate mockery --name=ArtifactManager --output=../mocks --case=underscore --with-expecter
 
 type ArtifactManager interface {
 	CreateArtifact(ctx context.Context, request *idl_datacatalog.CreateArtifactRequest) (*idl_datacatalog.CreateArtifactResponse, error)

--- a/datacatalog/pkg/repositories/interfaces/artifact_repo.go
+++ b/datacatalog/pkg/repositories/interfaces/artifact_repo.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 )
 
-//go:generate mockery --name=ArtifactRepo --output=../mocks --case=underscore --with-expecter
 
 type ArtifactRepo interface {
 	Create(ctx context.Context, in models.Artifact) error

--- a/datacatalog/pkg/repositories/interfaces/dataset_repo.go
+++ b/datacatalog/pkg/repositories/interfaces/dataset_repo.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 )
 
-//go:generate mockery --name=DatasetRepo --output=../mocks --case=underscore --with-expecter
 
 type DatasetRepo interface {
 	Create(ctx context.Context, in models.Dataset) error

--- a/datacatalog/pkg/repositories/interfaces/partition_repo.go
+++ b/datacatalog/pkg/repositories/interfaces/partition_repo.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 )
 
-//go:generate mockery --name=PartitionRepo --output=../mocks --case=underscore --with-expecter
 
 type PartitionRepo interface {
 	Create(ctx context.Context, in models.Partition) error

--- a/datacatalog/pkg/repositories/interfaces/reservation_repo.go
+++ b/datacatalog/pkg/repositories/interfaces/reservation_repo.go
@@ -7,7 +7,6 @@ import (
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 )
 
-//go:generate mockery --name=ReservationRepo --output=../mocks --case=underscore --with-expecter
 
 // Interface to interact with Reservation Table
 type ReservationRepo interface {

--- a/datacatalog/pkg/repositories/interfaces/tag_repo.go
+++ b/datacatalog/pkg/repositories/interfaces/tag_repo.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/datacatalog/pkg/repositories/models"
 )
 
-//go:generate mockery --name=TagRepo --output=../mocks --case=underscore --with-expecter
 
 type TagRepo interface {
 	Create(ctx context.Context, in models.Tag) error

--- a/flyteadmin/auth/interfaces/context.go
+++ b/flyteadmin/auth/interfaces/context.go
@@ -17,7 +17,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 type HandlerRegisterer interface {
 	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))

--- a/flyteadmin/auth/interfaces/cookie.go
+++ b/flyteadmin/auth/interfaces/cookie.go
@@ -9,7 +9,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 )
 
-//go:generate mockery --name=CookieHandler --output=mocks/ --case=underscore --with-expecter
 
 type CookieHandler interface {
 	SetTokenCookies(ctx context.Context, writer http.ResponseWriter, token *oauth2.Token) error

--- a/flyteadmin/pkg/async/cloudevent/interfaces/publisher.go
+++ b/flyteadmin/pkg/async/cloudevent/interfaces/publisher.go
@@ -6,7 +6,6 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-//go:generate mockery --name=Publisher --output=../mocks --case=underscore --with-expecter
 
 // Publisher Defines the interface for Publishing execution event to other services (AWS pub/sub, Kafka, Nats).
 type Publisher interface {

--- a/flyteadmin/pkg/async/cloudevent/interfaces/sender.go
+++ b/flyteadmin/pkg/async/cloudevent/interfaces/sender.go
@@ -6,7 +6,6 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
-//go:generate mockery --name=Sender --output=../mocks --case=underscore --with-expecter
 
 // Sender Defines the interface for sending cloudevents.
 type Sender interface {

--- a/flyteadmin/pkg/async/events/interfaces/node_execution.go
+++ b/flyteadmin/pkg/async/events/interfaces/node_execution.go
@@ -4,7 +4,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=NodeExecutionEventWriter --output=../mocks --case=underscore --with-expecter
 
 type NodeExecutionEventWriter interface {
 	Run()

--- a/flyteadmin/pkg/async/events/interfaces/workflow_execution.go
+++ b/flyteadmin/pkg/async/events/interfaces/workflow_execution.go
@@ -4,7 +4,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=WorkflowExecutionEventWriter --output=../mocks --case=underscore --with-expecter
 
 type WorkflowExecutionEventWriter interface {
 	Run()

--- a/flyteadmin/pkg/async/notifications/implementations/sendgrid_emailer.go
+++ b/flyteadmin/pkg/async/notifications/implementations/sendgrid_emailer.go
@@ -19,7 +19,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
-//go:generate mockery --all --case=underscore --output=../mocks --case=underscore --with-expecter
 
 type SendgridClient interface {
 	Send(email *mail.SGMailV3) (*rest.Response, error)

--- a/flyteadmin/pkg/async/notifications/interfaces/emailer.go
+++ b/flyteadmin/pkg/async/notifications/interfaces/emailer.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=Emailer --output=../mocks --case=underscore --with-expecter
 
 // The implementation of Emailer needs to be passed to the implementation of Processor
 // in order for emails to be sent.

--- a/flyteadmin/pkg/async/notifications/interfaces/processor.go
+++ b/flyteadmin/pkg/async/notifications/interfaces/processor.go
@@ -1,6 +1,5 @@
 package interfaces
 
-//go:generate mockery --name=Processor --output=../mocks --case=underscore --with-expecter
 
 // Exposes the common methods required for a subscriber.
 // There is one ProcessNotification per type.

--- a/flyteadmin/pkg/async/notifications/interfaces/publisher.go
+++ b/flyteadmin/pkg/async/notifications/interfaces/publisher.go
@@ -6,7 +6,6 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-//go:generate mockery --name=Publisher --output=../mocks --case=underscore --with-expecter
 
 // Note on Notifications
 

--- a/flyteadmin/pkg/async/notifications/interfaces/smtp_client.go
+++ b/flyteadmin/pkg/async/notifications/interfaces/smtp_client.go
@@ -8,7 +8,6 @@ import (
 
 // This interface is introduced to allow for mocking of the smtp.Client object.
 
-//go:generate mockery --name=SMTPClient --output=../mocks --case=underscore --with-expecter
 type SMTPClient interface {
 	Hello(localName string) error
 	Extension(ext string) (bool, string)

--- a/flyteadmin/pkg/async/schedule/interfaces/event_scheduler.go
+++ b/flyteadmin/pkg/async/schedule/interfaces/event_scheduler.go
@@ -27,7 +27,6 @@ type RemoveScheduleInput struct {
 	ScheduleNamePrefix string
 }
 
-//go:generate mockery --name=EventScheduler --output=../mocks --case=underscore --with-expecter
 
 type EventScheduler interface {
 	// Schedules an event.

--- a/flyteadmin/pkg/async/schedule/interfaces/workflow_executor.go
+++ b/flyteadmin/pkg/async/schedule/interfaces/workflow_executor.go
@@ -1,6 +1,5 @@
 package interfaces
 
-//go:generate mockery --name=WorkflowExecutor --output=../mocks --case=underscore --with-expecter
 
 // Handles responding to scheduled workflow execution events and creating executions.
 type WorkflowExecutor interface {

--- a/flyteadmin/pkg/clusterresource/interfaces/admin.go
+++ b/flyteadmin/pkg/clusterresource/interfaces/admin.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=FlyteAdminDataProvider --output=../mocks --case=underscore --with-expecter
 
 type FlyteAdminDataProvider interface {
 	GetClusterResourceAttributes(ctx context.Context, project, domain string) (*admin.ClusterResourceAttributes, error)

--- a/flyteadmin/pkg/data/interfaces/remote.go
+++ b/flyteadmin/pkg/data/interfaces/remote.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=RemoteURLInterface --output=../mocks --case=underscore --with-expecter
 
 // Defines an interface for fetching pre-signed URLs.
 type RemoteURLInterface interface {

--- a/flyteadmin/pkg/executioncluster/interfaces/execution_target_provider.go
+++ b/flyteadmin/pkg/executioncluster/interfaces/execution_target_provider.go
@@ -7,7 +7,6 @@ import (
 	"github.com/flyteorg/flyte/flyteadmin/pkg/runtime/interfaces"
 )
 
-//go:generate mockery --all --case=underscore --output=../mocks --case=underscore --with-expecter
 
 type ExecutionTargetProvider interface {
 	GetExecutionTarget(initializationErrorCounter prometheus.Counter, k8sCluster interfaces.ClusterConfig) (*executioncluster.ExecutionTarget, error)

--- a/flyteadmin/pkg/manager/interfaces/execution.go
+++ b/flyteadmin/pkg/manager/interfaces/execution.go
@@ -7,7 +7,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=ExecutionInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Workflow Executions
 type ExecutionInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/launch_plan.go
+++ b/flyteadmin/pkg/manager/interfaces/launch_plan.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=LaunchPlanInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Launch Plans
 type LaunchPlanInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/metrics.go
+++ b/flyteadmin/pkg/manager/interfaces/metrics.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=MetricsInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte execution metrics
 type MetricsInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/named_entity.go
+++ b/flyteadmin/pkg/manager/interfaces/named_entity.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=NamedEntityInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing metadata associated with NamedEntityIdentifiers
 type NamedEntityInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/node_execution.go
+++ b/flyteadmin/pkg/manager/interfaces/node_execution.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=NodeExecutionInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Workflow NodeExecutions
 type NodeExecutionInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/project.go
+++ b/flyteadmin/pkg/manager/interfaces/project.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=ProjectInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing projects (and domains).
 type ProjectInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/resource.go
+++ b/flyteadmin/pkg/manager/interfaces/resource.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=ResourceInterface --output=../mocks --case=underscore --with-expecter
 
 // ResourceInterface manages project, domain and workflow -specific attributes.
 type ResourceInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/signal.go
+++ b/flyteadmin/pkg/manager/interfaces/signal.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=SignalInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Signals
 type SignalInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/task.go
+++ b/flyteadmin/pkg/manager/interfaces/task.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=TaskInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Tasks
 type TaskInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/task_execution.go
+++ b/flyteadmin/pkg/manager/interfaces/task_execution.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=TaskExecutionInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Workflow TaskExecutions
 type TaskExecutionInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/version.go
+++ b/flyteadmin/pkg/manager/interfaces/version.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=VersionInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte admin version
 type VersionInterface interface {

--- a/flyteadmin/pkg/manager/interfaces/workflow.go
+++ b/flyteadmin/pkg/manager/interfaces/workflow.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
-//go:generate mockery --name=WorkflowInterface --output=../mocks --case=underscore --with-expecter
 
 // Interface for managing Flyte Workflows
 type WorkflowInterface interface {

--- a/flyteadmin/pkg/repositories/interfaces/description_entity.go
+++ b/flyteadmin/pkg/repositories/interfaces/description_entity.go
@@ -19,7 +19,6 @@ type DescriptionEntityCollectionOutput struct {
 	Entities []models.DescriptionEntity
 }
 
-//go:generate mockery --name=DescriptionEntityRepoInterface --output=../mocks --case=underscore --with-expecter
 
 // DescriptionEntityRepoInterface Defines the interface for interacting with Description models.
 type DescriptionEntityRepoInterface interface {

--- a/flyteadmin/pkg/repositories/interfaces/execution_event_repo.go
+++ b/flyteadmin/pkg/repositories/interfaces/execution_event_repo.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteadmin/pkg/repositories/models"
 )
 
-//go:generate mockery --name=ExecutionEventRepoInterface --output=../mocks --case=underscore --with-expecter
 
 type ExecutionEventRepoInterface interface {
 	// Inserts a workflow execution event into the database store.

--- a/flyteadmin/pkg/repositories/interfaces/named_entity_repo.go
+++ b/flyteadmin/pkg/repositories/interfaces/named_entity_repo.go
@@ -26,7 +26,6 @@ type NamedEntityCollectionOutput struct {
 	Entities []models.NamedEntity
 }
 
-//go:generate mockery --name=NamedEntityRepoInterface --output=../mocks --case=underscore --with-expecter
 
 // Defines the interface for interacting with NamedEntity models
 type NamedEntityRepoInterface interface {

--- a/flyteadmin/pkg/repositories/interfaces/node_execution_event_repo.go
+++ b/flyteadmin/pkg/repositories/interfaces/node_execution_event_repo.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteadmin/pkg/repositories/models"
 )
 
-//go:generate mockery --name=NodeExecutionEventRepoInterface --output=../mocks --case=underscore --with-expecter
 
 type NodeExecutionEventRepoInterface interface {
 	// Inserts a node execution event into the database store.

--- a/flyteadmin/pkg/repositories/interfaces/signal_repo.go
+++ b/flyteadmin/pkg/repositories/interfaces/signal_repo.go
@@ -7,7 +7,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
-//go:generate mockery --name=SignalRepoInterface --output=../mocks --case=underscore --with-expecter
 
 // Defines the interface for interacting with signal models.
 type SignalRepoInterface interface {

--- a/flyteadmin/pkg/runtime/interfaces/cluster_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/cluster_configuration.go
@@ -51,7 +51,6 @@ type Clusters struct {
 	DefaultExecutionLabel string                     `json:"defaultExecutionLabel"`
 }
 
-//go:generate mockery --name ClusterConfiguration --case=underscore --output=../mocks --case=underscore --with-expecter
 
 // Provides values set in runtime configuration files.
 // These files can be changed without requiring a full server restart.

--- a/flyteadmin/pkg/runtime/interfaces/cluster_pools.go
+++ b/flyteadmin/pkg/runtime/interfaces/cluster_pools.go
@@ -1,6 +1,5 @@
 package interfaces
 
-//go:generate mockery --name ClusterPoolAssignmentConfiguration --output=mocks --case=underscore --with-expecter
 
 type ClusterPoolAssignment struct {
 	Pool string `json:"pool"`

--- a/flyteadmin/pkg/runtime/interfaces/namespace_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/namespace_configuration.go
@@ -6,7 +6,6 @@ type NamespaceMappingConfig struct {
 	TemplateData TemplateData `json:"templateData"`
 }
 
-//go:generate mockery --name NamespaceMappingConfiguration --output=../mocks --case=underscore --with-expecter
 
 type NamespaceMappingConfiguration interface {
 	GetNamespaceTemplate() string

--- a/flyteadmin/pkg/runtime/interfaces/quality_of_service_configuration.go
+++ b/flyteadmin/pkg/runtime/interfaces/quality_of_service_configuration.go
@@ -8,7 +8,6 @@ import (
 type TierName = string
 
 // Just incrementally start using mockery, replace with -all when working on https://github.com/flyteorg/flyte/issues/149
-//go:generate mockery --name QualityOfServiceConfiguration --output=mocks --case=underscore --with-expecter
 
 type QualityOfServiceSpec struct {
 	QueueingBudget config.Duration `json:"queueingBudget"`

--- a/flyteadmin/pkg/runtime/interfaces/whitelist.go
+++ b/flyteadmin/pkg/runtime/interfaces/whitelist.go
@@ -8,7 +8,6 @@ type WhitelistScope struct {
 // Defines specific task types whitelisted for support.
 type TaskTypeWhitelist = map[string][]WhitelistScope
 
-//go:generate mockery --name WhitelistConfiguration --case=underscore --output=../mocks --case=underscore --with-expecter
 type WhitelistConfiguration interface {
 	// Returns whitelisted task types defined in runtime configuration files.
 	GetTaskTypeWhitelist() TaskTypeWhitelist

--- a/flyteadmin/pkg/workflowengine/interfaces/builder.go
+++ b/flyteadmin/pkg/workflowengine/interfaces/builder.go
@@ -5,7 +5,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery --name FlyteWorkflowBuilder --output=../mocks --case=underscore --with-expecter
 
 // FlyteWorkflowBuilder produces a v1alpha1.FlyteWorkflow definition from a compiled workflow closure and execution inputs
 type FlyteWorkflowBuilder interface {

--- a/flyteadmin/pkg/workflowengine/interfaces/executor.go
+++ b/flyteadmin/pkg/workflowengine/interfaces/executor.go
@@ -10,7 +10,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery --name=WorkflowExecutor --output=../mocks/ --case=underscore --with-expecter
 
 type TaskResources struct {
 	Defaults runtime.TaskResourceSet

--- a/flyteadmin/scheduler/executor/executor.go
+++ b/flyteadmin/scheduler/executor/executor.go
@@ -7,7 +7,6 @@ import (
 	"github.com/flyteorg/flyte/flyteadmin/scheduler/repositories/models"
 )
 
-//go:generate mockery --name Executor --output=mocks --case=underscore --with-expecter
 
 // Executor allows the ability to create scheduled executions on admin
 type Executor interface {

--- a/flyteadmin/scheduler/repositories/interfaces/schedulable_entity_repo.go
+++ b/flyteadmin/scheduler/repositories/interfaces/schedulable_entity_repo.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteadmin/scheduler/repositories/models"
 )
 
-//go:generate mockery --name=SchedulableEntityRepoInterface --output=../mocks --case=underscore --with-expecter
 
 // SchedulableEntityRepoInterface : An Interface for interacting with the schedulable entity in the database
 type SchedulableEntityRepoInterface interface {

--- a/flyteadmin/scheduler/repositories/interfaces/schedule_entities_snapshot_repo.go
+++ b/flyteadmin/scheduler/repositories/interfaces/schedule_entities_snapshot_repo.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flyteadmin/scheduler/repositories/models"
 )
 
-//go:generate mockery --name=ScheduleEntitiesSnapShotRepoInterface --output=../mocks --case=underscore --with-expecter
 
 // ScheduleEntitiesSnapShotRepoInterface : An Interface for interacting with the snapshot of schedulable entities in the database
 type ScheduleEntitiesSnapShotRepoInterface interface {

--- a/flytectl/cmd/update/interfaces/updater.go
+++ b/flytectl/cmd/update/interfaces/updater.go
@@ -7,7 +7,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
-//go:generate mockery --name=Updater --case=underscore --with-expecter
 
 type Updater interface {
 	UpdateNamedEntity(ctx context.Context, name, project, domain string, rsType core.ResourceType, cmdCtx cmdCore.CommandContext) error

--- a/flytectl/pkg/docker/docker.go
+++ b/flytectl/pkg/docker/docker.go
@@ -13,7 +13,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 type Docker interface {
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)

--- a/flytectl/pkg/ext/deleter.go
+++ b/flytectl/pkg/ext/deleter.go
@@ -7,7 +7,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // AdminDeleterExtInterface Interface for exposing the update capabilities from the admin
 type AdminDeleterExtInterface interface {

--- a/flytectl/pkg/ext/fetcher.go
+++ b/flytectl/pkg/ext/fetcher.go
@@ -8,7 +8,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // AdminFetcherExtInterface Interface for exposing the fetch capabilities from the admin and also allow this to be injectable into other
 // modules. eg : create execution which requires to fetch launchplan details to construct the execution spec.

--- a/flytectl/pkg/ext/updater.go
+++ b/flytectl/pkg/ext/updater.go
@@ -7,7 +7,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // AdminUpdaterExtInterface Interface for exposing the update capabilities from the admin
 type AdminUpdaterExtInterface interface {

--- a/flytectl/pkg/github/githubutil.go
+++ b/flytectl/pkg/github/githubutil.go
@@ -52,7 +52,6 @@ var (
 	arch = platformutil.Arch(runtime.GOARCH)
 )
 
-//go:generate mockery --name=GHRepoService --case=underscore --with-expecter
 
 type GHRepoService interface {
 	GetLatestRelease(ctx context.Context, owner, repo string) (*github.RepositoryRelease, *github.Response, error)

--- a/flytectl/pkg/k8s/k8s.go
+++ b/flytectl/pkg/k8s/k8s.go
@@ -16,7 +16,6 @@ type K8s interface {
 	CoreV1() corev1.CoreV1Interface
 }
 
-//go:generate mockery --name=ContextOps --case=underscore --with-expecter
 type ContextOps interface {
 	CheckConfig() error
 	CopyContext(srcConfigAccess clientcmd.ConfigAccess, srcCtxName, targetCtxName, targetNamespace string) error

--- a/flytectl/pkg/visualize/graphvizer.go
+++ b/flytectl/pkg/visualize/graphvizer.go
@@ -2,7 +2,6 @@ package visualize
 
 import graphviz "github.com/awalterschulze/gographviz"
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 type Graphvizer interface {
 	AddEdge(src, dst string, directed bool, attrs map[string]string) error

--- a/flyteidl/clients/go/admin/cache/token_cache.go
+++ b/flyteidl/clients/go/admin/cache/token_cache.go
@@ -6,7 +6,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 var (
 	ErrNotFound = fmt.Errorf("secret not found in keyring")

--- a/flyteidl/clients/go/admin/client.go
+++ b/flyteidl/clients/go/admin/client.go
@@ -20,7 +20,6 @@ import (
 )
 
 // IDE "Go Generate File". This will create a mocks/AdminServiceClient.go file
-//go:generate mockery --dir ../../../gen/pb-go/flyteidl/service --name AdminServiceClient --output ../admin/mocks --with-expecter
 
 // Clientset contains the clients exposed to communicate with various admin services.
 type Clientset struct {

--- a/flyteidl/clients/go/admin/token_source_provider.go
+++ b/flyteidl/clients/go/admin/token_source_provider.go
@@ -25,7 +25,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
-//go:generate mockery --name TokenSource --with-expecter
 type TokenSource interface {
 	Token() (*oauth2.Token, error)
 }

--- a/flyteplugins/go/tasks/pluginmachinery/catalog/client.go
+++ b/flyteplugins/go/tasks/pluginmachinery/catalog/client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // Metadata to be associated with the catalog object
 type Metadata struct {

--- a/flyteplugins/go/tasks/pluginmachinery/core/exec_context.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/exec_context.go
@@ -9,7 +9,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // An interface to access a remote/sharable location that contains the serialized TaskTemplate
 type TaskTemplatePath interface {

--- a/flyteplugins/go/tasks/pluginmachinery/core/exec_metadata.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/exec_metadata.go
@@ -8,7 +8,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // TaskOverrides interface to expose any overrides that have been set for this task (like resource overrides etc)
 type TaskOverrides interface {

--- a/flyteplugins/go/tasks/pluginmachinery/core/plugin.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/plugin.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // https://github.com/flyteorg/flytepropeller/blob/979fabe1d1b22b01645259a03b8096f227681d08/pkg/utils/encoder.go#L25-L26
 const minGeneratedNameLength = 8

--- a/flyteplugins/go/tasks/pluginmachinery/core/secret_manager.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/secret_manager.go
@@ -2,7 +2,6 @@ package core
 
 import "context"
 
-//go:generate mockery --all --case=underscore --with-expecter
 type SecretManager interface {
 	Get(ctx context.Context, key string) (string, error)
 }

--- a/flyteplugins/go/tasks/pluginmachinery/internal/webapi/cache.go
+++ b/flyteplugins/go/tasks/pluginmachinery/internal/webapi/cache.go
@@ -16,7 +16,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 const (
 	BadReturnCodeError stdErrors.ErrorCode = "RETURNED_UNKNOWN"

--- a/flyteplugins/go/tasks/pluginmachinery/io/iface.go
+++ b/flyteplugins/go/tasks/pluginmachinery/io/iface.go
@@ -7,7 +7,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // InputFilePaths contains the different ways available for downstream systems to retrieve inputs.
 // If using Files for IO with tasks, then the input will be written to this path. All the files are always created in a

--- a/flyteplugins/go/tasks/pluginmachinery/k8s/plugin.go
+++ b/flyteplugins/go/tasks/pluginmachinery/k8s/plugin.go
@@ -10,7 +10,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // PluginEntry is a structure that is used to indicate to the system a K8s plugin
 type PluginEntry struct {

--- a/flyteplugins/go/tasks/pluginmachinery/webapi/plugin.go
+++ b/flyteplugins/go/tasks/pluginmachinery/webapi/plugin.go
@@ -16,7 +16,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // A Lazy loading function, that will load the plugin. Plugins should be initialized in this method. It is guaranteed
 // that the plugin loader will be called before any Handle/Abort/Finalize functions are invoked

--- a/flyteplugins/go/tasks/pluginmachinery/workqueue/queue.go
+++ b/flyteplugins/go/tasks/pluginmachinery/workqueue/queue.go
@@ -15,7 +15,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 //go:generate enumer --type=WorkStatus
 
 type WorkItemID = string

--- a/flyteplugins/go/tasks/plugins/array/awsbatch/client.go
+++ b/flyteplugins/go/tasks/plugins/array/awsbatch/client.go
@@ -19,7 +19,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/utils"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // AWS Batch Client interface.
 type Client interface {

--- a/flyteplugins/go/tasks/plugins/array/core/state.go
+++ b/flyteplugins/go/tasks/plugins/array/core/state.go
@@ -17,7 +17,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 //go:generate enumer -type=Phase
 
 type Phase uint8

--- a/flyteplugins/go/tasks/plugins/presto/client/presto_client.go
+++ b/flyteplugins/go/tasks/plugins/presto/client/presto_client.go
@@ -17,7 +17,6 @@ type PrestoExecuteResponse struct {
 	NextURI string `json:"nextUri,omitempty"`
 }
 
-//go:generate mockery --all --case=snake --with-expecter
 
 // Interface to interact with PrestoClient for Presto tasks
 type PrestoClient interface {

--- a/flytepropeller/events/node_event_recorder.go
+++ b/flytepropeller/events/node_event_recorder.go
@@ -16,7 +16,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery --all --output=mocks --case=underscore --with-expecter
 
 // NodeEventRecorder records Node events
 type NodeEventRecorder interface {

--- a/flytepropeller/events/task_event_recorder.go
+++ b/flytepropeller/events/task_event_recorder.go
@@ -16,7 +16,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery --all --output=mocks --case=underscore --with-expecter
 
 // Recorder for Task events
 type TaskEventRecorder interface {

--- a/flytepropeller/events/workflow_event_recorder.go
+++ b/flytepropeller/events/workflow_event_recorder.go
@@ -16,7 +16,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery --all --output=mocks --case=underscore --with-expecter
 
 // Recorder for Workflow events
 type WorkflowEventRecorder interface {

--- a/flytepropeller/manager/shardstrategy/shard_strategy.go
+++ b/flytepropeller/manager/shardstrategy/shard_strategy.go
@@ -13,7 +13,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery --name ShardStrategy --case=underscore --with-expecter
 
 // ShardStrategy defines necessary functionality for a sharding strategy.
 type ShardStrategy interface {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
@@ -19,7 +19,6 @@ import (
 // The intention of these interfaces is to decouple the algorithm and usage from the actual CRD definition.
 // this would help in ease of changes underneath without affecting the code.
 
-//go:generate mockery --all --with-expecter
 
 type WorkflowID = string
 type TaskID = string

--- a/flytepropeller/pkg/compiler/common/builder.go
+++ b/flytepropeller/pkg/compiler/common/builder.go
@@ -19,7 +19,6 @@ const (
 	EdgeDirectionUpstream
 )
 
-//go:generate mockery --all --output=mocks --case=underscore --with-expecter
 
 // A mutable workflow used during the build of the intermediate layer.
 type WorkflowBuilder interface {

--- a/flytepropeller/pkg/controller/executors/dag_structure.go
+++ b/flytepropeller/pkg/controller/executors/dag_structure.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery --name DAGStructure --name DAGStructureWithStartNode --case=underscore --with-expecter
 
 // An interface that captures the Directed Acyclic Graph structure in which the nodes are connected.
 // If NodeLookup and DAGStructure are used together a traversal can be implemented.

--- a/flytepropeller/pkg/controller/executors/execution_context.go
+++ b/flytepropeller/pkg/controller/executors/execution_context.go
@@ -4,7 +4,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 type TaskDetailsGetter interface {
 	GetTask(id v1alpha1.TaskID) (v1alpha1.ExecutableTask, error)

--- a/flytepropeller/pkg/controller/executors/kube.go
+++ b/flytepropeller/pkg/controller/executors/kube.go
@@ -13,7 +13,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
-//go:generate mockery --name Client --case=underscore --with-expecter
 
 // Client is a friendlier controller-runtime client that gets passed to executors
 type Client interface {

--- a/flytepropeller/pkg/controller/executors/node_lookup.go
+++ b/flytepropeller/pkg/controller/executors/node_lookup.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery --name NodeLookup --case=underscore --with-expecter
 
 // NodeLookup provides a structure that enables looking up all nodes within the current execution hierarchy/context.
 // NOTE: execution hierarchy may change the nodes available, this is because when a SubWorkflow is being executed, only

--- a/flytepropeller/pkg/controller/executors/workflow.go
+++ b/flytepropeller/pkg/controller/executors/workflow.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery --name Workflow --case=underscore --with-expecter
 
 type Workflow interface {
 	Initialize(ctx context.Context) error

--- a/flytepropeller/pkg/controller/interfaces/rate_limiter.go
+++ b/flytepropeller/pkg/controller/interfaces/rate_limiter.go
@@ -7,8 +7,6 @@ import (
 	"golang.org/x/time/rate"
 )
 
-//go:generate mockery --name Limiter --output ../mocks --case=snake --with-expecter
-//go:generate mockery --name Reservation --output ../mocks --case=snake --with-expecter
 
 type Limiter interface {
 	Allow() bool

--- a/flytepropeller/pkg/controller/nodes/array/event_recorder.go
+++ b/flytepropeller/pkg/controller/nodes/array/event_recorder.go
@@ -49,7 +49,6 @@ func (t *taskExecutionID) GetUniqueNodeID() string {
 	return t.nodeID
 }
 
-//go:generate mockery --all --case=underscore
 
 type arrayEventRecorder interface {
 	interfaces.EventRecorder

--- a/flytepropeller/pkg/controller/nodes/array/handler.go
+++ b/flytepropeller/pkg/controller/nodes/array/handler.go
@@ -44,7 +44,6 @@ var (
 	}
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // arrayNodeHandler is a handle implementation for processing array nodes
 type arrayNodeHandler struct {

--- a/flytepropeller/pkg/controller/nodes/dynamic/handler.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/handler.go
@@ -22,7 +22,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils/labeled"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 const dynamicNodeID = "dynamic-node"
 

--- a/flytepropeller/pkg/controller/nodes/gate/handler.go
+++ b/flytepropeller/pkg/controller/nodes/gate/handler.go
@@ -18,7 +18,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // SignalServiceClient is a SignalServiceClient wrapper interface used specifically for generating
 // mocks for testing

--- a/flytepropeller/pkg/controller/nodes/interfaces/handler.go
+++ b/flytepropeller/pkg/controller/nodes/interfaces/handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // NodeExecutor defines the interface for handling a single Flyte Node of any Node type.
 type NodeExecutor interface {

--- a/flytepropeller/pkg/controller/nodes/interfaces/handler_factory.go
+++ b/flytepropeller/pkg/controller/nodes/interfaces/handler_factory.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery --name HandlerFactory --case=underscore --with-expecter
 
 type HandlerFactory interface {
 	GetHandler(kind v1alpha1.NodeKind) (NodeHandler, error)

--- a/flytepropeller/pkg/controller/nodes/interfaces/node.go
+++ b/flytepropeller/pkg/controller/nodes/interfaces/node.go
@@ -9,7 +9,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/executors"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // p of the node
 type NodePhase int

--- a/flytepropeller/pkg/controller/nodes/interfaces/node_exec_context.go
+++ b/flytepropeller/pkg/controller/nodes/interfaces/node_exec_context.go
@@ -15,7 +15,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 type TaskReader interface {
 	Read(ctx context.Context) (*core.TaskTemplate, error)

--- a/flytepropeller/pkg/controller/nodes/output_resolver.go
+++ b/flytepropeller/pkg/controller/nodes/output_resolver.go
@@ -14,7 +14,6 @@ import (
 
 type VarName = string
 
-//go:generate mockery --name=OutputResolver --case=underscore --with-expecter
 
 type OutputResolver interface {
 	// Extracts a subset of node outputs to literals.

--- a/flytepropeller/pkg/controller/nodes/recovery/client.go
+++ b/flytepropeller/pkg/controller/nodes/recovery/client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
 )
 
-//go:generate mockery --name Client --output=mocks --case=underscore --with-expecter
 
 type Client interface {
 	RecoverNodeExecution(ctx context.Context, execID *core.WorkflowExecutionIdentifier, nodeID string) (*admin.NodeExecution, error)

--- a/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/launchplan.go
+++ b/flytepropeller/pkg/controller/nodes/subworkflow/launchplan/launchplan.go
@@ -8,7 +8,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // LaunchContext is a simple context that is used to start an execution of a LaunchPlan. It encapsulates enough parent information
 // to tie the executions

--- a/flytepropeller/pkg/controller/nodes/task/resourcemanager/redis_client.go
+++ b/flytepropeller/pkg/controller/nodes/task/resourcemanager/redis_client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
-//go:generate mockery --name RedisClient --case=underscore --with-expecter
 
 type RedisClient interface {
 	// A pass-through method. Getting the cardinality of the Redis set

--- a/flytepropeller/pkg/controller/workflowstore/iface.go
+++ b/flytepropeller/pkg/controller/workflowstore/iface.go
@@ -6,7 +6,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
-//go:generate mockery --all --with-expecter
 
 // FlyteWorkflow store interface provides an abstraction of accessing the actual FlyteWorkflow object.
 type FlyteWorkflow interface {

--- a/flytepropeller/pkg/webhook/global_secrets.go
+++ b/flytepropeller/pkg/webhook/global_secrets.go
@@ -12,7 +12,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 type GlobalSecretProvider interface {
 	GetForSecret(ctx context.Context, secret *coreIdl.Secret) (string, error)

--- a/flytestdlib/cache/auto_refresh.go
+++ b/flytestdlib/cache/auto_refresh.go
@@ -13,7 +13,6 @@ const (
 	ErrNotFound errors.ErrorCode = "NOT_FOUND"
 )
 
-//go:generate mockery --all --with-expecter
 
 // AutoRefresh with regular GetOrCreate and Delete along with background asynchronous refresh. Caller provides
 // callbacks for create, refresh and delete item.

--- a/flytestdlib/fastcheck/iface.go
+++ b/flytestdlib/fastcheck/iface.go
@@ -14,7 +14,6 @@ import (
 // resolution
 // The Data-structure is thread-safe and can be accessed by multiple threads concurrently.
 
-//go:generate mockery --name Filter --case=underscore --with-expecter
 
 type Filter interface {
 	// Contains returns a True if the id was previously seen or false otherwise

--- a/flytestdlib/random/weighted_random_list.go
+++ b/flytestdlib/random/weighted_random_list.go
@@ -10,7 +10,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // Interface to use the Weighted Random
 type WeightedRandomList interface {

--- a/flytestdlib/storage/storage.go
+++ b/flytestdlib/storage/storage.go
@@ -105,7 +105,6 @@ type SignedURLResponse struct {
 	RequiredRequestHeaders map[string]string
 }
 
-//go:generate mockery --name RawStore --case=underscore --with-expecter
 
 // RawStore defines a low level interface for accessing and storing bytes.
 type RawStore interface {
@@ -134,7 +133,6 @@ type RawStore interface {
 	Delete(ctx context.Context, reference DataReference) error
 }
 
-//go:generate mockery --name ReferenceConstructor --case=underscore --with-expecter
 
 // ReferenceConstructor defines an interface for building data reference paths.
 type ReferenceConstructor interface {
@@ -154,7 +152,6 @@ type ProtobufStore interface {
 	WriteProtobuf(ctx context.Context, reference DataReference, opts Options, msg proto.Message) error
 }
 
-//go:generate mockery --name ComposedProtobufStore --case=underscore --with-expecter
 
 // ComposedProtobufStore interface includes all the necessary data to allow a ProtobufStore to interact with storage
 // through a RawStore.

--- a/flytestdlib/utils/auto_refresh_cache.go
+++ b/flytestdlib/utils/auto_refresh_cache.go
@@ -12,7 +12,6 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/promutils"
 )
 
-//go:generate mockery --all --case=underscore --with-expecter
 
 // AutoRefreshCache with regular GetOrCreate and Delete along with background asynchronous refresh. Caller provides
 // callbacks for create, refresh and delete item.


### PR DESCRIPTION
## Summary

This PR addresses #6815 by moving all `//go:generate mockery` comments to a centralized `.mockery.yaml` configuration file.

## Changes

- **Added `.mockery.yaml`** with all mockery definitions organized by package sections:
  - datacatalog (6 interfaces)
  - flytectl (7 packages)
  - flytepropeller (16 packages)
  - flytestdlib (5 packages)
  - flyteplugins (11 packages)
  - flyteadmin (17 packages)
  - flyteidl (3 packages)

- **Removed `//go:generate mockery`** comments from 107 Go files across the codebase

## Benefits

1. **Centralized configuration**: All mockery settings in one place
2. **Easier maintenance**: Modify mock generation settings without touching source files
3. **Consistency**: Uniform mockery options across all packages
4. **Better discoverability**: Easy to see all mocked interfaces at a glance

## Testing

Run `mockery` from the repository root to regenerate all mocks:
```bash
mockery
```

Fixes #6815

## Checklist
- [x] Added `.mockery.yaml` configuration file
- [x] Removed all `//go:generate mockery` comments
- [x] Verified no remaining mockery generate comments in codebase
