### PR TITLE
fix(plugins): classify CreateContainerError as system-retryable instead of user error

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -1030,7 +1030,8 @@ func demystifyPendingHelper(status v1.PodStatus, info pluginsCore.TaskInfo) (plu
 								// allow a grace period for kubelet to resolve
 								// transient issues with the container runtime. If the
 								// error persists beyond this time, the corresponding
-								// task is marked as failed.
+								// task is marked as a system-retryable failure so that
+								// system retries can handle transient infrastructure errors.
 								// NOTE: The current implementation checks for a timeout
 								// by comparing the condition's LastTransitionTime
 								// based on the corresponding kubelet's clock with the
@@ -1042,7 +1043,7 @@ func demystifyPendingHelper(status v1.PodStatus, info pluginsCore.TaskInfo) (plu
 
 								gracePeriod := config.GetK8sPluginConfig().CreateContainerErrorGracePeriod.Duration
 								if time.Since(t) >= gracePeriod {
-									return pluginsCore.PhaseInfoFailureWithCleanup(finalReason, GetMessageAfterGracePeriod(finalMessage, gracePeriod), &pluginsCore.TaskInfo{
+									return pluginsCore.PhaseInfoSystemRetryableFailureWithCleanup(finalReason, GetMessageAfterGracePeriod(finalMessage, gracePeriod), &pluginsCore.TaskInfo{
 										OccurredAt: &t,
 									}), t
 								}
@@ -1051,7 +1052,7 @@ func demystifyPendingHelper(status v1.PodStatus, info pluginsCore.TaskInfo) (plu
 							case "CreateContainerConfigError":
 								gracePeriod := config.GetK8sPluginConfig().CreateContainerConfigErrorGracePeriod.Duration
 								if time.Since(t) >= gracePeriod {
-									return pluginsCore.PhaseInfoFailureWithCleanup(finalReason, GetMessageAfterGracePeriod(finalMessage, gracePeriod), &pluginsCore.TaskInfo{
+									return pluginsCore.PhaseInfoSystemRetryableFailureWithCleanup(finalReason, GetMessageAfterGracePeriod(finalMessage, gracePeriod), &pluginsCore.TaskInfo{
 										OccurredAt: &t,
 									}), t
 								}

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -1387,7 +1387,7 @@ func TestDemystifyPending(t *testing.T) {
 		}
 		taskStatus, err := DemystifyPending(s2, pluginsCore.TaskInfo{})
 		assert.NoError(t, err)
-		assert.Equal(t, pluginsCore.PhasePermanentFailure, taskStatus.Phase())
+		assert.Equal(t, pluginsCore.PhaseRetryableFailure, taskStatus.Phase())
 		assert.True(t, taskStatus.CleanupOnFailure())
 	})
 
@@ -1426,7 +1426,7 @@ func TestDemystifyPending(t *testing.T) {
 		}
 		taskStatus, err := DemystifyPending(s2, pluginsCore.TaskInfo{})
 		assert.NoError(t, err)
-		assert.Equal(t, pluginsCore.PhasePermanentFailure, taskStatus.Phase())
+		assert.Equal(t, pluginsCore.PhaseRetryableFailure, taskStatus.Phase())
 		assert.True(t, taskStatus.CleanupOnFailure())
 	})
 }


### PR DESCRIPTION
## Summary

When a pod fails with `CreateContainerError` or `CreateContainerConfigError` and the configured grace period is exceeded, the error is classified as a USER permanent failure (`PhaseInfoFailureWithCleanup`). This prevents system retries from triggering — the task fails immediately even when `retries` is configured.

These errors are typically transient infrastructure issues (e.g. "failed to reserve container name", "container name already in use") that should be retried by the system.

## Root Cause

In `pod_helper.go`, both `CreateContainerError` and `CreateContainerConfigError` use `PhaseInfoFailureWithCleanup` after the grace period, which creates:
- Phase: `PhasePermanentFailure`
- Error kind: `ExecutionError_USER`

USER errors do not trigger system retries (`max-node-retries-system-failures`), so the task fails immediately.

## Fix

Changed both error paths to use `PhaseInfoSystemRetryableFailureWithCleanup`, which creates:
- Phase: `PhaseRetryableFailure`
- Error kind: `ExecutionError_SYSTEM`

This allows the system retry mechanism to handle transient container creation failures.

## Testing

- Updated existing `CreateContainerErrorOutsideGracePeriod` test to assert `PhaseRetryableFailure` instead of `PhasePermanentFailure`
- Updated existing `CreateContainerConfigErrorOutsideGracePeriod` test similarly
- Both tests verify `CleanupOnFailure()` remains `true`
- Within-grace-period tests remain unchanged (still `PhaseInitializing`)

Closes #6786