### PR TITLE
[V2] Set ReportUri in ActionEvent output references

### DIFF
--- a/executor/pkg/controller/output_refs_test.go
+++ b/executor/pkg/controller/output_refs_test.go
@@ -70,6 +70,18 @@ func TestOutputRefs(t *testing.T) {
 		assert.Equal(t, "1", parts[len(parts)-1])
 	})
 
+	t.Run("report URI ends with report.html and shares prefix with output URI", func(t *testing.T) {
+		ta := taskActionForOutputRefs("flyte", "ta-abc", "s3://my-bucket/org/proj/dev/run123", "action-0", 1)
+		refs := outputRefs(ctx, ta)
+		require.NotNil(t, refs)
+		assert.True(t, strings.HasSuffix(refs.GetReportUri(), "/report.html"),
+			"expected report URI to end with /report.html, got: %s", refs.GetReportUri())
+		assert.Equal(t,
+			strings.TrimSuffix(refs.GetOutputUri(), "/outputs.pb"),
+			strings.TrimSuffix(refs.GetReportUri(), "/report.html"),
+			"report URI and output URI should share the same prefix")
+	})
+
 	t.Run("output URI is consistent with ComputeActionOutputPath", func(t *testing.T) {
 		// outputRefs and NewTaskExecutionContext must agree on the output path.
 		// Verify outputRefs produces a URI whose directory matches the plugin's output prefix.

--- a/executor/pkg/controller/taskaction_controller.go
+++ b/executor/pkg/controller/taskaction_controller.go
@@ -490,8 +490,10 @@ func outputRefs(ctx context.Context, taskAction *flyteorgv1.TaskAction) *task.Ou
 	if err != nil {
 		return nil
 	}
+	base := strings.TrimRight(string(prefix), "/")
 	return &task.OutputReferences{
-		OutputUri: strings.TrimRight(string(prefix), "/") + "/outputs.pb",
+		OutputUri: base + "/outputs.pb",
+		ReportUri: base + "/report.html",
 	}
 }
 


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

The `OutputReferences` proto (`flyteidl2/task/common.proto`) defines both `output_uri` and `report_uri`, but the executor only populated `output_uri` when building `ActionEvent`s. Consumers that need the HTML report URI had no way to locate it.

## What changes were proposed in this pull request?

In `executor/pkg/controller/taskaction_controller.go`, `outputRefs` now also sets `ReportUri` using the convention path `<outputPrefix>/report.html`, alongside the existing `<outputPrefix>/outputs.pb`.

## How was this patch tested?
<img width="1699" height="1207" alt="image" src="https://github.com/user-attachments/assets/d602532f-5d7c-43b8-96a6-4bd0854d6c91" />


Added a unit test in `executor/pkg/controller/output_refs_test.go` that verifies:

- The report URI ends with `/report.html`.
- The report URI and output URI share the same directory prefix.

```
go test ./executor/pkg/controller/ -run TestOutputRefs -count=1
ok  	github.com/flyteorg/flyte/v2/executor/pkg/controller	0.851s
```

### Labels

- changed

### Setup process

### Screenshots

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

## Stack

- `main` <!-- branch-stack -->
  - \#6583
    - **\[V2] Set ReportUri in ActionEvent output references** :point\_left:

## Docs link
