### PR TITLE
Add log links to task template

### DIFF
--- a/flyteplugins/go/tasks/logs/logging_utils.go
+++ b/flyteplugins/go/tasks/logs/logging_utils.go
@@ -96,10 +96,21 @@ func (t templateLogPluginCollection) GetTaskLogs(input tasklog.Input) (tasklog.O
 }
 
 // InitializeLogPlugins initializes log plugin based on config.
-func InitializeLogPlugins(cfg *LogConfig) (tasklog.Plugin, error) {
+func InitializeLogPlugins(cfg *LogConfig, taskTemplate *core.TaskTemplate) (tasklog.Plugin, error) {
 	// Use a list to maintain order.
 	var plugins []tasklog.Plugin
 	var dynamicPlugins []tasklog.Plugin
+
+	// If the task template has log links, prepend them as TemplateLogPlugin entries.
+	if taskTemplate != nil && taskTemplate.GetMetadata() != nil {
+		for _, logLink := range taskTemplate.GetMetadata().GetLogLinks() {
+			plugins = append(plugins, tasklog.TemplateLogPlugin{
+				DisplayName:  logLink.GetName(),
+				TemplateURIs: []tasklog.TemplateURI{logLink.GetUri()},
+				IconUri:      logLink.GetIconUri(),
+			})
+		}
+	}
 
 	if cfg.IsKubernetesEnabled {
 		if len(cfg.KubernetesTemplateURI) > 0 {

--- a/flyteplugins/go/tasks/logs/logging_utils_test.go
+++ b/flyteplugins/go/tasks/logs/logging_utils_test.go
@@ -42,7 +42,7 @@ func dummyTaskExecID() pluginCore.TaskExecutionID {
 }
 
 func TestGetLogsForContainerInPod_NoPlugins(t *testing.T) {
-	logPlugin, err := InitializeLogPlugins(&LogConfig{})
+	logPlugin, err := InitializeLogPlugins(&LogConfig{}, nil)
 	assert.NoError(t, err)
 	l, err := GetLogsForContainerInPod(context.TODO(), logPlugin, dummyTaskExecID(), nil, 0, " Suffix", nil, nil)
 	assert.NoError(t, err)
@@ -54,7 +54,7 @@ func TestGetLogsForContainerInPod_NoLogs(t *testing.T) {
 		IsCloudwatchEnabled: true,
 		CloudwatchRegion:    "us-east-1",
 		CloudwatchLogGroup:  "/kubernetes/flyte-production",
-	})
+	}, nil)
 	assert.NoError(t, err)
 	p, err := GetLogsForContainerInPod(context.TODO(), logPlugin, dummyTaskExecID(), nil, 0, " Suffix", nil, nil)
 	assert.NoError(t, err)
@@ -66,7 +66,7 @@ func TestGetLogsForContainerInPod_BadIndex(t *testing.T) {
 		IsCloudwatchEnabled: true,
 		CloudwatchRegion:    "us-east-1",
 		CloudwatchLogGroup:  "/kubernetes/flyte-production",
-	})
+	}, nil)
 	assert.NoError(t, err)
 
 	pod := &v1.Pod{
@@ -97,7 +97,7 @@ func TestGetLogsForContainerInPod_BadIndex_WithoutStatus(t *testing.T) {
 		IsCloudwatchEnabled: true,
 		CloudwatchRegion:    "us-east-1",
 		CloudwatchLogGroup:  "/kubernetes/flyte-production",
-	})
+	}, nil)
 	assert.NoError(t, err)
 
 	pod := &v1.Pod{
@@ -121,7 +121,7 @@ func TestGetLogsForContainerInPod_MissingStatus(t *testing.T) {
 		IsCloudwatchEnabled: true,
 		CloudwatchRegion:    "us-east-1",
 		CloudwatchLogGroup:  "/kubernetes/flyte-production",
-	})
+	}, nil)
 	assert.NoError(t, err)
 
 	pod := &v1.Pod{
@@ -145,7 +145,7 @@ func TestGetLogsForContainerInPod_Cloudwatch(t *testing.T) {
 	logPlugin, err := InitializeLogPlugins(&LogConfig{IsCloudwatchEnabled: true,
 		CloudwatchRegion:   "us-east-1",
 		CloudwatchLogGroup: "/kubernetes/flyte-production",
-	})
+	}, nil)
 	assert.NoError(t, err)
 
 	pod := &v1.Pod{
@@ -181,7 +181,7 @@ func TestGetLogsForContainerInPod_K8s(t *testing.T) {
 				MessageFormat: core.TaskLog_JSON,
 			},
 		},
-	})
+	}, nil)
 	assert.NoError(t, err)
 
 	pod := &v1.Pod{
@@ -220,7 +220,7 @@ func TestGetLogsForContainerInPod_All(t *testing.T) {
 		IsCloudwatchEnabled: true,
 		CloudwatchRegion:    "us-east-1",
 		CloudwatchLogGroup:  "/kubernetes/flyte-production",
-	})
+	}, nil)
 	assert.NoError(t, err)
 
 	pod := &v1.Pod{
@@ -253,7 +253,7 @@ func TestGetLogsForContainerInPod_HostName(t *testing.T) {
 		IsCloudwatchEnabled: true,
 		CloudwatchRegion:    "us-east-1",
 		CloudwatchLogGroup:  "/kubernetes/flyte-production",
-	})
+	}, nil)
 	assert.NoError(t, err)
 
 	pod := &v1.Pod{
@@ -285,7 +285,7 @@ func TestGetLogsForContainerInPod_Stackdriver(t *testing.T) {
 		IsStackDriverEnabled:       true,
 		GCPProjectName:             "myGCPProject",
 		StackdriverLogResourceName: "aws_ec2_instance",
-	})
+	}, nil)
 	assert.NoError(t, err)
 
 	pod := &v1.Pod{
@@ -360,7 +360,7 @@ func TestGetLogsForContainerInPod_LegacyTemplate(t *testing.T) {
 }
 
 func assertTestSucceeded(tb testing.TB, config *LogConfig, taskTemplate *core.TaskTemplate, expectedTaskLogs []*core.TaskLog, hostname string) {
-	logPlugin, err := InitializeLogPlugins(config)
+	logPlugin, err := InitializeLogPlugins(config, nil)
 	assert.NoError(tb, err)
 
 	pod := &v1.Pod{

--- a/flyteplugins/go/tasks/pluginmachinery/tasklog/plugin.go
+++ b/flyteplugins/go/tasks/pluginmachinery/tasklog/plugin.go
@@ -68,4 +68,5 @@ type TemplateLogPlugin struct {
 	ShowWhilePending bool           `json:"showWhilePending" pflag:",If true, the log link will be shown even if the task is in a pending state."`
 	HideOnceFinished bool           `json:"hideOnceFinished" pflag:",If true, the log link will be hidden once the task has finished."`
 	LinkType         string         `json:"linkType" pflag:",Type of the log. (external, dashboard, or ide). This is used to distinguish between different log links."`
+	IconUri          string         `json:"iconUri" pflag:",Icon URI for the log link."`
 }

--- a/flyteplugins/go/tasks/plugins/k8s/dask/dask.go
+++ b/flyteplugins/go/tasks/plugins/k8s/dask/dask.go
@@ -304,7 +304,11 @@ func createJobSpec(workerSpec daskAPI.WorkerSpec, schedulerSpec daskAPI.Schedule
 }
 
 func (p daskResourceHandler) GetTaskPhase(ctx context.Context, pluginContext k8s.PluginContext, r client.Object) (pluginsCore.PhaseInfo, error) {
-	logPlugin, err := logs.InitializeLogPlugins(&GetConfig().Logs)
+	taskTemplate, err := pluginContext.TaskReader().Read(ctx)
+	if err != nil {
+		return pluginsCore.PhaseInfoUndefined, err
+	}
+	logPlugin, err := logs.InitializeLogPlugins(&GetConfig().Logs, taskTemplate)
 	if err != nil {
 		return pluginsCore.PhaseInfoUndefined, err
 	}

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator.go
@@ -98,7 +98,7 @@ func GetLogs(pluginContext k8s.PluginContext, taskType string, objectMeta meta_v
 	taskLogs := make([]*core.TaskLog, 0, 10)
 	taskExecID := pluginContext.TaskExecutionMetadata().GetTaskExecutionID()
 
-	logPlugin, err := logs.InitializeLogPlugins(logs.GetLogConfig())
+	logPlugin, err := logs.InitializeLogPlugins(logs.GetLogConfig(), taskTemplate)
 
 	if err != nil {
 		return nil, err

--- a/flyteplugins/go/tasks/plugins/k8s/pod/plugin.go
+++ b/flyteplugins/go/tasks/plugins/k8s/pod/plugin.go
@@ -172,7 +172,11 @@ func (p plugin) BuildResource(ctx context.Context, taskCtx pluginsCore.TaskExecu
 }
 
 func (p plugin) GetTaskPhase(ctx context.Context, pluginContext k8s.PluginContext, r client.Object) (pluginsCore.PhaseInfo, error) {
-	logPlugin, err := logs.InitializeLogPlugins(logs.GetLogConfig())
+	taskTemplate, err := pluginContext.TaskReader().Read(ctx)
+	if err != nil {
+		return pluginsCore.PhaseInfoUndefined, err
+	}
+	logPlugin, err := logs.InitializeLogPlugins(logs.GetLogConfig(), taskTemplate)
 	if err != nil {
 		return pluginsCore.PhaseInfoUndefined, err
 	}

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -586,7 +586,11 @@ func (rayJobResourceHandler) BuildIdentityResource(ctx context.Context, taskCtx 
 }
 
 func getEventInfoForRayJob(ctx context.Context, logConfig logs.LogConfig, pluginContext k8s.PluginContext, rayJob *rayv1.RayJob) (*pluginsCore.TaskInfo, error) {
-	logPlugin, err := logs.InitializeLogPlugins(&logConfig)
+	taskTemplate, err := pluginContext.TaskReader().Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read task template. Error: %w", err)
+	}
+	logPlugin, err := logs.InitializeLogPlugins(&logConfig, taskTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize log plugins. Error: %w", err)
 	}

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -896,6 +896,10 @@ func newPluginContext(pluginState k8s.PluginState) *k8smocks.PluginContext {
 
 	plg.EXPECT().PluginStateReader().Return(&pluginStateReaderMock)
 
+	taskReader := &mocks.TaskReader{}
+	taskReader.EXPECT().Read(mock.Anything).Return(&core.TaskTemplate{}, nil)
+	plg.EXPECT().TaskReader().Return(taskReader)
+
 	return plg
 }
 

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -369,6 +369,10 @@ func (sparkResourceHandler) BuildIdentityResource(ctx context.Context, taskCtx p
 }
 
 func getEventInfoForSpark(ctx context.Context, pluginContext k8s.PluginContext, sj *sparkOp.SparkApplication) (*pluginsCore.TaskInfo, error) {
+	taskTemplate, err := pluginContext.TaskReader().Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read task template: %w", err)
+	}
 
 	sparkConfig := GetSparkConfig()
 	taskLogs := make([]*core.TaskLog, 0, 3)
@@ -376,7 +380,7 @@ func getEventInfoForSpark(ctx context.Context, pluginContext k8s.PluginContext, 
 	taskExecID := pluginContext.TaskExecutionMetadata().GetTaskExecutionID()
 
 	if sj.Status.DriverInfo.PodName != "" {
-		p, err := logs.InitializeLogPlugins(&sparkConfig.LogConfig.Mixed)
+		p, err := logs.InitializeLogPlugins(&sparkConfig.LogConfig.Mixed, taskTemplate)
 		if err != nil {
 			return nil, err
 		}
@@ -397,7 +401,7 @@ func getEventInfoForSpark(ctx context.Context, pluginContext k8s.PluginContext, 
 		}
 	}
 
-	p, err := logs.InitializeLogPlugins(&sparkConfig.LogConfig.User)
+	p, err := logs.InitializeLogPlugins(&sparkConfig.LogConfig.User, taskTemplate)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +445,7 @@ func getEventInfoForSpark(ctx context.Context, pluginContext k8s.PluginContext, 
 		}
 	}
 
-	p, err = logs.InitializeLogPlugins(&sparkConfig.LogConfig.System)
+	p, err = logs.InitializeLogPlugins(&sparkConfig.LogConfig.System, taskTemplate)
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +464,7 @@ func getEventInfoForSpark(ctx context.Context, pluginContext k8s.PluginContext, 
 		taskLogs = append(taskLogs, o.TaskLogs...)
 	}
 
-	p, err = logs.InitializeLogPlugins(&sparkConfig.LogConfig.AllUser)
+	p, err = logs.InitializeLogPlugins(&sparkConfig.LogConfig.AllUser, taskTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
@@ -285,7 +285,7 @@ func (p *Plugin) Delete(ctx context.Context, taskCtx webapi.DeleteContext) error
 }
 
 func (p *Plugin) getEventInfoForConnectorApp(taskCtx webapi.StatusContext, resource ResourceWrapper) ([]*flyteIdl.TaskLog, error) {
-	logPlugin, err := logs.InitializeLogPlugins(&p.cfg.Logs)
+	logPlugin, err := logs.InitializeLogPlugins(&p.cfg.Logs, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize log plugins with error: %v", err)
 	}


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?

When a task template has `log_links` in its metadata, those links should be passed through to the log plugin system so they appear in the UI. This enables task authors to attach custom log links (e.g., to external monitoring systems) directly to task templates.

## What changes were proposed in this pull request?

- Add `taskTemplate *core.TaskTemplate` as a second parameter to `InitializeLogPlugins`
- When the task template has `log_links` in its metadata, prepend them as `TemplateLogPlugin` entries
- Add `IconUri` field to `TemplateLogPlugin` struct
- Update all callers of `InitializeLogPlugins` across dask, kfoperators, pod, ray, spark, and connector plugins to pass the task template (or `nil` where unavailable)
- Update tests accordingly

## How was this patch tested?

- All existing tests pass: `go test ./flyteplugins/...`
- `go vet ./flyteplugins/...` passes cleanly
- `go build ./flyteplugins/...` compiles successfully

### Labels

- **added**: New feature for task template log links pass-through

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- `main` <!-- branch-stack -->
  - \#6583
    - \#7030 :point\_left:
