### PR TITLE
[V2] phase info reason to cluster event

### DIFF
--- a/executor/pkg/controller/taskaction_controller.go
+++ b/executor/pkg/controller/taskaction_controller.go
@@ -437,7 +437,7 @@ func (r *TaskActionReconciler) buildActionEvent(
 		ErrorInfo:     toActionErrorInfo(phaseInfo.Err()),
 		Cluster:       r.cluster,
 		Outputs:       outputRefs(ctx, taskAction),
-		ClusterEvents: toClusterEvents(info, updatedTime),
+		ClusterEvents: toClusterEvents(phaseInfo, updatedTime),
 		ReportedTime:  timestamppb.New(time.Now()),
 	}
 
@@ -524,11 +524,29 @@ func toActionErrorInfo(err *core.ExecutionError) *workflow.ErrorInfo {
 	return out
 }
 
-func toClusterEvents(info *pluginsCore.TaskInfo, fallbackTime *timestamppb.Timestamp) []*workflow.ClusterEvent {
-	if info == nil || len(info.AdditionalReasons) == 0 {
+func toClusterEvents(phaseInfo pluginsCore.PhaseInfo, fallbackTime *timestamppb.Timestamp) []*workflow.ClusterEvent {
+	info := phaseInfo.Info()
+	if phaseInfo.Reason() == "" && (info == nil || len(info.AdditionalReasons) == 0) {
 		return nil
 	}
-	out := make([]*workflow.ClusterEvent, 0, len(info.AdditionalReasons))
+
+	out := []*workflow.ClusterEvent{}
+	if phaseInfo.Reason() != "" {
+		e := &workflow.ClusterEvent{
+			Message: phaseInfo.Reason(),
+		}
+		if info != nil && info.OccurredAt != nil {
+			e.OccurredAt = timestamppb.New(*info.OccurredAt)
+		} else {
+			e.OccurredAt = fallbackTime
+		}
+		out = append(out, e)
+	}
+
+	if info == nil {
+		return out
+	}
+
 	for _, reason := range info.AdditionalReasons {
 		e := &workflow.ClusterEvent{
 			Message: reason.Reason,

--- a/executor/pkg/controller/taskaction_controller_test.go
+++ b/executor/pkg/controller/taskaction_controller_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -283,6 +284,36 @@ var _ = Describe("TaskAction Controller", func() {
 				},
 			}
 			Expect(taskActionStatusChanged(oldStatus, newStatus)).To(BeTrue())
+		})
+	})
+
+	Context("toClusterEvents", func() {
+		It("should include both phase reason and additional reasons", func() {
+			phaseOccurredAt := time.Date(2026, 4, 2, 10, 0, 0, 0, time.UTC)
+			eventOccurredAt := phaseOccurredAt.Add(2 * time.Minute)
+			fallbackTime := metav1.NewTime(phaseOccurredAt.Add(5 * time.Minute))
+
+			phaseInfo := pluginsCore.PhaseInfoQueuedWithTaskInfo(
+				phaseOccurredAt,
+				pluginsCore.DefaultPhaseVersion,
+				"cluster is creating",
+				&pluginsCore.TaskInfo{
+					OccurredAt: &phaseOccurredAt,
+					AdditionalReasons: []pluginsCore.ReasonInfo{
+						{
+							Reason:     "Head pod pending",
+							OccurredAt: &eventOccurredAt,
+						},
+					},
+				},
+			)
+
+			events := toClusterEvents(phaseInfo, timestamppb.New(fallbackTime.Time))
+			Expect(events).To(HaveLen(2))
+			Expect(events[0].GetMessage()).To(Equal("cluster is creating"))
+			Expect(events[0].GetOccurredAt().AsTime()).To(Equal(phaseOccurredAt))
+			Expect(events[1].GetMessage()).To(Equal("Head pod pending"))
+			Expect(events[1].GetOccurredAt().AsTime()).To(Equal(eventOccurredAt))
 		})
 	})
 })


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

Also add `phaseInfo.reason` as cluster event

## What changes were proposed in this pull request?

Also add `phaseInfo.reason` as cluster event


## How was this patch tested?

Tested locally and ensure we can see phase info reason in k8s event tab:

<img width="3298" height="1414" alt="image" src="https://github.com/user-attachments/assets/3e0c98ee-8008-4fd1-bcbe-375c15851648" />


### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
