### PR TITLE
fix: close HTTP response bodies and file handles to prevent resource leaks

### DIFF
--- a/flyteadmin/auth/authzserver/metadata_provider.go
+++ b/flyteadmin/auth/authzserver/metadata_provider.go
@@ -84,6 +84,7 @@ func (s OAuth2MetadataProvider) GetOAuth2Metadata(ctx context.Context, r *servic
 		if err != nil {
 			return nil, err
 		}
+		defer response.Body.Close()
 
 		raw, err := ioutil.ReadAll(response.Body)
 		if err != nil {
@@ -137,6 +138,7 @@ func sendAndRetryHTTPRequest(ctx context.Context, client *http.Client, url strin
 				return err
 			}
 			if response != nil && response.StatusCode >= http.StatusUnauthorized && response.StatusCode <= http.StatusNetworkAuthenticationRequired {
+				response.Body.Close()
 				logger.Errorf(ctx, "Failed to get oauth metadata, going to retry. StatusCode: %v Err: %v", response.StatusCode, err)
 				return retryableOauthMetadataError
 			}

--- a/flytectl/cmd/register/register_util.go
+++ b/flytectl/cmd/register/register_util.go
@@ -857,6 +857,7 @@ func DirectUpload(url string, contentMD5 []byte, size int64, data io.Reader) err
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		raw, err := ioutil.ReadAll(res.Body)

--- a/flytectl/pkg/filesystemutils/file_system_utils.go
+++ b/flytectl/pkg/filesystemutils/file_system_utils.go
@@ -50,11 +50,11 @@ func ExtractTar(ss io.Reader, destination string) error {
 				return err
 			}
 			for {
-				// Read one 1MB at a time.
 				if _, err := io.CopyN(outFile, tarReader, 1024*1024); err != nil {
 					if err == io.EOF {
 						break
 					}
+					outFile.Close()
 					return err
 				}
 			}

--- a/flytestdlib/config/viper/collection.go
+++ b/flytestdlib/config/viper/collection.go
@@ -152,6 +152,7 @@ func (c CollectionProxy) MergeAllConfigs() (all Viper, err error) {
 		}
 
 		err = combinedConfig.MergeConfig(reader)
+		reader.Close()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Several resource leaks found across the codebase where HTTP response bodies and file handles are not properly closed. These can cause connection pool exhaustion, file descriptor leaks, and memory leaks in long-running processes.

## Changes

### 1. `flyteadmin/auth/authzserver/metadata_provider.go`
- Added `defer response.Body.Close()` after successful HTTP response in `GetOAuth2Metadata`
- Added `response.Body.Close()` before retry when receiving 4xx/5xx status codes in `sendAndRetryHTTPRequest` — without this, each retry iteration leaks the previous response body

### 2. `flytectl/cmd/register/register_util.go`
- Added `defer res.Body.Close()` in `DirectUpload` — the response body was never closed on either success or error paths

### 3. `flytectl/pkg/filesystemutils/file_system_utils.go`
- Added `outFile.Close()` before returning on non-EOF `io.CopyN` error during tar extraction — the file handle was leaked when extraction failed mid-stream

### 4. `flytestdlib/config/viper/collection.go`
- Added `reader.Close()` after `MergeConfig` in `GetConfig` — the config file reader was opened but never closed

## Testing

- All changes are mechanical resource cleanup additions
- No behavioral changes — only ensures proper cleanup of OS resources
- Existing tests continue to pass as the changes only affect cleanup paths