### PR TITLE
Fix missing LinkType for task template log links

### DIFF
--- a/flyteplugins/go/tasks/logs/logging_utils.go
+++ b/flyteplugins/go/tasks/logs/logging_utils.go
@@ -105,9 +105,11 @@ func InitializeLogPlugins(cfg *LogConfig, taskTemplate *core.TaskTemplate) (task
 	if taskTemplate != nil && taskTemplate.GetMetadata() != nil {
 		for _, logLink := range taskTemplate.GetMetadata().GetLogLinks() {
 			plugins = append(plugins, tasklog.TemplateLogPlugin{
-				DisplayName:  logLink.GetName(),
-				TemplateURIs: []tasklog.TemplateURI{logLink.GetUri()},
-				IconUri:      logLink.GetIconUri(),
+				DisplayName:   logLink.GetName(),
+				TemplateURIs:  []tasklog.TemplateURI{logLink.GetUri()},
+				MessageFormat: logLink.GetMessageFormat(),
+				LinkType:      core.TaskLog_DASHBOARD.String(),
+				IconUri:       logLink.GetIconUri(),
 			})
 		}
 	}
@@ -147,6 +149,7 @@ func InitializeLogPlugins(cfg *LogConfig, taskTemplate *core.TaskTemplate) (task
 				ShowWhilePending:    dynamicLogLink.ShowWhilePending,
 				HideOnceFinished:    dynamicLogLink.HideOnceFinished,
 				LinkType:            dynamicLogLink.LinkType,
+				IconUri:             dynamicLogLink.IconUri,
 			})
 	}
 

--- a/flyteplugins/go/tasks/logs/logging_utils_test.go
+++ b/flyteplugins/go/tasks/logs/logging_utils_test.go
@@ -360,7 +360,7 @@ func TestGetLogsForContainerInPod_LegacyTemplate(t *testing.T) {
 }
 
 func assertTestSucceeded(tb testing.TB, config *LogConfig, taskTemplate *core.TaskTemplate, expectedTaskLogs []*core.TaskLog, hostname string) {
-	logPlugin, err := InitializeLogPlugins(config, nil)
+	logPlugin, err := InitializeLogPlugins(config, taskTemplate)
 	assert.NoError(tb, err)
 
 	pod := &v1.Pod{
@@ -450,6 +450,89 @@ func TestGetLogsForContainerInPodTemplates_Hostname(t *testing.T) {
 			Ready:         true,
 		},
 	}, "my-hostname")
+}
+
+func TestGetLogsForContainerInPod_TaskTemplateLogLinks(t *testing.T) {
+	t.Run("LogLinks with LinkType and MessageFormat", func(t *testing.T) {
+		assertTestSucceeded(t, &LogConfig{}, &core.TaskTemplate{
+			Metadata: &core.TaskMetadata{
+				LogLinks: []*core.TaskLog{
+					{
+						Name:          "Spark UI",
+						Uri:           "https://spark.example.com/{{ .executionName }}",
+						MessageFormat: core.TaskLog_JSON,
+					},
+				},
+			},
+		}, []*core.TaskLog{
+			{
+				Uri:           "https://spark.example.com/my-execution-name",
+				MessageFormat: core.TaskLog_JSON,
+				Name:          "Spark UI my-Suffix",
+				LinkType:      core.TaskLog_DASHBOARD,
+				Ready:         true,
+			},
+		}, "")
+	})
+
+	t.Run("Multiple LogLinks all get DASHBOARD LinkType", func(t *testing.T) {
+		assertTestSucceeded(t, &LogConfig{}, &core.TaskTemplate{
+			Metadata: &core.TaskMetadata{
+				LogLinks: []*core.TaskLog{
+					{
+						Name: "Spark UI",
+						Uri:  "https://spark.example.com/{{ .executionName }}",
+					},
+					{
+						Name: "Ray Dashboard",
+						Uri:  "https://ray.example.com/{{ .executionName }}",
+					},
+				},
+			},
+		}, []*core.TaskLog{
+			{
+				Uri:      "https://spark.example.com/my-execution-name",
+				Name:     "Spark UI my-Suffix",
+				LinkType: core.TaskLog_DASHBOARD,
+				Ready:    true,
+			},
+			{
+				Uri:      "https://ray.example.com/my-execution-name",
+				Name:     "Ray Dashboard my-Suffix",
+				LinkType: core.TaskLog_DASHBOARD,
+				Ready:    true,
+			},
+		}, "")
+	})
+
+	t.Run("LogLinks combined with K8s logs", func(t *testing.T) {
+		assertTestSucceeded(t, &LogConfig{
+			IsKubernetesEnabled:   true,
+			KubernetesTemplateURI: "https://k8s.com/{{ .namespace }}/{{ .podName }}/{{ .containerName }}/{{ .containerId }}",
+		}, &core.TaskTemplate{
+			Metadata: &core.TaskMetadata{
+				LogLinks: []*core.TaskLog{
+					{
+						Name: "Spark UI",
+						Uri:  "https://spark.example.com/{{ .executionName }}",
+					},
+				},
+			},
+		}, []*core.TaskLog{
+			{
+				Uri:      "https://spark.example.com/my-execution-name",
+				Name:     "Spark UI my-Suffix",
+				LinkType: core.TaskLog_DASHBOARD,
+				Ready:    true,
+			},
+			{
+				Uri:           "https://k8s.com/my-namespace/my-pod/ContainerName/ContainerID",
+				MessageFormat: core.TaskLog_JSON,
+				Name:          "Kubernetes Logs my-Suffix",
+				Ready:         true,
+			},
+		}, "")
+	})
 }
 
 func TestGetLogsForContainerInPod_Flyteinteractive(t *testing.T) {


### PR DESCRIPTION
## Tracking issue

N/A

## Why are the changes needed?

When `InitializeLogPlugins` creates `TemplateLogPlugin` entries from task template metadata log links (e.g., Spark UI, Ray Dashboard), it was not setting `LinkType` or `MessageFormat`. This caused `GetTaskLogs()` to default `LinkType` to `EXTERNAL` (the zero value) instead of `DASHBOARD`, resulting in the API response returning `link_type: "EXTERNAL"` for all task template log links.

Note: The `flyte` (v1) branch already has this fix — it was just never ported to v2.

## What changes were proposed in this pull request?

In `flyteplugins/go/tasks/logs/logging_utils.go`:

1. Set `LinkType: core.TaskLog_DASHBOARD.String()` and `MessageFormat: logLink.GetMessageFormat()` when creating `TemplateLogPlugin` from task template log links
2. Add missing `IconUri: dynamicLogLink.IconUri` to dynamic log link plugins

## How was this patch tested?

- Existing unit tests pass (`go test ./flyteplugins/go/tasks/logs/... -count=1`)
- Verified the fix matches the v1 branch implementation

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.