### PR TITLE
fix(helm): set catalog-cache to noop when datacatalog is disabled in flyte-core

### DIFF
--- a/charts/flyte-core/templates/propeller/configmap.yaml
+++ b/charts/flyte-core/templates/propeller/configmap.yaml
@@ -9,8 +9,14 @@ data:
 {{- with .Values.configmap.admin }}
   admin.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
 {{- end }}
+{{- if .Values.datacatalog.enabled }}
 {{- with .Values.configmap.catalog }}
   catalog.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
+{{- end }}
+{{- else }}
+  catalog.yaml: |
+    catalog-cache:
+      type: noop
 {{- end }}
 {{- with .Values.configmap.catalog_cache }}
   catalog_cache.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}

--- a/deployment/eks/flyte_helm_dataplane_generated.yaml
+++ b/deployment/eks/flyte_helm_dataplane_generated.yaml
@@ -85,11 +85,9 @@ data:
       capacity: 1000
       rate: 500
       type: admin
-  catalog.yaml: | 
+  catalog.yaml: |
     catalog-cache:
-      endpoint: datacatalog:89
-      insecure: true
-      type: datacatalog
+      type: noop
   copilot.yaml: | 
     plugins:
       k8s:
@@ -436,7 +434,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "97265f70f47a3e1ac710100719e47cebd553a1185229e18d8ed4bbe76200013"
+        configChecksum: "9a9f82053df3a70b3887205eaabf5bfcee55c8349fbe1b036d69943f0ffef34"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -522,7 +520,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.6
       annotations:
-        configChecksum: "97265f70f47a3e1ac710100719e47cebd553a1185229e18d8ed4bbe76200013"
+        configChecksum: "9a9f82053df3a70b3887205eaabf5bfcee55c8349fbe1b036d69943f0ffef34"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/deployment/gcp/flyte_helm_dataplane_generated.yaml
+++ b/deployment/gcp/flyte_helm_dataplane_generated.yaml
@@ -85,11 +85,9 @@ data:
       capacity: 1000
       rate: 500
       type: admin
-  catalog.yaml: | 
+  catalog.yaml: |
     catalog-cache:
-      endpoint: datacatalog:89
-      insecure: true
-      type: datacatalog
+      type: noop
   copilot.yaml: | 
     plugins:
       k8s:
@@ -444,7 +442,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "0d5f06fa15eb8ba65d62486dce30297ab18e1ca95e55db51819bfa2ce47c5de"
+        configChecksum: "6efab023be81e64928658e841bbff6631ea3c96c1b09a9f487dbc19a1520301"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -529,7 +527,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.6
       annotations:
-        configChecksum: "0d5f06fa15eb8ba65d62486dce30297ab18e1ca95e55db51819bfa2ce47c5de"
+        configChecksum: "6efab023be81e64928658e841bbff6631ea3c96c1b09a9f487dbc19a1520301"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:

--- a/deployment/sandbox/flyte_helm_generated.yaml
+++ b/deployment/sandbox/flyte_helm_generated.yaml
@@ -715,6 +715,7 @@ data:
   resource_manager.yaml: | 
     propeller:
       resourcemanager:
+        redis: null
         type: noop
   storage.yaml: | 
     storage:
@@ -7227,7 +7228,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a7f80c4bc2e56c53048e7fdda25f8c153b8f22ee6cfbb8bc7fe0d0d6855a0c3"
+        configChecksum: "d32e90ba21c593bb965c40e3ca48de856a3df06dec72a42212308fdcc91883e"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
       labels: 
@@ -7305,7 +7306,7 @@ spec:
         app.kubernetes.io/name: flyte-pod-webhook
         app.kubernetes.io/version: v1.16.6
       annotations:
-        configChecksum: "a7f80c4bc2e56c53048e7fdda25f8c153b8f22ee6cfbb8bc7fe0d0d6855a0c3"
+        configChecksum: "d32e90ba21c593bb965c40e3ca48de856a3df06dec72a42212308fdcc91883e"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "10254"
     spec:


### PR DESCRIPTION
## Tracking issue
Closes #7155

## Why are the changes needed?
When `datacatalog.enabled=false` in the flyte-core Helm chart, the `catalog-cache` configuration still defaults to `type: datacatalog` with `endpoint: datacatalog:89`. Since the datacatalog service is not deployed in this case, every task execution triggers a DNS lookup failure:

```
Failed to check Catalog for previous results:
rpc error: code = Unavailable
  desc = connection error: dial tcp: lookup datacatalog on x.x.x.x:x: no such host
```

These two related settings are far apart in `values.yaml` (datacatalog toggle at line 273, catalog-cache config buried inside configmaps at line 1055), making it easy to miss the dependency.

## What changes were proposed in this pull request?
In `charts/flyte-core/templates/propeller/configmap.yaml`, the `catalog.yaml` configmap entry is now rendered conditionally:

- When `datacatalog.enabled=true` (default): renders the existing `configmap.catalog` value as before, preserving full backward compatibility.
- When `datacatalog.enabled=false`: renders `catalog-cache.type: noop` so propeller skips catalog lookups entirely, preventing DNS failures.

## How was this patch tested?
Verified with `helm template` that:
- `--set datacatalog.enabled=false` produces `catalog-cache:\n  type: noop`
- `--set datacatalog.enabled=true` (default) produces the original datacatalog endpoint config unchanged

### Labels
- **fixed**

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.