### PR TITLE
Optimize dynamic workflow by pruning node inputs (#6888)

### DIFF
--- a/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go
@@ -201,6 +201,8 @@ func (d dynamicNodeTaskNodeHandler) buildContextualDynamicWorkflow(ctx context.C
 		return dynamicWorkflowContext{}, err
 	}
 
+	// Clear the inputs of the nodes in the dynamic workflow. This is done to avoid bloating the node event.
+	clearNodeInputs(ctx, closure.GetPrimary().GetTemplate().GetNodes())
 	if err := f.Cache(ctx, dynamicWf, closure); err != nil {
 		logger.Errorf(ctx, "Failed to cache Dynamic workflow [%s]", err.Error())
 	}
@@ -219,6 +221,19 @@ func (d dynamicNodeTaskNodeHandler) buildContextualDynamicWorkflow(ctx context.C
 		nodeLookup:         executors.NewNodeLookup(dynamicWf, dynamicNodeStatus, dynamicWf),
 		dynamicJobSpecURI:  string(f.GetLoc()),
 	}, nil
+}
+
+// This function is used to clear the inputs of the nodes in the dynamic workflow. This is done to avoid bloating the node event.
+func clearNodeInputs(ctx context.Context, nodes []*core.Node) {
+	for _, node := range nodes {
+		node.Inputs = nil
+		switch node.GetTarget().(type) {
+		case *core.Node_ArrayNode:
+			node.GetTarget().(*core.Node_ArrayNode).ArrayNode.Node.Inputs = nil
+		default:
+			logger.Debugf(ctx, "node type %T not supported for clearing inputs", node.GetTarget())
+		}
+	}
 }
 
 func (d dynamicNodeTaskNodeHandler) buildDynamicWorkflow(ctx context.Context, nCtx interfaces.NodeExecutionContext,

--- a/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow_test.go
+++ b/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow_test.go
@@ -604,3 +604,37 @@ func (e existsMetadata) Size() int64 {
 func (e existsMetadata) Etag() string {
 	return ""
 }
+func TestClearNodeInputs_WithCoreBindings(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("clear inputs for regular nodes with core bindings", func(t *testing.T) {
+		nodes := []*core.Node{
+			{Inputs: []*core.Binding{{Var: "input1"}}},
+			{Inputs: []*core.Binding{{Var: "input2"}}},
+		}
+		clearNodeInputs(ctx, nodes)
+		for _, node := range nodes {
+			assert.Nil(t, node.GetInputs())
+		}
+	})
+
+	t.Run("clear inputs for array nodes with core bindings", func(t *testing.T) {
+		nodes := []*core.Node{
+			{
+				Inputs: []*core.Binding{{Var: "input1"}},
+				Target: &core.Node_ArrayNode{
+					ArrayNode: &core.ArrayNode{
+						Node: &core.Node{Inputs: []*core.Binding{{Var: "input2"}}},
+					},
+				},
+			},
+		}
+		clearNodeInputs(ctx, nodes)
+		for _, node := range nodes {
+			assert.Nil(t, node.GetInputs())
+			if arrayNode, ok := node.GetTarget().(*core.Node_ArrayNode); ok {
+				assert.Nil(t, arrayNode.ArrayNode.GetNode().GetInputs())
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Tracking issue
Closes #6888

## Why are the changes needed?
Dynamic workflows in Flyte can fail or suffer from performance issues when the dynamic closure becomes too large, exceeding gRPC message limits (the "message too large" error). Even if execution succeeds, the Flyte UI becomes sluggish because it has to download and parse these massive blobs. This is primarily caused by the inclusion of all node inputs in the dynamic closure, which is redundant since this data is already persisted in metadata storage.

## What changes were proposed in this pull request?
1. **Pruning Logic**: Added a [clearNodeInputs](cci:1://file:///Users/vishnu/Desktop/Go_learn/flyte/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go:225:0-236:1) helper in [flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go](cci:7://file:///Users/vishnu/Desktop/Go_learn/flyte/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go:0:0-0:0) to nullify the [Inputs](cci:1://file:///Users/vishnu/Desktop/Go_learn/flyte/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go:225:0-236:1) field for nodes in the dynamic closure.
2. **Recursive Support**: The function specifically handles `ArrayNode` (Map Tasks) to ensure nested node inputs are also pruned, which are often the largest contributors to payload bloat.
3. **Integration**: Integrated the pruning step into [buildContextualDynamicWorkflow](cci:1://file:///Users/vishnu/Desktop/Go_learn/flyte/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow.go:129:0-221:1) so it triggers just before the closure is cached and sent as an event.

This effectively reduces the "blueprint" size of the dynamic workflow without affecting execution, as nodes continue to read their actual inputs from the defined storage locations.

## How was this patch tested?
Added a new test suite [TestClearNodeInputs_WithCoreBindings](cci:1://file:///Users/vishnu/Desktop/Go_learn/flyte/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow_test.go:606:0-639:1) in [flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow_test.go](cci:7://file:///Users/vishnu/Desktop/Go_learn/flyte/flytepropeller/pkg/controller/nodes/dynamic/dynamic_workflow_test.go:0:0-0:0).
- **Positive Case**: Verified that standard node inputs are set to `nil`.
- **Nested Case**: Verified that inputs inside `ArrayNode` targets are also nullified.
- **Verification Command**:
  ```bash
  go test -v ./pkg/controller/nodes/dynamic/... -run TestClearNodeInputs_WithCoreBindings