### PR TITLE
Fix type error for suspended kubeflow jobs

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator.go
@@ -63,6 +63,8 @@ func GetPhaseInfo(currentCondition kubeflowv1.JobCondition, occurredAt time.Time
 		return pluginsCore.PhaseInfoRetryableFailure(flyteerr.DownstreamSystemError, details, &taskPhaseInfo), nil
 	case kubeflowv1.JobRestarting:
 		return pluginsCore.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion, &taskPhaseInfo), nil
+	case kubeflowv1.JobSuspended:
+		return pluginsCore.PhaseInfoQueuedWithTaskInfo(pluginsCore.DefaultPhaseVersion, "Suspended", &taskPhaseInfo), nil
 	}
 
 	return pluginsCore.PhaseInfoUndefined, nil
@@ -83,6 +85,8 @@ func GetMPIPhaseInfo(currentCondition kubeflowv1.JobCondition, occurredAt time.T
 		return pluginsCore.PhaseInfoRetryableFailure(flyteerr.DownstreamSystemError, details, &taskPhaseInfo), nil
 	case kubeflowv1.JobRestarting:
 		return pluginsCore.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion, &taskPhaseInfo), nil
+	case kubeflowv1.JobSuspended:
+		return pluginsCore.PhaseInfoQueuedWithTaskInfo(pluginsCore.DefaultPhaseVersion, "Suspended", &taskPhaseInfo), nil
 	}
 
 	return pluginsCore.PhaseInfoUndefined, nil

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/common_operator_test.go
@@ -114,6 +114,16 @@ func TestGetPhaseInfo(t *testing.T) {
 	assert.Equal(t, pluginsCore.PhaseRunning, taskPhase.Phase())
 	assert.NotNil(t, taskPhase.Info())
 	assert.Nil(t, err)
+
+	jobSuspended := kubeflowv1.JobCondition{
+		Type: kubeflowv1.JobSuspended,
+	}
+	taskPhase, err = GetPhaseInfo(jobSuspended, time.Now(), pluginsCore.TaskInfo{})
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseQueued, taskPhase.Phase())
+	assert.Equal(t, "Suspended", taskPhase.Reason())
+	assert.NotNil(t, taskPhase.Info())
+	assert.Nil(t, err)
 }
 
 func TestGetMPIPhaseInfo(t *testing.T) {
@@ -159,6 +169,16 @@ func TestGetMPIPhaseInfo(t *testing.T) {
 	taskPhase, err = GetMPIPhaseInfo(jobRestarting, time.Now(), pluginsCore.TaskInfo{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginsCore.PhaseRunning, taskPhase.Phase())
+	assert.NotNil(t, taskPhase.Info())
+	assert.Nil(t, err)
+
+	jobSuspended := kubeflowv1.JobCondition{
+		Type: kubeflowv1.JobSuspended,
+	}
+	taskPhase, err = GetMPIPhaseInfo(jobSuspended, time.Now(), pluginsCore.TaskInfo{})
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseQueued, taskPhase.Phase())
+	assert.Equal(t, "Suspended", taskPhase.Reason())
 	assert.NotNil(t, taskPhase.Info())
 	assert.Nil(t, err)
 }

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/mpi/mpi_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/mpi/mpi_test.go
@@ -255,6 +255,18 @@ func dummyMPIJobResource(mpiResourceHandler mpiOperatorResourceHandler,
 			Time: now.Add(3 * time.Minute),
 		},
 	}
+	jobSuspended := kubeflowv1.JobCondition{
+		Type:    kubeflowv1.JobSuspended,
+		Status:  corev1.ConditionTrue,
+		Reason:  "MPIJobSuspended",
+		Message: "MPIJob the-job is suspended.",
+		LastUpdateTime: v1.Time{
+			Time: now.Add(time.Minute),
+		},
+		LastTransitionTime: v1.Time{
+			Time: now.Add(time.Minute),
+		},
+	}
 
 	switch conditionType {
 	case kubeflowv1.JobCreated:
@@ -284,6 +296,11 @@ func dummyMPIJobResource(mpiResourceHandler mpiOperatorResourceHandler,
 			jobRunningInactive,
 			jobFailed,
 			jobRestarting,
+		}
+	case kubeflowv1.JobSuspended:
+		jobConditions = []kubeflowv1.JobCondition{
+			jobCreated,
+			jobSuspended,
 		}
 	}
 
@@ -545,6 +562,27 @@ func TestGetTaskPhase(t *testing.T) {
 	assert.Equal(t, pluginsCore.PhaseRunning, taskPhase.Phase())
 	assert.NotNil(t, taskPhase.Info())
 	assert.Nil(t, err)
+
+	taskPhase, err = mpiResourceHandler.GetTaskPhase(ctx, taskCtx, dummyMPIJobResourceCreator(kubeflowv1.JobSuspended))
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseQueued, taskPhase.Phase())
+	assert.Equal(t, "Suspended", taskPhase.Reason())
+	assert.NotNil(t, taskPhase.Info())
+	assert.Nil(t, err)
+
+	// Resume-from-suspended lifecycle: Created -> Suspended -> Running.
+	resumedMPIJob := dummyMPIJobResourceCreator(kubeflowv1.JobSuspended)
+	resumedMPIJob.Status.Conditions = append(resumedMPIJob.Status.Conditions, kubeflowv1.JobCondition{
+		Type:               kubeflowv1.JobRunning,
+		Status:             corev1.ConditionTrue,
+		Reason:             "MPIJobRunning",
+		Message:            "MPIJob the-job is running.",
+		LastTransitionTime: v1.Time{Time: time.Now().Add(time.Minute)},
+	})
+	taskPhase, err = mpiResourceHandler.GetTaskPhase(ctx, taskCtx, resumedMPIJob)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRunning, taskPhase.Phase())
+	assert.NotNil(t, taskPhase.Info())
 
 	// Training operator did not modify the job even though it is not suspended
 	mpiJob := dummyMPIJobResourceCreator(kubeflowv1.JobCreated)

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
@@ -263,6 +263,18 @@ func dummyPytorchJobResource(pytorchResourceHandler pytorchOperatorResourceHandl
 			Time: now.Add(3 * time.Minute),
 		},
 	}
+	jobSuspended := kubeflowv1.JobCondition{
+		Type:    kubeflowv1.JobSuspended,
+		Status:  corev1.ConditionTrue,
+		Reason:  "PyTorchJobSuspended",
+		Message: "PyTorchJob the-job is suspended.",
+		LastUpdateTime: v1.Time{
+			Time: now.Add(time.Minute),
+		},
+		LastTransitionTime: v1.Time{
+			Time: now.Add(time.Minute),
+		},
+	}
 
 	switch conditionType {
 	case kubeflowv1.JobCreated:
@@ -292,6 +304,11 @@ func dummyPytorchJobResource(pytorchResourceHandler pytorchOperatorResourceHandl
 			jobRunningInactive,
 			jobFailed,
 			jobRestarting,
+		}
+	case kubeflowv1.JobSuspended:
+		jobConditions = []kubeflowv1.JobCondition{
+			jobCreated,
+			jobSuspended,
 		}
 	}
 
@@ -666,6 +683,27 @@ func TestGetTaskPhase(t *testing.T) {
 	assert.Equal(t, pluginsCore.PhaseRunning, taskPhase.Phase())
 	assert.NotNil(t, taskPhase.Info())
 	assert.Nil(t, err)
+
+	taskPhase, err = pytorchResourceHandler.GetTaskPhase(ctx, taskCtx, dummyPytorchJobResourceCreator(kubeflowv1.JobSuspended))
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseQueued, taskPhase.Phase())
+	assert.Equal(t, "Suspended", taskPhase.Reason())
+	assert.NotNil(t, taskPhase.Info())
+	assert.Nil(t, err)
+
+	// Resume-from-suspended lifecycle: Created -> Suspended -> Running.
+	resumedPytorchJob := dummyPytorchJobResourceCreator(kubeflowv1.JobSuspended)
+	resumedPytorchJob.Status.Conditions = append(resumedPytorchJob.Status.Conditions, kubeflowv1.JobCondition{
+		Type:               kubeflowv1.JobRunning,
+		Status:             corev1.ConditionTrue,
+		Reason:             "PyTorchJobRunning",
+		Message:            "PyTorchJob the-job is running.",
+		LastTransitionTime: v1.Time{Time: time.Now().Add(time.Minute)},
+	})
+	taskPhase, err = pytorchResourceHandler.GetTaskPhase(ctx, taskCtx, resumedPytorchJob)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRunning, taskPhase.Phase())
+	assert.NotNil(t, taskPhase.Info())
 
 	// Training operator did not modify the job even though it is not suspended
 	pytorchJob := dummyPytorchJobResourceCreator(kubeflowv1.JobCreated)

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow_test.go
@@ -256,6 +256,18 @@ func dummyTensorFlowJobResource(tensorflowResourceHandler tensorflowOperatorReso
 			Time: now.Add(3 * time.Minute),
 		},
 	}
+	jobSuspended := kubeflowv1.JobCondition{
+		Type:    kubeflowv1.JobSuspended,
+		Status:  corev1.ConditionTrue,
+		Reason:  "TensorFlowJobSuspended",
+		Message: "TensorFlowJob the-job is suspended.",
+		LastUpdateTime: v1.Time{
+			Time: now.Add(time.Minute),
+		},
+		LastTransitionTime: v1.Time{
+			Time: now.Add(time.Minute),
+		},
+	}
 
 	switch conditionType {
 	case kubeflowv1.JobCreated:
@@ -285,6 +297,11 @@ func dummyTensorFlowJobResource(tensorflowResourceHandler tensorflowOperatorReso
 			jobRunningInactive,
 			jobFailed,
 			jobRestarting,
+		}
+	case kubeflowv1.JobSuspended:
+		jobConditions = []kubeflowv1.JobCondition{
+			jobCreated,
+			jobSuspended,
 		}
 	}
 
@@ -591,6 +608,27 @@ func TestGetTaskPhase(t *testing.T) {
 	assert.Equal(t, pluginsCore.PhaseRunning, taskPhase.Phase())
 	assert.NotNil(t, taskPhase.Info())
 	assert.Nil(t, err)
+
+	taskPhase, err = tensorflowResourceHandler.GetTaskPhase(ctx, taskCtx, dummyTensorFlowJobResourceCreator(kubeflowv1.JobSuspended))
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseQueued, taskPhase.Phase())
+	assert.Equal(t, "Suspended", taskPhase.Reason())
+	assert.NotNil(t, taskPhase.Info())
+	assert.Nil(t, err)
+
+	// Resume-from-suspended lifecycle: Created -> Suspended -> Running.
+	resumedTFJob := dummyTensorFlowJobResourceCreator(kubeflowv1.JobSuspended)
+	resumedTFJob.Status.Conditions = append(resumedTFJob.Status.Conditions, kubeflowv1.JobCondition{
+		Type:               kubeflowv1.JobRunning,
+		Status:             corev1.ConditionTrue,
+		Reason:             "TensorFlowJobRunning",
+		Message:            "TensorFlowJob the-job is running.",
+		LastTransitionTime: v1.Time{Time: time.Now().Add(time.Minute)},
+	})
+	taskPhase, err = tensorflowResourceHandler.GetTaskPhase(ctx, taskCtx, resumedTFJob)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRunning, taskPhase.Phase())
+	assert.NotNil(t, taskPhase.Info())
 
 	// Training operator did not modify the job even though it is not suspended
 	tfJob := dummyTensorFlowJobResourceCreator(kubeflowv1.JobCreated)


### PR DESCRIPTION
When kubeflow jobs are suspended by an external system (eg kueue), the controller error's with the following [0].

https://github.com/flyteorg/flyte/pull/6295/changes relies only on app.Spec.RunPolicy.Suspend and does not take into account the phase.

[0]  `failed Execute for node. Error: failed at Node[dn1]. RuntimeExecutionError: failed during plugin execution, caused by: Invalid transition for plugin [pytorch]: transition doesn't have task info nor an execution error filled [TransitionTypeEphemeral,Phase<PhaseUndefined:0 <nil> Reason:>]`

related: #6294 #6295

Observed in versions:  v1.16.3, v1.16.4, v1.16.5