### PR TITLE
fix: normalize msgpack Binary scalars for deterministic cache hashing

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/catalog/hashing.go
+++ b/flyteplugins/go/tasks/pluginmachinery/catalog/hashing.go
@@ -21,15 +21,16 @@ func toJSONCompatible(v interface{}) interface{} {
 	switch val := v.(type) {
 	case map[interface{}]interface{}:
 		m := make(map[string]interface{}, len(val))
-		for k, v := range val {
-			m[fmt.Sprintf("%v", k)] = toJSONCompatible(v)
+		for k, elem := range val {
+			m[fmt.Sprintf("%v", k)] = toJSONCompatible(elem)
 		}
 		return m
 	case []interface{}:
+		result := make([]interface{}, len(val))
 		for i, item := range val {
-			val[i] = toJSONCompatible(item)
+			result[i] = toJSONCompatible(item)
 		}
-		return val
+		return result
 	default:
 		return v
 	}

--- a/flyteplugins/go/tasks/pluginmachinery/catalog/hashing.go
+++ b/flyteplugins/go/tasks/pluginmachinery/catalog/hashing.go
@@ -3,7 +3,10 @@ package catalog
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
+	"fmt"
 
+	"github.com/shamaton/msgpack/v2"
 	"k8s.io/utils/strings/slices"
 
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
@@ -11,6 +14,43 @@ import (
 )
 
 var emptyLiteralMap = core.LiteralMap{Literals: map[string]*core.Literal{}}
+
+// toJSONCompatible recursively converts map[interface{}]interface{} (produced by msgpack
+// unmarshal) into map[string]interface{} so that encoding/json can marshal it.
+func toJSONCompatible(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[interface{}]interface{}:
+		m := make(map[string]interface{}, len(val))
+		for k, v := range val {
+			m[fmt.Sprintf("%v", k)] = toJSONCompatible(v)
+		}
+		return m
+	case []interface{}:
+		for i, item := range val {
+			val[i] = toJSONCompatible(item)
+		}
+		return val
+	default:
+		return v
+	}
+}
+
+// normalizeMsgpackBytes unmarshals msgpack bytes and re-marshals them to JSON, which
+// deterministically sorts map keys at every nesting level. This ensures that semantically
+// identical dicts serialized with different key orderings produce the same hash.
+// If normalization fails, the original bytes are returned unchanged.
+func normalizeMsgpackBytes(data []byte) []byte {
+	var obj interface{}
+	if err := msgpack.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	obj = toJSONCompatible(obj)
+	normalized, err := json.Marshal(obj)
+	if err != nil {
+		return data
+	}
+	return normalized
+}
 
 // Hashify a literal, in other words, produce a new literal where the corresponding value is removed in case
 // the literal hash is set.
@@ -49,6 +89,23 @@ func hashify(literal *core.Literal) *core.Literal {
 			Value: &core.Literal_Map{
 				Map: &core.LiteralMap{
 					Literals: literalsMap,
+				},
+			},
+		}
+	}
+
+	// Normalize msgpack Binary scalars to ensure deterministic hashing regardless of key order
+	if binary := literal.GetScalar().GetBinary(); binary != nil && binary.GetTag() == "msgpack" {
+		normalized := normalizeMsgpackBytes(binary.GetValue())
+		return &core.Literal{
+			Value: &core.Literal_Scalar{
+				Scalar: &core.Scalar{
+					Value: &core.Scalar_Binary{
+						Binary: &core.Binary{
+							Value: normalized,
+							Tag:   binary.GetTag(),
+						},
+					},
 				},
 			},
 		}

--- a/flyteplugins/go/tasks/pluginmachinery/catalog/hashing_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/catalog/hashing_test.go
@@ -657,17 +657,17 @@ func TestNoInputValues(t *testing.T) {
 func TestHashLiteralMap_MsgpackBinaryDeterministic(t *testing.T) {
 	// Manually constructed msgpack bytes for {a:1, b:2, c:3} with key order a, b, c
 	msgpackABC := []byte{
-		0x83,                   // fixmap, 3 entries
-		0xa1, 0x61, 0x01,      // "a": 1
-		0xa1, 0x62, 0x02,      // "b": 2
-		0xa1, 0x63, 0x03,      // "c": 3
+		0x83,             // fixmap, 3 entries
+		0xa1, 0x61, 0x01, // "a": 1
+		0xa1, 0x62, 0x02, // "b": 2
+		0xa1, 0x63, 0x03, // "c": 3
 	}
 	// Same map {a:1, b:2, c:3} with key order c, a, b
 	msgpackCAB := []byte{
-		0x83,                   // fixmap, 3 entries
-		0xa1, 0x63, 0x03,      // "c": 3
-		0xa1, 0x61, 0x01,      // "a": 1
-		0xa1, 0x62, 0x02,      // "b": 2
+		0x83,             // fixmap, 3 entries
+		0xa1, 0x63, 0x03, // "c": 3
+		0xa1, 0x61, 0x01, // "a": 1
+		0xa1, 0x62, 0x02, // "b": 2
 	}
 
 	litABC := &core.Literal{
@@ -689,16 +689,16 @@ func TestHashLiteralMap_MsgpackBinaryDeterministic(t *testing.T) {
 
 	// Nested: {a: {x:1, y:2}, b:3} with order a(x,y), b
 	msgpackNested1 := []byte{
-		0x82,                         // fixmap, 2 entries
-		0xa1, 0x61,                   // "a"
+		0x82,       // fixmap, 2 entries
+		0xa1, 0x61, // "a"
 		0x82, 0xa1, 0x78, 0x01, 0xa1, 0x79, 0x02, // {x:1, y:2}
-		0xa1, 0x62, 0x03,             // "b": 3
+		0xa1, 0x62, 0x03, // "b": 3
 	}
 	// Same nested map with order b, a(y,x)
 	msgpackNested2 := []byte{
-		0x82,                         // fixmap, 2 entries
-		0xa1, 0x62, 0x03,             // "b": 3
-		0xa1, 0x61,                   // "a"
+		0x82,             // fixmap, 2 entries
+		0xa1, 0x62, 0x03, // "b": 3
+		0xa1, 0x61, // "a"
 		0x82, 0xa1, 0x79, 0x02, 0xa1, 0x78, 0x01, // {y:2, x:1}
 	}
 

--- a/flyteplugins/go/tasks/pluginmachinery/catalog/hashing_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/catalog/hashing_test.go
@@ -653,6 +653,73 @@ func TestNoInputValues(t *testing.T) {
 	assert.Equal(t, hashDupe, hash)
 }
 
+// Ensure that msgpack Binary scalars with different key orderings produce the same hash
+func TestHashLiteralMap_MsgpackBinaryDeterministic(t *testing.T) {
+	// Manually constructed msgpack bytes for {a:1, b:2, c:3} with key order a, b, c
+	msgpackABC := []byte{
+		0x83,                   // fixmap, 3 entries
+		0xa1, 0x61, 0x01,      // "a": 1
+		0xa1, 0x62, 0x02,      // "b": 2
+		0xa1, 0x63, 0x03,      // "c": 3
+	}
+	// Same map {a:1, b:2, c:3} with key order c, a, b
+	msgpackCAB := []byte{
+		0x83,                   // fixmap, 3 entries
+		0xa1, 0x63, 0x03,      // "c": 3
+		0xa1, 0x61, 0x01,      // "a": 1
+		0xa1, 0x62, 0x02,      // "b": 2
+	}
+
+	litABC := &core.Literal{
+		Value: &core.Literal_Scalar{Scalar: &core.Scalar{
+			Value: &core.Scalar_Binary{Binary: &core.Binary{Value: msgpackABC, Tag: "msgpack"}},
+		}},
+	}
+	litCAB := &core.Literal{
+		Value: &core.Literal_Scalar{Scalar: &core.Scalar{
+			Value: &core.Scalar_Binary{Binary: &core.Binary{Value: msgpackCAB, Tag: "msgpack"}},
+		}},
+	}
+
+	hashABC, err := HashLiteralMap(context.TODO(), &core.LiteralMap{Literals: map[string]*core.Literal{"o0": litABC}}, nil)
+	assert.NoError(t, err)
+	hashCAB, err := HashLiteralMap(context.TODO(), &core.LiteralMap{Literals: map[string]*core.Literal{"o0": litCAB}}, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, hashABC, hashCAB, "identical dicts with different msgpack key orderings must hash equally")
+
+	// Nested: {a: {x:1, y:2}, b:3} with order a(x,y), b
+	msgpackNested1 := []byte{
+		0x82,                         // fixmap, 2 entries
+		0xa1, 0x61,                   // "a"
+		0x82, 0xa1, 0x78, 0x01, 0xa1, 0x79, 0x02, // {x:1, y:2}
+		0xa1, 0x62, 0x03,             // "b": 3
+	}
+	// Same nested map with order b, a(y,x)
+	msgpackNested2 := []byte{
+		0x82,                         // fixmap, 2 entries
+		0xa1, 0x62, 0x03,             // "b": 3
+		0xa1, 0x61,                   // "a"
+		0x82, 0xa1, 0x79, 0x02, 0xa1, 0x78, 0x01, // {y:2, x:1}
+	}
+
+	litNested1 := &core.Literal{
+		Value: &core.Literal_Scalar{Scalar: &core.Scalar{
+			Value: &core.Scalar_Binary{Binary: &core.Binary{Value: msgpackNested1, Tag: "msgpack"}},
+		}},
+	}
+	litNested2 := &core.Literal{
+		Value: &core.Literal_Scalar{Scalar: &core.Scalar{
+			Value: &core.Scalar_Binary{Binary: &core.Binary{Value: msgpackNested2, Tag: "msgpack"}},
+		}},
+	}
+
+	hashNested1, err := HashLiteralMap(context.TODO(), &core.LiteralMap{Literals: map[string]*core.Literal{"o0": litNested1}}, nil)
+	assert.NoError(t, err)
+	hashNested2, err := HashLiteralMap(context.TODO(), &core.LiteralMap{Literals: map[string]*core.Literal{"o0": litNested2}}, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, hashNested1, hashNested2, "identical nested dicts with different msgpack key orderings must hash equally")
+}
+
 // Ensure that empty inputs are hashed the same way
 func TestCacheIgnoreInputVars(t *testing.T) {
 	literalMap, err := coreutils.MakeLiteralMap(map[string]interface{}{"1": 1, "2": 2})

--- a/flyteplugins/go/tasks/pluginmachinery/catalog/hashing_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/catalog/hashing_test.go
@@ -720,6 +720,25 @@ func TestHashLiteralMap_MsgpackBinaryDeterministic(t *testing.T) {
 	assert.Equal(t, hashNested1, hashNested2, "identical nested dicts with different msgpack key orderings must hash equally")
 }
 
+// Ensure normalizeMsgpackBytes returns original bytes on invalid input
+func TestNormalizeMsgpackBytes_InvalidInput(t *testing.T) {
+	invalidBytes := []byte{0xff, 0xfe, 0xfd}
+	result := normalizeMsgpackBytes(invalidBytes)
+	assert.Equal(t, invalidBytes, result, "invalid msgpack should return original bytes unchanged")
+}
+
+// Ensure non-msgpack binary tags pass through hashify unmodified
+func TestHashify_NonMsgpackBinaryTag(t *testing.T) {
+	data := []byte{0x01, 0x02, 0x03}
+	lit := &core.Literal{
+		Value: &core.Literal_Scalar{Scalar: &core.Scalar{
+			Value: &core.Scalar_Binary{Binary: &core.Binary{Value: data, Tag: "protobuf"}},
+		}},
+	}
+	result := hashify(lit)
+	assert.Equal(t, lit, result, "non-msgpack binary should pass through unmodified")
+}
+
 // Ensure that empty inputs are hashed the same way
 func TestCacheIgnoreInputVars(t *testing.T) {
 	literalMap, err := coreutils.MakeLiteralMap(map[string]interface{}{"1": 1, "2": 2})


### PR DESCRIPTION
## Tracking issue

Closes #6776

## Why are the changes needed?

`DictTransformer` uses msgpack for serialization, which does not enforce key ordering. When the same dict is serialized on different machines or Python versions, the key order can vary, producing different bytes and therefore different cache hashes. This causes unexpected cache misses for identical inputs.

## What changes were proposed in this pull request?

In `hashify()` (`hashing.go`), added a normalization step for `Binary` scalars with the `msgpack` tag: unmarshal the msgpack bytes, then re-marshal to JSON (which sorts map keys alphabetically at every nesting level). The normalized JSON bytes replace the original value for hashing purposes only — stored data is unchanged.

If normalization fails (e.g., non-standard msgpack), the original bytes are used as-is, preserving backward compatibility.

Changes:
- Added `normalizeMsgpackBytes()` helper in `hashing.go`
- Called it from `hashify()` for Binary literals tagged `msgpack`
- Added tests covering flat dicts, nested dicts, non-msgpack tags, and invalid input fallback

## How was this patch tested?

Added the following tests in `hashing_test.go`:
- `TestHashLiteralMap_MsgpackBinaryDeterministic`: verifies that two msgpack-encoded maps with identical content but different key orders produce the same hash, including nested structures
- `TestHashify_NonMsgpackBinaryTag`: verifies Binary literals with non-msgpack tags are not modified
- `TestNormalizeMsgpackBytes_InvalidInput`: verifies graceful fallback on invalid msgpack input

All existing tests pass:
```
cd flyteplugins && go test ./go/tasks/pluginmachinery/catalog/ -v
```

### Labels

- **fixed**: Bug fix for non-deterministic cache hashing

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.