### PR TITLE
flytestdlib: add scoped storage metrics

### DIFF
--- a/flytestdlib/promutils/labeled/counter_test.go
+++ b/flytestdlib/promutils/labeled/counter_test.go
@@ -59,6 +59,21 @@ func TestLabeledCounter(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("LeadingDigit", func(t *testing.T) {
+		scope := promutils.NewScope("testscope_counter")
+		c := NewCounter("2xx", "some desc", scope)
+		assert.NotNil(t, c)
+
+		c.Inc(context.TODO())
+		expected := `
+			# HELP testscope_counter:_2xx some desc
+			# TYPE testscope_counter:_2xx counter
+			testscope_counter:_2xx{domain="",project="",task="",wf=""} 1
+		`
+		err := testutil.CollectAndCompare(c.CounterVec, strings.NewReader(expected))
+		assert.NoError(t, err)
+	})
+
 	t.Run("Unlabeled", func(t *testing.T) {
 		scope := promutils.NewScope("testscope_counter")
 		c := NewCounter("c2", "some desc", scope, EmitUnlabeledMetric)

--- a/flytestdlib/promutils/mirrored_scope.go
+++ b/flytestdlib/promutils/mirrored_scope.go
@@ -1,0 +1,285 @@
+package promutils
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// mirroredScope registers each metric under a primary scope and one or more alias scopes.
+// All registrations collect from the same metric instance.
+type mirroredScope struct {
+	primary Scope
+	scopes  []string
+}
+
+var _ Scope = mirroredScope{}
+
+// NewMirroredScope creates a scope that publishes metrics under the primary scope and each alias.
+func NewMirroredScope(primary Scope, aliases ...Scope) Scope {
+	if primary == nil {
+		panic("primary metric scope cannot be nil")
+	}
+
+	scopes := make([]string, 0, len(aliases)+1)
+	seen := make(map[string]struct{}, len(aliases)+1)
+	for _, scope := range append([]Scope{primary}, aliases...) {
+		if scope == nil {
+			panic("metric alias scope cannot be nil")
+		}
+		name := scope.CurrentScope()
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		scopes = append(scopes, name)
+	}
+
+	return mirroredScope{primary: primary, scopes: scopes}
+}
+
+func (m mirroredScope) register(collector prometheus.Collector) error {
+	registered := make([]prometheus.Registerer, 0, len(m.scopes))
+	for _, scope := range m.scopes {
+		registerer := prometheus.WrapRegistererWithPrefix(scope, prometheus.DefaultRegisterer)
+		if err := registerer.Register(collector); err != nil {
+			for i := len(registered) - 1; i >= 0; i-- {
+				registered[i].Unregister(collector)
+			}
+			return fmt.Errorf("register metric in scope %q: %w", scope, err)
+		}
+		registered = append(registered, registerer)
+	}
+	return nil
+}
+
+func metricName(name string) string {
+	if name == "" {
+		panic("metric name cannot be an empty string")
+	}
+	return SanitizeMetricName(name)
+}
+
+func (m mirroredScope) NewGauge(name, description string) (prometheus.Gauge, error) {
+	gauge := prometheus.NewGauge(prometheus.GaugeOpts{Name: metricName(name), Help: description})
+	return gauge, m.register(gauge)
+}
+
+func (m mirroredScope) MustNewGauge(name, description string) prometheus.Gauge {
+	gauge, err := m.NewGauge(name, description)
+	panicIfError(err)
+	return gauge
+}
+
+func (m mirroredScope) NewGaugeVec(name, description string, labelNames ...string) (*prometheus.GaugeVec, error) {
+	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: metricName(name), Help: description}, labelNames)
+	return gauge, m.register(gauge)
+}
+
+func (m mirroredScope) MustNewGaugeVec(name, description string, labelNames ...string) *prometheus.GaugeVec {
+	gauge, err := m.NewGaugeVec(name, description, labelNames...)
+	panicIfError(err)
+	return gauge
+}
+
+func (m mirroredScope) NewSummary(name, description string) (prometheus.Summary, error) {
+	return m.NewSummaryWithOptions(name, description, SummaryOptions{Objectives: defaultObjectives})
+}
+
+func (m mirroredScope) MustNewSummary(name, description string) prometheus.Summary {
+	summary, err := m.NewSummary(name, description)
+	panicIfError(err)
+	return summary
+}
+
+func (m mirroredScope) NewSummaryWithOptions(
+	name, description string, options SummaryOptions,
+) (prometheus.Summary, error) {
+	summary := prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       metricName(name),
+		Help:       description,
+		Objectives: options.Objectives,
+	})
+	return summary, m.register(summary)
+}
+
+func (m mirroredScope) MustNewSummaryWithOptions(name, description string, options SummaryOptions) prometheus.Summary {
+	summary, err := m.NewSummaryWithOptions(name, description, options)
+	panicIfError(err)
+	return summary
+}
+
+func (m mirroredScope) NewSummaryVec(name, description string, labelNames ...string) (*prometheus.SummaryVec, error) {
+	summary := prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       metricName(name),
+		Help:       description,
+		Objectives: defaultObjectives,
+	}, labelNames)
+	return summary, m.register(summary)
+}
+
+func (m mirroredScope) MustNewSummaryVec(name, description string, labelNames ...string) *prometheus.SummaryVec {
+	summary, err := m.NewSummaryVec(name, description, labelNames...)
+	panicIfError(err)
+	return summary
+}
+
+func (m mirroredScope) NewHistogram(name, description string) (prometheus.Histogram, error) {
+	histogram := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    metricName(name),
+		Help:    description,
+		Buckets: defaultBuckets,
+	})
+	return histogram, m.register(histogram)
+}
+
+func (m mirroredScope) MustNewHistogram(name, description string) prometheus.Histogram {
+	histogram, err := m.NewHistogram(name, description)
+	panicIfError(err)
+	return histogram
+}
+
+func (m mirroredScope) NewHistogramVec(
+	name, description string, labelNames ...string,
+) (*prometheus.HistogramVec, error) {
+	return m.NewHistogramVecWithOptions(name, description, HistogramOptions{Buckets: defaultBuckets}, labelNames...)
+}
+
+func (m mirroredScope) MustNewHistogramVec(name, description string, labelNames ...string) *prometheus.HistogramVec {
+	histogram, err := m.NewHistogramVec(name, description, labelNames...)
+	panicIfError(err)
+	return histogram
+}
+
+func (m mirroredScope) NewHistogramVecWithOptions(
+	name, description string, options HistogramOptions, labelNames ...string,
+) (*prometheus.HistogramVec, error) {
+	histogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    metricName(name),
+		Help:    description,
+		Buckets: options.Buckets,
+	}, labelNames)
+	return histogram, m.register(histogram)
+}
+
+func (m mirroredScope) MustNewHistogramVecWithOptions(
+	name, description string, options HistogramOptions, labelNames ...string,
+) *prometheus.HistogramVec {
+	histogram, err := m.NewHistogramVecWithOptions(name, description, options, labelNames...)
+	panicIfError(err)
+	return histogram
+}
+
+func (m mirroredScope) NewCounter(name, description string) (prometheus.Counter, error) {
+	counter := prometheus.NewCounter(prometheus.CounterOpts{Name: metricName(name), Help: description})
+	return counter, m.register(counter)
+}
+
+func (m mirroredScope) MustNewCounter(name, description string) prometheus.Counter {
+	counter, err := m.NewCounter(name, description)
+	panicIfError(err)
+	return counter
+}
+
+func (m mirroredScope) NewCounterVec(name, description string, labelNames ...string) (*prometheus.CounterVec, error) {
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: metricName(name), Help: description}, labelNames)
+	return counter, m.register(counter)
+}
+
+func (m mirroredScope) MustNewCounterVec(name, description string, labelNames ...string) *prometheus.CounterVec {
+	counter, err := m.NewCounterVec(name, description, labelNames...)
+	panicIfError(err)
+	return counter
+}
+
+func (m mirroredScope) NewStopWatch(name, description string, scale time.Duration) (StopWatch, error) {
+	name = scaledMetricName(name, scale)
+	summary, err := m.NewSummary(name, description)
+	if err != nil {
+		return StopWatch{}, err
+	}
+	return StopWatch{Observer: summary, outputScale: scale}, nil
+}
+
+func (m mirroredScope) MustNewStopWatch(name, description string, scale time.Duration) StopWatch {
+	stopwatch, err := m.NewStopWatch(name, description, scale)
+	panicIfError(err)
+	return stopwatch
+}
+
+func (m mirroredScope) NewStopWatchVec(
+	name, description string, scale time.Duration, labelNames ...string,
+) (*StopWatchVec, error) {
+	name = scaledMetricName(name, scale)
+	summary, err := m.NewSummaryVec(name, description, labelNames...)
+	if err != nil {
+		return &StopWatchVec{}, err
+	}
+	return &StopWatchVec{SummaryVec: summary, outputScale: scale}, nil
+}
+
+func (m mirroredScope) MustNewStopWatchVec(
+	name, description string, scale time.Duration, labelNames ...string,
+) *StopWatchVec {
+	stopwatch, err := m.NewStopWatchVec(name, description, scale, labelNames...)
+	panicIfError(err)
+	return stopwatch
+}
+
+func (m mirroredScope) NewHistogramStopWatch(name, description string) (HistogramStopWatch, error) {
+	histogram, err := m.NewHistogram(name, description)
+	if err != nil {
+		return HistogramStopWatch{}, err
+	}
+	return HistogramStopWatch{StopWatch: StopWatch{Observer: histogram, outputScale: time.Second}}, nil
+}
+
+func (m mirroredScope) MustNewHistogramStopWatch(name, description string) HistogramStopWatch {
+	stopwatch, err := m.NewHistogramStopWatch(name, description)
+	panicIfError(err)
+	return stopwatch
+}
+
+func (m mirroredScope) NewHistogramStopWatchVec(
+	name, description string, labelNames ...string,
+) (*HistogramStopWatchVec, error) {
+	histogram, err := m.NewHistogramVec(name, description, labelNames...)
+	if err != nil {
+		return &HistogramStopWatchVec{}, err
+	}
+	return &HistogramStopWatchVec{HistogramVec: histogram, outputScale: time.Second}, nil
+}
+
+func (m mirroredScope) MustNewHistogramStopWatchVec(
+	name, description string, labelNames ...string,
+) *HistogramStopWatchVec {
+	stopwatch, err := m.NewHistogramStopWatchVec(name, description, labelNames...)
+	panicIfError(err)
+	return stopwatch
+}
+
+func (m mirroredScope) NewSubScope(name string) Scope {
+	primary := m.primary.NewSubScope(name)
+	aliases := make([]Scope, 0, len(m.scopes)-1)
+	for _, scope := range m.scopes[1:] {
+		aliases = append(aliases, NewScope(scope).NewSubScope(name))
+	}
+	return NewMirroredScope(primary, aliases...)
+}
+
+func (m mirroredScope) CurrentScope() string {
+	return m.primary.CurrentScope()
+}
+
+func (m mirroredScope) NewScopedMetricName(name string) string {
+	return m.primary.NewScopedMetricName(name)
+}
+
+func scaledMetricName(name string, scale time.Duration) string {
+	if !strings.HasSuffix(name, defaultMetricDelimiterStr) {
+		name += defaultMetricDelimiterStr
+	}
+	return name + DurationToString(scale)
+}

--- a/flytestdlib/promutils/mirrored_scope_test.go
+++ b/flytestdlib/promutils/mirrored_scope_test.go
@@ -1,0 +1,138 @@
+package promutils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func useTestRegistry(t *testing.T) *prometheus.Registry {
+	t.Helper()
+	registerer := prometheus.DefaultRegisterer
+	gatherer := prometheus.DefaultGatherer
+	registry := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer = registry
+	prometheus.DefaultGatherer = registry
+	t.Cleanup(func() {
+		prometheus.DefaultRegisterer = registerer
+		prometheus.DefaultGatherer = gatherer
+	})
+	return registry
+}
+
+func gatherMetricFamilies(t *testing.T, gatherer prometheus.Gatherer) map[string]*dto.MetricFamily {
+	t.Helper()
+	families, err := gatherer.Gather()
+	require.NoError(t, err)
+	result := make(map[string]*dto.MetricFamily, len(families))
+	for _, family := range families {
+		result[family.GetName()] = family
+	}
+	return result
+}
+
+func TestMirroredScope(t *testing.T) {
+	registry := useTestRegistry(t)
+	scope := NewMirroredScope(NewScope("primary"), NewScope("legacy"))
+
+	counter := scope.MustNewCounter("counter", "counter")
+	counter.Add(2)
+	gauge := scope.MustNewGauge("gauge", "gauge")
+	gauge.Set(3)
+	counterVec := scope.MustNewCounterVec("counter_vec", "counter vec", "kind")
+	counterVec.WithLabelValues("test").Add(4)
+	gaugeVec := scope.MustNewGaugeVec("gauge_vec", "gauge vec", "kind")
+	gaugeVec.WithLabelValues("test").Set(5)
+	summary := scope.MustNewSummary("summary", "summary")
+	summary.Observe(6)
+	summaryWithOptions := scope.MustNewSummaryWithOptions("summary_options", "summary options", SummaryOptions{
+		Objectives: map[float64]float64{0.75: 0.01},
+	})
+	summaryWithOptions.Observe(6.5)
+	summaryVec := scope.MustNewSummaryVec("summary_vec", "summary vec", "kind")
+	summaryVec.WithLabelValues("test").Observe(7)
+	histogram := scope.MustNewHistogram("histogram", "histogram")
+	histogram.Observe(8)
+	histogramVec := scope.MustNewHistogramVec("histogram_vec", "histogram vec", "kind")
+	histogramVec.WithLabelValues("test").Observe(9)
+	histogramVecWithOptions := scope.MustNewHistogramVecWithOptions(
+		"histogram_vec_options", "histogram vec options", HistogramOptions{Buckets: []float64{1, 10}}, "kind",
+	)
+	histogramVecWithOptions.WithLabelValues("test").Observe(9.5)
+	stopwatch := scope.MustNewStopWatch("stopwatch", "stopwatch", time.Millisecond)
+	stopwatch.Observe(time.Unix(0, 0), time.Unix(0, int64(10*time.Millisecond)))
+	stopwatchVec := scope.MustNewStopWatchVec("stopwatch_vec", "stopwatch vec", time.Millisecond, "kind")
+	stopwatchVec.WithLabelValues("test").Observe(time.Unix(0, 0), time.Unix(0, int64(11*time.Millisecond)))
+	histogramStopwatch := scope.MustNewHistogramStopWatch("histogram_stopwatch", "histogram stopwatch")
+	histogramStopwatch.Observe(time.Unix(0, 0), time.Unix(0, int64(time.Second)))
+	histogramStopwatchVec := scope.MustNewHistogramStopWatchVec(
+		"histogram_stopwatch_vec", "histogram stopwatch vec", "kind",
+	)
+	histogramStopwatchVec.WithLabelValues("test").Observe(time.Unix(0, 0), time.Unix(0, int64(2*time.Second)))
+	nested := scope.NewSubScope("nested").MustNewCounter("counter", "nested counter")
+	nested.Inc()
+
+	require.Equal(t, "primary:", scope.CurrentScope())
+	require.Equal(t, "primary:metric", scope.NewScopedMetricName("metric"))
+
+	families := gatherMetricFamilies(t, registry)
+	for _, name := range []string{
+		"counter", "gauge", "counter_vec", "gauge_vec", "summary", "summary_options", "summary_vec",
+		"histogram", "histogram_vec", "histogram_vec_options", "stopwatch_ms", "stopwatch_vec_ms",
+		"histogram_stopwatch", "histogram_stopwatch_vec",
+	} {
+		require.Contains(t, families, "primary:"+name)
+		require.Contains(t, families, "legacy:"+name)
+		require.Equal(t, families["primary:"+name].Metric, families["legacy:"+name].Metric, name)
+	}
+	require.Contains(t, families, "primary:nested:counter")
+	require.Contains(t, families, "legacy:nested:counter")
+	require.Equal(t, families["primary:nested:counter"].Metric, families["legacy:nested:counter"].Metric)
+}
+
+func TestMirroredScopeDeduplicatesScopes(t *testing.T) {
+	registry := useTestRegistry(t)
+	primary := NewScope("same")
+	scope := NewMirroredScope(primary, primary, NewScope("same"))
+	scope.MustNewCounter("counter", "counter").Inc()
+
+	families := gatherMetricFamilies(t, registry)
+	require.Contains(t, families, "same:counter")
+	require.Len(t, families, 1)
+}
+
+func TestMirroredScopeSanitizesLeadingDigitMetricNames(t *testing.T) {
+	registry := useTestRegistry(t)
+	scope := NewMirroredScope(NewScope("primary"), NewScope("legacy"))
+	scope.MustNewCounter("2xx", "leading digit").Inc()
+	scope.MustNewCounter("xx", "without leading digit").Add(2)
+
+	families := gatherMetricFamilies(t, registry)
+	for _, name := range []string{"_2xx", "xx"} {
+		require.Contains(t, families, "primary:"+name)
+		require.Contains(t, families, "legacy:"+name)
+		require.Equal(t, families["primary:"+name].Metric, families["legacy:"+name].Metric)
+	}
+	require.Len(t, families, 4)
+}
+
+func TestMirroredScopeRollsBackPartialRegistration(t *testing.T) {
+	registry := useTestRegistry(t)
+	registry.MustRegister(prometheus.NewCounter(prometheus.CounterOpts{Name: "legacy:counter", Help: "conflict"}))
+
+	scope := NewMirroredScope(NewScope("primary"), NewScope("legacy"))
+	_, err := scope.NewCounter("counter", "counter")
+	require.Error(t, err)
+
+	families := gatherMetricFamilies(t, registry)
+	require.NotContains(t, families, "primary:counter")
+	require.Contains(t, families, "legacy:counter")
+}
+
+func TestMirroredScopeRejectsNilScopes(t *testing.T) {
+	require.Panics(t, func() { NewMirroredScope(nil) })
+	require.Panics(t, func() { NewMirroredScope(NewScope("primary"), nil) })
+}

--- a/flytestdlib/promutils/scope.go
+++ b/flytestdlib/promutils/scope.go
@@ -518,7 +518,7 @@ func (m metricsScope) NewScopedMetricName(name string) string {
 		panic("metric name cannot be an empty string")
 	}
 
-	return SanitizeMetricName(m.scope + name)
+	return m.scope + SanitizeMetricName(name)
 }
 
 func (m metricsScope) NewSubScope(subscopeName string) Scope {
@@ -552,13 +552,20 @@ func NewScope(name string) Scope {
 	}
 }
 
-// SanitizeMetricName ensures the generates metric name is compatible with the underlying prometheus library.
+// SanitizeMetricName returns a Prometheus-compatible metric name. If the first retained character is a digit,
+// the name is prefixed with an underscore.
 func SanitizeMetricName(name string) string {
 	out := strings.Builder{}
-	for i, b := range name {
-		if (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || b == ':' || (b >= '0' && b <= '9' && i > 0) {
+	for _, b := range name {
+		switch {
+		case (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || b == ':':
 			out.WriteRune(b)
-		} else if b == '-' {
+		case b >= '0' && b <= '9':
+			if out.Len() == 0 {
+				out.WriteRune('_')
+			}
+			out.WriteRune(b)
+		case b == '-':
 			out.WriteRune('_')
 		}
 	}

--- a/flytestdlib/promutils/scope_test.go
+++ b/flytestdlib/promutils/scope_test.go
@@ -42,14 +42,37 @@ func TestNewScope(t *testing.T) {
 	})
 	s := NewScope("test")
 	assert.Equal(t, "test:", s.CurrentScope())
+	assert.Equal(t, "_2scope:", NewScope("2scope").CurrentScope())
 	assert.Equal(t, "test:hello:", s.NewSubScope("hello").CurrentScope())
 	assert.Panics(t, func() {
 		s.NewSubScope("")
 	})
 	assert.Equal(t, "test:timer_x", s.NewScopedMetricName("timer_x"))
+	assert.Equal(t, "test:_2xx", s.NewScopedMetricName("2xx"))
 	assert.Equal(t, "test:hello:timer:", s.NewSubScope("hello").NewSubScope("timer").CurrentScope())
 	assert.Equal(t, "test:hello:timer:", s.NewSubScope("hello").NewSubScope("timer:").CurrentScope())
 	assert.Equal(t, "test:k8s_array:test_1:", s.NewSubScope("k8s-array").NewSubScope("test-1:").CurrentScope())
+}
+
+func TestSanitizeMetricName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		expected string
+	}{
+		{name: "metric", expected: "metric"},
+		{name: "test-1", expected: "test_1"},
+		{name: "2xx", expected: "_2xx"},
+		{name: ".2xx", expected: "_2xx"},
+		{name: "_2xx", expected: "_2xx"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := SanitizeMetricName(testCase.name)
+			assert.Equal(t, testCase.expected, actual)
+			assert.Equal(t, actual, SanitizeMetricName(actual))
+		})
+	}
 }
 
 func TestMetricsScope(t *testing.T) {

--- a/flytestdlib/storage/cached_rawstore.go
+++ b/flytestdlib/storage/cached_rawstore.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"io"
 	"runtime/debug"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/coocood/freecache"
@@ -19,12 +21,41 @@ import (
 
 const neverExpire = 0
 
-// TODO Freecache has bunch of metrics it calculates. Lets write a prom collector to publish these metrics
+type freecacheCollector struct {
+	cache          atomic.Pointer[freecache.Cache]
+	registerOnce   sync.Once
+	entryCount     *prometheus.Desc
+	evacuateCount  *prometheus.Desc
+	overwriteCount *prometheus.Desc
+	expiredCount   *prometheus.Desc
+}
+
+func (c *freecacheCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.entryCount
+	ch <- c.evacuateCount
+	ch <- c.overwriteCount
+	ch <- c.expiredCount
+}
+
+func (c *freecacheCollector) Collect(ch chan<- prometheus.Metric) {
+	cache := c.cache.Load()
+	if cache == nil {
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(c.entryCount, prometheus.GaugeValue, float64(cache.EntryCount()))
+	ch <- prometheus.MustNewConstMetric(c.evacuateCount, prometheus.CounterValue, float64(cache.EvacuateCount()))
+	ch <- prometheus.MustNewConstMetric(c.overwriteCount, prometheus.CounterValue, float64(cache.OverwriteCount()))
+	ch <- prometheus.MustNewConstMetric(c.expiredCount, prometheus.CounterValue, float64(cache.ExpiredCount()))
+}
+
 type cacheMetrics struct {
 	CacheHit        prometheus.Counter
 	CacheMiss       prometheus.Counter
 	CacheWriteError prometheus.Counter
 	FetchLatency    promutils.StopWatch
+	CacheReadBytes  prometheus.Counter
+	CacheWriteBytes prometheus.Counter
+	collector       *freecacheCollector
 }
 
 type cachedRawStore struct {
@@ -59,6 +90,7 @@ func (s *cachedRawStore) ReadRaw(ctx context.Context, reference DataReference) (
 	if oRaw, err := s.cache.Get(key); err == nil {
 		// Found, Cache hit
 		s.metrics.CacheHit.Inc()
+		s.metrics.CacheReadBytes.Add(float64(len(oRaw)))
 		return ioutils.NewBytesReadCloser(oRaw), nil
 	}
 	s.metrics.CacheMiss.Inc()
@@ -81,8 +113,11 @@ func (s *cachedRawStore) ReadRaw(ctx context.Context, reference DataReference) (
 
 	err = s.cache.Set(key, b, 0)
 	if err != nil {
-		logger.Debugf(ctx, "Failed to Cache the metadata")
+		s.metrics.CacheWriteError.Inc()
 		err = errors.Wrapf(ErrFailedToWriteCache, err, "Failed to Cache the metadata")
+		logger.Warn(ctx, err.Error())
+	} else {
+		s.metrics.CacheWriteBytes.Add(float64(len(b)))
 	}
 
 	return ioutils.NewBytesReadCloser(b), err
@@ -104,6 +139,9 @@ func (s *cachedRawStore) WriteRaw(ctx context.Context, reference DataReference, 
 	if err != nil {
 		s.metrics.CacheWriteError.Inc()
 		err = errors.Wrapf(ErrFailedToWriteCache, err, "Failed to Cache the metadata")
+		logger.Warn(ctx, err.Error())
+	} else {
+		s.metrics.CacheWriteBytes.Add(float64(buf.Len()))
 	}
 
 	return err
@@ -121,12 +159,36 @@ func (s *cachedRawStore) Delete(ctx context.Context, reference DataReference) er
 	return s.RawStore.Delete(ctx, reference)
 }
 
-func newCacheMetrics(scope promutils.Scope) *cacheMetrics {
+func newCacheMetrics(existingScope, canonicalScope promutils.Scope) *cacheMetrics {
 	return &cacheMetrics{
-		FetchLatency:    scope.MustNewStopWatch("remote_fetch", "Total Time to read from remote metastore", time.Millisecond),
-		CacheHit:        scope.MustNewCounter("cache_hit", "Number of times metadata was found in cache"),
-		CacheMiss:       scope.MustNewCounter("cache_miss", "Number of times metadata was not found in cache and remote fetch was required"),
-		CacheWriteError: scope.MustNewCounter("cache_write_err", "Failed to write to cache"),
+		FetchLatency: existingScope.MustNewStopWatch(
+			"remote_fetch", "Total Time to read from remote metastore", time.Millisecond,
+		),
+		CacheHit: existingScope.MustNewCounter("cache_hit", "Number of times metadata was found in cache"),
+		CacheMiss: existingScope.MustNewCounter(
+			"cache_miss", "Number of times metadata was not found in cache and remote fetch was required",
+		),
+		CacheWriteError: existingScope.MustNewCounter("cache_write_err", "Failed to write to cache"),
+		CacheReadBytes:  canonicalScope.MustNewCounter("read_bytes_total", "Bytes read from in-memory cache"),
+		CacheWriteBytes: canonicalScope.MustNewCounter("write_bytes_total", "Bytes written to in-memory cache"),
+		collector: &freecacheCollector{
+			entryCount: prometheus.NewDesc(
+				canonicalScope.NewScopedMetricName("entry_count"),
+				"Current number of entries in the in-memory cache", nil, nil,
+			),
+			evacuateCount: prometheus.NewDesc(
+				canonicalScope.NewScopedMetricName("evacuate_count_total"),
+				"Number of entries evicted from the in-memory cache due to memory pressure", nil, nil,
+			),
+			overwriteCount: prometheus.NewDesc(
+				canonicalScope.NewScopedMetricName("overwrite_count_total"),
+				"Number of times an entry was overwritten in the in-memory cache", nil, nil,
+			),
+			expiredCount: prometheus.NewDesc(
+				canonicalScope.NewScopedMetricName("expired_count_total"),
+				"Number of entries expired from the in-memory cache", nil, nil,
+			),
+		},
 	}
 }
 
@@ -136,11 +198,17 @@ func newCachedRawStore(cfg *Config, store RawStore, metrics *cacheMetrics) RawSt
 		if cfg.Cache.TargetGCPercent > 0 {
 			debug.SetGCPercent(cfg.Cache.TargetGCPercent)
 		}
+		fc := freecache.NewCache(cfg.Cache.MaxSizeMegabytes * 1024 * 1024)
+		metrics.collector.cache.Store(fc)
+		metrics.collector.registerOnce.Do(func() {
+			prometheus.MustRegister(metrics.collector)
+		})
 		return &cachedRawStore{
 			RawStore: store,
-			cache:    freecache.NewCache(cfg.Cache.MaxSizeMegabytes * 1024 * 1024),
+			cache:    fc,
 			metrics:  metrics,
 		}
 	}
+	metrics.collector.cache.Store(nil)
 	return store
 }

--- a/flytestdlib/storage/cached_rawstore_test.go
+++ b/flytestdlib/storage/cached_rawstore_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime/debug"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/ioutils"
@@ -166,12 +167,15 @@ func TestCachedRawStore(t *testing.T) {
 	})
 
 	t.Run("ReadCachePopulate", func(t *testing.T) {
+		readBytes := testutil.ToFloat64(metrics.cacheMetrics.CacheReadBytes)
+		writeBytes := testutil.ToFloat64(metrics.cacheMetrics.CacheWriteBytes)
 		o, err := cStore.ReadRaw(ctx, k1)
 		assert.NoError(t, err)
 		b, err := io.ReadAll(o)
 		assert.NoError(t, err)
 		assert.Equal(t, d1, b)
 		assert.True(t, readCalled)
+		assert.Equal(t, writeBytes+float64(len(d1)), testutil.ToFloat64(metrics.cacheMetrics.CacheWriteBytes))
 		readCalled = false
 		o, err = cStore.ReadRaw(ctx, k1)
 		assert.NoError(t, err)
@@ -179,6 +183,7 @@ func TestCachedRawStore(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, d1, b)
 		assert.False(t, readCalled)
+		assert.Equal(t, readBytes+float64(len(d1)), testutil.ToFloat64(metrics.cacheMetrics.CacheReadBytes))
 	})
 
 	t.Run("ReadFail", func(t *testing.T) {
@@ -189,9 +194,12 @@ func TestCachedRawStore(t *testing.T) {
 	})
 
 	t.Run("WriteAndRead", func(t *testing.T) {
+		readBytes := testutil.ToFloat64(metrics.cacheMetrics.CacheReadBytes)
+		writeBytes := testutil.ToFloat64(metrics.cacheMetrics.CacheWriteBytes)
 		readCalled = false
 		assert.NoError(t, cStore.WriteRaw(ctx, k2, int64(len(d2)), Options{}, bytes.NewReader(d2)))
 		assert.True(t, writeCalled)
+		assert.Equal(t, writeBytes+float64(len(d2)), testutil.ToFloat64(metrics.cacheMetrics.CacheWriteBytes))
 
 		o, err := cStore.ReadRaw(ctx, k2)
 		assert.NoError(t, err)
@@ -199,14 +207,18 @@ func TestCachedRawStore(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, d2, b)
 		assert.False(t, readCalled)
+		assert.Equal(t, readBytes+float64(len(d2)), testutil.ToFloat64(metrics.cacheMetrics.CacheReadBytes))
 	})
 
 	t.Run("WriteAndReadBigData", func(t *testing.T) {
+		writeBytes := testutil.ToFloat64(metrics.cacheMetrics.CacheWriteBytes)
+		writeErrors := testutil.ToFloat64(metrics.cacheMetrics.CacheWriteError)
 		writeCalled = false
 		readCalled = false
 		err := cStore.WriteRaw(ctx, bigK, int64(len(bigD)), Options{}, bytes.NewReader(bigD))
 		assert.True(t, writeCalled)
 		assert.True(t, IsFailedWriteToCache(err))
+		assert.Equal(t, writeBytes, testutil.ToFloat64(metrics.cacheMetrics.CacheWriteBytes))
 
 		o, err := cStore.ReadRaw(ctx, bigK)
 		assert.True(t, IsFailedWriteToCache(err))
@@ -214,6 +226,8 @@ func TestCachedRawStore(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, bigD, b)
 		assert.True(t, readCalled)
+		assert.Equal(t, writeBytes, testutil.ToFloat64(metrics.cacheMetrics.CacheWriteBytes))
+		assert.Equal(t, writeErrors+2, testutil.ToFloat64(metrics.cacheMetrics.CacheWriteError))
 	})
 
 	t.Run("DeleteExists", func(t *testing.T) {

--- a/flytestdlib/storage/config.go
+++ b/flytestdlib/storage/config.go
@@ -58,6 +58,9 @@ type Config struct {
 	Type  Type        `json:"type" pflag:",Sets the type of storage [s3/minio/local/mem/stow/redis]."`
 	Stow  StowConfig  `json:"stow,omitempty" pflag:",Storage config for stow backend."`
 	Redis RedisConfig `json:"redis,omitempty" pflag:"-,Storage config for the redis backend."`
+	// EnableLegacyMetrics publishes aliases for storage metrics that predate the cache, proto, and stow subscopes.
+	// Changing this value requires recreating the DataStore.
+	EnableLegacyMetrics bool `json:"enableLegacyMetrics" pflag:",Publish legacy unscoped storage metric aliases. Requires a service restart when changed."` //nolint:lll
 
 	// Container here is misleading, it refers to a Bucket (AWS S3) like blobstore entity. In some terms it could be a table
 	InitContainer string `json:"container" pflag:",Initial container (in s3 a bucket) to create -if it doesn't exist-.'"`

--- a/flytestdlib/storage/config_flags.go
+++ b/flytestdlib/storage/config_flags.go
@@ -53,6 +53,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "type"), defaultConfig.Type, "Sets the type of storage [s3/minio/local/mem/stow/redis].")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "stow.kind"), defaultConfig.Stow.Kind, "Kind of Stow backend to use. Refer to github/flyteorg/stow")
 	cmdFlags.StringToString(fmt.Sprintf("%v%v", prefix, "stow.config"), defaultConfig.Stow.Config, "Configuration for stow backend. Refer to github/flyteorg/stow")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "enableLegacyMetrics"), defaultConfig.EnableLegacyMetrics, "Publish legacy unscoped storage metric aliases. Requires a service restart when changed.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "container"), defaultConfig.InitContainer, "Initial container (in s3 a bucket) to create -if it doesn't exist-.'")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "enable-multicontainer"), defaultConfig.MultiContainerEnabled, "If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "cache.max_size_mbs"), defaultConfig.Cache.MaxSizeMegabytes, "Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used")

--- a/flytestdlib/storage/config_flags_test.go
+++ b/flytestdlib/storage/config_flags_test.go
@@ -141,6 +141,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_enableLegacyMetrics", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("enableLegacyMetrics", testValue)
+			if vBool, err := cmdFlags.GetBool("enableLegacyMetrics"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vBool), &actual.EnableLegacyMetrics)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_container", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/flytestdlib/storage/init_test.go
+++ b/flytestdlib/storage/init_test.go
@@ -11,5 +11,5 @@ var metrics *dataStoreMetrics
 func init() {
 	labeled.SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey)
 	scope := promutils.NewTestScope()
-	metrics = newDataStoreMetrics(scope)
+	metrics = newDataStoreMetrics(scope, false)
 }

--- a/flytestdlib/storage/metrics_test.go
+++ b/flytestdlib/storage/metrics_test.go
@@ -1,0 +1,166 @@
+package storage
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/coocood/freecache"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
+)
+
+func useStorageTestRegistry(t *testing.T) *prometheus.Registry {
+	t.Helper()
+	registerer := prometheus.DefaultRegisterer
+	gatherer := prometheus.DefaultGatherer
+	registry := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer = registry
+	prometheus.DefaultGatherer = registry
+	t.Cleanup(func() {
+		prometheus.DefaultRegisterer = registerer
+		prometheus.DefaultGatherer = gatherer
+	})
+	return registry
+}
+
+func storageMetricNames(t *testing.T, registry *prometheus.Registry) map[string]struct{} {
+	t.Helper()
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	names := make(map[string]struct{}, len(families))
+	for _, family := range families {
+		names[family.GetName()] = struct{}{}
+	}
+	return names
+}
+
+func TestDataStoreMetricScopes(t *testing.T) {
+	t.Run("CanonicalOnlyByDefault", func(t *testing.T) {
+		registry := useStorageTestRegistry(t)
+		newDataStoreMetrics(promutils.NewScope("storage"), false)
+		names := storageMetricNames(t, registry)
+
+		require.Contains(t, names, "storage:cache:cache_hit")
+		require.Contains(t, names, "storage:proto:proto_fetch_ms")
+		require.Contains(t, names, "storage:stow:bad_key_unlabeled")
+		require.Contains(t, names, "storage:copy:overall_unlabeled_ms")
+		require.NotContains(t, names, "storage:cache_hit")
+		require.NotContains(t, names, "storage:proto_fetch_ms")
+		require.NotContains(t, names, "storage:bad_key_unlabeled")
+	})
+
+	t.Run("LegacyAliasesExcludeNewMetrics", func(t *testing.T) {
+		registry := useStorageTestRegistry(t)
+		newDataStoreMetrics(promutils.NewScope("storage"), true)
+		names := storageMetricNames(t, registry)
+
+		for _, name := range []string{
+			"storage:cache:cache_hit", "storage:cache_hit",
+			"storage:proto:proto_fetch_ms", "storage:proto_fetch_ms",
+			"storage:stow:bad_key_unlabeled", "storage:bad_key_unlabeled",
+		} {
+			require.Contains(t, names, name)
+		}
+		require.Contains(t, names, "storage:cache:read_bytes_total")
+		require.Contains(t, names, "storage:cache:write_bytes_total")
+		require.Contains(t, names, "storage:proto:read_bytes_total")
+		require.Contains(t, names, "storage:proto:written_bytes_total")
+		require.NotContains(t, names, "storage:read_bytes_total")
+		require.NotContains(t, names, "storage:write_bytes_total")
+		require.NotContains(t, names, "storage:written_bytes_total")
+	})
+}
+
+func TestLegacyMetricConfigurationRequiresNewDataStore(t *testing.T) {
+	t.Run("Enable", func(t *testing.T) {
+		registry := useStorageTestRegistry(t)
+		scope := promutils.NewScope("storage")
+		store, err := NewDataStore(&Config{Type: TypeMemory}, scope)
+		require.NoError(t, err)
+
+		err = store.RefreshConfig(context.Background(), &Config{Type: TypeMemory, EnableLegacyMetrics: true})
+		require.NoError(t, err)
+		names := storageMetricNames(t, registry)
+		require.Contains(t, names, "storage:cache:cache_hit")
+		require.NotContains(t, names, "storage:cache_hit")
+	})
+
+	t.Run("Disable", func(t *testing.T) {
+		registry := useStorageTestRegistry(t)
+		scope := promutils.NewScope("storage")
+		store, err := NewDataStore(&Config{Type: TypeMemory, EnableLegacyMetrics: true}, scope)
+		require.NoError(t, err)
+
+		err = store.RefreshConfig(context.Background(), &Config{Type: TypeMemory})
+		require.NoError(t, err)
+		names := storageMetricNames(t, registry)
+		require.Contains(t, names, "storage:cache:cache_hit")
+		require.Contains(t, names, "storage:cache_hit")
+	})
+}
+
+func TestFreecacheCollectorLifecycle(t *testing.T) {
+	registry := useStorageTestRegistry(t)
+	scope := promutils.NewScope("storage:cache")
+	cacheMetrics := newCacheMetrics(scope, scope)
+
+	newCachedRawStore(&Config{}, nil, cacheMetrics)
+	require.NotContains(t, storageMetricNames(t, registry), "storage:cache:entry_count")
+
+	config := &Config{Cache: CachingConfig{MaxSizeMegabytes: 1}}
+	newCachedRawStore(config, nil, cacheMetrics)
+	names := storageMetricNames(t, registry)
+	for _, name := range []string{
+		"storage:cache:entry_count",
+		"storage:cache:evacuate_count_total",
+		"storage:cache:overwrite_count_total",
+		"storage:cache:expired_count_total",
+	} {
+		require.Contains(t, names, name)
+	}
+
+	newCachedRawStore(&Config{}, nil, cacheMetrics)
+	require.NotContains(t, storageMetricNames(t, registry), "storage:cache:entry_count")
+
+	newCachedRawStore(config, nil, cacheMetrics)
+	require.Contains(t, storageMetricNames(t, registry), "storage:cache:entry_count")
+}
+
+func TestFreecacheCollectorConcurrentRefresh(t *testing.T) {
+	registry := useStorageTestRegistry(t)
+	scope := promutils.NewScope("storage:cache")
+	cacheMetrics := newCacheMetrics(scope, scope)
+	cache := freecache.NewCache(1024 * 1024)
+	cacheMetrics.collector.cache.Store(cache)
+	cacheMetrics.collector.registerOnce.Do(func() {
+		registry.MustRegister(cacheMetrics.collector)
+	})
+
+	errors := make(chan error, 4)
+	var waitGroup sync.WaitGroup
+	for range 4 {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			for range 100 {
+				_, err := registry.Gather()
+				if err != nil {
+					errors <- err
+					return
+				}
+			}
+		}()
+	}
+	for range 100 {
+		cacheMetrics.collector.cache.Store(nil)
+		cacheMetrics.collector.cache.Store(cache)
+	}
+	waitGroup.Wait()
+	close(errors)
+	for err := range errors {
+		require.NoError(t, err)
+	}
+}

