### PR TITLE
fix: suppress pflag usage output on startup errors

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -46,8 +46,9 @@ func (a *App) Run() error {
 // Command returns the root cobra.Command with config init wired in.
 func (a *App) Command() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   a.Name,
-		Short: a.Short,
+		Use:          a.Name,
+		Short:        a.Short,
+		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			return initConfig(cmd)
 		},


### PR DESCRIPTION
## Summary

- Set `SilenceUsage: true` on the root cobra command so that runtime errors (e.g. database connection failures) only print the error message instead of dumping the full flags list

Before:
```
{"json":{"src":"k8s.go:74"},"level":"info","msg":"Using kubeconfig from: /Users/kevin/.kube/cong","ts":"2026-03-27T11:27:24-07:00"}
Error: setup failed: failed to initialize Kubernetes client: failed to build k8s config from /Users/kevin/.kube/cong: stat /Users/kevin/.kube/cong: no such file or directory
Usage:
  flyte [flags]

Flags:
      --config string                                                                     config file (default is ./config.yaml)
      --database.connMaxLifeTime string                                                   sets the maximum amount of time a connection may be reused (default "1h0m0s")
      --database.enableForeignKeyConstraintWhenMigrating                                  Whether to enable gorm foreign keys when migrating the db
      --database.maxIdleConnections int                                                   maxIdleConnections sets the maximum number of connections in the idle connection pool. (default 10)
      --database.maxOpenConnections int                                                   maxOpenConnections sets the maximum number of open connections to the database. (default 100)
      --database.postgres.dbname string                                                   The database name (default "postgres")
      --database.postgres.debug                                                           
      --database.postgres.host string                                                     The host name of the database server (default "localhost")
      --database.postgres.options string                                                  See http://gorm.io/docs/connecting_to_the_database.html for available options passed,  in addition to the above. (default "sslmode=disable")
      --database.postgres.password string                                                 The database password. (default "postgres")
      --database.postgres.passwordPath string                                             Points to the file containing the database password.
      --database.postgres.port int                                                        The port name of the database server (default 30001)
      --database.postgres.readReplicaHost string                                          The host name of the read replica database server (default "localhost")
      --database.postgres.username string                                                 The database user who is connecting to the server. (default "postgres")
      --database.sqlite.file string                                                       The path to the file (existing or new) where the DB should be created / stored. If existing,  then this will be reused,  else a new will be created
      --dataproxy.download.maxExpiresIn string                                            Maximum allowed expiration duration. (default "1h0m0s")
      --dataproxy.upload.defaultFileNameLength int                                        Default length for the generated file name if file name not provided in the request. (default 20)
      --dataproxy.upload.maxExpiresIn string                                              Maximum allowed expiration duration. (default "1h0m0s")
      --dataproxy.upload.maxSize string                                                   Maximum allowed upload size. (default "100Mi")
      --dataproxy.upload.storagePrefix string                                             Storage prefix to use for all upload requests. (default "uploads")
      --executor.EventsServiceURL string                                                  URL of the Event Service for action event updates (default "http://localhost:8090")
      --executor.cluster string                                                           Cluster identifier for action events
      --executor.enableHTTP2                                                              Enable HTTP/2 for metrics and webhook servers
      --executor.gc.interval string                                                       How often the garbage collector runs. 0 disables GC. (default "30m0s")
      --executor.gc.maxTTL string                                                         Time-to-live for terminal TaskActions before deletion. (default "1h0m0s")
      --executor.healthProbeBindAddress string                                            Address the probe endpoint binds to (default ":8081")
      --executor.leaderElect                                                              Enable leader election for controller manager
      --executor.metricsBindAddress string                                                Address the metrics endpoint binds to (default ":10254")
      --executor.metricsCertKey string                                                    Name of the metrics server key file (default "tls.key")
      --executor.metricsCertName string                                                   Name of the metrics server certificate file (default "tls.crt")
      --executor.metricsCertPath string                                                   Directory containing the metrics server certificate
      --executor.metricsSecure                                                            Serve metrics endpoint via HTTPS (default true)
      --executor.webhookCertKey string                                                    Name of the webhook key file (default "tls.key")
      --executor.webhookCertName string                                                   Name of the webhook certificate file (default "tls.crt")
      --executor.webhookCertPath string                                                   Directory containing the webhook certificate
  -h, --help                                                                              help for flyte
      --logger.formatter.type string                                                      Sets logging format type. (default "json")
      --logger.level int                                                                  Sets the minimum logging level. (default 3)
      --logger.mute                                                                       Mutes all logs regardless of severity. Intended for benchmarks/tests only.
      --logger.show-source                                                                Includes source code location in logs.
      --manager.executor.healthProbePort int                                              Port for executor health probes (default 8081)
      --manager.kubernetes.burst int                                                      Max burst queries to the API server (default 2000)
      --manager.kubernetes.kubeconfig string                                              Path to kubeconfig file (optional)
      --manager.kubernetes.namespace string                                               Kubernetes namespace (default "flyte")
      --manager.kubernetes.qps int                                                        Max sustained queries per second to the API server (default 1000)
      --manager.kubernetes.timeout string                                                 Default timeout for API server requests (e.g. 30s) (default "30s")
      --manager.server.host string                                                        Host to bind the HTTP server (default "0.0.0.0")
      --manager.server.port int                                                           Port to bind the HTTP server (default 8090)
      --otel.file.filename string                                                         Filename to store exported telemetry traces (default "/tmp/trace.txt")
      --otel.jaeger.endpoint string                                                       Endpoint for the jaeger telemetry trace ingestor (default "http://localhost:14268/api/traces")
      --otel.otlpgrpc.endpoint string                                                     Endpoint for the OTLP telemetry trace collector (default "http://localhost:4317")
      --otel.otlphttp.endpoint string                                                     Endpoint for the OTLP telemetry trace collector (default "http://localhost:4318/v1/traces")
      --otel.sampler.parentSampler string                                                 Sets the parent sampler to use for the tracer (default "always")
      --otel.type string                                                                  Sets the type of exporter to configure [noop/file/jaeger/otlpgrpc/otlphttp]. (default "noop")
      --plugins.catalogcache.reader.maxItems int                                          Maximum number of entries to keep in the index. (default 10000)
      --plugins.catalogcache.reader.maxRetries int                                        Maximum number of retries per item. (default 3)
      --plugins.catalogcache.reader.workers int                                           Number of concurrent workers to start processing the queue. (default 10)
      --plugins.catalogcache.writer.maxItems int                                          Maximum number of entries to keep in the index. (default 10000)
      --plugins.catalogcache.writer.maxRetries int                                        Maximum number of retries per item. (default 3)
      --plugins.catalogcache.writer.workers int                                           Number of concurrent workers to start processing the queue. (default 10)
      --plugins.ioutils.remoteFileOutputPaths.deckFilename string                         Filename to use for the deck file. (default "deck.html")
      --plugins.k8s.add-tolerations-for-extended-resources strings                        Name of the extended resources for which tolerations should be added.
      --plugins.k8s.co-pilot.cpu string                                                   Used to set cpu for co-pilot containers (default "500m")
      --plugins.k8s.co-pilot.default-input-path string                                    Default path where the volume should be mounted (default "/var/flyte/inputs")
      --plugins.k8s.co-pilot.default-output-path string                                   Default path where the volume should be mounted (default "/var/flyte/outputs")
      --plugins.k8s.co-pilot.image string                                                 Flyte co-pilot Docker Image FQN (default "cr.flyte.org/flyteorg/flytecopilot:v0.0.15")
      --plugins.k8s.co-pilot.input-vol-name string                                        Name of the data volume that is created for storing inputs (default "flyte-inputs")
      --plugins.k8s.co-pilot.memory string                                                Used to set memory for co-pilot containers (default "128Mi")
      --plugins.k8s.co-pilot.name string                                                  Flyte co-pilot sidecar container name prefix. (additional bits will be added after this) (default "flyte-copilot-")
      --plugins.k8s.co-pilot.output-vol-name string                                       Name of the data volume that is created for storing outputs (default "flyte-outputs")
      --plugins.k8s.co-pilot.storage string                                               Default storage limit for individual inputs / outputs
      --plugins.k8s.default-cpus string                                                   Defines a default value for cpu for containers if not specified. (default "1")
      --plugins.k8s.default-memory string                                                 Defines a default value for memory for containers if not specified. (default "1Gi")
      --plugins.k8s.default-pod-template-name string                                      Name of the PodTemplate to use as the base for all k8s pods created by FlytePropeller.
      --plugins.k8s.default-pod-template-resync string                                    Frequency of resyncing default pod templates (default "30s")
      --plugins.k8s.delete-resource-on-finalize                                           Instructs the system to delete the resource upon successful execution of a k8s pod rather than have the k8s garbage collector clean it up. This ensures that no resources are kept around (potentially consuming cluster resources). This,  however,  will cause k8s log links to expire as soon as the resource is finalized.
      --plugins.k8s.disable-inject-owner-references                                       Override to not set owner references on k8s resources. This is useful for V2 node execution
      --plugins.k8s.inject-finalizer                                                      Instructs the plugin to inject a finalizer on startTask and remove it on task termination.
      --plugins.k8s.scheduler-name string                                                 Defines scheduler name.
      --plugins.k8s.send-object-events                                                    If true,  will send k8s object events in TaskExecutionEvent updates.
      --plugins.k8s.update-backoff-retries int                                            Number of retries for exponential backoff when updating a resource. (default 5)
      --plugins.k8s.update-base-backoff-duration int                                      Initial delay in exponential backoff when updating a resource in milliseconds. (default 10)
      --plugins.logs.cloudwatch-enabled                                                   Enable Cloudwatch Logging
      --plugins.logs.cloudwatch-log-group string                                          Log group to which streams are associated.
      --plugins.logs.cloudwatch-region string                                             AWS region in which Cloudwatch logs are stored.
      --plugins.logs.cloudwatch-template-uri string                                       Template Uri to use when building cloudwatch log links
      --plugins.logs.gcp-project string                                                   Name of the project in GCP
      --plugins.logs.kubernetes-enabled                                                   Enable Kubernetes Logging (default true)
      --plugins.logs.kubernetes-template-uri string                                       Template Uri to use when building kubernetes log links (default "http://localhost:30082/#!/log/{{ .namespace }}/{{ .podName }}/pod?namespace={{ .namespace }}")
      --plugins.logs.kubernetes-url string                                                Console URL for Kubernetes logs
      --plugins.logs.stackdriver-enabled                                                  Enable Log-links to stackdriver
      --plugins.logs.stackdriver-logresourcename string                                   Name of the logresource in stackdriver
      --plugins.logs.stackdriver-template-uri string                                      Template Uri to use when building stackdriver log links
      --runs.actionsServiceUrl string                                                     URL of the actions service (default "http://localhost:8090")
      --runs.database.connMaxLifeTime string                                              sets the maximum amount of time a connection may be reused (default "0s")
      --runs.database.enableForeignKeyConstraintWhenMigrating                             Whether to enable gorm foreign keys when migrating the db
      --runs.database.maxIdleConnections int                                              maxIdleConnections sets the maximum number of connections in the idle connection pool.
      --runs.database.maxOpenConnections int                                              maxOpenConnections sets the maximum number of open connections to the database.
      --runs.database.postgres.dbname string                                              The database name
      --runs.database.postgres.debug                                                      
      --runs.database.postgres.host string                                                The host name of the database server
      --runs.database.postgres.options string                                             See http://gorm.io/docs/connecting_to_the_database.html for available options passed,  in addition to the above.
      --runs.database.postgres.password string                                            The database password.
      --runs.database.postgres.passwordPath string                                        Points to the file containing the database password.
      --runs.database.postgres.port int                                                   The port name of the database server
      --runs.database.postgres.readReplicaHost string                                     The host name of the read replica database server
      --runs.database.postgres.username string                                            The database user who is connecting to the server.
      --runs.database.sqlite.file string                                                  The path to the file (existing or new) where the DB should be created / stored. If existing,  then this will be reused,  else a new will be created
      --runs.seedProjects strings                                                         Projects to create by default at startup (default [flytesnacks])
      --runs.server.host string                                                           Host to bind the HTTP server (default "0.0.0.0")
      --runs.server.port int                                                              Port to bind the HTTP server (default 8090)
      --runs.storagePrefix string                                                         Base URI prefix for storing run inputs and outputs (default "file:///tmp/flyte/data")
      --runs.watchBufferSize int                                                          Buffer size for watch streams (default 100)
      --secret.kubernetes.burst int                                                       Maximum burst above QPS for Kubernetes API server requests (default 200)
      --secret.kubernetes.clusterName string                                              Logical name of the cluster for secret status reporting (default "flyte-sandbox")
      --secret.kubernetes.kubeconfig string                                               Path to kubeconfig file (optional)
      --secret.kubernetes.namespace string                                                Kubernetes namespace for secret operations (default "flyte")
      --secret.kubernetes.qps int                                                         Maximum queries per second to the Kubernetes API server (default 100)
      --secret.kubernetes.timeout string                                                  Request timeout for Kubernetes API server calls (default "30s")
      --secret.server.host string                                                         Host to bind the HTTP server (default "0.0.0.0")
      --secret.server.port int                                                            Port to bind the HTTP server (default 8093)
      --secrets.env-prefix string                                                          Prefix for environment variables (default "FLYTE_SECRET_")
      --secrets.secrets-prefix string                                                      Prefix where to look for secrets file (default "/etc/secrets")
      --secrets.type string                                                               Sets the type of storage to configure [local]. (default "local")
      --storage.cache.max_size_mbs int                                                    Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
      --storage.cache.target_gc_percent int                                               Sets the garbage collection target percentage.
      --storage.connection.access-key string                                              Access key to use. Only required when authtype is set to accesskey.
      --storage.connection.auth-type string                                               Auth Type to use [iam, accesskey]. (default "iam")
      --storage.connection.disable-ssl                                                    Disables SSL connection. Should only be used for development.
      --storage.connection.endpoint string                                                URL for storage client to connect to.
      --storage.connection.region string                                                  Region to connect to. (default "us-east-1")
      --storage.connection.secret-key string                                              Secret to use when accesskey is set.
      --storage.container string                                                          Initial container (in s3 a bucket) to create -if it doesn't exist-.'
      --storage.defaultHttpClient.timeout string                                          Sets time out on the http client. (default "0s")
      --storage.enable-multicontainer                                                     If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
      --storage.limits.maxDownloadMBs int                                                 Maximum allowed download size (in MBs) per call. (default 2)
      --storage.stow.config stringToString                                                Configuration for stow backend. Refer to github/flyteorg/stow (default [])
      --storage.stow.kind string                                                          Kind of Stow backend to use. Refer to github/flyteorg/stow
      --storage.type string                                                               Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
      --webhook.awsSecretManager.sidecarImage string                                      Specifies the sidecar docker image to use (default "docker.io/amazon/aws-secrets-manager-secret-sidecar:v0.1.4")
      --webhook.azureSecretManager.sidecarImage string                                    Specifies the sidecar docker image to use (default "mcr.microsoft.com/azure-cli:cbl-mariner2.0")
      --webhook.certDir string                                                            Certificate directory to use to write generated certs. Defaults to /etc/webhook/certs/ (default "/etc/webhook/certs")
      --webhook.disableCreateMutatingWebhookConfig                                        
      --webhook.embeddedSecretManagerConfig.awsConfig.region string                       AWS region
      --webhook.embeddedSecretManagerConfig.azureConfig.vaultURI string                   Azure Vault URI
      --webhook.embeddedSecretManagerConfig.fileMountInitContainer.containerName string   Specifies the name of the init container that mounts secrets as files. (default "init-embedded-secret")
      --webhook.embeddedSecretManagerConfig.fileMountInitContainer.image string           Specifies init container image to use for mounting secrets as files. (default "busybox:1.28")
      --webhook.embeddedSecretManagerConfig.gcpConfig.project string                      GCP project to be used for secret manager
      --webhook.embeddedSecretManagerConfig.imagePullSecrets.enabled                      Whether to enable image pull secrets for the webhook pod.
      --webhook.embeddedSecretManagerConfig.k8sConfig.kubeClientConfig.burst int          Max burst rate for throttle. 0 defaults to 10
      --webhook.embeddedSecretManagerConfig.k8sConfig.kubeClientConfig.qps int32          Max QPS to the master for requests to KubeAPI. 0 defaults to 5.
      --webhook.embeddedSecretManagerConfig.k8sConfig.kubeClientConfig.timeout string     Max duration allowed for every request to KubeAPI before giving up. 0 implies no timeout. (default "0s")
      --webhook.embeddedSecretManagerConfig.k8sConfig.namespace string                    K8s namespace to be used for storing union secrets
      --webhook.embeddedSecretManagerConfig.type string                                    (default "AWS")
      --webhook.gcpSecretManager.sidecarImage string                                      Specifies the sidecar docker image to use (default "gcr.io/google.com/cloudsdktool/cloud-sdk:alpine")
      --webhook.kubeClientConfig.burst int                                                Max burst rate for throttle. 0 defaults to 10 (default 25)
      --webhook.kubeClientConfig.qps int32                                                Max QPS to the master for requests to KubeAPI. 0 defaults to 5. (default 100)
      --webhook.kubeClientConfig.timeout string                                           Max duration allowed for every request to KubeAPI before giving up. 0 implies no timeout. (default "30s")
      --webhook.listenPort int                                                            The port to use to listen to webhook calls. Defaults to 9443 (default 9443)
      --webhook.localCert                                                                 write certs locally. Defaults to false
      --webhook.metrics-prefix string                                                     An optional prefix for all published metrics. (default "flyte:")
      --webhook.secretEnvVarPrefix string                                                 The prefix for secret environment variables. Used by K8s,  Global,  and Embedded secret managers. Defaults to _UNION_ (default "_UNION_")
      --webhook.secretName string                                                         Secret name to write generated certs to. (default "flyte-pod-webhook")
      --webhook.serviceName string                                                        The name of the webhook service. (default "flyte-pod-webhook")
      --webhook.servicePort int32                                                         The port on the service that hosting webhook. (default 443)
      --webhook.vaultSecretManager.role string                                            Specifies the vault role to use (default "flyte")
      --webhook.webhookTimeout int32                                                      Timeout for webhook calls in seconds. Defaults to 30 seconds. (default 30)
```
After:
```
ns:0 OpenConnections:0 InUse:0 Idle:0 WaitCount:0 WaitDuration:0s MaxIdleClosed:1 MaxIdleTimeClosed:0 MaxLifetimeClosed:0}]","ts":"2026-03-27T11:27:24-07:00"}
{"json":{"src":"db.go:20"},"level":"info","msg":"Database connection established","ts":"2026-03-27T11:27:24-07:00"}
{"json":{"src":"k8s.go:74"},"level":"info","msg":"Using kubeconfig from: /Users/kevin/.kube/cong","ts":"2026-03-27T11:27:24-07:00"}
Error: setup failed: failed to initialize Kubernetes client: failed to build k8s config from /Users/kevin/.kube/cong: stat /Users/kevin/.kube/cong: no such file or directory
```
## Test plan

- [x] Start the binary without a database and confirm only the error is printed (no flags list)
- [x] Run with `--help` and confirm usage/flags are still displayed

- `main` <!-- branch-stack -->
  - \#6583
    - **fix: suppress pflag usage output on startup errors** :point\_left:
