### PR TITLE
[Run Service] Fix CreateRun response fields and fill missing default …

### DIFF
--- a/runs/service/run_service_test.go
+++ b/runs/service/run_service_test.go
@@ -270,6 +270,146 @@ func TestGetRunDetails_TaskSpecLookupFails(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestFillDefaultInputsForCreateRun(t *testing.T) {
+	inputs := &task.Inputs{
+		Literals: []*task.NamedLiteral{
+			{
+				Name: "x",
+				Value: &core.Literal{
+					Value: &core.Literal_Scalar{
+						Scalar: &core.Scalar{
+							Value: &core.Scalar_Primitive{
+								Primitive: &core.Primitive{Value: &core.Primitive_Integer{Integer: 7}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	defaultInputs := []*task.NamedParameter{
+		{
+			Name: "x",
+			Parameter: &core.Parameter{
+				Behavior: &core.Parameter_Default{
+					Default: &core.Literal{
+						Value: &core.Literal_Scalar{
+							Scalar: &core.Scalar{
+								Value: &core.Scalar_Primitive{
+									Primitive: &core.Primitive{Value: &core.Primitive_Integer{Integer: 42}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "y",
+			Parameter: &core.Parameter{
+				Behavior: &core.Parameter_Default{
+					Default: &core.Literal{
+						Value: &core.Literal_Scalar{
+							Scalar: &core.Scalar{
+								Value: &core.Scalar_Primitive{
+									Primitive: &core.Primitive{Value: &core.Primitive_StringValue{StringValue: "default"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	gotInputs := fillDefaultInputs(inputs, defaultInputs)
+
+	assert.Len(t, gotInputs.Literals, 2)
+	got := make(map[string]*core.Literal, len(gotInputs.Literals))
+	for _, nl := range gotInputs.Literals {
+		got[nl.Name] = nl.Value
+	}
+	assert.Equal(t, int64(7), got["x"].GetScalar().GetPrimitive().GetInteger(), "provided input should not be overwritten")
+	assert.Equal(t, "default", got["y"].GetScalar().GetPrimitive().GetStringValue(), "missing input should be filled from default")
+}
+
+func TestCreateRunResponseIncludesMetadataAndStatus(t *testing.T) {
+	actionRepo := &repoMocks.ActionRepo{}
+	taskRepo := &repoMocks.TaskRepo{}
+	actionsClient := &mockActionsClient{}
+	repo := &repoMocks.Repository{}
+	store := &storageMocks.ComposedProtobufStore{}
+	dataStore := &storage.DataStore{ComposedProtobufStore: store}
+
+	repo.On("ActionRepo").Return(actionRepo)
+	repo.On("TaskRepo").Maybe().Return(taskRepo)
+
+	svc := &RunService{
+		repo:          repo,
+		actionsClient: actionsClient,
+		storagePrefix: "s3://flyte-data",
+		dataStore:     dataStore,
+	}
+
+	runID := &common.RunIdentifier{
+		Org:     "test-org",
+		Project: "test-project",
+		Domain:  "test-domain",
+		Name:    "rtest12345",
+	}
+	createdAt := time.Now().UTC().Truncate(time.Second)
+
+	store.On("WriteProtobuf", mock.Anything, mock.Anything, storage.Options{}, mock.Anything).Return(nil).Once()
+
+	actionRepo.On("CreateRun", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(&models.Run{
+			Org:         runID.Org,
+			Project:     runID.Project,
+			Domain:      runID.Domain,
+			Name:        runID.Name,
+			Phase:       int32(common.ActionPhase_ACTION_PHASE_QUEUED),
+			CreatedAt:   createdAt,
+			Attempts:    1,
+			CacheStatus: core.CatalogCacheStatus_CACHE_DISABLED,
+		}, nil).Once()
+
+	actionsClient.On("Enqueue", mock.Anything, mock.Anything).
+		Return(connect.NewResponse(&actions.EnqueueResponse{}), nil).Once()
+
+	resp, err := svc.CreateRun(context.Background(), connect.NewRequest(&workflow.CreateRunRequest{
+		Id: &workflow.CreateRunRequest_RunId{
+			RunId: runID,
+		},
+		Task: &workflow.CreateRunRequest_TaskSpec{
+			TaskSpec: &task.TaskSpec{},
+		},
+	}))
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.NotNil(t, resp.Msg.GetRun())
+	assert.NotNil(t, resp.Msg.GetRun().GetAction())
+	assert.NotNil(t, resp.Msg.GetRun().GetAction().GetId())
+	assert.Equal(t, runID.Name, resp.Msg.GetRun().GetAction().GetId().GetName())
+	assert.NotNil(t, resp.Msg.GetRun().GetAction().GetMetadata())
+
+	status := resp.Msg.GetRun().GetAction().GetStatus()
+	assert.NotNil(t, status)
+	assert.Equal(t, common.ActionPhase_ACTION_PHASE_QUEUED, status.GetPhase())
+	assert.NotNil(t, status.GetStartTime())
+	assert.True(t, status.GetStartTime().AsTime().Equal(createdAt))
+	assert.Equal(t, uint32(1), status.GetAttempts())
+	assert.Equal(t, core.CatalogCacheStatus_CACHE_DISABLED, status.GetCacheStatus())
+	assert.Nil(t, status.EndTime)
+	assert.Nil(t, status.DurationMs)
+
+	repo.AssertExpectations(t)
+	actionRepo.AssertExpectations(t)
+	taskRepo.AssertExpectations(t)
+	actionsClient.AssertExpectations(t)
+	store.AssertExpectations(t)
+}
+
 func TestAbortRun(t *testing.T) {
 	runID := &common.RunIdentifier{
 		Org:     "test-org",


### PR DESCRIPTION
## Tracking issue

## <https://github.com/flyteorg/flyte/issues/6972>

## Why are the changes needed?

This PR addresses gaps in the `CreateRun` workflow to ensure consistent behavior and a complete API response.

Specifically:

1. **Missing default input handling**
   When users do not provide certain inputs, `CreateRun` should populate them using the task’s `default_inputs`, without overriding user-provided values.

2. **Incomplete response fields**
   The `CreateRun` response previously lacked essential fields required by downstream consumers, such as metadata and execution status.

***

## What changes were proposed in this pull request?

### 1. Add `fillDefaultInputs` to `CreateRun`

**File:** `runs/service/run_service.go`

- Introduced `s.fillDefaultInputs(ctx, req.Msg)` before persisting inputs.
- Logic:

  - Build a set of existing input names from the request
  - Iterate through `taskSpec.default_inputs`
  - Fill missing inputs only if a default value exists
  - Preserve user-provided values (no overwrite)
  - Use `proto.Clone` to avoid shared pointer side effects

***

### 2. Add `getCreateRunTaskSpec`

**File:** `runs/service/run_service.go`

Supports both task specification sources:

- `CreateRunRequest_TaskSpec`: use inline spec directly
- `CreateRunRequest_TaskId`: fetch from `TaskRepo.GetTask` and `proto.Unmarshal`

This ensures consistent handling regardless of how the task is provided.

***

### 3. Introduce a dedicated response builder for `CreateRun`

**File:** `runs/service/run_service.go`

- `CreateRun` now returns:

  - `buildCreateRunResponse(run)`

- The response includes:

  - `run.action.metadata`
  - `run.action.status.phase`
  - `run.action.status.start_time`
  - `run.action.status.attempts = 1`
  - `run.action.status.cache_status = CACHE_DISABLED`

- Fields intentionally excluded at creation time:

  - `end_time`
  - `duration_ms`

***

### Design decision: Not passing `actionID` into `buildCreateRunResponse`

Instead of passing `actionID`, it is reconstructed from the persisted `run`.

**Rationale:**

1. **Single source of truth**
   Ensures the response is fully derived from the persisted state, avoiding inconsistencies.

2. **Better testability**
   The function depends only on `run`, making it easier to test in isolation.

3. **Reduced coupling**
   Avoids passing intermediate variables across layers solely for response construction.

> Note: Passing `actionID` is technically valid, but this approach was chosen for cleaner design.

***

### Why not modify `convertRunToProto`?

`convertRunToProto` is shared by `ListRuns` and `WatchRuns`.

To avoid unintended side effects or breaking existing contracts, this PR isolates `CreateRun` response logic in a separate builder (`buildCreateRunResponse`).

***

## How was this patch tested?

### Unit Tests (Added)

**File:** `runs/service/run_service_test.go`

- `TestFillDefaultInputs`

  - Verifies user inputs are not overridden
  - Verifies missing inputs are populated from defaults

- `TestCreateRunResponseIncludesMetadataAndStatus`

  - Verifies presence of `metadata` and `status`
  - Verifies:

    - `phase`
    - `startTime`
    - `attempts`
    - `cacheStatus`

***

### Test Results

```bash
GOCACHE=/tmp/gocache go test ./runs/service
# ok
```

***

### Local Integration Test Steps

1. Start dev environment

```bash
make sandbox-run FLYTE_DEV=True
make -C manager run
```

2. Call `CreateRun`

```bash
ENDPOINT=http://localhost:30080 bash runs/test/scripts/create_run.sh
```

3. Validate response fields

```bash
jq '.run.action' /tmp/create_run_resp.json
jq -e '.run.action.metadata != null' /tmp/create_run_resp.json
jq -e '.run.action.status != null' /tmp/create_run_resp.json
jq -e '.run.action.status.phase == "ACTION_PHASE_QUEUED"' /tmp/create_run_resp.json
jq -e '.run.action.status.startTime != null' /tmp/create_run_resp.json
jq -e '.run.action.status.attempts == 1' /tmp/create_run_resp.json
```

***

### Known Observations

- When `cacheStatus` is set to `CACHE_DISABLED (enum=0)`, it may be omitted in proto3 JSON output.
- This is expected serialization behavior and does not indicate a backend issue.

***

### Labels

- **added**
- **changed**

***

### Setup process

See local integration steps above.

***

### Screenshots

N/A (backend/API change)

***

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

***

## Related PRs

N/A

***

## Docs link

N/A

- `main` <!-- branch-stack -->
  - \#6583
    - **\[Run Service] Fix CreateRun response fields and fill missing default …** :point\_left:
