### PR TITLE
fix: prevent os.RemoveAll on empty path and add missing transaction rollbacks

### DIFF
--- a/flyteadmin/pkg/repositories/config/seed_data.go
+++ b/flyteadmin/pkg/repositories/config/seed_data.go
@@ -58,6 +58,7 @@ func uniqueProjects(seedProjects []string, seedProjectsWithDetails []SeedProject
 // Returns a function to seed the database with default values.
 func SeedProjects(db *gorm.DB, projects []SeedProject) error {
 	tx := db.Begin()
+	defer tx.Rollback()
 	for _, project := range projects {
 		projectModel := models.Project{
 			Identifier:  project.Name,
@@ -66,7 +67,6 @@ func SeedProjects(db *gorm.DB, projects []SeedProject) error {
 		}
 		if err := tx.Where(models.Project{Identifier: project.Name}).Omit("id").FirstOrCreate(&projectModel).Error; err != nil {
 			logger.Warningf(context.Background(), "failed to save project [%s]", project)
-			tx.Rollback()
 			return err
 		}
 	}

--- a/flyteadmin/pkg/repositories/gormimpl/launch_plan_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/launch_plan_repo.go
@@ -85,12 +85,12 @@ func (r *LaunchPlanRepo) SetActive(
 	defer timer.Stop()
 	// Use a transaction to guarantee no partial updates.
 	tx := r.db.WithContext(ctx).Begin()
+	defer tx.Rollback()
 
 	// There is a launch plan to disable as part of this transaction
 	if toDisable != nil {
 		tx.Model(&toDisable).UpdateColumns(toDisable)
 		if err := tx.Error; err != nil {
-			tx.Rollback()
 			return r.errorTransformer.ToFlyteAdminError(err)
 		}
 	}
@@ -98,7 +98,6 @@ func (r *LaunchPlanRepo) SetActive(
 	// And update the desired version.
 	tx.Model(&toEnable).UpdateColumns(toEnable)
 	if err := tx.Error; err != nil {
-		tx.Rollback()
 		return r.errorTransformer.ToFlyteAdminError(err)
 	}
 	if err := tx.Commit().Error; err != nil {

--- a/flytectl/cmd/compile/compile.go
+++ b/flytectl/cmd/compile/compile.go
@@ -35,7 +35,9 @@ compilation is done locally so no flyte cluster is required.
 func compileFromPackage(packagePath string) error {
 	args := []string{packagePath}
 	fileList, tmpDir, err := register.GetSerializeOutputFiles(context.Background(), args, true)
-	defer os.RemoveAll(tmpDir)
+	if tmpDir != "" {
+		defer os.RemoveAll(tmpDir)
+	}
 	if err != nil {
 		fmt.Println("Error found while extracting package..")
 		return err


### PR DESCRIPTION
## Summary

Three safety fixes addressing potential data loss and transaction leaks.

## Changes

### 1. `flytectl/cmd/compile/compile.go` — Critical: `os.RemoveAll("")` can delete current directory

When `GetSerializeOutputFiles` fails, `tmpDir` is `""`. The deferred `os.RemoveAll(tmpDir)` then calls `os.RemoveAll("")`, which resolves to the current working directory and **deletes it recursively**.

**Fix:** Guard the defer with `if tmpDir != ""`.

### 2. `flyteadmin/pkg/repositories/gormimpl/launch_plan_repo.go` — Transaction leak on Commit failure

`SetActive` uses `tx.Begin()` with manual `tx.Rollback()` calls on error paths, but if `tx.Commit()` fails (line 104), the transaction is never rolled back. Depending on the database driver, this can leave the transaction open and leak a connection.

**Fix:** Add `defer tx.Rollback()` immediately after `Begin()`. Rollback after a successful commit is a no-op in GORM, making this safe and idiomatic. Removed the now-redundant manual `tx.Rollback()` calls.

### 3. `flyteadmin/pkg/repositories/config/seed_data.go` — Same transaction leak pattern

Same issue as above in `SeedProjects`.

**Fix:** Add `defer tx.Rollback()` after `Begin()`.

## Testing

- `os.RemoveAll("")` fix is a guard condition — no behavioral change on the success path
- Transaction rollback changes are idiomatic Go patterns — GORM's `Rollback()` is a no-op after `Commit()`
- Existing tests continue to pass