### PR TITLE
[V2] Merge k3s kubeconfig to default kubeconfig

### DIFF
--- a/docker/sandbox-bundled/Makefile
+++ b/docker/sandbox-bundled/Makefile
@@ -92,8 +92,7 @@ start:
 			--env FLYTE_DEV=$(FLYTE_DEV) \
 			--env K3S_KUBECONFIG_OUTPUT=/.kube/kubeconfig \
 			--volume $(PWD)/.kube:/.kube \
-			--volume $(HOME)/.flyte/sandboxv2:/var/lib/flyte/config \
-			--volume flyte-sandbox:/var/lib/flyte/storage \
+				--volume flyte-sandbox:/var/lib/flyte/storage \
 			--publish "6443":"6443" \
 			--publish "30000:30000" \
 			--publish "30001:30001" \
@@ -106,9 +105,14 @@ start:
 	@until [ -s $(PWD)/.kube/kubeconfig ]; do sleep 1; done
 	@# On WSL, the bind-mounted kubeconfig may be root-owned, which makes the host-side cp fail with permission denied.
 	@docker exec flyte-sandbox chown $(shell id -u):$(shell id -g) /.kube/kubeconfig
-	@mkdir -p $(HOME)/.flyte/sandboxv2
-	@cp $(PWD)/.kube/kubeconfig $(HOME)/.flyte/sandboxv2/kubeconfig
-	@echo "Kubeconfig copied to ~/.flyte/sandboxv2/kubeconfig"
+	@mkdir -p $(HOME)/.kube
+	@if [ -f $(HOME)/.kube/config ]; then \
+		KUBECONFIG=$(PWD)/.kube/kubeconfig:$(HOME)/.kube/config kubectl config view --flatten > /tmp/kubeconfig-merged && \
+		mv /tmp/kubeconfig-merged $(HOME)/.kube/config; \
+	else \
+		cp $(PWD)/.kube/kubeconfig $(HOME)/.kube/config; \
+	fi
+	@echo "Kubeconfig merged into ~/.kube/config"
 .PHONY: kubeconfig
 .SILENT: kubeconfig
 kubeconfig:

--- a/manager/config.yaml
+++ b/manager/config.yaml
@@ -13,6 +13,7 @@ manager:
     namespace: "flyte"
     kubeconfig: "~/.kube/config"
 
+
 # Webhook configuration
 # localCert: true writes the generated TLS cert to disk so the webhook server can read it.
 webhook:


### PR DESCRIPTION
## Tracking issue

n/a

<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?

For better local dev experience, the process of sandbox k3s config generation fixed in this PR as bellow:

1. k3s generate k3s kubeconfig
2. Merge k3s kubeconfig into local default kubeconfig
3. Done, the user don't need to execute export shell command anymore

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
4. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

Makefile

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Labels

Please add one or more of the following labels to categorize your PR:

- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->

- `main` <!-- branch-stack -->
  - \#6583
    - **\[V2] Merge k3s kubeconfig to default kubeconfig** :point\_left:
