### PR TITLE
Use request host in SelectCluster

### DIFF
--- a/dataproxy/service/cluster_service.go
+++ b/dataproxy/service/cluster_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
+	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/cluster"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/cluster/clusterconnect"
@@ -11,13 +12,10 @@ import (
 
 type ClusterService struct {
 	clusterconnect.UnimplementedClusterServiceHandler
-	dataplaneDomain string
 }
 
-func NewClusterService(dataplaneDomain string) *ClusterService {
-	return &ClusterService{
-		dataplaneDomain: dataplaneDomain,
-	}
+func NewClusterService() *ClusterService {
+	return &ClusterService{}
 }
 
 var _ clusterconnect.ClusterServiceHandler = (*ClusterService)(nil)
@@ -26,7 +24,9 @@ func (s *ClusterService) SelectCluster(
 	ctx context.Context,
 	req *connect.Request[cluster.SelectClusterRequest],
 ) (*connect.Response[cluster.SelectClusterResponse], error) {
+	requestHost := req.Header().Get("Host")
+	logger.Debugf(ctx, "Request Host: %s", requestHost)
 	return connect.NewResponse(&cluster.SelectClusterResponse{
-		ClusterEndpoint: s.dataplaneDomain,
+		ClusterEndpoint: requestHost,
 	}), nil
 }

--- a/dataproxy/setup.go
+++ b/dataproxy/setup.go
@@ -3,12 +3,13 @@ package dataproxy
 import (
 	"context"
 	"fmt"
-	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow/workflowconnect"
 	"net/http"
 
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow/workflowconnect"
+
 	"github.com/flyteorg/flyte/v2/dataproxy/config"
-	"github.com/flyteorg/flyte/v2/dataproxy/service"
 	"github.com/flyteorg/flyte/v2/dataproxy/logs"
+	"github.com/flyteorg/flyte/v2/dataproxy/service"
 	"github.com/flyteorg/flyte/v2/flytestdlib/app"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/cluster/clusterconnect"
@@ -42,7 +43,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	sc.Mux.Handle(path, handler)
 	logger.Infof(ctx, "Mounted DataProxyService at %s", path)
 
-	clusterSvc := service.NewClusterService(baseURL)
+	clusterSvc := service.NewClusterService()
 	clusterPath, clusterHandler := clusterconnect.NewClusterServiceHandler(clusterSvc)
 	sc.Mux.Handle(clusterPath, clusterHandler)
 	logger.Infof(ctx, "Mounted ClusterService at %s", clusterPath)


### PR DESCRIPTION
## Why are the changes needed?

`SelectCluster` previously returned a statically configured `dataplaneDomain` (the dataproxy `baseURL`) as the cluster endpoint for every caller. That forced all clients to talk to the same hostname regardless of how they actually reached the service — breaking setups where the same deployment is fronted by multiple hostnames (e.g. per-tenant/per-region ingresses, local port-forwards, or internal vs. external URLs).

Using the request's `Host` header lets the server echo back whatever host the client used to reach it, so clients keep talking to the endpoint they already have a working route to.

## What changes were proposed in this pull request?

- `SelectCluster` now reads the `Host` header off the inbound request and returns it as `ClusterEndpoint`.
- Removed the `dataplaneDomain` field and constructor argument from `ClusterService`; `NewClusterService()` no longer needs the configured base URL.
- Updated `dataproxy/setup.go` to call the simplified constructor, plus a minor import ordering cleanup.

## How was this patch tested?

Manual verification via the dataproxy endpoint — `SelectCluster` now returns the host the client used to reach it rather than the configured dataplane domain.

### Labels

- **fixed**

## Check all the applicable boxes

- [x] All commits are signed-off.