### PR TITLE
fix: convert CoPilot timeout to seconds for terminationGracePeriodSeconds

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -274,7 +274,8 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 			// Let the sidecar container start before the downloader; it will ensure the signal watcher is started before the main container finishes.
 			coPilotPod.InitContainers = append([]v1.Container{sidecar}, coPilotPod.InitContainers...)
 
-			coPilotPod.TerminationGracePeriodSeconds = (*int64)(&cfg.Timeout.Duration)
+			terminationGracePeriodSeconds := int64(cfg.Timeout.Duration.Seconds())
+		coPilotPod.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Fix unit mismatch in `AddCoPilotToPod`: `cfg.Timeout.Duration` is a `time.Duration` (nanoseconds) but `TerminationGracePeriodSeconds` expects seconds
- Previously a 1h timeout produced `terminationGracePeriodSeconds: 3600000000000` (~114,000 years), causing pods to hang in Terminating state indefinitely

Fixes #7097