### PR TITLE
Fix duplicate VolumeMounts when merging pod templates

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -851,7 +851,10 @@ func MergeBasePodSpecOntoTemplate(templatePodSpec *v1.PodSpec, basePodSpec *v1.P
 				continue
 			}
 
-			// skip containers already applied as magic templates to avoid double-merging
+			// skip "default" and "primary" magic template containers as they are already
+			// merged above. Without this guard, WithAppendSlice causes duplicate
+			// VolumeMounts / EnvVars when the base container name collides with a
+			// magic template name.
 			if templateContainer.Name == defaultContainerTemplateName || templateContainer.Name == primaryContainerTemplateName {
 				continue
 			}
@@ -909,7 +912,10 @@ func MergeBasePodSpecOntoTemplate(templatePodSpec *v1.PodSpec, basePodSpec *v1.P
 				continue
 			}
 
-			// skip containers already applied as magic templates to avoid double-merging
+			// skip "default-init" and "primary-init" magic template containers as they
+			// are already merged above. Without this guard, WithAppendSlice causes
+			// duplicate VolumeMounts / EnvVars when the base init container name
+			// collides with a magic template name.
 			if templateInitContainer.Name == defaultInitContainerTemplateName || templateInitContainer.Name == primaryInitContainerTemplateName {
 				continue
 			}

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -3543,6 +3543,95 @@ func TestMergeBasePodSpecsOntoTemplate(t *testing.T) {
 			primaryContainerName:     "task-1",
 			primaryInitContainerName: "task-init-1",
 		},
+		{
+			name: "primary container template with volume mounts does not duplicate when base container is also named primary",
+			templatePodSpec: &v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "primary",
+						Image: "default-task-image",
+						VolumeMounts: []v1.VolumeMount{
+							{Name: "shared-data", MountPath: "/mnt/shared"},
+							{Name: "scratch", MountPath: "/mnt/scratch"},
+						},
+					},
+				},
+				InitContainers: []v1.Container{
+					{
+						Name:  "primary-init",
+						Image: "default-init-image",
+						VolumeMounts: []v1.VolumeMount{
+							{Name: "init-data", MountPath: "/mnt/init"},
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{Name: "shared-data", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+					{Name: "scratch", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+					{Name: "init-data", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+				},
+			},
+			basePodSpec: &v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "primary",
+						Image: "task-image",
+						VolumeMounts: []v1.VolumeMount{
+							{Name: "shared-data1", MountPath: "/mnt/shared1"},
+							{Name: "scratch1", MountPath: "/mnt/scratch1"},
+						},
+					},
+				},
+				InitContainers: []v1.Container{
+					{
+						Name:  "primary-init",
+						Image: "task-init-image",
+						VolumeMounts: []v1.VolumeMount{
+							{Name: "init-data1", MountPath: "/mnt/init1"},
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{Name: "shared-data1", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+					{Name: "scratch1", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+					{Name: "init-data1", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+				},
+			},
+			primaryContainerName:     "primary",
+			primaryInitContainerName: "primary-init",
+			expectedResult: &v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "primary",
+						Image: "task-image",
+						VolumeMounts: []v1.VolumeMount{
+							{Name: "shared-data", MountPath: "/mnt/shared"},
+							{Name: "scratch", MountPath: "/mnt/scratch"},
+							{Name: "shared-data1", MountPath: "/mnt/shared1"},
+							{Name: "scratch1", MountPath: "/mnt/scratch1"},
+						},
+					},
+				},
+				InitContainers: []v1.Container{
+					{
+						Name:  "primary-init",
+						Image: "task-init-image",
+						VolumeMounts: []v1.VolumeMount{
+							{Name: "init-data", MountPath: "/mnt/init"},
+							{Name: "init-data1", MountPath: "/mnt/init1"},
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{Name: "shared-data", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+					{Name: "scratch", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+					{Name: "init-data", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+					{Name: "shared-data1", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+					{Name: "scratch1", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+					{Name: "init-data1", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Fix duplicate VolumeMounts when merging a task-level pod template with the executor's default pod template
- In `MergeBasePodSpecOntoTemplate`, template containers with magic names (`"primary"`, `"default"`) were being applied twice: once as a magic template and again in the name-matching loop. With `mergo.WithAppendSlice`, this caused VolumeMounts (and other slice fields) to be appended twice, producing duplicates that Kubernetes rejects
- Added guards to skip magic template containers in the name-matching loop since they are already merged earlier

## Test Plan

- Added unit test `primary_container_template_with_volume_mounts_does_not_duplicate_when_base_container_is_also_named_primary` that reproduces the exact scenario and verifies no duplicate VolumeMounts
- All existing `TestMergeBasePodSpecsOntoTemplate` tests pass

## Rollout Plan

- Standard rollout, this is a bug fix in pod template merging logic

## Rollback Plan

- Revert this PR

* `main` <!-- branch-stack -->
  - \#6583
    - \#6958 :point\_left:
