### PR TITLE
fix(runs): make TestWatchActionUpdates_OnlyStreamsTargetAction deterministic

### DIFF
--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -133,11 +133,10 @@ func TestWatchActionUpdates_OnlyStreamsTargetAction(t *testing.T) {
 	otherActionID := &common.ActionIdentifier{Run: runID, Name: "other"}
 
 	ctx := context.Background()
-	_, err = actionRepo.CreateAction(ctx, models.NewActionModel(targetActionID), false)
-	require.NoError(t, err)
-	_, err = actionRepo.CreateAction(ctx, models.NewActionModel(otherActionID), false)
-	require.NoError(t, err)
 
+	// Start watcher before creating actions so we can deterministically
+	// drain the creation notification and avoid a race where the async
+	// NOTIFY arrives after the subscriber registers.
 	watchCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -145,8 +144,21 @@ func TestWatchActionUpdates_OnlyStreamsTargetAction(t *testing.T) {
 	errs := make(chan error, 1)
 	go actionRepo.WatchActionUpdates(watchCtx, targetActionID, updates, errs)
 
-	time.Sleep(1100 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond) // let the subscriber register
 
+	_, err = actionRepo.CreateAction(ctx, models.NewActionModel(targetActionID), false)
+	require.NoError(t, err)
+	_, err = actionRepo.CreateAction(ctx, models.NewActionModel(otherActionID), false)
+	require.NoError(t, err)
+
+	// Drain the creation notification for the target action.
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for creation notification")
+	}
+
+	// Update "other" — should NOT produce an update for "target".
 	err = actionRepo.UpdateActionPhase(ctx, otherActionID, common.ActionPhase_ACTION_PHASE_RUNNING, 1, core.CatalogCacheStatus_CACHE_DISABLED, nil)
 	require.NoError(t, err)
 
@@ -158,6 +170,7 @@ func TestWatchActionUpdates_OnlyStreamsTargetAction(t *testing.T) {
 	case <-time.After(1200 * time.Millisecond):
 	}
 
+	// Update "target" — should produce an update.
 	err = actionRepo.UpdateActionPhase(ctx, targetActionID, common.ActionPhase_ACTION_PHASE_RUNNING, 1, core.CatalogCacheStatus_CACHE_DISABLED, nil)
 	require.NoError(t, err)
 

--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -120,8 +120,9 @@ func TestUpdateActionPhasePersistsAttemptsAndCacheStatus(t *testing.T) {
 func TestWatchActionUpdates_OnlyStreamsTargetAction(t *testing.T) {
 	db := setupActionDB(t)
 	defer func() { db.Exec("DELETE FROM actions") }()
-	actionRepo, err := NewActionRepo(db, testDbConfig)
+	repo, err := NewActionRepo(db, testDbConfig)
 	require.NoError(t, err)
+	repoImpl := repo.(*actionRepo)
 
 	runID := &common.RunIdentifier{
 		Org:     "org1",
@@ -142,13 +143,17 @@ func TestWatchActionUpdates_OnlyStreamsTargetAction(t *testing.T) {
 
 	updates := make(chan *models.Action, 2)
 	errs := make(chan error, 1)
-	go actionRepo.WatchActionUpdates(watchCtx, targetActionID, updates, errs)
+	go repo.WatchActionUpdates(watchCtx, targetActionID, updates, errs)
 
-	time.Sleep(100 * time.Millisecond) // let the subscriber register
+	require.Eventually(t, func() bool {
+		repoImpl.mu.RLock()
+		defer repoImpl.mu.RUnlock()
+		return len(repoImpl.actionSubscribers) > 0
+	}, 2*time.Second, 10*time.Millisecond, "timed out waiting for watcher registration")
 
-	_, err = actionRepo.CreateAction(ctx, models.NewActionModel(targetActionID), false)
+	_, err = repo.CreateAction(ctx, models.NewActionModel(targetActionID), false)
 	require.NoError(t, err)
-	_, err = actionRepo.CreateAction(ctx, models.NewActionModel(otherActionID), false)
+	_, err = repo.CreateAction(ctx, models.NewActionModel(otherActionID), false)
 	require.NoError(t, err)
 
 	// Drain the creation notification for the target action.
@@ -159,7 +164,7 @@ func TestWatchActionUpdates_OnlyStreamsTargetAction(t *testing.T) {
 	}
 
 	// Update "other" — should NOT produce an update for "target".
-	err = actionRepo.UpdateActionPhase(ctx, otherActionID, common.ActionPhase_ACTION_PHASE_RUNNING, 1, core.CatalogCacheStatus_CACHE_DISABLED, nil)
+	err = repo.UpdateActionPhase(ctx, otherActionID, common.ActionPhase_ACTION_PHASE_RUNNING, 1, core.CatalogCacheStatus_CACHE_DISABLED, nil)
 	require.NoError(t, err)
 
 	select {
@@ -171,7 +176,7 @@ func TestWatchActionUpdates_OnlyStreamsTargetAction(t *testing.T) {
 	}
 
 	// Update "target" — should produce an update.
-	err = actionRepo.UpdateActionPhase(ctx, targetActionID, common.ActionPhase_ACTION_PHASE_RUNNING, 1, core.CatalogCacheStatus_CACHE_DISABLED, nil)
+	err = repo.UpdateActionPhase(ctx, targetActionID, common.ActionPhase_ACTION_PHASE_RUNNING, 1, core.CatalogCacheStatus_CACHE_DISABLED, nil)
 	require.NoError(t, err)
 
 	select {


### PR DESCRIPTION
## Summary

- Fix flaky `TestWatchActionUpdates_OnlyStreamsTargetAction` test
- The test was racy: `CreateAction("target")` sends a PostgreSQL NOTIFY that could arrive *after* the watcher subscribed, causing a spurious "unexpected update for action target" failure
- Fix: start the watcher before creating actions and deterministically drain the creation notification before assertions

## Test plan

- [ ] CI passes consistently (test was intermittently failing before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- `main` <!-- branch-stack -->
  - \#6583
    - **fix(runs): make TestWatchActionUpdates\_OnlyStreamsTargetAction deterministic** :point\_left:
