### PR TITLE
Fix non-deterministic workflow digest and oversized error messages

### DIFF
--- a/flyteadmin/pkg/errors/errors.go
+++ b/flyteadmin/pkg/errors/errors.go
@@ -16,6 +16,22 @@ import (
 	"github.com/flyteorg/flyte/flytestdlib/logger"
 )
 
+// maxErrorMessageBytes is the maximum size for gRPC error messages. gRPC has a
+// default MaxSendMsgSize of 4MB. The jsondiff output for large workflows can
+// exceed this limit, causing RST_STREAM INTERNAL_ERROR instead of a proper
+// error status. We cap at 3MB to leave room for gRPC framing and metadata.
+const maxErrorMessageBytes = 3 * 1024 * 1024
+
+// truncateErrorMessage truncates a message to stay within gRPC message size
+// limits. When truncated, appends a note indicating the diff was cut short.
+func truncateErrorMessage(msg string) string {
+	if len(msg) <= maxErrorMessageBytes {
+		return msg
+	}
+	const suffix = "\n\n... [diff truncated — exceeded gRPC max message size]"
+	return msg[:maxErrorMessageBytes-len(suffix)] + suffix
+}
+
 type FlyteAdminError interface {
 	Error() string
 	Code() codes.Code
@@ -135,7 +151,7 @@ func NewTaskExistsDifferentStructureError(ctx context.Context, request *admin.Ta
 
 	errorMsg += strings.Join(rs, "\n")
 
-	return NewFlyteAdminError(codes.InvalidArgument, errorMsg)
+	return NewFlyteAdminError(codes.InvalidArgument, truncateErrorMessage(errorMsg))
 }
 
 func NewTaskExistsIdenticalStructureError() FlyteAdminError {
@@ -149,7 +165,7 @@ func NewWorkflowExistsDifferentStructureError(ctx context.Context, request *admi
 	rdiff, _ := jsondiff.Compare(newSpec, oldSpec)
 	rs := compareJsons(diff, rdiff)
 
-	errorMsg += strings.Join(rs, "\n")
+	errorMsg = truncateErrorMessage(errorMsg + strings.Join(rs, "\n"))
 
 	statusErr, transformationErr := NewFlyteAdminError(codes.InvalidArgument, errorMsg).WithDetails(&admin.CreateWorkflowFailureReason{
 		Reason: &admin.CreateWorkflowFailureReason_ExistsDifferentStructure{
@@ -189,7 +205,7 @@ func NewLaunchPlanExistsDifferentStructureError(ctx context.Context, request *ad
 
 	errorMsg += strings.Join(rs, "\n")
 
-	return NewFlyteAdminError(codes.InvalidArgument, errorMsg)
+	return NewFlyteAdminError(codes.InvalidArgument, truncateErrorMessage(errorMsg))
 }
 
 func NewLaunchPlanExistsIdenticalStructureError() FlyteAdminError {

--- a/flytepropeller/pkg/compiler/workflow_compiler.go
+++ b/flytepropeller/pkg/compiler/workflow_compiler.go
@@ -32,6 +32,7 @@
 package compiler
 
 import (
+	"sort"
 	"strings"
 
 	// #noSA1019
@@ -216,13 +217,16 @@ func (w workflowBuilder) ValidateWorkflow(fg *flyteWorkflow, errs errors.Compile
 		}
 	}
 
-	// Add explicitly and implicitly declared edges
-	for nodeID, n := range wf.Nodes {
+	// Add explicitly and implicitly declared edges.
+	// Sort node IDs for deterministic iteration — Go map order is random,
+	// and the edge order affects the compiled workflow digest.
+	sortedNodeIDs := sortedKeys(wf.Nodes)
+	for _, nodeID := range sortedNodeIDs {
 		if nodeID == c.StartNodeID {
 			continue
 		}
 
-		wf.AddEdges(n, c.EdgeDirectionBidirectional, errs.NewScope())
+		wf.AddEdges(wf.Nodes[nodeID], c.EdgeDirectionBidirectional, errs.NewScope())
 	}
 
 	if fg.GetTemplate().GetFailureNode() != nil {
@@ -232,7 +236,8 @@ func (w workflowBuilder) ValidateWorkflow(fg *flyteWorkflow, errs errors.Compile
 	}
 
 	// Add execution edges for orphan nodes that don't have any inward/outward edges.
-	for nodeID := range wf.Nodes {
+	// Reuse sortedNodeIDs for deterministic iteration.
+	for _, nodeID := range sortedNodeIDs {
 		if nodeID == c.StartNodeID || nodeID == c.EndNodeID {
 			continue
 		}
@@ -287,6 +292,16 @@ func (w workflowBuilder) validateAllRequirements(errs errors.CompileErrors) bool
 	}
 
 	return !errs.HasErrors()
+}
+
+// sortedKeys returns the keys of a map in sorted order for deterministic iteration.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // CompileWorkflow compiles a flyte workflow a and all of its dependencies into a single executable Workflow. Refer to


### PR DESCRIPTION
## Tracking issue

Closes https://github.com/flyteorg/flyte/issues/7212
Related to https://github.com/flyteorg/flyte/issues/4780

## Why are the changes needed?

When re-registering a workflow with the same version, FlyteAdmin computes a digest of the compiled workflow to check if the structure is identical. Two bugs cause this to fail for large workflows:

**Bug 1: Non-deterministic digest (compiler)**
`ValidateWorkflow` in `workflow_compiler.go` iterates `wf.Nodes` (a Go map) in two places without sorting keys. Since Go map iteration is randomized, the same workflow produces different `CompiledWorkflowClosure` outputs across compilations, leading to different digests. FlyteAdmin then incorrectly takes the "different structure" code path instead of returning `ALREADY_EXISTS`.

**Bug 2: Oversized error message (errors)**
The "different structure" code path computes a `jsondiff` of two large compiled workflow closures and includes the full diff in the gRPC error description. For workflows with many dependencies (e.g. 400+ JARs), this diff exceeds gRPC's default 4MB `MaxSendMsgSize`. gRPC-Go silently rejects the response at the transport layer, sending `RST_STREAM INTERNAL_ERROR` to the client with no server-side log.

The client sees `INTERNAL: RST_STREAM closed stream. HTTP/2 error code: INTERNAL_ERROR` instead of any useful error.

## What changes were proposed in this pull request?

**Commit 1: Truncate diff in error messages** (`flyteadmin/pkg/errors/errors.go`)
- Cap error messages at 3MB (leaving room for gRPC framing) in all three `*ExistsDifferentStructureError` functions
- When truncated, append `... [diff truncated — exceeded gRPC max message size]`
- Safety net that prevents RST_STREAM regardless of diff size

**Commit 2: Sort node IDs for deterministic compilation** (`flytepropeller/pkg/compiler/workflow_compiler.go`)
- Sort `wf.Nodes` map keys before iterating in `ValidateWorkflow`
- Ensures identical workflows produce identical `CompiledWorkflowClosure` and therefore identical digests
- Root cause fix: re-registration of identical workflows correctly returns `ALREADY_EXISTS`

## How did you test it?

- All existing tests pass: `go test ./pkg/errors/` and `go test ./pkg/compiler/...`
- Reproduced the original issue on a production FlyteAdmin instance by calling `CreateWorkflow` with a modified template (same version) — confirmed `RST_STREAM INTERNAL_ERROR`
- Same call with identical template returns `ALREADY_EXISTS` (correct behavior)
- `CreateTask` always returns `ALREADY_EXISTS` (task digests are already deterministic — no map iteration in task compilation)