### PR TITLE
fix(runs): allow phase update after terminal state for retry

### DIFF
--- a/runs/repository/impl/action.go
+++ b/runs/repository/impl/action.go
@@ -512,10 +512,16 @@ func (r *actionRepo) UpdateActionPhase(
 		}
 	}
 
+	// Allow forward phase transitions (phase <= new) and retries from
+	// retryable terminal states (FAILED, TIMED_OUT) back to earlier phases.
+	retryablePhases := []int32{
+		int32(common.ActionPhase_ACTION_PHASE_FAILED),
+		int32(common.ActionPhase_ACTION_PHASE_TIMED_OUT),
+	}
 	result := r.db.WithContext(ctx).
 		Model(&models.Action{}).
-		Where("org = ? AND project = ? AND domain = ? AND run_name = ? AND name = ?",
-			actionID.Run.Org, actionID.Run.Project, actionID.Run.Domain, actionID.Run.Name, actionID.Name).
+		Where("org = ? AND project = ? AND domain = ? AND run_name = ? AND name = ? AND (phase <= ? OR phase IN ?)",
+			actionID.Run.Org, actionID.Run.Project, actionID.Run.Domain, actionID.Run.Name, actionID.Name, phase, retryablePhases).
 		Updates(updates)
 
 	if result.Error != nil {

--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -210,6 +210,89 @@ func TestUpdateActionPhase_AllowsRetryTransition(t *testing.T) {
 	assert.Equal(t, uint32(2), action.Attempts)
 }
 
+func TestUpdateActionPhase_BlocksBackwardFromNonRetryable(t *testing.T) {
+	db := setupActionDB(t)
+	defer func() { _ = db.Exec("DELETE FROM actions") }()
+	actionRepo, err := NewActionRepo(db, database.DbConfig{})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	actionID := &common.ActionIdentifier{
+		Run: &common.RunIdentifier{
+			Org:     "org1",
+			Project: "proj1",
+			Domain:  "domain1",
+			Name:    "run1",
+		},
+		Name: "action-no-backward",
+	}
+
+	_, err = actionRepo.CreateAction(ctx, &workflow.ActionSpec{
+		ActionId: actionID,
+		InputUri: "s3://bucket/input",
+	}, nil)
+	require.NoError(t, err)
+
+	// Move to RUNNING
+	err = actionRepo.UpdateActionPhase(ctx, actionID,
+		common.ActionPhase_ACTION_PHASE_RUNNING, 1,
+		core.CatalogCacheStatus_CACHE_DISABLED, nil)
+	require.NoError(t, err)
+
+	// Try to downgrade from RUNNING to QUEUED — should be a no-op (phase guard)
+	err = actionRepo.UpdateActionPhase(ctx, actionID,
+		common.ActionPhase_ACTION_PHASE_QUEUED, 1,
+		core.CatalogCacheStatus_CACHE_DISABLED, nil)
+	require.NoError(t, err)
+
+	action, err := actionRepo.GetAction(ctx, actionID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(common.ActionPhase_ACTION_PHASE_RUNNING), action.Phase,
+		"phase should not downgrade from RUNNING to QUEUED")
+}
+
+func TestUpdateActionPhase_BlocksBackwardFromSucceeded(t *testing.T) {
+	db := setupActionDB(t)
+	defer func() { _ = db.Exec("DELETE FROM actions") }()
+	actionRepo, err := NewActionRepo(db, database.DbConfig{})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	actionID := &common.ActionIdentifier{
+		Run: &common.RunIdentifier{
+			Org:     "org1",
+			Project: "proj1",
+			Domain:  "domain1",
+			Name:    "run1",
+		},
+		Name: "action-no-backward-succeeded",
+	}
+
+	_, err = actionRepo.CreateAction(ctx, &workflow.ActionSpec{
+		ActionId: actionID,
+		InputUri: "s3://bucket/input",
+	}, nil)
+	require.NoError(t, err)
+
+	// Move to SUCCEEDED (terminal, non-retryable)
+	endTime := time.Now()
+	err = actionRepo.UpdateActionPhase(ctx, actionID,
+		common.ActionPhase_ACTION_PHASE_SUCCEEDED, 1,
+		core.CatalogCacheStatus_CACHE_DISABLED, &endTime)
+	require.NoError(t, err)
+
+	// Try to downgrade from SUCCEEDED to QUEUED — should be a no-op
+	err = actionRepo.UpdateActionPhase(ctx, actionID,
+		common.ActionPhase_ACTION_PHASE_QUEUED, 2,
+		core.CatalogCacheStatus_CACHE_DISABLED, nil)
+	require.NoError(t, err)
+
+	action, err := actionRepo.GetAction(ctx, actionID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(common.ActionPhase_ACTION_PHASE_SUCCEEDED), action.Phase,
+		"phase should not downgrade from SUCCEEDED to QUEUED")
+}
+
 func TestListRuns(t *testing.T) {
 	db := setupActionDB(t)
 	defer func() { _ = db.Exec("DELETE FROM actions") }()


### PR DESCRIPTION
## Summary

- Remove the phase-forward-only guard (`phase <= ?`) from `UpdateActionPhase` so that actions in terminal states (e.g. FAILED) can transition back to QUEUED when retried.
- Update tests to validate the retry transition (FAILED → QUEUED).

## Test plan

- [x] Updated `TestUpdateActionPhase_AllowsRetryTransition` to verify FAILED → QUEUED transition succeeds
- [x] All existing action tests pass locally

* `main` <!-- branch-stack -->
  - \#6583
    - **fix(runs): allow phase update after terminal state for retry** :point\_left:
