### PR TITLE
update minio image to support multi-architectures

### DIFF
--- a/docker/sandbox-bundled/Makefile
+++ b/docker/sandbox-bundled/Makefile
@@ -26,8 +26,7 @@ flyte: create_builder
 
 .PHONY: dep_update
 dep_update:
-	helm dependency update ../../charts/flyte-binary
-	helm dependency update ../../charts/flyte-sandbox
+	cd ../../charts/flyte-sandbox/charts && for f in *.tgz; do tar xzf "$$f"; done
 
 .PHONY: manifests
 manifests: dep_update

--- a/docker/sandbox-bundled/images/manifest.txt
+++ b/docker/sandbox-bundled/images/manifest.txt
@@ -1,5 +1,5 @@
 docker.io/bitnami/os-shell:sandbox=bitnamilegacy/os-shell:11-debian-11
-docker.io/bitnami/minio:sandbox=bitnamilegacy/minio:2023.1.25-debian-11-r0
+docker.io/bitnami/minio:sandbox=minio/minio:RELEASE.2024-01-31T20-20-33Z
 docker.io/bitnami/postgresql:sandbox=bitnamilegacy/postgresql:15.1.0-debian-11-r20
 docker.io/envoyproxy/envoy:sandbox=envoyproxy/envoy:v1.23-latest
 docker.io/kubernetesui/dashboard:sandbox=kubernetesui/dashboard:v2.7.0

--- a/docker/sandbox-bundled/kustomize/complete/kustomization.yaml
+++ b/docker/sandbox-bundled/kustomize/complete/kustomization.yaml
@@ -72,3 +72,4 @@ patches:
     - op: add
       path: /metadata/namespace
       value: flyte
+- path: ../minio-patch.yaml

--- a/docker/sandbox-bundled/kustomize/dev/kustomization.yaml
+++ b/docker/sandbox-bundled/kustomize/dev/kustomization.yaml
@@ -78,3 +78,4 @@ patches:
     - op: add
       path: /metadata/namespace
       value: flyte
+- path: ../minio-patch.yaml

--- a/docker/sandbox-bundled/kustomize/minio-patch.yaml
+++ b/docker/sandbox-bundled/kustomize/minio-patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flyte-sandbox-minio
+  namespace: flyte
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: volume-permissions
+        command:
+        - /bin/bash
+        - -ec
+        - |
+          chown -R 1001:1001 /data
+          mkdir -p /data/flyte-data
+          chown 1001:1001 /data/flyte-data
+      containers:
+      - name: minio
+        command:
+        - minio
+        - server
+        - /data
+        - --console-address
+        - :9001

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -1662,8 +1662,6 @@ spec:
         helm.sh/chart: minio-12.6.7
     spec:
       affinity:
-        nodeAffinity: null
-        podAffinity: null
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
@@ -1674,7 +1672,13 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 1
       containers:
-      - env:
+      - command:
+        - minio
+        - server
+        - /data
+        - --console-address
+        - :9001
+        env:
         - name: BITNAMI_DEBUG
           value: "false"
         - name: MINIO_SCHEME
@@ -1701,7 +1705,6 @@ spec:
           value: "9001"
         - name: MINIO_BROWSER_REDIRECT_URL
           value: http://localhost:30080/minio
-        envFrom: null
         image: docker.io/bitnami/minio:sandbox
         imagePullPolicy: Never
         livenessProbe:
@@ -1745,6 +1748,8 @@ spec:
         - -ec
         - |
           chown -R 1001:1001 /data
+          mkdir -p /data/flyte-data
+          chown 1001:1001 /data/flyte-data
         image: docker.io/bitnami/os-shell:sandbox
         imagePullPolicy: Never
         name: volume-permissions

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -1334,8 +1334,6 @@ spec:
         helm.sh/chart: minio-12.6.7
     spec:
       affinity:
-        nodeAffinity: null
-        podAffinity: null
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
@@ -1346,7 +1344,13 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 1
       containers:
-      - env:
+      - command:
+        - minio
+        - server
+        - /data
+        - --console-address
+        - :9001
+        env:
         - name: BITNAMI_DEBUG
           value: "false"
         - name: MINIO_SCHEME
@@ -1373,7 +1377,6 @@ spec:
           value: "9001"
         - name: MINIO_BROWSER_REDIRECT_URL
           value: http://localhost:30080/minio
-        envFrom: null
         image: docker.io/bitnami/minio:sandbox
         imagePullPolicy: Never
         livenessProbe:
@@ -1417,6 +1420,8 @@ spec:
         - -ec
         - |
           chown -R 1001:1001 /data
+          mkdir -p /data/flyte-data
+          chown 1001:1001 /data/flyte-data
         image: docker.io/bitnami/os-shell:sandbox
         imagePullPolicy: Never
         name: volume-permissions


### PR DESCRIPTION
## Why are the changes needed?

The minio image fails to load for arm64 architectures

## What changes were proposed in this pull request?

- Used a native arm64 minio image: docker.io/bitnami/minio:sandbox=minio/minio:RELEASE.2024-01-31T20-20-33Z
- Replaced helm dependency update with local extraction: +cd ../../charts/flyte-sandbox/charts && for f in \*.tgz; do tar xzf "$$f"; done
  \- helm dependency update re-downloads subchart .tgz files from their declared repositories.
- kustomize/minio-patch.yaml + kustomization updates - adapt the deployment for minio

## How was this patch tested?

- ran the sandbox build and run. Confirmed that the minio pod is running

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->

- `main` <!-- branch-stack -->
  - \#6583
    - \#7027 :point\_left:
