### PR TITLE
Fix problems including missing charts and the kubeconfig permission

### DIFF
--- a/docker/sandbox-bundled/Makefile
+++ b/docker/sandbox-bundled/Makefile
@@ -26,9 +26,9 @@ flyte: create_builder
 
 .PHONY: helm-repos
 helm-repos:
-	helm repo add docker-registry https://twuni.github.io/docker-registry.helm || true
-	helm repo add kubernetes-dashboard https://kubernetes-retired.github.io/dashboard/ || true
-	helm repo add bitnami https://charts.bitnami.com/bitnami || true
+	helm repo add docker-registry https://twuni.github.io/docker-registry.helm
+	helm repo add kubernetes-dashboard https://kubernetes-retired.github.io/dashboard/
+	helm repo add bitnami https://charts.bitnami.com/bitnami
 	helm repo update
 
 .PHONY: dep_build


### PR DESCRIPTION
## Tracking issue
#Close #7032

## Why are the changes needed?

- Environment: wsl ubuntu

1. Fix `make sandbox-build` failure caused by missing directory.
<img width="705" height="158" alt="image" src="https://github.com/user-attachments/assets/6d1a59a7-1e47-4607-a26f-f809769b3381" />

2. Update permission of kubeconfig from k3s in order to execute `make sandbox-run` command to copy it.
<img width="821" height="327" alt="image" src="https://github.com/user-attachments/assets/6a989fa4-67b0-4c10-b915-d7faf72135ea" />

## What changes were proposed in this pull request?
1. `helm dependency update` creates charts and downloads  related tar if missing directory or empty directory happens
2. Update the group and user of kubeconfig to allow make command to copy it.

## How was this patch tested?
1. git clone https://github.com/flyteorg/flyte.git -b  `<this pr branch>`
2. cd flyte
3. make sandbox-build
4. make sandbox-run
5. export KUBECONFIG=~/.flyte/sandboxv2/kubeconfig
6. kubectl get pods -A or k9s

### Labels
- **fixed**

### Setup process

### Screenshots
<img width="1014" height="655" alt="image" src="https://github.com/user-attachments/assets/e81a24bd-dae2-43fd-bb1c-e202942d4e66" />


- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
