### PR TITLE
fix: set isDir to true when upload dir

### DIFF
--- a/flytecopilot/data/upload.go
+++ b/flytecopilot/data/upload.go
@@ -107,7 +107,7 @@ func (u Uploader) handleBlobType(ctx context.Context, localPath string, toPath s
 			}
 		}
 
-		return coreutils.MakeLiteralForBlob(toPath, false, ""), nil
+		return coreutils.MakeLiteralForBlob(toPath, true, ""), nil
 	}
 	size := info.Size()
 	// Should we make this a go routine as well, so that we can introduce timeouts


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

When flytecopilot upload directory, we should set isDir to true for coreutils.MakeLiteralForBlob, so downstream task can parse its output correctly.

Originally we will get this error when set container task output as "Dir" :

```sh
Error converting input 'greeting_dir':
Literal value: scalar {
  blob {
    metadata {
      type {
      }
    }
    uri: "s3://bucket/iz/testorg/testproject/development/rnrk5xkrhj7g9gfkr5w9/eur05tom4dfe8j4t3obyux2qc/1/9k/rnrk5xkrhj7g9gfkr5w9-eur05tom4dfe8j4t3obyux2qc-0/greeting_dir"
  }
}

Expected Python type: <class 'flyte.io._dir.Dir'>
Exception: Expected multipart, received 0
```

## How was this patch tested?

Build the copilot image locally

```sh
docker buildx build -f Dockerfile.flytecopilot -t ghcr.io/machichima/flytecopilot:dev --push .
```

### Labels

Please add one or more of the following labels to categorize your PR:

- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->

- `main` <!-- branch-stack -->
  - \#6583
    - **fix: set isDir to true when upload dir** :point\_left:
