### PR TITLE
[v2][Run Service] write empty input Literal if no input

### DIFF
--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -149,16 +149,15 @@ func (s *RunService) CreateRun(
 	inputPrefix := buildInputPrefix(s.storagePrefix, org, project, domain, name)
 	runOutputBase := buildRunOutputBase(s.storagePrefix, org, project, domain, name)
 
-	// Persist inputs to storage
-	if req.Msg.Inputs != nil && len(req.Msg.Inputs.Literals) > 0 {
-		literalMap := inputsToLiteralMap(req.Msg.Inputs)
-		inputRef := storage.DataReference(inputPrefix + "/inputs.pb")
-		if err := s.dataStore.WriteProtobuf(ctx, inputRef, storage.Options{}, literalMap); err != nil {
-			logger.Errorf(ctx, "Failed to write inputs to storage: %v", err)
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to write inputs: %w", err))
-		}
-		logger.Infof(ctx, "Wrote inputs to %s", inputRef)
+	// Persist inputs to storage. The task runtime always tries to load inputs.pb,
+	// even when the task has no user inputs, so we must write an empty LiteralMap.
+	literalMap := inputsToLiteralMap(req.Msg.Inputs)
+	inputRef := storage.DataReference(inputPrefix + "/inputs.pb")
+	if err := s.dataStore.WriteProtobuf(ctx, inputRef, storage.Options{}, literalMap); err != nil {
+		logger.Errorf(ctx, "Failed to write inputs to storage: %v", err)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to write inputs: %w", err))
 	}
+	logger.Infof(ctx, "Wrote inputs to %s", inputRef)
 
 	// Create run in database with storage URIs
 	run, err := s.repo.ActionRepo().CreateRun(ctx, req.Msg, inputPrefix, runOutputBase)
@@ -893,6 +892,9 @@ func buildInputPrefix(storagePrefix, org, project, domain, name string) string {
 
 // inputsToLiteralMap converts task.Inputs (ordered NamedLiteral list) to core.LiteralMap (map).
 func inputsToLiteralMap(inputs *task.Inputs) *core.LiteralMap {
+	if inputs == nil || len(inputs.Literals) == 0 {
+		return &core.LiteralMap{Literals: map[string]*core.Literal{}}
+	}
 	m := make(map[string]*core.Literal, len(inputs.Literals))
 	for _, nl := range inputs.Literals {
 		m[nl.Name] = nl.Value

--- a/runs/service/run_service_test.go
+++ b/runs/service/run_service_test.go
@@ -7,13 +7,19 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
+	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
+	storageMocks "github.com/flyteorg/flyte/v2/flytestdlib/storage/mocks"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/actions"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow"
 	repoMocks "github.com/flyteorg/flyte/v2/runs/repository/mocks"
+	"github.com/flyteorg/flyte/v2/runs/repository/models"
 )
 
 // mockActionsClient implements actionsconnect.ActionsServiceClient for testing.
@@ -214,4 +220,60 @@ func TestGenerateRunName(t *testing.T) {
 		name2 := generateRunName(12345)
 		assert.Equal(t, name1, name2)
 	})
+}
+
+func TestCreateRun_WritesEmptyInputsProto(t *testing.T) {
+	actionRepo := &repoMocks.ActionRepo{}
+	actionsClient := &mockActionsClient{}
+	repo := &repoMocks.Repository{}
+	store := &storageMocks.ComposedProtobufStore{}
+	dataStore := &storage.DataStore{ComposedProtobufStore: store}
+
+	repo.On("ActionRepo").Return(actionRepo)
+
+	svc := &RunService{
+		repo:          repo,
+		actionsClient: actionsClient,
+		storagePrefix: "s3://flyte-data",
+		dataStore:     dataStore,
+	}
+
+	req := &workflow.CreateRunRequest{
+		Id: &workflow.CreateRunRequest_ProjectId{
+			ProjectId: &common.ProjectIdentifier{
+				Organization: "testorg",
+				Domain:       "development",
+				Name:         "testproject",
+			},
+		},
+		Task: &workflow.CreateRunRequest_TaskSpec{
+			TaskSpec: &task.TaskSpec{},
+		},
+	}
+
+	expectedRun := &models.Run{
+		Org:     "testorg",
+		Project: "testproject",
+		Domain:  "development",
+		Name:    "generated-run",
+	}
+
+	store.On("WriteProtobuf", mock.Anything, mock.AnythingOfType("storage.DataReference"), storage.Options{}, mock.MatchedBy(func(msg proto.Message) bool {
+		lm, ok := msg.(*core.LiteralMap)
+		return ok && len(lm.Literals) == 0
+	})).Return(nil).Once()
+
+	actionRepo.On("CreateRun", mock.Anything, mock.AnythingOfType("*workflow.CreateRunRequest"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+		Return(expectedRun, nil).Once()
+
+	actionsClient.On("Enqueue", mock.Anything, mock.Anything).
+		Return(connect.NewResponse(&actions.EnqueueResponse{}), nil).Once()
+
+	_, err := svc.CreateRun(context.Background(), connect.NewRequest(req))
+	assert.NoError(t, err)
+
+	repo.AssertExpectations(t)
+	actionRepo.AssertExpectations(t)
+	actionsClient.AssertExpectations(t)
+	store.AssertExpectations(t)
 }


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

When running task without input, we will get following errors in pod

```sh
FileNotFoundError: Object at location testorg/testproject/development/r9dl4lm95nvzfsftp84f/inputs/inputs.pb not found: Error performing HEAD http://flyte-sandbox-minio.flyte:9000/flyte-data/testorg/testproject/development/r9dl4lm95nvzfsftp84f/inputs/inputs.pb in 2.922346ms - Server returned non-2xx status code: 404 Not Found:
```

This is because runtime always expect input file exists, but originally we do not write input file if there's no input for the action.

## What changes were proposed in this pull request?

This PR writes an empty input if there's no input provided in the action

## How was this patch tested?

Run with following script and ensure there's no error

```sh
# modified from the examples/basics/hello.py in flyte-sdk

import flyte

# TaskEnvironments provide a simple way of grouping configuration used by tasks (more later).
env = flyte.TaskEnvironment(
    name="hello_world",
    resources=flyte.Resources(memory="250Mi"),
)


# use TaskEnvironments to define tasks, which are regular Python functions.
@env.task
def fn(x: int) -> int:  # type annotations are recommended.
    slope, intercept = 2, 5
    return slope * x + intercept


# tasks can also call other tasks, which will be manifested in different containers.
@env.task
def main() -> float:
    x_list: list[int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
    x_len = len(x_list)
    if x_len < 10:
        raise ValueError(f"x_list doesn't have a larger enough sample size, found: {x_len}")

    y_list = list(flyte.map(fn, x_list))  # flyte.map is like Python map, but runs in parallel.
    y_mean = sum(y_list) / len(y_list)
    return y_mean


if __name__ == "__main__":
    flyte.init_from_config()  # establish remote connection from within your script.
    run = flyte.run(main)  # run remotely inline and pass data.

    # print various attributes of the run.
    print(run.name)
    print(run.url)

    run.wait()  # stream the logs from the root action to the terminal.
```

Result:

```sh
❯ python examples/basics/hello.py
  > Building 1 image...
    > Building image flyte for environment hello_world
    i Image ghcr.io/flyteorg/flyte:16b2b307f1864d4a76e0224b38da6444 already exists, skipping build
  ✓ Built image for environment hello_world: ghcr.io/flyteorg/flyte:16b2b307f1864d4a76e0224b38da6444
  > Bundling code...
  ✓ Code bundle: 1 files, 0.009765625 MB (compressed 0.0008516311645507812 MB)
  > Uploading code bundle...
rhl2rxlhk68x5b5ntmh7
http://localhost:8080/v2/domain/development/project/testproject/runs/rhl2rxlhk68x5b5ntmh7
Run 'rhl2rxlhk68x5b5ntmh7' completed successfully.
```

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
