### PR TITLE
Fix: Prevent dropping of empty string args when constructing RayJob entrypoint

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -226,6 +226,17 @@ func constructRayJob(taskCtx pluginsCore.TaskExecutionContext, rayJob *plugins.R
 		}
 	}
 
+	// We mustn't drop empty string arguments when converting from the yaml
+	// array representation of K8s container args to the single string representation
+	// of RayJobSpec's Entrypoint field.
+	//
+	// Example: ["--resolver", "ArrayNodeMapTaskResolver", "--", "vars", "", "resolver", "DefaultResolver"]
+	for i, arg := range primaryContainer.Args {
+		if arg == "" {
+			primaryContainer.Args[i] = "''"
+		}
+	}
+
 	jobSpec := rayv1.RayJobSpec{
 		RayClusterSpec:           &rayClusterSpec,
 		Entrypoint:               strings.Join(primaryContainer.Args, " "),


### PR DESCRIPTION
## Why are the changes needed?

When applying `map_task` to a normal `PythonFunctionTask`, the primary container's `args` might look like this:

```yaml
- pyflyte-map-execute
- ...
- --resolver
- flytekit.core.array_node_map_task.ArrayNodeMapTaskResolver
- --
- vars
- ""
- resolver
- ...
```

When applying the `map_task` to a ray task, this currently gets converted to:

```
pyflyte-map-execute ... --resolver flytekit.core.array_node_map_task.ArrayNodeMapTaskResolver -- vars  resolver
```

Notice the dropped `""`. This causes the following error:

```console
Traceback (most recent call last):
  File ".../flytekit/bin/entrypoint.py", line 191, in _dispatch_execute
    task_def = load_task()
  File ".../flytekit/bin/entrypoint.py", line 747, in load_task
    return mtr.load_task(loader_args=resolver_args, max_concurrency=max_concurrency)
  File ".../flytekit/core/array_node_map_task.py", line 485, in load_task
    resolver_obj = load_object_from_module(resolver)
  File ".../flytekit/tools/module_loader.py", line 51, in load_object_from_module
    class_obj_mod = importlib.import_module(".".join(class_obj_mod))
  File ".../importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ValueError: Empty module name
```

## What changes were proposed in this pull request?

We mustn't drop the empty string when converting from the yaml array to the single string representation the JayJobSpec expects.

## How was this patch tested?

- Added unit test
- Ran flytepropeller with this change and made sure that my `map_task` + ray task works

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
