### PR TITLE
fix(clients): cache GetPublicClientConfig response to avoid redundant API calls

### DIFF
--- a/flyteidl/clients/go/admin/cached_metadata_client.go
+++ b/flyteidl/clients/go/admin/cached_metadata_client.go
@@ -1,0 +1,37 @@
+package admin
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/grpc"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/service"
+)
+
+// cachedMetadataClient wraps an AuthMetadataServiceClient and caches the
+// GetPublicClientConfig response. The server returns static configuration
+// that does not change at runtime, so a single fetch is sufficient.
+type cachedMetadataClient struct {
+	service.AuthMetadataServiceClient
+	once   sync.Once
+	cached *service.PublicClientAuthConfigResponse
+	err    error
+}
+
+// NewCachedMetadataClient returns an AuthMetadataServiceClient that calls
+// GetPublicClientConfig at most once and returns the cached result thereafter.
+func NewCachedMetadataClient(inner service.AuthMetadataServiceClient) service.AuthMetadataServiceClient {
+	return &cachedMetadataClient{AuthMetadataServiceClient: inner}
+}
+
+func (c *cachedMetadataClient) GetPublicClientConfig(
+	ctx context.Context,
+	in *service.PublicClientAuthConfigRequest,
+	opts ...grpc.CallOption,
+) (*service.PublicClientAuthConfigResponse, error) {
+	c.once.Do(func() {
+		c.cached, c.err = c.AuthMetadataServiceClient.GetPublicClientConfig(ctx, in, opts...)
+	})
+	return c.cached, c.err
+}

--- a/flyteidl/clients/go/admin/client.go
+++ b/flyteidl/clients/go/admin/client.go
@@ -121,7 +121,7 @@ func InitializeAuthMetadataClient(ctx context.Context, cfg *Config, proxyCredent
 		return nil, fmt.Errorf("failed to initialized admin connection. Error: %w", err)
 	}
 
-	return service.NewAuthMetadataServiceClient(authMetadataConnection), nil
+	return NewCachedMetadataClient(service.NewAuthMetadataServiceClient(authMetadataConnection)), nil
 }
 
 func NewAdminConnection(ctx context.Context, cfg *Config, proxyCredentialsFuture *PerRPCCredentialsFuture, opts ...grpc.DialOption) (*grpc.ClientConn, error) {


### PR DESCRIPTION
## Tracking issue

Closes #6868

## Why are the changes needed?

`GetPublicClientConfig` is called up to 4 times during client initialization (`token_source_provider.go:64`, `client.go:100`, `auth_interceptor.go:142`, `oauth/config.go:22`). The response contains static server configuration (client ID, redirect URI, scopes, audience, authorization metadata key) that does not change at runtime.

As noted in the issue, this shows up as unnecessary API call volume on monitoring dashboards. The success criteria from the issue is reducing these calls to 0 after the first fetch.

## What changes were proposed in this pull request?

Added a `cachedMetadataClient` decorator in `flyteidl/clients/go/admin/cached_metadata_client.go` that wraps `AuthMetadataServiceClient` and caches the `GetPublicClientConfig` response using `sync.Once`. The first call makes the RPC; subsequent calls return the cached result.

The decorator is applied in `InitializeAuthMetadataClient` (`client.go:124`), which is the single point where the auth metadata client is created. All 4 downstream call sites automatically benefit from caching without any changes.

`GetOAuth2Metadata` is not cached in this PR since it's called less frequently and serves a different purpose, but the same pattern could be applied if needed.

## How was this patch tested?

- `go fmt ./...` and `go vet ./clients/go/admin/...` pass clean
- The `sync.Once` pattern is well-established for this use case. The cached value is immutable after first write, so there are no concurrency concerns.

This contribution was developed with AI assistance (Claude Code + Codex).

### Labels

- **changed**: Caches previously redundant API calls.