### PR TITLE
Speed up sandbox envoy proxy startup by ~40s

### DIFF
--- a/charts/flyte-sandbox/templates/proxy/configmap.yaml
+++ b/charts/flyte-sandbox/templates/proxy/configmap.yaml
@@ -133,6 +133,10 @@ data:
             - name: flyte
               connect_timeout: 0.25s
               type: STRICT_DNS
+              dns_refresh_rate: 1s
+              dns_failure_refresh_rate:
+                  base_interval: 1s
+                  max_interval: 5s
               lb_policy: ROUND_ROBIN
               http2_protocol_options: {}
               load_assignment:
@@ -153,6 +157,10 @@ data:
             - name: console
               connect_timeout: 0.25s
               type: STRICT_DNS
+              dns_refresh_rate: 1s
+              dns_failure_refresh_rate:
+                  base_interval: 1s
+                  max_interval: 5s
               lb_policy: ROUND_ROBIN
               load_assignment:
                   cluster_name: console
@@ -168,6 +176,10 @@ data:
             - name: kubernetes-dashboard
               connect_timeout: 0.25s
               type: STRICT_DNS
+              dns_refresh_rate: 1s
+              dns_failure_refresh_rate:
+                  base_interval: 1s
+                  max_interval: 5s
               lb_policy: ROUND_ROBIN
               load_assignment:
                   cluster_name: kubernetes-dashboard
@@ -183,6 +195,10 @@ data:
             - name: minio
               connect_timeout: 0.25s
               type: STRICT_DNS
+              dns_refresh_rate: 1s
+              dns_failure_refresh_rate:
+                  base_interval: 1s
+                  max_interval: 5s
               lb_policy: ROUND_ROBIN
               load_assignment:
                   cluster_name: minio

--- a/charts/flyte-sandbox/templates/proxy/deployment.yaml
+++ b/charts/flyte-sandbox/templates/proxy/deployment.yaml
@@ -13,6 +13,11 @@ spec:
     metadata:
       labels: {{- include "flyte-sandbox.proxySelectorLabels" . | nindent 8 }}
     spec:
+      initContainers:
+        - name: wait-for-dns
+          image: "rancher/mirrored-library-busybox:1.34.1"
+          imagePullPolicy: Never
+          command: ['sh', '-c', 'until nslookup kube-dns.kube-system.svc.cluster.local; do sleep 1; done']
       containers:
         - name: proxy
           {{- with .Values.sandbox.proxy.image }}
@@ -28,12 +33,14 @@ spec:
           livenessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
+            periodSeconds: 5
             failureThreshold: 10
           readinessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 5
+            initialDelaySeconds: 1
+            periodSeconds: 3
       volumes:
         - name: config
           configMap:

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -1013,6 +1013,10 @@ data:
             - name: flyte
               connect_timeout: 0.25s
               type: STRICT_DNS
+              dns_refresh_rate: 1s
+              dns_failure_refresh_rate:
+                  base_interval: 1s
+                  max_interval: 5s
               lb_policy: ROUND_ROBIN
               http2_protocol_options: {}
               load_assignment:
@@ -1027,6 +1031,10 @@ data:
             - name: console
               connect_timeout: 0.25s
               type: STRICT_DNS
+              dns_refresh_rate: 1s
+              dns_failure_refresh_rate:
+                  base_interval: 1s
+                  max_interval: 5s
               lb_policy: ROUND_ROBIN
               load_assignment:
                   cluster_name: console
@@ -1040,6 +1048,10 @@ data:
             - name: kubernetes-dashboard
               connect_timeout: 0.25s
               type: STRICT_DNS
+              dns_refresh_rate: 1s
+              dns_failure_refresh_rate:
+                  base_interval: 1s
+                  max_interval: 5s
               lb_policy: ROUND_ROBIN
               load_assignment:
                   cluster_name: kubernetes-dashboard
@@ -1053,6 +1065,10 @@ data:
             - name: minio
               connect_timeout: 0.25s
               type: STRICT_DNS
+              dns_refresh_rate: 1s
+              dns_failure_refresh_rate:
+                  base_interval: 1s
+                  max_interval: 5s
               lb_policy: ROUND_ROBIN
               load_assignment:
                   cluster_name: minio
@@ -1997,12 +2013,21 @@ spec:
         app.kubernetes.io/instance: flyte-sandbox
         app.kubernetes.io/name: flyte-sandbox
     spec:
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nslookup kube-dns.kube-system.svc.cluster.local; do sleep 1; done
+        image: rancher/mirrored-library-busybox:1.34.1
+        imagePullPolicy: Never
+        name: wait-for-dns
       containers:
       - image: envoyproxy/envoy:sandbox
         imagePullPolicy: Never
         livenessProbe:
           failureThreshold: 10
-          initialDelaySeconds: 15
+          initialDelaySeconds: 30
+          periodSeconds: 5
           tcpSocket:
             port: http
         name: proxy
@@ -2010,7 +2035,8 @@ spec:
         - containerPort: 8000
           name: http
         readinessProbe:
-          initialDelaySeconds: 5
+          initialDelaySeconds: 1
+          periodSeconds: 3
           tcpSocket:
             port: http
         volumeMounts:

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -750,6 +750,10 @@ data:
             - name: flyte
               connect_timeout: 0.25s
               type: STRICT_DNS
+              dns_refresh_rate: 1s
+              dns_failure_refresh_rate:
+                  base_interval: 1s
+                  max_interval: 5s
               lb_policy: ROUND_ROBIN
               http2_protocol_options: {}
               load_assignment:
@@ -764,6 +768,10 @@ data:
             - name: console
               connect_timeout: 0.25s
               type: STRICT_DNS
+              dns_refresh_rate: 1s
+              dns_failure_refresh_rate:
+                  base_interval: 1s
+                  max_interval: 5s
               lb_policy: ROUND_ROBIN
               load_assignment:
                   cluster_name: console
@@ -777,6 +785,10 @@ data:
             - name: kubernetes-dashboard
               connect_timeout: 0.25s
               type: STRICT_DNS
+              dns_refresh_rate: 1s
+              dns_failure_refresh_rate:
+                  base_interval: 1s
+                  max_interval: 5s
               lb_policy: ROUND_ROBIN
               load_assignment:
                   cluster_name: kubernetes-dashboard
@@ -790,6 +802,10 @@ data:
             - name: minio
               connect_timeout: 0.25s
               type: STRICT_DNS
+              dns_refresh_rate: 1s
+              dns_failure_refresh_rate:
+                  base_interval: 1s
+                  max_interval: 5s
               lb_policy: ROUND_ROBIN
               load_assignment:
                   cluster_name: minio
@@ -1613,12 +1629,21 @@ spec:
         app.kubernetes.io/instance: flyte-sandbox
         app.kubernetes.io/name: flyte-sandbox
     spec:
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nslookup kube-dns.kube-system.svc.cluster.local; do sleep 1; done
+        image: rancher/mirrored-library-busybox:1.34.1
+        imagePullPolicy: Never
+        name: wait-for-dns
       containers:
       - image: envoyproxy/envoy:sandbox
         imagePullPolicy: Never
         livenessProbe:
           failureThreshold: 10
-          initialDelaySeconds: 15
+          initialDelaySeconds: 30
+          periodSeconds: 5
           tcpSocket:
             port: http
         name: proxy
@@ -1626,7 +1651,8 @@ spec:
         - containerPort: 8000
           name: http
         readinessProbe:
-          initialDelaySeconds: 5
+          initialDelaySeconds: 1
+          periodSeconds: 3
           tcpSocket:
             port: http
         volumeMounts:


### PR DESCRIPTION
## Summary

- Add `wait-for-dns` init container to the envoy proxy deployment that blocks until CoreDNS is available, preventing a \~40s DNS resolution timeout during envoy cluster initialization
- Add `dns_refresh_rate` (1s) and `dns_failure_refresh_rate` (1s base, 5s max) to all envoy upstream clusters for faster recovery
- Tune readiness probe (`initialDelaySeconds: 1`, `periodSeconds: 3`) and liveness probe (`initialDelaySeconds: 30`, `periodSeconds: 5`) for faster detection

**Before:** Envoy blocked \~40s on DNS resolution timeout → proxy pod ready at \~44s\
**After:** Envoy initializes in <1s after CoreDNS is up → proxy pod ready at \~30s

## Test plan

- [x] `make sandbox-run` starts successfully
- [x] `make sandbox-stop` stops cleanly
- [x] Verified envoy logs show instant cluster initialization (`cm init: all clusters initialized` within milliseconds of `starting main dispatch loop`)
- [x] All 7 pods reach Ready state

* `main` <!-- branch-stack -->
  - \#6583
    - **Speed up sandbox envoy proxy startup by \~40s** :point\_left:
