### PR TITLE
fix(propeller): treat K8s BadRequest/Invalid as permanent failure instead of retrying

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -261,7 +261,7 @@ func (e *PluginManager) launchResource(ctx context.Context, tCtx pluginsCore.Tas
 			return pluginsCore.DoTransition(pluginsCore.PhaseInfoRetryableFailure("RuntimeFailure", err.Error(), nil)), nil
 		} else if k8serrors.IsBadRequest(err) || k8serrors.IsInvalid(err) {
 			logger.Errorf(ctx, "Badly formatted resource for plugin [%s], err %s", e.id, err)
-			// return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("BadTaskFormat", err.Error(), nil)), nil
+			return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("BadTaskFormat", err.Error(), nil)), nil
 		} else if k8serrors.IsRequestEntityTooLargeError(err) {
 			logger.Errorf(ctx, "Badly formatted resource for plugin [%s], err %s", e.id, err)
 			return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("EntityTooLarge", err.Error(), nil)), nil

--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager_test.go
@@ -408,6 +408,32 @@ func TestK8sTaskExecutor_Handle_LaunchResource(t *testing.T) {
 		assert.True(t, k8serrors.IsNotFound(err))
 	})
 
+	t.Run("jobBadRequest", func(t *testing.T) {
+		tctx := getMockTaskContext(PluginPhaseNotStarted, PluginPhaseNotStarted)
+		mockResourceHandler := &pluginsk8sMock.Plugin{}
+		mockResourceHandler.EXPECT().GetProperties().Return(k8s.PluginProperties{})
+		mockResourceHandler.EXPECT().BuildResource(mock.Anything, mock.Anything).Return(&v1.Pod{}, nil)
+		fakeClient := extendedFakeClient{
+			Client:      fake.NewClientBuilder().WithRuntimeObjects().Build(),
+			CreateError: k8serrors.NewBadRequest("admission webhook denied the request"),
+		}
+		mockClientset := k8sfake.NewSimpleClientset()
+
+		pluginManager, err := NewPluginManager(ctx, dummySetupContext(fakeClient), k8s.PluginEntry{
+			ID:              "x",
+			ResourceToWatch: &v1.Pod{},
+			Plugin:          mockResourceHandler,
+		}, NewResourceMonitorIndex(), mockClientset)
+		assert.NoError(t, err)
+
+		transition, err := pluginManager.Handle(ctx, tctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, transition)
+		transitionInfo := transition.Info()
+		assert.NotNil(t, transitionInfo)
+		assert.Equal(t, pluginsCore.PhasePermanentFailure, transitionInfo.Phase())
+	})
+
 	t.Run("Insufficient resource blocking pod creation for the first time", func(t *testing.T) {
 		tctx := getMockTaskContext(PluginPhaseNotStarted, PluginPhaseNotStarted)
 		var tmpl *core.TaskTemplate


### PR DESCRIPTION
## Summary

- Uncomment the `PhaseInfoFailure` return for `BadRequest`/`Invalid` K8s errors in `plugin_manager.go` so they are treated as permanent failures instead of being retried indefinitely

## Problem

When a Kubernetes API server returns a `BadRequest` (400) or `Invalid` (422) error during resource creation (e.g., an admission webhook rejection), FlytePropeller logs the error but falls through to the generic system error handler. This causes the task to be retried indefinitely, wasting resources and delaying user feedback.

The return statement on line 264 was commented out:
```go
} else if k8serrors.IsBadRequest(err) || k8serrors.IsInvalid(err) {
    logger.Errorf(ctx, "Badly formatted resource for plugin [%s], err %s", e.id, err)
    // return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("BadTaskFormat", err.Error(), nil)), nil
}
```

Without the return, execution falls through to line 271 which wraps the error as a generic system error and returns `UnknownTransition`, causing infinite retries.

## Root Cause

The sibling code in `flyteplugins/go/tasks/plugins/array/k8s/subtask.go` handles the same case correctly (uncommented), confirming this was an oversight.

## Fix

Uncomment the return statement so `BadRequest`/`Invalid` errors immediately transition to `PhasePermanentFailure` with a clear `"BadTaskFormat"` reason. Added a unit test (`jobBadRequest`) that verifies the fix.

## Testing

- Added `TestK8sTaskExecutor_Handle_LaunchResource/jobBadRequest` test that creates a fake client returning `k8serrors.NewBadRequest(...)` and verifies the transition phase is `PhasePermanentFailure`
- Existing tests remain unchanged

Closes #6531