--- a/flytestdlib/storage/protobuf_store.go
+++ b/flytestdlib/storage/protobuf_store.go
@@ -24,6 +24,8 @@ type protoMetrics struct {
 	UnmarshalFailure             prometheus.Counter
 	WriteFailureUnrelatedToCache prometheus.Counter
 	ReadFailureUnrelatedToCache  prometheus.Counter
+	WrittenBytes                 prometheus.Counter
+	ReadBytes                    prometheus.Counter
 }
 
 // Implements ProtobufStore to marshal and unmarshal protobufs to/from a RawStore
@@ -54,6 +56,7 @@ func (s DefaultProtobufStore) ReadProtobuf(ctx context.Context, reference DataRe
 	if err != nil {
 		return errs.Wrap(err, fmt.Sprintf("readAll: %v", reference))
 	}
+	s.metrics.ReadBytes.Add(float64(len(docContents)))
 
 	t := s.metrics.UnmarshalTime.Start()
 	err = proto.Unmarshal(docContents, msg)
@@ -84,23 +87,36 @@ func (s DefaultProtobufStore) WriteProtobuf(ctx context.Context, reference DataR
 		s.metrics.WriteFailureUnrelatedToCache.Inc()
 		return err
 	}
+	s.metrics.WrittenBytes.Add(float64(len(raw)))
 	return nil
 }
 
