### PR TITLE
fix(flytectl): fall back to Docker Desktop socket paths when default is unavailable

### DIFF
--- a/flytectl/pkg/docker/docker_util.go
+++ b/flytectl/pkg/docker/docker_util.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -60,6 +62,24 @@ var (
 	ExtraHosts         = []string{"host.docker.internal:host-gateway"}
 )
 
+// dockerDesktopSocketPaths returns well-known Docker Desktop socket paths
+// for macOS and Linux when the default /var/run/docker.sock is absent.
+func dockerDesktopSocketPaths() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	paths := []string{
+		filepath.Join(home, ".docker", "run", "docker.sock"),
+	}
+	if runtime.GOOS == "darwin" {
+		paths = append(paths,
+			filepath.Join(home, "Library", "Containers", "com.docker.docker", "Data", "docker-cli.sock"),
+		)
+	}
+	return paths
+}
+
 // GetDockerClient will returns the docker client
 func GetDockerClient() (Docker, error) {
 	if Client == nil {
@@ -68,6 +88,23 @@ func GetDockerClient() (Docker, error) {
 			fmt.Printf("%v Please Check your docker client %v \n", emoji.GrimacingFace, emoji.Whale)
 			return nil, err
 		}
+
+		if _, pingErr := cli.Ping(context.Background()); pingErr != nil && os.Getenv("DOCKER_HOST") == "" {
+			for _, sock := range dockerDesktopSocketPaths() {
+				if _, statErr := os.Stat(sock); statErr == nil {
+					altCli, altErr := client.NewClientWithOpts(
+						client.WithHost("unix://"+sock),
+						client.WithAPIVersionNegotiation(),
+					)
+					if altErr == nil {
+						if _, altPingErr := altCli.Ping(context.Background()); altPingErr == nil {
+							return altCli, nil
+						}
+					}
+				}
+			}
+		}
+
 		return cli, nil
 	}
 	return Client, nil

--- a/flytectl/pkg/docker/docker_util.go
+++ b/flytectl/pkg/docker/docker_util.go
@@ -98,8 +98,10 @@ func GetDockerClient() (Docker, error) {
 					)
 					if altErr == nil {
 						if _, altPingErr := altCli.Ping(context.Background()); altPingErr == nil {
+							cli.Close()
 							return altCli, nil
 						}
+						altCli.Close()
 					}
 				}
 			}

--- a/flytectl/pkg/docker/docker_util_test.go
+++ b/flytectl/pkg/docker/docker_util_test.go
@@ -335,6 +335,14 @@ func TestWaitForSandbox(t *testing.T) {
 	})
 }
 
+func TestDockerDesktopSocketPaths(t *testing.T) {
+	paths := dockerDesktopSocketPaths()
+	assert.NotEmpty(t, paths)
+	home, err := os.UserHomeDir()
+	assert.NoError(t, err)
+	assert.Contains(t, paths[0], filepath.Join(home, ".docker", "run", "docker.sock"))
+}
+
 func TestDockerClient(t *testing.T) {
 	t.Run("Successfully get docker mock client", func(t *testing.T) {
 		mockDocker := &mocks.Docker{}


### PR DESCRIPTION
## Summary

On macOS with Docker Desktop, the Docker socket may not be at the default `/var/run/docker.sock`. Docker Desktop places it at `~/.docker/run/docker.sock` or `~/Library/Containers/com.docker.docker/Data/docker-cli.sock` instead. This causes `flytectl demo start` to fail with:

```
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

## Root Cause

`GetDockerClient()` in `docker_util.go` uses `client.NewClientWithOpts(client.FromEnv)`, which defaults to `/var/run/docker.sock` when `DOCKER_HOST` is not set. Docker Desktop for Mac does not always create a symlink at that path.

## Fix

After the initial client creation, if a ping fails and `DOCKER_HOST` is not explicitly set, try well-known Docker Desktop socket paths:
1. `~/.docker/run/docker.sock` (Docker Desktop default on macOS and Linux)
2. `~/Library/Containers/com.docker.docker/Data/docker-cli.sock` (macOS-specific)

For each candidate, check if the socket file exists, create a client, and verify with a ping. Use the first working socket. If none work, return the original client (preserving the existing error behavior).

## Testing

- Existing behavior unchanged when `/var/run/docker.sock` works or `DOCKER_HOST` is set
- On macOS Docker Desktop without the default symlink, the fallback finds the correct socket
- Socket paths are only tried when the initial connection fails (no performance impact on working setups)

Closes #6138