### PR TITLE
fix(webhook): replace invalid namespaced owner reference with labels

### DIFF
--- a/flytepropeller/cmd/controller/cmd/webhook.go
+++ b/flytepropeller/cmd/controller/cmd/webhook.go
@@ -34,9 +34,8 @@ In order to use this Webhook:
 1) Keys need to be mounted to the POD that runs this command; tls.crt should be a CA-issued cert (not a self-signed 
    cert), tls.key as the private key for that cert and, optionally, ca.crt in case tls.crt's CA is not a known 
    Certificate Authority (e.g. in case ca.crt is self-issued).
-2) POD_NAME and POD_NAMESPACE environment variables need to be populated because the webhook initialization will lookup
-   this pod to copy OwnerReferences into the new MutatingWebhookConfiguration object it'll create to ensure proper
-   cleanup.
+2) POD_NAME and POD_NAMESPACE environment variables need to be populated because the webhook initialization will add
+   labels to the new MutatingWebhookConfiguration object it creates for tracking and identification.
 
 A sample Container for this webhook might look like this:
 

--- a/flytepropeller/pkg/webhook/entrypoint.go
+++ b/flytepropeller/pkg/webhook/entrypoint.go
@@ -59,7 +59,7 @@ func Run(ctx context.Context, propellerCfg *config.Config, cfg *config2.Config,
 	return nil
 }
 
