### PR TITLE
Remove ray SubmitterPodTemplate

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -562,12 +562,6 @@ func TestBuildResourceRayCustomK8SPod(t *testing.T) {
 			rayJob, ok := r.(*rayv1.RayJob)
 			assert.True(t, ok)
 
-			submitterPodResources := rayJob.Spec.SubmitterPodTemplate.Spec.Containers[0].Resources
-			assert.EqualValues(t,
-				p.expectedSubmitterResources,
-				&submitterPodResources,
-			)
-
 			headPodSpec := rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec
 			headPodResources := headPodSpec.Containers[0].Resources
 			assert.EqualValues(t,


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Remove ray SubmitterPodTemplate, and just use the default pod template from kuberay.

The problem is that if the head node uses a GPU, the submitter will also try to use a GPU and fail to get scheduled


## What changes were proposed in this pull request?
Remove ray SubmitterPodTemplate

## How was this patch tested?
Run a rayjob with GPU

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
