### PR TITLE
Fix manager hanging on shutdown

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -167,11 +167,13 @@ func (a *App) serve(ctx context.Context) error {
 	}()
 
 	workerCancel()
+	var shutdownErr error
 	if server != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		if err := server.Shutdown(shutdownCtx); err != nil {
 			logger.Errorf(ctx, "Server shutdown error: %v", err)
+			shutdownErr = err
 		}
 	}
 
@@ -187,7 +189,7 @@ func (a *App) serve(ctx context.Context) error {
 	case <-time.After(shutdownTimeout):
 		logger.Warnf(ctx, "%s: graceful shutdown timed out after %v, forcing exit", a.Name, shutdownTimeout)
 	}
-	return nil
+	return shutdownErr
 }
 
 func initConfig(cmd *cobra.Command) error {


### PR DESCRIPTION
## Summary

- Fix the manager process hanging indefinitely on Ctrl+C by adding `wg.Wait()` with a 30-second timeout for worker goroutines
- Support force exit on a second SIGINT/SIGTERM signal, matching the common Go pattern used by controller-runtime and Kubernetes components
- Make HTTP server shutdown errors non-fatal so the rest of the shutdown sequence (worker cleanup) still runs

## Test plan

- `main` <!-- branch-stack -->
  - \#6583
    - **Fix manager hanging on shutdown** :point\_left:
