### PR TITLE
fix: propagate action group through TaskAction CRD to runs service

### DIFF
--- a/actions/k8s/client.go
+++ b/actions/k8s/client.go
@@ -529,6 +529,7 @@ func (c *ActionsClient) notifyRunService(ctx context.Context, taskAction *execut
 				ActionId: update.ActionID,
 				Parent:   update.ParentActionName,
 				InputUri: taskAction.Spec.InputURI,
+				Group:    taskAction.Spec.Group,
 			}
 			if taskAction.Spec.TaskType != "" {
 				ta := &workflow.TaskAction{

--- a/charts/flyte-binary/templates/crds/flyte.org_taskactions.yaml
+++ b/charts/flyte-binary/templates/crds/flyte.org_taskactions.yaml
@@ -90,6 +90,10 @@ spec:
                 description: EnvVars are run-scoped environment variables projected
                   from RunSpec for executor runtime use.
                 type: object
+              group:
+                description: Group is the group this action belongs to, if applicable.
+                maxLength: 256
+                type: string
               inputUri:
                 description: InputURI is the path to the input data for this action
                 minLength: 1

--- a/docker/sandbox-bundled/manifests/complete.yaml
+++ b/docker/sandbox-bundled/manifests/complete.yaml
@@ -94,6 +94,10 @@ spec:
                 description: EnvVars are run-scoped environment variables projected
                   from RunSpec for executor runtime use.
                 type: object
+              group:
+                description: Group is the group this action belongs to, if applicable.
+                maxLength: 256
+                type: string
               inputUri:
                 description: InputURI is the path to the input data for this action
                 minLength: 1

--- a/docker/sandbox-bundled/manifests/dev.yaml
+++ b/docker/sandbox-bundled/manifests/dev.yaml
@@ -94,6 +94,10 @@ spec:
                 description: EnvVars are run-scoped environment variables projected
                   from RunSpec for executor runtime use.
                 type: object
+              group:
+                description: Group is the group this action belongs to, if applicable.
+                maxLength: 256
+                type: string
               inputUri:
                 description: InputURI is the path to the input data for this action
                 minLength: 1

--- a/executor/api/v1/taskaction_types.go
+++ b/executor/api/v1/taskaction_types.go
@@ -159,6 +159,11 @@ type TaskActionSpec struct {
 	// Interruptible is the run-scoped interruptibility override projected from RunSpec.
 	// +optional
 	Interruptible *bool `json:"interruptible,omitempty"`
+
+	// Group is the group this action belongs to, if applicable.
+	// +optional
+	// +kubebuilder:validation:MaxLength=256
+	Group string `json:"group,omitempty"`
 }
 
 func (in *TaskActionSpec) GetActionSpec() (*workflow.ActionSpec, error) {
@@ -176,6 +181,7 @@ func (in *TaskActionSpec) GetActionSpec() (*workflow.ActionSpec, error) {
 		ParentActionName: in.ParentActionName,
 		InputUri:         in.InputURI,
 		RunOutputBase:    in.RunOutputBase,
+		Group:            in.Group,
 	}
 
 	return spec, nil
@@ -195,6 +201,7 @@ func (in *TaskActionSpec) SetActionSpec(spec *workflow.ActionSpec) error {
 	in.ParentActionName = spec.ParentActionName
 	in.InputURI = spec.InputUri
 	in.RunOutputBase = spec.RunOutputBase
+	in.Group = spec.Group
 
 	return nil
 }

--- a/executor/config/crd/bases/flyte.org_taskactions.yaml
+++ b/executor/config/crd/bases/flyte.org_taskactions.yaml
@@ -90,6 +90,10 @@ spec:
                 description: EnvVars are run-scoped environment variables projected
                   from RunSpec for executor runtime use.
                 type: object
+              group:
+                description: Group is the group this action belongs to, if applicable.
+                maxLength: 256
+                type: string
               inputUri:
                 description: InputURI is the path to the input data for this action
                 minLength: 1

--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -1517,9 +1517,8 @@ func (s *RunService) convertNodeUpdateToEnrichedProto(
 	}
 
 	metadata := &workflow.ActionMetadata{
-		Parent:     CoalesceNullString(action.ParentActionName),
-		Group:      CoalesceNullString(action.ActionGroup),
-		ActionType: workflow.ActionType(action.ActionType),
+		Parent: CoalesceNullString(action.ParentActionName),
+		Group:  CoalesceNullString(action.ActionGroup),
 	}
 
 	// Pivot on known task types for response types


### PR DESCRIPTION
## Why are the changes needed?

The UI groups related actions under a collapsible folder using ActionMetadata.group, but actions were always recorded with an empty group because the field was silently dropped at the TaskAction CRD boundary.

## What changes were proposed in this pull request?

- Added Group field to TaskActionSpec and wired it through SetActionSpec / GetActionSpec
- Pass Group in RecordActionRequest when the actions service notifies the runs service of a new action
- Fixed convertActionToEnrichedProto to always populate ActionMetadata (including Group) rather than conditionally on ParentActionName
- Regenerated CRD manifests to allow k8s to accept the group field on TaskAction resources

## How was this patch tested?

- Ran local UI against sandbox with make -C manager run and verified that action groups render as collapsible folder items with their group name visible in the run sidebar

### Setup process

### Screenshots

<img width="515" height="806" alt="image" src="https://github.com/user-attachments/assets/5dd5d107-f050-4999-80e8-476c3daf09ec" />

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->

- `main` <!-- branch-stack -->
  - \#6583
    - **fix: propagate action group through TaskAction CRD to runs service** :point\_left:
