### PR TITLE
fix(propeller): use configured GPU resource name instead of hardcoded nvidia.com/gpu

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/taskexec_context.go
+++ b/flytepropeller/pkg/controller/nodes/task/taskexec_context.go
@@ -13,6 +13,7 @@ import (
 	pluginCatalog "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/catalog"
 	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/encoding"
+	k8sConfig "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
@@ -21,7 +22,6 @@ import (
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/errors"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/interfaces"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/resourcemanager"
-	"github.com/flyteorg/flyte/flytepropeller/pkg/utils"
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 	"github.com/flyteorg/flyte/flytestdlib/storage"
 )
@@ -192,21 +192,21 @@ func assignResource(resourceName v1.ResourceName, execConfigRequest, execConfigL
 }
 
 func convertTaskResourcesToRequirements(taskResources v1alpha1.TaskResources) *v1.ResourceRequirements {
+	gpuResourceName := k8sConfig.GetK8sPluginConfig().GpuResourceName
 	return &v1.ResourceRequirements{
 		Requests: v1.ResourceList{
 			v1.ResourceCPU:              taskResources.Requests.CPU,
 			v1.ResourceMemory:           taskResources.Requests.Memory,
 			v1.ResourceEphemeralStorage: taskResources.Requests.EphemeralStorage,
-			utils.ResourceNvidiaGPU:     taskResources.Requests.GPU,
+			gpuResourceName:             taskResources.Requests.GPU,
 		},
 		Limits: v1.ResourceList{
 			v1.ResourceCPU:              taskResources.Limits.CPU,
 			v1.ResourceMemory:           taskResources.Limits.Memory,
 			v1.ResourceEphemeralStorage: taskResources.Limits.EphemeralStorage,
-			utils.ResourceNvidiaGPU:     taskResources.Limits.GPU,
+			gpuResourceName:             taskResources.Limits.GPU,
 		},
 	}
-
 }
 
 // ComputeRawOutputPrefix constructs the output directory, where raw outputs of a task can be stored by the task. FlytePropeller may not have

--- a/flytepropeller/pkg/controller/nodes/task/taskexec_context_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/taskexec_context_test.go
@@ -17,6 +17,7 @@ import (
 	pluginCore "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core"
 	pluginCoreMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/core/mocks"
 	ioMocks "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/io/mocks"
+	k8sConfig "github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
 	"github.com/flyteorg/flyte/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	flyteMocks "github.com/flyteorg/flyte/flytepropeller/pkg/apis/flyteworkflow/v1alpha1/mocks"
@@ -374,7 +375,7 @@ func TestAssignResource(t *testing.T) {
 }
 
 func TestConvertTaskResourcesToRequirements(t *testing.T) {
-	resourceRequirements := convertTaskResourcesToRequirements(v1alpha1.TaskResources{
+	taskRes := v1alpha1.TaskResources{
 		Requests: v1alpha1.TaskResourceSpec{
 			CPU:              resource.MustParse("1"),
 			Memory:           resource.MustParse("2"),
@@ -387,21 +388,36 @@ func TestConvertTaskResourcesToRequirements(t *testing.T) {
 			EphemeralStorage: resource.MustParse("30"),
 			GPU:              resource.MustParse("50"),
 		},
+	}
+
+	t.Run("default nvidia GPU resource name", func(t *testing.T) {
+		resourceRequirements := convertTaskResourcesToRequirements(taskRes)
+		assert.EqualValues(t, &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:              resource.MustParse("1"),
+				corev1.ResourceMemory:           resource.MustParse("2"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("3"),
+				utils.ResourceNvidiaGPU:         resource.MustParse("5"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:              resource.MustParse("10"),
+				corev1.ResourceMemory:           resource.MustParse("20"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("30"),
+				utils.ResourceNvidiaGPU:         resource.MustParse("50"),
+			},
+		}, resourceRequirements)
 	})
-	assert.EqualValues(t, &corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:              resource.MustParse("1"),
-			corev1.ResourceMemory:           resource.MustParse("2"),
-			corev1.ResourceEphemeralStorage: resource.MustParse("3"),
-			utils.ResourceNvidiaGPU:         resource.MustParse("5"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:              resource.MustParse("10"),
-			corev1.ResourceMemory:           resource.MustParse("20"),
-			corev1.ResourceEphemeralStorage: resource.MustParse("30"),
-			utils.ResourceNvidiaGPU:         resource.MustParse("50"),
-		},
-	}, resourceRequirements)
+
+	t.Run("custom GPU resource name from config", func(t *testing.T) {
+		cfg := k8sConfig.GetK8sPluginConfig()
+		origName := cfg.GpuResourceName
+		cfg.GpuResourceName = "amd.com/gpu"
+		defer func() { cfg.GpuResourceName = origName }()
+
+		resourceRequirements := convertTaskResourcesToRequirements(taskRes)
+		assert.Equal(t, resource.MustParse("5"), resourceRequirements.Requests[corev1.ResourceName("amd.com/gpu")])
+		assert.Equal(t, resource.MustParse("50"), resourceRequirements.Limits[corev1.ResourceName("amd.com/gpu")])
+	})
 }
 
 func TestComputeRawOutputPrefix(t *testing.T) {


### PR DESCRIPTION
## Summary

- Read `GpuResourceName` from the K8s plugin config instead of hardcoding `"nvidia.com/gpu"` in `convertTaskResourcesToRequirements()`

## Problem

`convertTaskResourcesToRequirements()` in `taskexec_context.go` uses the hardcoded constant `utils.ResourceNvidiaGPU` (`"nvidia.com/gpu"`) for GPU resource requests and limits. The K8s plugin config already provides a configurable `GpuResourceName` field (via `gpu-resource-name` in the config), but this function ignores it.

This means operators using alternative GPU resource types (e.g. `"amd.com/gpu"`, `"nvidia.com/gpu.shared"`, `"habana.ai/gaudi"`) cannot use the existing configuration to change the GPU resource name — it's always hardcoded to `nvidia.com/gpu`.

The config field is already used correctly in `flyteplugins/go/tasks/pluginmachinery/flytek8s/` (e.g. `container_helper.go`), but `flytepropeller` bypasses it.

## Fix

Replace `utils.ResourceNvidiaGPU` with `k8sConfig.GetK8sPluginConfig().GpuResourceName` in `convertTaskResourcesToRequirements()`. This reads the configured GPU resource name at runtime, defaulting to `"nvidia.com/gpu"` when not explicitly set.

## Testing

- Default behavior unchanged: `GpuResourceName` defaults to `"nvidia.com/gpu"`
- Custom GPU resource names (e.g. `"amd.com/gpu"`) are now respected in task resource requirements

Closes #6746