-func newProtoMetrics(scope promutils.Scope) *protoMetrics {
+func newProtoMetrics(existingScope, canonicalScope promutils.Scope) *protoMetrics {
 	return &protoMetrics{
-		FetchLatency:                 scope.MustNewStopWatch("proto_fetch", "Time to read data before unmarshalling", time.Millisecond),
-		MarshalTime:                  scope.MustNewStopWatch("marshal", "Time incurred in marshalling data before writing", time.Millisecond),
-		UnmarshalTime:                scope.MustNewStopWatch("unmarshal", "Time incurred in unmarshalling received data", time.Millisecond),
-		MarshalFailure:               scope.MustNewCounter("marshal_failure", "Failures when marshalling"),
-		UnmarshalFailure:             scope.MustNewCounter("unmarshal_failure", "Failures when unmarshalling"),
-		WriteFailureUnrelatedToCache: scope.MustNewCounter("write_failure_unrelated_to_cache", "Raw store write failures that are not caused by ErrFailedToWriteCache"),
-		ReadFailureUnrelatedToCache:  scope.MustNewCounter("read_failure_unrelated_to_cache", "Raw store read failures that are not caused by ErrFailedToWriteCache"),
+		FetchLatency: existingScope.MustNewStopWatch(
+			"proto_fetch", "Time to read data before unmarshalling", time.Millisecond,
+		),
+		MarshalTime: existingScope.MustNewStopWatch(
+			"marshal", "Time incurred in marshalling data before writing", time.Millisecond,
+		),
+		UnmarshalTime: existingScope.MustNewStopWatch(
+			"unmarshal", "Time incurred in unmarshalling received data", time.Millisecond,
+		),
+		MarshalFailure:   existingScope.MustNewCounter("marshal_failure", "Failures when marshalling"),
+		UnmarshalFailure: existingScope.MustNewCounter("unmarshal_failure", "Failures when unmarshalling"),
+		WriteFailureUnrelatedToCache: existingScope.MustNewCounter(
+			"write_failure_unrelated_to_cache", "Raw store write failures that are not caused by ErrFailedToWriteCache",
+		),
+		ReadFailureUnrelatedToCache: existingScope.MustNewCounter(
+			"read_failure_unrelated_to_cache", "Raw store read failures that are not caused by ErrFailedToWriteCache",
+		),
+		WrittenBytes: canonicalScope.MustNewCounter("written_bytes_total", "Bytes written after marshalling"),
+		ReadBytes:    canonicalScope.MustNewCounter("read_bytes_total", "Bytes read before unmarshalling"),
 	}
 }
 
 func NewDefaultProtobufStore(store RawStore, scope promutils.Scope) DefaultProtobufStore {
-	return NewDefaultProtobufStoreWithMetrics(store, newProtoMetrics(scope))
+	return NewDefaultProtobufStoreWithMetrics(store, newProtoMetrics(scope, scope))
 }
 
 func NewDefaultProtobufStoreWithMetrics(store RawStore, metrics *protoMetrics) DefaultProtobufStore {

--- a/flytestdlib/storage/protobuf_store_test.go
+++ b/flytestdlib/storage/protobuf_store_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -11,9 +12,11 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	errs "github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/flyteorg/flyte/v2/flytestdlib/ioutils"
 	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 	"github.com/flyteorg/stow/s3"
 )
@@ -110,6 +113,36 @@ func TestDefaultProtobufStore(t *testing.T) {
 
 		assert.EqualError(t, err, "initContainer is required even with `enable-multicontainer`")
 	})
