### PR TITLE
fix: always call writeOutput on connector SUCCEEDED

### DIFF
--- a/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
@@ -331,18 +331,17 @@ func (p *Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phas
 	case flyteIdl.TaskExecution_RUNNING:
 		return core.PhaseInfoRunning(core.DefaultPhaseVersion, taskInfo), nil
 	case flyteIdl.TaskExecution_SUCCEEDED:
+		var literalMap *flyteIdl.LiteralMap
 		if resource.Outputs != nil {
-			var literalMap *flyteIdl.LiteralMap
 			literalMap = &flyteIdl.LiteralMap{Literals: make(map[string]*flyteIdl.Literal)}
 			for _, val := range resource.Outputs.Literals {
 				literalMap.Literals[val.Name] = val.Value
 			}
-			// TODO: Add support writing outputs proto.
-			err = writeOutput(ctx, taskCtx, literalMap)
-			if err != nil {
-				logger.Errorf(ctx, "failed to write output with err %s", err.Error())
-				return core.PhaseInfoUndefined, err
-			}
+		}
+		err = writeOutput(ctx, taskCtx, literalMap)
+		if err != nil {
+			logger.Errorf(ctx, "failed to write output with err %s", err.Error())
+			return core.PhaseInfoUndefined, err
 		}
 		return core.PhaseInfoSuccess(taskInfo), nil
 	case flyteIdl.TaskExecution_ABORTED:


### PR DESCRIPTION
## Summary

- When a connector task succeeds but returns nil outputs (relying on file-based outputs written to remote storage), `writeOutput` was skipped entirely, leaving the `BufferedOutputWriter` without a reader
- This caused `ValidateOutput` to fail with "Outputs not generated by task execution"
- Always call `writeOutput` on `SUCCEEDED` so the `RemoteFileOutputReader` fallback is used when outputs are nil, matching v1 behavior

## Test plan

- [ ] Existing connector plugin tests pass (`go test ./flyteplugins/go/tasks/plugins/webapi/connector/...`)
- [ ] Run connector tasks (e.g. `examples/basics/connectors.py`) with executor-v2 and verify outputs are resolved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- `main` <!-- branch-stack -->
  - \#6583
    - **fix: always call writeOutput on connector SUCCEEDED** :point\_left:
