### PR TITLE
fix: sanitize generatedName in tasklog template to be DNS-1123 compatible

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/tasklog/template.go
+++ b/flyteplugins/go/tasks/pluginmachinery/tasklog/template.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 )
 
@@ -135,7 +136,7 @@ func (input Input) templateVars() []TemplateVar {
 			},
 			TemplateVar{
 				defaultRegexes.GeneratedName,
-				input.TaskExecutionID.GetGeneratedName(),
+				utils.ConvertToDNS1123SubdomainCompatibleString(input.TaskExecutionID.GetGeneratedName()),
 			},
 			TemplateVar{
 				defaultRegexes.TaskRetryAttempt,

--- a/flyteplugins/go/tasks/pluginmachinery/tasklog/template_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/tasklog/template_test.go
@@ -613,6 +613,115 @@ func TestTemplateLogPlugin(t *testing.T) {
 	}
 }
 
+func taskExecIDWithGeneratedName(generatedName string) pluginCore.TaskExecutionID {
+	tID := &coreMocks.TaskExecutionID{}
+	tID.EXPECT().GetGeneratedName().Return(generatedName)
+	tID.EXPECT().GetID().Return(&core.TaskExecutionIdentifier{
+		TaskId: &core.Identifier{
+			ResourceType: core.ResourceType_TASK,
+			Name:         "my-task-name",
+			Project:      "my-task-project",
+			Domain:       "my-task-domain",
+			Version:      "1",
+			Org:          "my-task-org",
+		},
+		NodeExecutionId: &core.NodeExecutionIdentifier{
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Name:    "my-execution-name",
+				Project: "my-execution-project",
+				Domain:  "my-execution-domain",
+				Org:     "my-execution-org",
+			},
+		},
+		RetryAttempt: 1,
+	})
+	tID.EXPECT().GetUniqueNodeID().Return("n0-0-n0")
+	return tID
+}
+
+func TestTemplateLogPlugin_GeneratedName(t *testing.T) {
+	tests := []struct {
+		name   string
+		plugin TemplateLogPlugin
+		input  Input
+		want   string
+	}{
+		{
+			name: "generatedName in URL",
+			plugin: TemplateLogPlugin{
+				TemplateURIs:  []TemplateURI{"https://example.com/logs/{{.generatedName}}/view"},
+				MessageFormat: core.TaskLog_JSON,
+			},
+			input: Input{
+				LogName:              "main_logs",
+				TaskExecutionID:      dummyTaskExecID(),
+				PodRFC3339StartTime:  "1970-01-01T01:02:03+01:00",
+				PodRFC3339FinishTime: "1970-01-01T04:25:45+01:00",
+				PodUnixStartTime:     123,
+				PodUnixFinishTime:    12345,
+			},
+			want: "https://example.com/logs/generated-name/view",
+		},
+		{
+			name: "generatedName with underscores are sanitized",
+			plugin: TemplateLogPlugin{
+				TemplateURIs:  []TemplateURI{"https://example.com/logs/{{.generatedName}}/view"},
+				MessageFormat: core.TaskLog_JSON,
+			},
+			input: Input{
+				LogName:              "main_logs",
+				TaskExecutionID:      taskExecIDWithGeneratedName("oregon_small_aoi-my_task-0"),
+				PodRFC3339StartTime:  "1970-01-01T01:02:03+01:00",
+				PodRFC3339FinishTime: "1970-01-01T04:25:45+01:00",
+				PodUnixStartTime:     123,
+				PodUnixFinishTime:    12345,
+			},
+			want: "https://example.com/logs/oregonsmallaoi-mytask-0/view",
+		},
+		{
+			name: "generatedName with uppercase is lowercased",
+			plugin: TemplateLogPlugin{
+				TemplateURIs:  []TemplateURI{"https://example.com/logs/{{.generatedName}}/view"},
+				MessageFormat: core.TaskLog_JSON,
+			},
+			input: Input{
+				LogName:              "main_logs",
+				TaskExecutionID:      taskExecIDWithGeneratedName("MyTask-Name-0"),
+				PodRFC3339StartTime:  "1970-01-01T01:02:03+01:00",
+				PodRFC3339FinishTime: "1970-01-01T04:25:45+01:00",
+				PodUnixStartTime:     123,
+				PodUnixFinishTime:    12345,
+			},
+			want: "https://example.com/logs/my-task-name-0/view",
+		},
+		{
+			name: "generatedName already DNS compatible unchanged",
+			plugin: TemplateLogPlugin{
+				TemplateURIs:  []TemplateURI{"https://example.com/logs/{{.generatedName}}/view"},
+				MessageFormat: core.TaskLog_JSON,
+			},
+			input: Input{
+				LogName:              "main_logs",
+				TaskExecutionID:      taskExecIDWithGeneratedName("valid-name-0"),
+				PodRFC3339StartTime:  "1970-01-01T01:02:03+01:00",
+				PodRFC3339FinishTime: "1970-01-01T04:25:45+01:00",
+				PodUnixStartTime:     123,
+				PodUnixFinishTime:    12345,
+			},
+			want: "https://example.com/logs/valid-name-0/view",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.plugin.GetTaskLogs(tt.input)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(got.TaskLogs))
+			assert.Equal(t, tt.want, got.TaskLogs[0].Uri)
+		})
+	}
+}
+
 func TestGetDynamicLogLinkTypes(t *testing.T) {
 	linkTypes := getDynamicLogLinkTypes(Input{})
 	assert.Nil(t, linkTypes)


### PR DESCRIPTION
## Summary

- Sanitize the `generatedName` template variable with `ConvertToDNS1123SubdomainCompatibleString` before substitution in tasklog templates
- The `generatedName` can contain underscores when derived from Python task names (e.g. `oregon_small_aoi-my_task-0`), which causes issues when used in log URLs expecting DNS-compatible names
- The fix is applied at the template substitution point only, so the raw output prefix and other downstream usages are unaffected
- Note: the K8s plugin manager already converts pod names to DNS-1123 compatible format (`flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go`), so the actual pod name will not have underscores. The `generatedName` template variable should match the sanitized pod name to ensure log URLs resolve correctly.

## Test plan

- [x] Added unit tests for underscore sanitization, uppercase lowercasing, and already-valid names
- [x] Existing tests continue to pass

## Rollout plan

- Standard rollout, no feature flags needed

## Rollback plan

- Revert the PR

* `main` <!-- branch-stack -->
  - \#6583
    - **fix: sanitize generatedName in tasklog template to be DNS-1123 compatible** :point\_left:
