### PR TITLE
feat(executor): support immediate GC cleanup when MaxTTL <= 0

### DIFF
--- a/executor/pkg/config/config.go
+++ b/executor/pkg/config/config.go
@@ -94,7 +94,8 @@ type GCConfig struct {
 	Interval stdconfig.Duration `json:"interval" pflag:",How often the garbage collector runs. 0 disables GC."`
 
 	// MaxTTL is the time-to-live for terminal TaskActions before deletion.
-	MaxTTL stdconfig.Duration `json:"maxTTL" pflag:",Time-to-live for terminal TaskActions before deletion."`
+	// A value <= 0 means terminal TaskActions are deleted immediately on the next GC cycle.
+	MaxTTL stdconfig.Duration `json:"maxTTL" pflag:",Time-to-live for terminal TaskActions before deletion. Use 0 or negative for immediate deletion."`
 }
 
 // GetConfig returns the parsed executor configuration

--- a/executor/pkg/controller/garbage_collector.go
+++ b/executor/pkg/controller/garbage_collector.go
@@ -55,7 +55,14 @@ const gcPageSize = 500
 func (gc *GarbageCollector) collect(ctx context.Context) error {
 	logger := log.FromContext(ctx).WithName("gc")
 
-	cutoff := time.Now().UTC().Add(-gc.maxTTL).Format(labelTimeFormat)
+	var cutoff string
+	if gc.maxTTL <= 0 {
+		// MaxTTL <= 0 means immediate deletion: use a far-future cutoff so all terminal
+		// TaskActions are eligible regardless of their completed time.
+		cutoff = "9999-12-31.23-59"
+	} else {
+		cutoff = time.Now().UTC().Add(-gc.maxTTL).Format(labelTimeFormat)
+	}
 	deleted := 0
 	total := 0
 	continueToken := ""

--- a/executor/pkg/controller/garbage_collector_test.go
+++ b/executor/pkg/controller/garbage_collector_test.go
@@ -101,6 +101,38 @@ var _ = Describe("GarbageCollector", func() {
 		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour)
 		Expect(gc.collect(ctx)).To(Succeed())
 	})
+
+	It("should delete all terminal TaskActions immediately when maxTTL is zero", func() {
+		recentTime := time.Now().UTC().Format(labelTimeFormat)
+		createTaskAction(ctx, "gc-zero-ttl", map[string]string{
+			LabelTerminationStatus: LabelValueTerminated,
+			LabelCompletedTime:     recentTime,
+		})
+
+		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 0)
+		Expect(gc.collect(ctx)).To(Succeed())
+
+		ta := &flyteorgv1.TaskAction{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: "gc-zero-ttl", Namespace: "default"}, ta)
+		Expect(err).To(HaveOccurred())
+		Expect(client.IgnoreNotFound(err)).To(Succeed())
+	})
+
+	It("should delete all terminal TaskActions immediately when maxTTL is negative", func() {
+		recentTime := time.Now().UTC().Format(labelTimeFormat)
+		createTaskAction(ctx, "gc-negative-ttl", map[string]string{
+			LabelTerminationStatus: LabelValueTerminated,
+			LabelCompletedTime:     recentTime,
+		})
+
+		gc := NewGarbageCollector(k8sClient, 1*time.Minute, -1*time.Hour)
+		Expect(gc.collect(ctx)).To(Succeed())
+
+		ta := &flyteorgv1.TaskAction{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: "gc-negative-ttl", Namespace: "default"}, ta)
+		Expect(err).To(HaveOccurred())
+		Expect(client.IgnoreNotFound(err)).To(Succeed())
+	})
 })
 
 var _ = Describe("ensureTerminalLabels", func() {

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -159,9 +159,6 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	}
 
 	if cfg.GC.Interval.Duration > 0 {
-		if cfg.GC.MaxTTL.Duration <= 0 {
-			return fmt.Errorf("executor: gc.maxTTL must be positive when gc is enabled, got %v", cfg.GC.MaxTTL.Duration)
-		}
 		gc := controller.NewGarbageCollector(mgr.GetClient(), cfg.GC.Interval.Duration, cfg.GC.MaxTTL.Duration)
 		if err := mgr.Add(gc); err != nil {
 			return fmt.Errorf("executor: failed to add garbage collector: %w", err)


### PR DESCRIPTION
## Tracking issue

Closes #7008

## Why are the changes needed?

The TaskAction garbage collector (added in #6994) currently rejects `MaxTTL <= 0` with a validation error at startup (`executor/setup.go:125`). Operators who want aggressive cleanup of completed TaskActions have no way to express "delete immediately on each GC cycle."

The issue proposes treating `MaxTTL <= 0` as "immediate deletion" - a natural extension of the existing TTL behavior where smaller values mean faster cleanup.

## What changes were proposed in this pull request?

1. **Removed the `MaxTTL <= 0` validation error** in `executor/setup.go`. GC now starts with any MaxTTL value when interval > 0.

2. **Added immediate-deletion logic** in `executor/pkg/controller/garbage_collector.go`. When `maxTTL <= 0`, the collect() function uses a far-future cutoff (`9999-12-31.23-59`) so all terminal TaskActions are eligible for deletion regardless of their completed time. The existing label-based string comparison (`completedTime < cutoff`) works unchanged since the far-future value is lexicographically greater than any real timestamp.

3. **Updated config documentation** in `executor/pkg/config/config.go` to note the `<= 0` behavior in the pflag help text.

| `MaxTTL` value | Behavior                                                  |
| -------------- | --------------------------------------------------------- |
| `> 0`          | Delete terminal TaskActions older than MaxTTL (unchanged) |
| `<= 0`         | Delete all terminal TaskActions on each GC cycle          |

Existing configurations with positive MaxTTL are not affected.

## How was this patch tested?

Added two Ginkgo test cases in `executor/pkg/controller/garbage_collector_test.go`:

- `maxTTL = 0`: verifies a recently-completed TaskAction is deleted immediately
- `maxTTL = -1h`: verifies negative values behave the same as zero

Ran `go fmt ./...` and `go vet ./...` locally - both pass clean.

This contribution was developed with AI assistance (Claude Code + Codex).

### Labels

- **added**: New GC behavior for `MaxTTL <= 0`.

* `main` <!-- branch-stack -->
  - \#6583
    - **feat(executor): support immediate GC cleanup when MaxTTL <= 0** :point\_left:
