### PR TITLE
fix: Add deterministic error clearing for FAIL_AFTER_EXECUTABLE_NODES_COMPLETE policy

### DIFF
--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/iface.go
@@ -346,6 +346,10 @@ type MutableNodeStatus interface {
 	GetArrayNodeStatus() MutableArrayNodeStatus
 	GetOrCreateArrayNodeStatus() MutableArrayNodeStatus
 	ClearArrayNodeStatus()
+
+	// ClearExecutionError clears the execution error stored in the node status.
+	// This is used to reduce etcd state size by removing old errors when new ones occur.
+	ClearExecutionError()
 }
 
 type ExecutionTimeInfo interface {

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks/ExecutableNodeStatus.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks/ExecutableNodeStatus.go
@@ -92,6 +92,38 @@ func (_c *ExecutableNodeStatus_ClearDynamicNodeStatus_Call) RunAndReturn(run fun
 	return _c
 }
 
+// ClearExecutionError provides a mock function with no fields
+func (_m *ExecutableNodeStatus) ClearExecutionError() {
+	_m.Called()
+}
+
+// ExecutableNodeStatus_ClearExecutionError_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ClearExecutionError'
+type ExecutableNodeStatus_ClearExecutionError_Call struct {
+	*mock.Call
+}
+
+// ClearExecutionError is a helper method to define mock.On call
+func (_e *ExecutableNodeStatus_Expecter) ClearExecutionError() *ExecutableNodeStatus_ClearExecutionError_Call {
+	return &ExecutableNodeStatus_ClearExecutionError_Call{Call: _e.mock.On("ClearExecutionError")}
+}
+
+func (_c *ExecutableNodeStatus_ClearExecutionError_Call) Run(run func()) *ExecutableNodeStatus_ClearExecutionError_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ExecutableNodeStatus_ClearExecutionError_Call) Return() *ExecutableNodeStatus_ClearExecutionError_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *ExecutableNodeStatus_ClearExecutionError_Call) RunAndReturn(run func()) *ExecutableNodeStatus_ClearExecutionError_Call {
+	_c.Run(run)
+	return _c
+}
+
 // ClearGateNodeStatus provides a mock function with no fields
 func (_m *ExecutableNodeStatus) ClearGateNodeStatus() {
 	_m.Called()

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks/MutableNodeStatus.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks/MutableNodeStatus.go
@@ -90,6 +90,38 @@ func (_c *MutableNodeStatus_ClearDynamicNodeStatus_Call) RunAndReturn(run func()
 	return _c
 }
 
+// ClearExecutionError provides a mock function with no fields
+func (_m *MutableNodeStatus) ClearExecutionError() {
+	_m.Called()
+}
+
+// MutableNodeStatus_ClearExecutionError_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ClearExecutionError'
+type MutableNodeStatus_ClearExecutionError_Call struct {
+	*mock.Call
+}
+
+// ClearExecutionError is a helper method to define mock.On call
+func (_e *MutableNodeStatus_Expecter) ClearExecutionError() *MutableNodeStatus_ClearExecutionError_Call {
+	return &MutableNodeStatus_ClearExecutionError_Call{Call: _e.mock.On("ClearExecutionError")}
+}
+
+func (_c *MutableNodeStatus_ClearExecutionError_Call) Run(run func()) *MutableNodeStatus_ClearExecutionError_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MutableNodeStatus_ClearExecutionError_Call) Return() *MutableNodeStatus_ClearExecutionError_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MutableNodeStatus_ClearExecutionError_Call) RunAndReturn(run func()) *MutableNodeStatus_ClearExecutionError_Call {
+	_c.Run(run)
+	return _c
+}
+
 // ClearGateNodeStatus provides a mock function with no fields
 func (_m *MutableNodeStatus) ClearGateNodeStatus() {
 	_m.Called()

--- a/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status.go
+++ b/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/node_status.go
@@ -568,6 +568,11 @@ func (in *NodeStatus) ClearArrayNodeStatus() {
 	in.SetDirty()
 }
 
+func (in *NodeStatus) ClearExecutionError() {
+	in.Error = nil
+	in.SetDirty()
+}
+
 func (in *NodeStatus) GetLastUpdatedAt() *metav1.Time {
 	return in.LastUpdatedAt
 }


### PR DESCRIPTION
## Summary

This PR addresses the determinism concern raised by @hamersaw in #4624 regarding error clearing behavior when multiple nodes fail with `FAIL_AFTER_EXECUTABLE_NODES_COMPLETE` policy.

### The Problem

When multiple nodes fail, we want to preserve only one error to reduce etcd state size. The original implementation in #4624 would clear errors during iteration, but didn't account for the fact that Go map iteration order is non-deterministic. This could cause ALL errors to be cleared if iteration order varied between reconciliation rounds:

1. Round 1: Iterate [node-a, node-b] - clear node-a's error, keep node-b's
2. Round 2: Iterate [node-b, node-a] - node-b has error, clear it, then node-a has no error anymore

### The Solution

Add a nil check before considering a node as having a "new" failure:

```go
if nodeStatus.GetExecutionError() != nil {
    if nodeStatusWithError != nil && !c.enableCRDebugMetadata {
        nodeStatusWithError.ClearExecutionError()
    }
    nodeStatusWithError = nodeStatus
}
```

Once an error is cleared, that node won't be re-processed in subsequent rounds, ensuring determinism regardless of iteration order.

### Changes

- Add `ClearExecutionError()` method to `MutableNodeStatus` interface
- Implement `ClearExecutionError()` in `NodeStatus` struct  
- Add nil check in `handleDownstream` before error clearing
- Add comprehensive unit tests validating the deterministic behavior

## Test Plan

- [x] Unit tests for `ClearExecutionError()` method
- [x] Test that only the last error is preserved when multiple failures occur
- [x] Test that clearing already-nil errors is a no-op
- [x] All existing node controller tests pass

## Related Issues

- Fixes part of #4569 (Reduce etcd state for large workflows)
- Addresses determinism concern in #4624