### PR TITLE
[V2] prevent update DB if already terminated

### DIFF
--- a/runs/repository/impl/action.go
+++ b/runs/repository/impl/action.go
@@ -512,21 +512,42 @@ func (r *actionRepo) UpdateActionPhase(
 		}
 	}
 
-	// Only move the phase forward or re-apply the same phase — never downgrade.
-	result := r.db.WithContext(ctx).
+	query := r.db.WithContext(ctx).
 		Model(&models.Action{}).
-		Where("org = ? AND project = ? AND domain = ? AND run_name = ? AND name = ? AND phase <= ?",
-			actionID.Run.Org, actionID.Run.Project, actionID.Run.Domain, actionID.Run.Name, actionID.Name, phase).
-		Updates(updates)
+		Where("org = ? AND project = ? AND domain = ? AND run_name = ? AND name = ?",
+			actionID.Run.Org, actionID.Run.Project, actionID.Run.Domain, actionID.Run.Name, actionID.Name)
+
+	// Terminal updates are idempotent after the final state has been fully recorded.
+	// Keep allowing retries until ended_at is persisted or other terminal fields differ.
+	if isTerminalActionPhase(phase) {
+		query = query.Where("(phase < ? OR ended_at IS NULL OR attempts <> ? OR cache_status <> ?)",
+			phase, attempts, cacheStatus)
+	} else {
+		// Only move the phase forward or re-apply the same phase
+		query = query.Where("phase <= ?", phase)
+	}
+
+	result := query.Updates(updates)
 
 	if result.Error != nil {
 		return result.Error
 	}
 
-	// Notify subscribers of the action update
+	if result.RowsAffected == 0 {
+		return nil
+	}
+
+	// Notify subscribers of the action update.
 	r.notifyActionUpdate(ctx, actionID)
 
 	return nil
+}
+
+func isTerminalActionPhase(phase common.ActionPhase) bool {
+	return phase == common.ActionPhase_ACTION_PHASE_FAILED ||
+		phase == common.ActionPhase_ACTION_PHASE_SUCCEEDED ||
+		phase == common.ActionPhase_ACTION_PHASE_ABORTED ||
+		phase == common.ActionPhase_ACTION_PHASE_TIMED_OUT
 }
 
 // AbortAction aborts a specific action

--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -208,6 +208,118 @@ func TestUpdateActionPhase_PhaseGuard(t *testing.T) {
 		"phase should not downgrade from RUNNING to QUEUED")
 }
 
+func TestUpdateActionPhase_TerminalDuplicateIsNoOp(t *testing.T) {
+	db := setupActionDB(t)
+	defer func() { _ = db.Exec("DELETE FROM actions") }()
+	actionRepo, err := NewActionRepo(db, database.DbConfig{})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	actionID := &common.ActionIdentifier{
+		Run: &common.RunIdentifier{
+			Org:     "org1",
+			Project: "proj1",
+			Domain:  "domain1",
+			Name:    "run1",
+		},
+		Name: "action1",
+	}
+
+	_, err = actionRepo.CreateAction(ctx, &workflow.ActionSpec{
+		ActionId: actionID,
+		InputUri: "s3://bucket/input",
+	}, nil)
+	require.NoError(t, err)
+
+	firstEndTime := time.Now().Add(-time.Minute).UTC().Truncate(time.Millisecond)
+	err = actionRepo.UpdateActionPhase(
+		ctx,
+		actionID,
+		common.ActionPhase_ACTION_PHASE_SUCCEEDED,
+		1,
+		core.CatalogCacheStatus_CACHE_DISABLED,
+		&firstEndTime,
+	)
+	require.NoError(t, err)
+
+	action, err := actionRepo.GetAction(ctx, actionID)
+	require.NoError(t, err)
+	require.True(t, action.EndedAt.Valid)
+	firstUpdatedAt := action.UpdatedAt
+	firstEndedAt := action.EndedAt.Time
+
+	secondEndTime := firstEndTime.Add(30 * time.Second)
+	err = actionRepo.UpdateActionPhase(
+		ctx,
+		actionID,
+		common.ActionPhase_ACTION_PHASE_SUCCEEDED,
+		1,
+		core.CatalogCacheStatus_CACHE_DISABLED,
+		&secondEndTime,
+	)
+	require.NoError(t, err)
+
+	action, err = actionRepo.GetAction(ctx, actionID)
+	require.NoError(t, err)
+	assert.Equal(t, firstUpdatedAt, action.UpdatedAt)
+	assert.Equal(t, firstEndedAt, action.EndedAt.Time)
+}
+
+func TestUpdateActionPhase_TerminalDuplicateRepairsMissingEndedAt(t *testing.T) {
+	db := setupActionDB(t)
+	defer func() { _ = db.Exec("DELETE FROM actions") }()
+	actionRepo, err := NewActionRepo(db, database.DbConfig{})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	actionID := &common.ActionIdentifier{
+		Run: &common.RunIdentifier{
+			Org:     "org1",
+			Project: "proj1",
+			Domain:  "domain1",
+			Name:    "run1",
+		},
+		Name: "action1",
+	}
+
+	_, err = actionRepo.CreateAction(ctx, &workflow.ActionSpec{
+		ActionId: actionID,
+		InputUri: "s3://bucket/input",
+	}, nil)
+	require.NoError(t, err)
+
+	result := db.Model(&models.Action{}).
+		Where("org = ? AND project = ? AND domain = ? AND run_name = ? AND name = ?",
+			actionID.Run.Org, actionID.Run.Project, actionID.Run.Domain, actionID.Run.Name, actionID.Name).
+		Updates(map[string]interface{}{
+			"phase":        int32(common.ActionPhase_ACTION_PHASE_SUCCEEDED),
+			"ended_at":     nil,
+			"duration_ms":  nil,
+			"updated_at":   time.Now().Add(-time.Minute),
+			"attempts":     0,
+			"cache_status": core.CatalogCacheStatus_CACHE_DISABLED,
+		})
+	require.NoError(t, result.Error)
+	require.Equal(t, int64(1), result.RowsAffected)
+
+	endTime := time.Now().UTC().Truncate(time.Millisecond)
+	err = actionRepo.UpdateActionPhase(
+		ctx,
+		actionID,
+		common.ActionPhase_ACTION_PHASE_SUCCEEDED,
+		1,
+		core.CatalogCacheStatus_CACHE_DISABLED,
+		&endTime,
+	)
+	require.NoError(t, err)
+
+	action, err := actionRepo.GetAction(ctx, actionID)
+	require.NoError(t, err)
+	assert.True(t, action.EndedAt.Valid)
+	assert.Equal(t, uint32(1), action.Attempts)
+	assert.NotZero(t, action.DurationMs)
+}
+
 func TestListRuns(t *testing.T) {
 	db := setupActionDB(t)
 	defer func() { _ = db.Exec("DELETE FROM actions") }()


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

Keep getting slow SQL error in manager log

## What changes were proposed in this pull request?

Prevent update action in DB if already terminated, to prevent duplicate update

### Alternatives

#### 1. Add label to CR after persisted

- We can add a new label to CR after it's successfully persisted
- Cons:
  - Update the CR outside the controller, can be harder to maintain as CR will be updated in different places

## How was this patch tested?

Run locally and ensure there's no "slow SQL" error

### Labels

Please add one or more of the following labels to categorize your PR:

- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->

- `main` <!-- branch-stack -->
  - \#6583
    - **\[V2] prevent update DB if already terminated** :point\_left:
