### PR TITLE
[V2] ListRuns return start/end time, duration, and environment name

### DIFF
--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -1336,10 +1336,20 @@ func (s *RunService) convertRunToProto(run *models.Run) *workflow.Run {
 			Run:  runID,
 			Name: run.Name,
 		},
-		Metadata: &workflow.ActionMetadata{},
+		Metadata: actionMetadataFromModel(run),
 		Status: &workflow.ActionStatus{
-			Phase: common.ActionPhase(run.Phase),
+			Phase:       common.ActionPhase(run.Phase),
+			StartTime:   timestamppb.New(run.CreatedAt),
+			Attempts:    run.Attempts,
+			CacheStatus: run.CacheStatus,
 		},
+	}
+	if run.EndedAt.Valid {
+		action.Status.EndTime = timestamppb.New(run.EndedAt.Time)
+	}
+	if run.DurationMs.Valid && run.DurationMs.Int64 >= 0 {
+		ms := uint64(run.DurationMs.Int64)
+		action.Status.DurationMs = &ms
 	}
 
 	var actionDetails workflow.ActionDetails
@@ -1356,7 +1366,9 @@ func (s *RunService) convertRunToProto(run *models.Run) *workflow.Run {
 		if actionDetails.Status.EndTime != nil {
 			action.Status.EndTime = actionDetails.Status.EndTime
 		}
-		if action.Status.StartTime != nil && action.Status.EndTime != nil {
+		if actionDetails.Status.DurationMs != nil {
+			action.Status.DurationMs = actionDetails.Status.DurationMs
+		} else if action.Status.StartTime != nil && action.Status.EndTime != nil {
 			ms := uint64(action.Status.EndTime.AsTime().Sub(action.Status.StartTime.AsTime()).Milliseconds())
 			action.Status.DurationMs = &ms
 		}

--- a/runs/service/run_service_test.go
+++ b/runs/service/run_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -387,7 +388,12 @@ func TestListRuns(t *testing.T) {
 	actionRepo, _, svc := newTestService(t)
 	runs := []*workflow.Run{}
 	sqlRes := []*models.Run{}
+	baseTime := time.Date(2026, time.March, 24, 10, 0, 0, 0, time.UTC)
 	for i := 0; i < 10; i++ {
+		startTime := timestamppb.New(baseTime.Add(time.Duration(i) * time.Minute))
+		endTime := timestamppb.New(startTime.AsTime().Add(2 * time.Minute))
+		durationMs := uint64(2 * time.Minute / time.Millisecond)
+		envName := fmt.Sprintf("env-%d", i)
 		runs = append(runs, &workflow.Run{
 			Action: &workflow.Action{
 				Id: &common.ActionIdentifier{
@@ -399,17 +405,31 @@ func TestListRuns(t *testing.T) {
 					},
 					Name: fmt.Sprintf("run-%d", i),
 				},
-				Metadata: &workflow.ActionMetadata{},
-				Status:   &workflow.ActionStatus{Phase: common.ActionPhase_ACTION_PHASE_SUCCEEDED},
+				Metadata: &workflow.ActionMetadata{
+					EnvironmentName: envName,
+				},
+				Status: &workflow.ActionStatus{
+					Phase:      common.ActionPhase_ACTION_PHASE_SUCCEEDED,
+					StartTime:  startTime,
+					EndTime:    endTime,
+					DurationMs: &durationMs,
+				},
 			},
 		})
 		sqlRes = append(sqlRes, &models.Run{
-			ID:      uint(i),
-			Org:     "test-org",
-			Project: "test-project",
-			Domain:  "test-domain",
-			Name:    fmt.Sprintf("run-%d", i),
-			Phase:   int32(common.ActionPhase_ACTION_PHASE_SUCCEEDED),
+			ID:         uint(i),
+			Org:        "test-org",
+			Project:    "test-project",
+			Domain:     "test-domain",
+			Name:       fmt.Sprintf("run-%d", i),
+			Phase:      int32(common.ActionPhase_ACTION_PHASE_SUCCEEDED),
+			CreatedAt:  startTime.AsTime(),
+			EndedAt:    sql.NullTime{Time: endTime.AsTime(), Valid: true},
+			DurationMs: sql.NullInt64{Int64: int64(durationMs), Valid: true},
+			EnvironmentName: sql.NullString{
+				String: envName,
+				Valid:  true,
+			},
 		})
 	}
 	type mockListRes struct {
@@ -486,7 +506,7 @@ func TestConvertRunToProto(t *testing.T) {
 	org := "test_org"
 	project := "test_project"
 	domain := "test_domain"
-	startTime := timestamppb.Now()
+	startTime := timestamppb.New(time.Date(2026, time.March, 24, 9, 0, 0, 0, time.UTC))
 	endTime := timestamppb.New(startTime.AsTime().Add(time.Minute))
 	durationMs := uint64(endTime.AsTime().Sub(startTime.AsTime()).Milliseconds())
 	status := &workflow.ActionStatus{
@@ -515,7 +535,12 @@ func TestConvertRunToProto(t *testing.T) {
 				Domain:        domain,
 				Name:          name,
 				Phase:         int32(common.ActionPhase_ACTION_PHASE_SUCCEEDED),
+				CreatedAt:     startTime.AsTime(),
 				ActionDetails: detailJson,
+				EnvironmentName: sql.NullString{
+					String: "prod",
+					Valid:  true,
+				},
 			},
 			&workflow.Run{
 				Action: &workflow.Action{
@@ -528,7 +553,9 @@ func TestConvertRunToProto(t *testing.T) {
 						},
 						Name: name,
 					},
-					Metadata: &workflow.ActionMetadata{},
+					Metadata: &workflow.ActionMetadata{
+						EnvironmentName: "prod",
+					},
 					Status:   status,
 				},
 			},
@@ -536,12 +563,19 @@ func TestConvertRunToProto(t *testing.T) {
 		{
 			"run with missing details",
 			&models.Run{
-				ID:      uint(0),
-				Org:     org,
-				Project: project,
-				Domain:  domain,
-				Name:    name,
-				Phase:   int32(common.ActionPhase_ACTION_PHASE_QUEUED),
+				ID:         uint(0),
+				Org:        org,
+				Project:    project,
+				Domain:     domain,
+				Name:       name,
+				Phase:      int32(common.ActionPhase_ACTION_PHASE_QUEUED),
+				CreatedAt:  startTime.AsTime(),
+				EndedAt:    sql.NullTime{Time: endTime.AsTime(), Valid: true},
+				DurationMs: sql.NullInt64{Int64: int64(durationMs), Valid: true},
+				EnvironmentName: sql.NullString{
+					String: "staging",
+					Valid:  true,
+				},
 			},
 			&workflow.Run{
 				Action: &workflow.Action{
@@ -554,8 +588,15 @@ func TestConvertRunToProto(t *testing.T) {
 						},
 						Name: name,
 					},
-					Metadata: &workflow.ActionMetadata{},
-					Status:   &workflow.ActionStatus{Phase: common.ActionPhase_ACTION_PHASE_QUEUED},
+					Metadata: &workflow.ActionMetadata{
+						EnvironmentName: "staging",
+					},
+					Status: &workflow.ActionStatus{
+						Phase:      common.ActionPhase_ACTION_PHASE_QUEUED,
+						StartTime:  startTime,
+						EndTime:    endTime,
+						DurationMs: &durationMs,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

ListRuns API miss some required return values

## What changes were proposed in this pull request?

Add start/end time, duration, and environment name in ListRuns response.

## How was this patch tested?

Tested locally and ensure UI showed correctly:

<img width="2798" height="1352" alt="image" src="https://github.com/user-attachments/assets/29ff259b-46eb-4f95-bdbd-f7ebeb7e26d7" />


### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