-func createMutationConfig(ctx context.Context, kubeClient *kubernetes.Clientset, webhookObj *PodMutator, defaultNamespace string) error {
+func createMutationConfig(ctx context.Context, kubeClient kubernetes.Interface, webhookObj *PodMutator, defaultNamespace string) error {
 	shouldAddLabels := true
 	podName, found := os.LookupEnv(PodNameEnvVar)
 	if !found {

--- a/flytepropeller/pkg/webhook/entrypoint.go
+++ b/flytepropeller/pkg/webhook/entrypoint.go
@@ -60,15 +60,15 @@ func Run(ctx context.Context, propellerCfg *config.Config, cfg *config2.Config,
 }
 
 func createMutationConfig(ctx context.Context, kubeClient *kubernetes.Clientset, webhookObj *PodMutator, defaultNamespace string) error {
-	shouldAddOwnerRef := true
+	shouldAddLabels := true
 	podName, found := os.LookupEnv(PodNameEnvVar)
 	if !found {
-		shouldAddOwnerRef = false
+		shouldAddLabels = false
 	}
 
 	podNamespace, found := os.LookupEnv(PodNamespaceEnvVar)
 	if !found {
-		shouldAddOwnerRef = false
+		shouldAddLabels = false
 		podNamespace = defaultNamespace
 	}
 
@@ -77,15 +77,13 @@ func createMutationConfig(ctx context.Context, kubeClient *kubernetes.Clientset,
 		return err
 	}
 
-	if shouldAddOwnerRef {
-		// Lookup the pod to retrieve its UID
-		p, err := kubeClient.CoreV1().Pods(podNamespace).Get(ctx, podName, v1.GetOptions{})
-		if err != nil {
-			logger.Infof(ctx, "Failed to get Pod [%v/%v]. Error: %v", podNamespace, podName, err)
-			return fmt.Errorf("failed to get pod. Error: %w", err)
+	if shouldAddLabels {
+		if mutateConfig.Labels == nil {
+			mutateConfig.Labels = make(map[string]string)
 		}
-
-		mutateConfig.OwnerReferences = p.OwnerReferences
+		mutateConfig.Labels["app.kubernetes.io/managed-by"] = "flyte-pod-webhook"
+		mutateConfig.Labels["flyte.org/webhook-pod-name"] = podName
+		mutateConfig.Labels["flyte.org/webhook-pod-namespace"] = podNamespace
 	}
 
 	logger.Infof(ctx, "Creating MutatingWebhookConfiguration [%v/%v]", mutateConfig.GetNamespace(), mutateConfig.GetName())

--- a/flytepropeller/pkg/webhook/entrypoint_test.go
+++ b/flytepropeller/pkg/webhook/entrypoint_test.go
@@ -1,0 +1,74 @@
+package webhook
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	latest "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/flyteorg/flyte/flytepropeller/pkg/webhook/config"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+)
+
+func Test_createMutationConfig(t *testing.T) {
+	pm := NewPodMutator(&config.Config{
+		CertDir:     "testdata",
+		ServiceName: "my-service",
+	}, latest.Scheme, promutils.NewTestScope())
+
+	t.Run("Labels set when both env vars present", func(t *testing.T) {
+		t.Setenv(PodNameEnvVar, "test-pod")
+		t.Setenv(PodNamespaceEnvVar, "")
+
+		kubeClient := fake.NewSimpleClientset()
+		err := createMutationConfig(context.Background(), kubeClient, pm, "")
+		assert.NoError(t, err)
+
+		cfgList, err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Len(t, cfgList.Items, 1)
+
+		labels := cfgList.Items[0].Labels
+		assert.Equal(t, "flyte-pod-webhook", labels["app.kubernetes.io/managed-by"])
+		assert.Equal(t, "test-pod", labels["flyte.org/webhook-pod-name"])
+		assert.Equal(t, "", labels["flyte.org/webhook-pod-namespace"])
+	})
+
+	t.Run("No labels when POD_NAME not set", func(t *testing.T) {
+		os.Unsetenv(PodNameEnvVar)
+		os.Unsetenv(PodNamespaceEnvVar)
+
+		kubeClient := fake.NewSimpleClientset()
+		err := createMutationConfig(context.Background(), kubeClient, pm, "")
+		assert.NoError(t, err)
+
+		cfgList, err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Len(t, cfgList.Items, 1)
+
+		labels := cfgList.Items[0].Labels
+		assert.Empty(t, labels["app.kubernetes.io/managed-by"])
+		assert.Empty(t, labels["flyte.org/webhook-pod-name"])
+	})
+
+	t.Run("No labels when POD_NAMESPACE not set", func(t *testing.T) {
+		t.Setenv(PodNameEnvVar, "test-pod")
+		os.Unsetenv(PodNamespaceEnvVar)
+
+		kubeClient := fake.NewSimpleClientset()
+		err := createMutationConfig(context.Background(), kubeClient, pm, "")
+		assert.NoError(t, err)
+
+		cfgList, err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Len(t, cfgList.Items, 1)
+
+		labels := cfgList.Items[0].Labels
+		assert.Empty(t, labels["app.kubernetes.io/managed-by"])
+		assert.Empty(t, labels["flyte.org/webhook-pod-name"])
+	})
+}


### PR DESCRIPTION
## Summary

- Replace invalid namespaced `OwnerReferences` on the cluster-scoped `MutatingWebhookConfiguration` with labels for pod identification

## Problem

The `flyte-pod-webhook` initialization copies the pod's `OwnerReferences` onto the `MutatingWebhookConfiguration` object. Since `MutatingWebhookConfiguration` is cluster-scoped and the pod is namespaced, this violates Kubernetes rules:

> Cluster-scoped dependents can only specify cluster-scoped owners. In v1.20+, if a cluster-scoped dependent specifies a namespaced kind as an owner, it is treated as having an unresolvable owner reference, and is not able to be garbage collected.

Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owner-references-in-object-specifications

This means the webhook configuration is never garbage collected on uninstall, leaving orphaned resources.

## Fix

Replace the `OwnerReferences` copy with labels:
- `app.kubernetes.io/managed-by: flyte-pod-webhook`
- `flyte.org/webhook-pod-name: <pod-name>`
- `flyte.org/webhook-pod-namespace: <pod-namespace>`

This preserves the tracking/identification capability without violating the cluster-scoped/namespaced boundary. The pod lookup (which was only needed to get OwnerReferences) is removed, simplifying the initialization path.

## Testing

- Verified the `MutatingWebhookConfiguration` no longer receives invalid `OwnerReferences`
- Labels are set correctly when `POD_NAME` and `POD_NAMESPACE` env vars are present
- When env vars are absent, behavior is unchanged (no labels added)

Closes #6692