### PR TITLE
fix(flytectl): handle NewRequest error and close response body in SendRequest

### DIFF
--- a/flytectl/pkg/util/util.go
+++ b/flytectl/pkg/util/util.go
@@ -128,12 +128,16 @@ func PrintSandboxTeardownMessage(flyteConsolePort int, kubeconfigLocation string
 // SendRequest will create request and return the response
 func SendRequest(method, url string, option io.Reader) (*http.Response, error) {
 	client := &http.Client{}
-	req, _ := http.NewRequest(method, url, option)
+	req, err := http.NewRequest(method, url, option)
+	if err != nil {
+		return nil, err
+	}
 	response, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	if response.StatusCode != 200 {
+		response.Body.Close()
 		return nil, fmt.Errorf("something goes wrong while sending request to %s. Got status code %v", url, response.StatusCode)
 	}
 	return response, nil

--- a/flytectl/pkg/util/util_test.go
+++ b/flytectl/pkg/util/util_test.go
@@ -54,6 +54,11 @@ func TestSendRequest(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Nil(t, response)
 	})
+	t.Run("Invalid method returns NewRequest error", func(t *testing.T) {
+		response, err := SendRequest("BAD METHOD", "https://github.com", nil)
+		assert.NotNil(t, err)
+		assert.Nil(t, response)
+	})
 }
 
 func TestIsVersionGreaterThan(t *testing.T) {


### PR DESCRIPTION
## Summary

Two bugs in `SendRequest` in `flytectl/pkg/util/util.go`:

### 1. Ignored `http.NewRequest` error causes nil pointer panic

```go
req, _ := http.NewRequest(method, url, option)
response, err := client.Do(req)  // panics if req is nil
```

If the method or URL is invalid, `http.NewRequest` returns an error and a nil `*Request`. The error was silently discarded with `_`, and `client.Do(nil)` panics.

**Fix:** Check the error from `http.NewRequest` and return it.

### 2. HTTP response body leaked on non-200 status

When the response has a non-200 status code, the function returns an error but never closes `response.Body`, leaking the underlying TCP connection.

**Fix:** Close `response.Body` before returning the error.

## Testing

- Existing test `TestSendRequest` with `"htp://github.com"` now returns a proper error from `NewRequest` instead of relying on `client.Do` to fail
- No behavioral change for callers on the success path