### PR TITLE
Support flag in ray plugin config to optionally disable ingress for Ray cluster

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/ray/config.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/config.go
@@ -20,7 +20,7 @@ var (
 		TTLSecondsAfterFinished:  3600,
 		ServiceType:              "NodePort",
 		IncludeDashboard:         true,
-		EnableIngress:            true,
+		DisableIngress:           false,
 		DashboardHost:            "0.0.0.0",
 		EnableUsageStats:         false,
 		ServiceAccount:           "",
@@ -73,9 +73,10 @@ type Config struct {
 	// IncludeDashboard is used to start a Ray Dashboard if set to true
 	IncludeDashboard bool `json:"includeDashboard,omitempty"`
 
-	// EnableIngress controls whether KubeRay will create an Ingress for the head service.
+	// DisableIngress controls whether KubeRay will create an Ingress for the head service.
 	// Nginx ingress is now officially retired, in favor of Gateway API.
-	EnableIngress bool `json:"enableIngress,omitempty"`
+	// If true, ingress creation is disabled.
+	DisableIngress bool `json:"disableIngress,omitempty"`
 
 	// DashboardHost the host to bind the dashboard server to, either localhost (127.0.0.1)
 	// or 0.0.0.0 (available from all interfaces). By default, this is localhost.

--- a/flyteplugins/go/tasks/plugins/k8s/ray/config_flags.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/config_flags.go
@@ -54,7 +54,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.Int32(fmt.Sprintf("%v%v", prefix, "ttlSecondsAfterFinished"), defaultConfig.TTLSecondsAfterFinished, "")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "serviceType"), defaultConfig.ServiceType, "")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "includeDashboard"), defaultConfig.IncludeDashboard, "")
-	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "enableIngress"), defaultConfig.EnableIngress, "")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "disableIngress"), defaultConfig.DisableIngress, "")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "dashboardHost"), defaultConfig.DashboardHost, "")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "remoteClusterConfig.name"), defaultConfig.RemoteClusterConfig.Name, "Friendly name of the remote cluster")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "remoteClusterConfig.endpoint"), defaultConfig.RemoteClusterConfig.Endpoint, " Remote K8s cluster endpoint")

--- a/flyteplugins/go/tasks/plugins/k8s/ray/config_flags_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/config_flags_test.go
@@ -155,14 +155,14 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
-	t.Run("Test_enableIngress", func(t *testing.T) {
+	t.Run("Test_disableIngress", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := "1"
 
-			cmdFlags.Set("enableIngress", testValue)
-			if vBool, err := cmdFlags.GetBool("enableIngress"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vBool), &actual.EnableIngress)
+			cmdFlags.Set("disableIngress", testValue)
+			if vBool, err := cmdFlags.GetBool("disableIngress"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vBool), &actual.DisableIngress)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -131,7 +131,7 @@ func (rayJobResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsC
 
 func constructRayJob(taskCtx pluginsCore.TaskExecutionContext, rayJob *plugins.RayJob, objectMeta *metav1.ObjectMeta, taskPodSpec v1.PodSpec, headNodeRayStartParams map[string]string, primaryContainerIdx int, primaryContainer v1.Container) (*rayv1.RayJob, error) {
 	cfg := GetConfig()
-	enableIngress := cfg.EnableIngress
+	enableIngress := !cfg.DisableIngress
 
 	headPodSpec := taskPodSpec.DeepCopy()
 	headPodTemplate, err := buildHeadPodTemplate(


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->
- Allow disabling ingress for KubeRay according to [spec](https://ray-project.github.io/kuberay/reference/api/#headgroupspec). 
- Default of this flag changes no behavior of existing Ray cluster creation

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
- Nginx ingress is now [official retired ](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/), and some organizations now banned its usage
- Disabling this mean that the dashboard won't work, but running of Rayjob itself isn't affected

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

- Added unit test
- Built locally and tested that rayplugin still launch job, created ephemeral cluster, head and workers correctly.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