+}
+
+func TestDefaultProtobufStoreByteMetrics(t *testing.T) {
+	message := &mockProtoMessage{X: 5}
+	raw, err := proto.Marshal(message)
+	require.NoError(t, err)
+
+	store := &dummyStore{
+		WriteRawCb: func(_ context.Context, _ DataReference, size int64, _ Options, reader io.Reader) error {
+			actual, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			require.Equal(t, int64(len(raw)), size)
+			require.True(t, bytes.Equal(raw, actual))
+			return nil
+		},
+		ReadRawCb: func(_ context.Context, _ DataReference) (io.ReadCloser, error) {
+			return ioutils.NewBytesReadCloser(raw), nil
+		},
+	}
+	scope := promutils.NewTestScope()
+	protoMetrics := newProtoMetrics(scope, scope)
+	protobufStore := NewDefaultProtobufStoreWithMetrics(store, protoMetrics)
+
+	require.NoError(t, protobufStore.WriteProtobuf(context.Background(), "key", Options{}, message))
+	require.Equal(t, float64(len(raw)), testutil.ToFloat64(protoMetrics.WrittenBytes))
+
+	readMessage := &mockProtoMessage{}
+	require.NoError(t, protobufStore.ReadProtobuf(context.Background(), "key", readMessage))
+	require.Equal(t, float64(len(raw)), testutil.ToFloat64(protoMetrics.ReadBytes))
+	require.Equal(t, message.X, readMessage.X)
 }
 
 func TestDefaultProtobufStore_BigDataReadAfterWrite(t *testing.T) {

--- a/flytestdlib/storage/rawstores.go
+++ b/flytestdlib/storage/rawstores.go
@@ -77,13 +77,25 @@ type dataStoreMetrics struct {
 	stowMetrics  *stowMetrics
 }
 
-// newDataStoreMetrics initialises all metrics required for DataStore
-func newDataStoreMetrics(scope promutils.Scope) *dataStoreMetrics {
+// newDataStoreMetrics initialises all metrics required for DataStore.
+func newDataStoreMetrics(scope promutils.Scope, enableLegacyMetrics bool) *dataStoreMetrics {
+	cacheScope := scope.NewSubScope("cache")
+	protoScope := scope.NewSubScope("proto")
+	stowScope := scope.NewSubScope("stow")
+	cacheExistingScope := cacheScope
+	protoExistingScope := protoScope
+	stowExistingScope := stowScope
+	if enableLegacyMetrics {
+		cacheExistingScope = promutils.NewMirroredScope(cacheScope, scope)
+		protoExistingScope = promutils.NewMirroredScope(protoScope, scope)
+		stowExistingScope = promutils.NewMirroredScope(stowScope, scope)
+	}
+
 	return &dataStoreMetrics{
-		cacheMetrics: newCacheMetrics(scope),
-		protoMetrics: newProtoMetrics(scope),
+		cacheMetrics: newCacheMetrics(cacheExistingScope, cacheScope),
+		protoMetrics: newProtoMetrics(protoExistingScope, protoScope),
 		copyMetrics:  newCopyMetrics(scope.NewSubScope("copy")),
-		stowMetrics:  newStowMetrics(scope),
+		stowMetrics:  newStowMetrics(stowExistingScope),
 	}
 }
 
@@ -94,7 +106,7 @@ func NewDataStore(cfg *Config, scope promutils.Scope) (s *DataStore, err error) 
 
 // NewDataStoreWithContext creates a new Data Store with the supplied config and context.
 func NewDataStoreWithContext(ctx context.Context, cfg *Config, scope promutils.Scope) (s *DataStore, err error) {
-	ds := &DataStore{metrics: newDataStoreMetrics(scope)}
+	ds := &DataStore{metrics: newDataStoreMetrics(scope, cfg.EnableLegacyMetrics)}
 	return ds, ds.RefreshConfig(ctx, cfg)
 }
 

--- a/flytestdlib/storage/routing_store_internal_test.go
+++ b/flytestdlib/storage/routing_store_internal_test.go
@@ -49,7 +49,7 @@ func (f *fakeRawStore) Delete(context.Context, DataReference) error { return nil
 // of any network/credential dependency.
 func newTestRoutingStore(t *testing.T, schemes ...string) (*routingStore, map[string]*int32) {
 	t.Helper()
-	metrics := newDataStoreMetrics(promutils.NewTestScope())
+	metrics := newDataStoreMetrics(promutils.NewTestScope(), false)
 	counts := map[string]*int32{}
 	registry := map[string]backendFactory{}
 	for _, sc := range schemes {
@@ -138,7 +138,7 @@ func TestRoutingStore_ConcurrentFirstUseDialsOnce(t *testing.T) {
 // factory, with the given cfg. The primary is an unrelated fake store.
 func newTestRedisRoutingStore(t *testing.T, cfg *Config) (*routingStore, *int32) {
 	t.Helper()
-	metrics := newDataStoreMetrics(promutils.NewTestScope())
+	metrics := newDataStoreMetrics(promutils.NewTestScope(), false)
 	var count int32
 	registry := map[string]backendFactory{
 		TypeRedis: func(_ context.Context, scheme string, _ DataReference, _ *Config, _ *http.Client, m *dataStoreMetrics) (RawStore, error) {

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/getsentry/sentry-go v0.48.0
+	github.com/prometheus/client_model v0.6.2
 )
 
 require (
@@ -190,7 +191,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.21.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect


### PR DESCRIPTION
## Summary

Organizes Flyte storage metrics into cache, protobuf, and stow scopes and adds visibility into cache pressure and I/O volume.

- Moves existing cache, proto, and stow metrics under `cache:`, `proto:`, and `stow:`.
- Adds protobuf `read_bytes_total` and `written_bytes_total`.
- Adds cache `read_bytes_total` and `write_bytes_total`, including successful read-through cache fills.
- Exposes freecache `entry_count`, `evacuate_count_total`, `overwrite_count_total`, and `expired_count_total`.
- Makes freecache collector registration and config refresh concurrency-safe.

## Compatibility

The scoped format is the default. Set `storage.enableLegacyMetrics: true` before service startup to also publish unscoped aliases for metrics that existed before this change. Changing the setting requires a restart.

New byte-volume and freecache metrics are only published in scoped form; they do not have legacy aliases.

## Testing

- `go test ./flytestdlib/promutils ./flytestdlib/storage -race -count=1`
- Full `flytestdlib` race and coverage suite, excluding an existing macOS filesystem-watcher failure reproduced on `origin/main`
- `golangci-lint run --new-from-rev=origin/main --timeout=5m`
