### PR TITLE
Improve make gen to avoid unnecessary file changes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -71,8 +71,29 @@ jobs:
       component: ${{ matrix.component }}
       cache_key: ${{ needs.flyteadmin-int-tests-image-build.outputs.cache_key }}
 
+  generate-filter:
+    name: Paths filter for generate
+    runs-on: ubuntu-latest
+    outputs:
+      generate: ${{ steps.filter.outputs.generate }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            generate:
+              - 'datacatalog/**'
+              - 'flyteadmin/**'
+              - 'flytecopilot/**'
+              - 'flytectl/**'
+              - 'flytepropeller/**'
+              - 'boilerplate/flyte/golang_test_targets/**'
+
   generate:
     name: Check Go Generate
+    needs: generate-filter
+    if: needs.generate-filter.outputs.generate == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/flyteidl-checks.yml
+++ b/.github/workflows/flyteidl-checks.yml
@@ -25,6 +25,21 @@ jobs:
       component: flyteidl
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  generate-filter:
+    name: Paths filter for generate
+    runs-on: ubuntu-latest
+    outputs:
+      generate: ${{ steps.filter.outputs.generate }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            generate:
+              - 'flyteidl/**'
+              - 'boilerplate/flyte/golang_test_targets/**'
+
   generate:
     name: Check Go Generate
     strategy:

--- a/.github/workflows/go_generate.yml
+++ b/.github/workflows/go_generate.yml
@@ -29,3 +29,12 @@ jobs:
           go-version-file: ${{ inputs.component }}/go.mod
       - name: Go generate and diff
         run: DELTA_CHECK=true make generate
+      - name: Verify idempotency (second run must not change anything)
+        run: |
+          make generate
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "FAILED: make generate is not idempotent (second run produced changes)."
+            git diff --name-only
+            exit 1
+          fi
+          echo "SUCCESS: make generate is idempotent."

--- a/boilerplate/flyte/golang_test_targets/go-gen.sh
+++ b/boilerplate/flyte/golang_test_targets/go-gen.sh
@@ -4,7 +4,10 @@ set -ex
 
 echo "Running go generate"
 go generate ./...
-go mod tidy
+# Only run go mod tidy when explicitly requested (avoids incidental go.sum/go.mod churn from make generate)
+if [ -n "${RUN_GO_TIDY:-}" ]; then
+  go mod tidy
+fi
 # This section is used by GitHub workflow to ensure that the generation step was run
 if [ -n "$DELTA_CHECK" ]; then
   DIRTY=$(git status --porcelain)

--- a/flyteidl/clients/go/assets/embed.go
+++ b/flyteidl/clients/go/assets/embed.go
@@ -7,6 +7,6 @@ import (
 
 // AdminSwaggerFile is the admin.swagger.json file embedded into the binary.
 //
-//go:generate cp ../../../gen/pb-go/gateway/flyteidl/service/admin.swagger.json admin.swagger.json
+//go:generate sh -c "cmp -s ../../../gen/pb-go/gateway/flyteidl/service/admin.swagger.json admin.swagger.json || cp ../../../gen/pb-go/gateway/flyteidl/service/admin.swagger.json admin.swagger.json"
 //go:embed admin.swagger.json
 var AdminSwaggerFile []byte

--- a/flyteidl/generate_protos.sh
+++ b/flyteidl/generate_protos.sh
@@ -7,15 +7,15 @@ rm -rf $DIR/gen
 # Override system locale during protos/docs generation to ensure consistent sorting (differences in system locale could e.g. lead to differently ordered docs)
 export LC_ALL=C.UTF-8
 
-# Buf migration
-docker run -u $(id -u):$(id -g) -e "BUF_CACHE_DIR=/tmp/cache" --volume "$(pwd):/workspace" --workdir /workspace bufbuild/buf generate
+# Buf migration (pinned to version tag for reproducible builds; use digest for stronger pinning)
+docker run -u $(id -u):$(id -g) -e "BUF_CACHE_DIR=/tmp/cache" --volume "$(pwd):/workspace" --workdir /workspace bufbuild/buf:v1.65.0 generate
 
 # Unfortunately the python protoc plugin does not add __init__.py files to the generated code
 # (as described in https://github.com/protocolbuffers/protobuf/issues/881). One of the
 # suggestions is to manually create such files, which is what we do here:
 find gen/pb_python -type d -exec touch {}/__init__.py \;
 
-# Generate JS code
+# Generate JS code (pinned to version tag for reproducible builds)
 docker run --rm -u $(id -u):$(id -g) -v $DIR:/defs schottra/docker-protobufjs:v0.0.2 --module-name flyteidl -d protos/flyteidl/core -d protos/flyteidl/event -d protos/flyteidl/admin -d protos/flyteidl/service -- --root flyteidl -t static-module -w default --no-delimited --force-long --no-convert -p /defs/protos
 
 # This section is used by Travis CI to ensure that the generation step was run


### PR DESCRIPTION
## Tracking issue

Related to #6845



## Why are the changes needed?

`make generate` was updating files such as `go.sum`, `go.mod`, `swagger.json`, and lockfiles even when no protobuf definitions or generation inputs changed. This resulted in unnecessary CI diffs, noisy PRs, and confusion about what actually changed. These updates ensure generation only modifies files when inputs change and that the process is deterministic and idempotent.

## What changes were proposed in this pull request?

- **Gate `go mod tidy` behind `RUN_GO_TIDY`**  
  (`boilerplate/flyte/golang_test_targets/go-gen.sh`)  
  `go mod tidy` is no longer run by default in the shared generate script.  
  It runs only when explicitly enabled (e.g. `RUN_GO_TIDY=1 make generate`).  
  Prevents incidental `go.mod` / `go.sum` churn. Tidy remains available via `make go-tidy` or the env var.

- **Add idempotency check in CI**  
  (`.github/workflows/go_generate.yml`)  
  After `DELTA_CHECK=true make generate`, CI runs `make generate` again and fails if the working tree is dirty.  
  Ensures deterministic generation and catches nondeterministic tools or environment differences.

- **Content-aware swagger copy**  
  (`flyteidl/clients/go/assets/embed.go`)  
  The swagger file is copied only if content differs (`cmp -s ... || cp ...`).  
  Prevents no-op diffs and timestamp-only changes.

- **Pin `buf` image**  
  (`flyteidl/generate_protos.sh`)  
  Updated from implicit `latest` to `bufbuild/buf:v1.65.0` for reproducible proto generation.

- **Add path filters to generate CI**  
  (`.github/workflows/checks.yml`, `.github/workflows/flyteidl-checks.yml`)  
  Generate checks run only when relevant paths change, reducing unnecessary CI runs and unrelated churn.

## How was this patch tested?

- Ran `make generate` locally in affected components and confirmed no unexpected diffs when inputs were unchanged.
- Verified `RUN_GO_TIDY=1 make generate` still runs `go mod tidy`.
- Confirmed CI idempotency step fails if the working tree becomes dirty.
- Validated path-filter behavior to ensure generate runs only when relevant files change.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.