### PR TITLE
Fix: [Run Service] Ensure GetActionData works expected

### DIFF
--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -347,7 +347,7 @@ func (s *RunService) GetActionData(
 
 	// Read inputs from storage
 	if inputURI != "" {
-		inputRef := storage.DataReference(inputURI + "/inputs.pb")
+		inputRef := storage.DataReference(inputURI)
 		logger.Debugf(ctx, "Reading inputs from: %s", inputRef)
 		if err := s.dataStore.ReadProtobuf(ctx, inputRef, resp.Inputs); err != nil {
 			if !storage.IsNotFound(err) {

--- a/runs/service/run_service_test.go
+++ b/runs/service/run_service_test.go
@@ -20,15 +20,7 @@ import (
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow"
 	repoMocks "github.com/flyteorg/flyte/v2/runs/repository/mocks"
-<<<<<<< HEAD
-	proto "github.com/golang/protobuf/proto"
-
-	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
-	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
-||||||| 1ef545024
-=======
 	"github.com/flyteorg/flyte/v2/runs/repository/models"
->>>>>>> c94a9a1d1faf819f297efff0600856909120477b
 )
 
 // mockActionsClient implements actionsconnect.ActionsServiceClient for testing.
@@ -230,7 +222,6 @@ func TestGenerateRunName(t *testing.T) {
 		assert.Equal(t, name1, name2)
 	})
 }
-<<<<<<< HEAD
 
 func newStringLiteral(s string) *core.Literal {
 	return &core.Literal{Value: &core.Literal_Scalar{
@@ -320,8 +311,6 @@ func TestInputsProtoCompat(t *testing.T) {
 		assert.Empty(t, got.Context)
 	})
 }
-||||||| 1ef545024
-=======
 
 func TestCreateRun_WritesEmptyInputsProto(t *testing.T) {
 	actionRepo := &repoMocks.ActionRepo{}
@@ -378,4 +367,3 @@ func TestCreateRun_WritesEmptyInputsProto(t *testing.T) {
 	actionsClient.AssertExpectations(t)
 	store.AssertExpectations(t)
 }
->>>>>>> c94a9a1d1faf819f297efff0600856909120477b


### PR DESCRIPTION
## Tracking issue

<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

Closes #6974

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

The `GetActionData` endpoint in Run Service currently returns inputs missing the literals and context fields, which is unexpected. This PR fixes the issue #6974 .

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

**Key Changes:**

- Fix the read path in `GetActionData` to match the write path used during storage.
- In `CreateRun`, store the full `task.Inputs` (which preserves both literals and context) instead of only `task.Inputs.Literals`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

This PR changes how `task.Inputs` is written and read: previously, `task.Inputs` was stored and read as a `core.LiteralMap`, preserving only literals. Now, the full `task.Inputs` is stored and read directly, preserving both literals and context.
To ensure backward compatibility between the old and new formats, the following wire-compatibility tests were added in `run_service_test.go`:

- `task.Inputs` written → read as `task.Inputs`
- `task.Inputs` written → read as `core.LiteralMap`
- `core.LiteralMap` written → read as `task.Inputs`

### Labels

- **changed**: For changes in existing functionality.
- **fixed**: For any bug fixed.

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->

- `main` <!-- branch-stack -->
  - \#6583
    - **Fix: \[Run Service] Ensure GetActionData works expected** :point\_left:
