### PR TITLE
fix(helm): add cloudwatch region and logGroup fields to flyte-binary chart

### DIFF
--- a/charts/flyte-binary/eks-production.yaml
+++ b/charts/flyte-binary/eks-production.yaml
@@ -13,15 +13,15 @@ configuration:
       s3:
         region: "<AWS-REGION-CODE>"
         authType: "iam"
-  #For logging to work, you need to setup an agent. 
+  #For logging to work, you need to setup an agent.
   # Learn more: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-EKS-logs.html
   logging:
     level: 5
     plugins:
       cloudwatch:
         enabled: true
-        templateUri: |-
-          https://console.aws.amazon.com/cloudwatch/home?region=<AWS_REGION>#logEventViewer:group=/aws/eks/<EKS_CLUSTER_NAME>/cluster;stream=var.log.containers.{{ .podName }}_{{ .namespace }}_{{ .containerName }}-{{ .containerId }}.log
+        region: "<AWS_REGION>"        # replace with your AWS region, e.g. us-east-1
+        logGroup: "/aws/eks/<EKS_CLUSTER_NAME>/cluster"  # replace <EKS_CLUSTER_NAME> with your cluster name
   # To configure auth, refer to https://docs.flyte.org/en/latest/deployment/configuration/auth_setup.html
   auth:
     enabled: false

--- a/charts/flyte-binary/eks-starter.yaml
+++ b/charts/flyte-binary/eks-starter.yaml
@@ -13,15 +13,15 @@ configuration:
       s3:
         region: "<AWS-REGION-CODE>"
         authType: "iam"
-  #For logging to work, you need to setup an agent. 
+  #For logging to work, you need to setup an agent.
   # Learn more: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-EKS-logs.html
   logging:
     level: 5
     plugins:
       cloudwatch:
         enabled: true
-        templateUri: |-
-          https://console.aws.amazon.com/cloudwatch/home?region=<AWS_REGION>#logEventViewer:group=/aws/eks/<EKS_CLUSTER_NAME>/cluster;stream=var.log.containers.{{ .podName }}_{{ .namespace }}_{{ .containerName }}-{{ .containerId }}.log
+        region: "<AWS_REGION>"        # replace with your AWS region, e.g. us-east-1
+        logGroup: "/aws/eks/<EKS_CLUSTER_NAME>/cluster"  # replace <EKS_CLUSTER_NAME> with your cluster name
   # To configure auth, refer to https://docs.flyte.org/en/latest/deployment/configuration/auth_setup.html
   auth:
     enabled: false

--- a/charts/flyte-binary/templates/_helpers.tpl
+++ b/charts/flyte-binary/templates/_helpers.tpl
@@ -115,7 +115,12 @@ kubernetes-template-uri: {{ required "Template URI required for Kubernetes loggi
 {{- end }}
 cloudwatch-enabled: {{ .cloudwatch.enabled }}
 {{- if .cloudwatch.enabled }}
-cloudwatch-template-uri: {{ required "Template URI required for CloudWatch logging plugin" .cloudwatch.templateUri }}
+{{- if .cloudwatch.templateUri }}
+cloudwatch-template-uri: {{ .cloudwatch.templateUri }}
+{{- else }}
+cloudwatch-region: {{ required "Either cloudwatch.templateUri or cloudwatch.region is required when CloudWatch logging is enabled" .cloudwatch.region }}
+cloudwatch-log-group: {{ required "cloudwatch.logGroup is required when cloudwatch.region is set" .cloudwatch.logGroup }}
+{{- end }}
 {{- end }}
 stackdriver-enabled: {{ .stackdriver.enabled }}
 {{- if .stackdriver.enabled }}

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -112,7 +112,16 @@ configuration:
       # cloudwatch Configure logging plugin to have logs visible in CloudWatch
       cloudwatch:
         enabled: false
+        # templateUri Provide a fully custom CloudWatch URL template. Supports Go template variables
+        # such as {{ .podName }}, {{ .namespace }}, {{ .containerName }}, {{ .containerId }}.
+        # When set, takes precedence over region and logGroup.
         templateUri: ""
+        # region AWS region where CloudWatch logs are stored (e.g. us-east-1).
+        # Used to construct the CloudWatch URL when templateUri is not set.
+        region: ""
+        # logGroup CloudWatch log group name (e.g. /aws/eks/my-cluster/cluster).
+        # Used to construct the CloudWatch URL when templateUri is not set.
+        logGroup: ""
       # stackdriver Configure logging plugin to have logs visible in StackDriver
       stackdriver:
         enabled: false


### PR DESCRIPTION
## Tracking issue
Closes #7065

## Why are the changes needed?
The `flyte-binary` chart only exposed `templateUri` for CloudWatch log configuration, requiring users to embed the AWS region and EKS cluster name directly in a URL template string. The eks example files shipped with literal `<AWS_REGION>` and `<EKS_CLUSTER_NAME>` placeholder strings. When users deployed without replacing these, the placeholders appeared URL-encoded (`%3CAWS_REGION%3E`) in the Flyte UI CloudWatch log links.

The `flyte-core` chart supports dedicated `cloudwatch-region` and `cloudwatch-log-group` fields, which the backend uses to construct the CloudWatch URL internally. The `flyte-binary` chart lacked equivalent fields.

## What changes were proposed in this pull request?

- **`charts/flyte-binary/values.yaml`**: Added `cloudwatch.region` and `cloudwatch.logGroup` fields under `configuration.logging.plugins.cloudwatch`.
- **`charts/flyte-binary/templates/_helpers.tpl`**: Updated the `flyte-binary.configuration.logging.plugins` helper to emit `cloudwatch-region` and `cloudwatch-log-group` when the new fields are set. The existing `templateUri` field takes precedence when set, preserving full backward compatibility.
- **`charts/flyte-binary/eks-production.yaml`** and **`eks-starter.yaml`**: Replaced the `templateUri` with the placeholder strings with the new `region` and `logGroup` fields, which users replace with their actual values.

## How was this patch tested?
Verified with `helm template` that:
- Setting `cloudwatch.region` and `cloudwatch.logGroup` produces `cloudwatch-region` and `cloudwatch-log-group` config keys in the rendered configmap.
- Setting `cloudwatch.templateUri` still produces `cloudwatch-template-uri` as before (backward-compatible path).

### Labels
- **fixed**

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.