### PR TITLE
fix: serve apps directly via Kourier, drop Traefik IngressRoute

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -40,16 +40,6 @@ type InternalAppConfig struct {
 	// MaxRequestTimeout is the hard cap on request timeout (Knative max is 3600s).
 	MaxRequestTimeout time.Duration `json:"maxRequestTimeout" pflag:",Maximum allowed request timeout for apps"`
 
-	// IngressEntryPoint is the Traefik entry point name that app routes are
-	// attached to (default: "apps").
-	IngressEntryPoint string `json:"ingressEntryPoint" pflag:",Traefik entry point name for app ingress routes"`
-
-	// IngressAppsDomain is the domain suffix for subdomain-based app URLs.
-	// Apps are exposed at {name}-{project}-{domain}.{IngressAppsDomain}.
-	// Use "localhost" for local devbox (resolves without /etc/hosts on macOS/Linux).
-	// Windows users can override to e.g. "localtest.me".
-	IngressAppsDomain string `json:"ingressAppsDomain" pflag:",Domain suffix for app subdomain URLs"`
-
 	// IngressAppsPort is the port appended to the public app URL (e.g. 30081).
 	// Set to 0 to omit the port when behind a standard 80/443 proxy.
 	IngressAppsPort int `json:"ingressAppsPort" pflag:",Port for app subdomain URLs (0 = omit)"`

--- a/app/internal/k8s/app_client.go
+++ b/app/internal/k8s/app_client.go
@@ -15,8 +15,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	k8swatch "k8s.io/apimachinery/pkg/watch"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -43,11 +41,6 @@ const (
 
 	// maxKServiceNameLen is the Kubernetes DNS label limit.
 	maxKServiceNameLen = 63
-)
-
-var (
-	traefikIngressRouteGVK = schema.GroupVersionKind{Group: "traefik.io", Version: "v1alpha1", Kind: "IngressRoute"}
-	traefikMiddlewareGVK   = schema.GroupVersionKind{Group: "traefik.io", Version: "v1alpha1", Kind: "Middleware"}
 )
 
 // AppK8sClientInterface defines the KService lifecycle operations for the App service.
@@ -129,17 +122,15 @@ func (c *AppK8sClient) Deploy(ctx context.Context, app *flyteapp.App) error {
 			return fmt.Errorf("failed to create KService %s: %w", name, err)
 		}
 		logger.Infof(ctx, "Created KService %s/%s", ns, name)
-		return c.deployIngress(ctx, app)
+		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("failed to get KService %s: %w", name, err)
 	}
 
-	// Skip KService update if spec has not changed, but still ensure ingress exists
-	// (it may be missing if the app was deployed before ingress support was added).
 	if existing.Annotations[annotationSpecSHA] == ksvc.Annotations[annotationSpecSHA] {
 		logger.Debugf(ctx, "KService %s/%s spec unchanged, skipping update", ns, name)
-		return c.deployIngress(ctx, app)
+		return nil
 	}
 
 	existing.Spec = ksvc.Spec
@@ -162,7 +153,7 @@ func (c *AppK8sClient) Deploy(ctx context.Context, app *flyteapp.App) error {
 		return fmt.Errorf("failed to update KService %s: %w", name, err)
 	}
 	logger.Infof(ctx, "Updated KService %s/%s", ns, name)
-	return c.deployIngress(ctx, app)
+	return nil
 }
 
 // Stop sets max-scale=0 on the KService, scaling it to zero without deleting it.
@@ -193,13 +184,11 @@ func (c *AppK8sClient) Delete(ctx context.Context, appID *flyteapp.Identifier) e
 	ksvc.Namespace = ns
 	if err := c.k8sClient.Delete(ctx, ksvc); err != nil {
 		if k8serrors.IsNotFound(err) {
-			c.deleteIngress(ctx, appID)
 			return nil
 		}
 		return fmt.Errorf("failed to delete KService %s: %w", name, err)
 	}
 	logger.Infof(ctx, "Deleted KService %s/%s", ns, name)
-	c.deleteIngress(ctx, appID)
 	return nil
 }
 
@@ -501,118 +490,11 @@ func (c *AppK8sClient) publicIngress(id *flyteapp.Identifier) *flyteapp.Ingress 
 	}
 	host := strings.ToLower(fmt.Sprintf("%s-%s-%s.%s",
 		id.GetName(), id.GetProject(), id.GetDomain(), c.cfg.BaseDomain))
-	return &flyteapp.Ingress{PublicUrl: scheme + "://" + host}
-}
-
-// deployIngress creates or updates the Traefik resources for the given app:
-//   - host-<name>   Middleware: rewrites Host to the Knative hostname so Kourier
-//     can route the request (Knative's K8s service is ExternalName → Kourier)
-//   - app-<name>    IngressRoute: matches Host header and applies the middleware
-//
-func (c *AppK8sClient) deployIngress(ctx context.Context, app *flyteapp.App) error {
-	appID := app.GetMetadata().GetId()
-	ns := appNamespace(appID.GetProject(), appID.GetDomain())
-	ksvcName := kserviceName(appID)
-	hostName := "host-" + ksvcName
-	routeName := "app-" + ksvcName
-	appHost := strings.ToLower(fmt.Sprintf("%s-%s-%s.%s",
-		appID.GetName(), appID.GetProject(), appID.GetDomain(), c.cfg.IngressAppsDomain))
-	entryPoint := c.cfg.IngressEntryPoint
-	if entryPoint == "" {
-		entryPoint = "apps"
+	url := scheme + "://" + host
+	if c.cfg.IngressAppsPort != 0 {
+		url += fmt.Sprintf(":%d", c.cfg.IngressAppsPort)
 	}
-
-	// Knative's K8s service is ExternalName → kourier-internal. Kourier routes by
-	// Host header, so we must rewrite it to the deterministic Knative hostname.
-	// hostname pattern matches the configured domain-template: {name}-{namespace}.{domain}
-	knativeHost := fmt.Sprintf("%s-%s.%s", ksvcName, ns, c.cfg.BaseDomain)
-
-	hostMW := &unstructured.Unstructured{}
-	hostMW.SetGroupVersionKind(traefikMiddlewareGVK)
-	hostMW.SetName(hostName)
-	hostMW.SetNamespace(ns)
-	hostMW.Object["spec"] = map[string]interface{}{
-		"headers": map[string]interface{}{
-			"customRequestHeaders": map[string]interface{}{
-				"Host": knativeHost,
-				// Rewrite Origin to match the Knative host so that apps with
-				// XSRF/CORS origin checks (e.g. Streamlit) accept the connection.
-				// Safe for devbox — XSRF provides no value in a local environment.
-				"Origin": "http://" + knativeHost,
-			},
-		},
-	}
-
-	ir := &unstructured.Unstructured{}
-	ir.SetGroupVersionKind(traefikIngressRouteGVK)
-	ir.SetName(routeName)
-	ir.SetNamespace(ns)
-	ir.Object["spec"] = map[string]interface{}{
-		"entryPoints": []interface{}{entryPoint},
-		"routes": []interface{}{
-			map[string]interface{}{
-				"match": fmt.Sprintf("Host(`%s`)", appHost),
-				"kind":  "Rule",
-				"middlewares": []interface{}{
-					map[string]interface{}{"name": hostName},
-				},
-				"services": []interface{}{
-					map[string]interface{}{
-						"name": ksvcName,
-						"port": int64(80),
-					},
-				},
-			},
-		},
-	}
-
-	for _, obj := range []*unstructured.Unstructured{hostMW, ir} {
-		existing := &unstructured.Unstructured{}
-		existing.SetGroupVersionKind(obj.GroupVersionKind())
-		err := c.k8sClient.Get(ctx, client.ObjectKey{Name: obj.GetName(), Namespace: obj.GetNamespace()}, existing)
-		if k8serrors.IsNotFound(err) {
-			if createErr := c.k8sClient.Create(ctx, obj); createErr != nil {
-				return fmt.Errorf("failed to create %s %s/%s: %w", obj.GetKind(), ns, obj.GetName(), createErr)
-			}
-			logger.Infof(ctx, "Created %s %s/%s", obj.GetKind(), ns, obj.GetName())
-		} else if err != nil {
-			return fmt.Errorf("failed to get %s %s/%s: %w", obj.GetKind(), ns, obj.GetName(), err)
-		} else {
-			obj.SetResourceVersion(existing.GetResourceVersion())
-			if updateErr := c.k8sClient.Update(ctx, obj); updateErr != nil {
-				return fmt.Errorf("failed to update %s %s/%s: %w", obj.GetKind(), ns, obj.GetName(), updateErr)
-			}
-			logger.Infof(ctx, "Updated %s %s/%s", obj.GetKind(), ns, obj.GetName())
-		}
-	}
-	return nil
-}
-
-// deleteIngress removes the Traefik IngressRoute and both Middlewares for the given app.
-// Errors are logged as warnings — ingress cleanup failure does not block app deletion.
-func (c *AppK8sClient) deleteIngress(ctx context.Context, appID *flyteapp.Identifier) {
-	ns := appNamespace(appID.GetProject(), appID.GetDomain())
-	ksvcName := kserviceName(appID)
-
-	type resource struct {
-		gvk  schema.GroupVersionKind
-		name string
-	}
-	resources := []resource{
-		{traefikIngressRouteGVK, "app-" + ksvcName},
-		{traefikMiddlewareGVK, "host-" + ksvcName},
-	}
-	for _, r := range resources {
-		obj := &unstructured.Unstructured{}
-		obj.SetGroupVersionKind(r.gvk)
-		obj.SetName(r.name)
-		obj.SetNamespace(ns)
-		if err := c.k8sClient.Delete(ctx, obj); err != nil && !k8serrors.IsNotFound(err) {
-			logger.Warnf(ctx, "Failed to delete %s %s/%s: %v", r.gvk.Kind, ns, r.name, err)
-		} else {
-			logger.Infof(ctx, "Deleted %s %s/%s", r.gvk.Kind, ns, r.name)
-		}
-	}
+	return &flyteapp.Ingress{PublicUrl: url}
 }
 
 // --- Helpers ---

--- a/app/internal/k8s/app_client.go
+++ b/app/internal/k8s/app_client.go
@@ -468,19 +468,6 @@ func (c *AppK8sClient) List(ctx context.Context, project, domain string, limit u
 // publicIngress returns the deterministic public URL for an app using the same
 // logic as the service layer so GetStatus/List/Watch are consistent with Create.
 func (c *AppK8sClient) publicIngress(id *flyteapp.Identifier) *flyteapp.Ingress {
-	if c.cfg.IngressAppsDomain != "" {
-		scheme := c.cfg.Scheme
-		if scheme == "" {
-			scheme = "http"
-		}
-		host := strings.ToLower(fmt.Sprintf("%s-%s-%s.%s",
-			id.GetName(), id.GetProject(), id.GetDomain(), c.cfg.IngressAppsDomain))
-		url := scheme + "://" + host
-		if c.cfg.IngressAppsPort != 0 {
-			url += fmt.Sprintf(":%d", c.cfg.IngressAppsPort)
-		}
-		return &flyteapp.Ingress{PublicUrl: url}
-	}
 	if c.cfg.BaseDomain == "" {
 		return nil
 	}

--- a/app/internal/service/internal_app_service.go
+++ b/app/internal/service/internal_app_service.go
@@ -68,18 +68,32 @@ func (s *InternalAppService) Create(
 }
 
 // publicIngress builds the deterministic public URL for an app.
-// URL is subdomain-based: {scheme}://{name}-{project}-{domain}.{IngressAppsDomain}[:{IngressAppsPort}].
-// Returns nil if IngressAppsDomain is not configured.
+// Prefers IngressAppsDomain when set; otherwise falls back to BaseDomain
+// (which matches Knative's default domain template so Kourier serves the URL directly).
+// Returns nil if neither domain is configured.
 func publicIngress(id *flyteapp.Identifier, cfg *appconfig.InternalAppConfig) *flyteapp.Ingress {
-	if cfg.IngressAppsDomain == "" {
+	if cfg.IngressAppsDomain != "" {
+		scheme := cfg.Scheme
+		if scheme == "" {
+			scheme = "http"
+		}
+		host := strings.ToLower(fmt.Sprintf("%s-%s-%s.%s",
+			id.GetName(), id.GetProject(), id.GetDomain(), cfg.IngressAppsDomain))
+		url := scheme + "://" + host
+		if cfg.IngressAppsPort != 0 {
+			url += fmt.Sprintf(":%d", cfg.IngressAppsPort)
+		}
+		return &flyteapp.Ingress{PublicUrl: url}
+	}
+	if cfg.BaseDomain == "" {
 		return nil
 	}
 	scheme := cfg.Scheme
 	if scheme == "" {
-		scheme = "http"
+		scheme = "https"
 	}
 	host := strings.ToLower(fmt.Sprintf("%s-%s-%s.%s",
-		id.GetName(), id.GetProject(), id.GetDomain(), cfg.IngressAppsDomain))
+		id.GetName(), id.GetProject(), id.GetDomain(), cfg.BaseDomain))
 	url := scheme + "://" + host
 	if cfg.IngressAppsPort != 0 {
 		url += fmt.Sprintf(":%d", cfg.IngressAppsPort)

--- a/app/internal/service/internal_app_service.go
+++ b/app/internal/service/internal_app_service.go
@@ -67,24 +67,10 @@ func (s *InternalAppService) Create(
 	return connect.NewResponse(&flyteapp.CreateResponse{App: app}), nil
 }
 
-// publicIngress builds the deterministic public URL for an app.
-// Prefers IngressAppsDomain when set; otherwise falls back to BaseDomain
-// (which matches Knative's default domain template so Kourier serves the URL directly).
-// Returns nil if neither domain is configured.
+// publicIngress builds the deterministic public URL for an app using
+// BaseDomain — which must match Knative's domain-template so Kourier
+// serves the URL directly. Returns nil if BaseDomain is unset.
 func publicIngress(id *flyteapp.Identifier, cfg *appconfig.InternalAppConfig) *flyteapp.Ingress {
-	if cfg.IngressAppsDomain != "" {
-		scheme := cfg.Scheme
-		if scheme == "" {
-			scheme = "http"
-		}
-		host := strings.ToLower(fmt.Sprintf("%s-%s-%s.%s",
-			id.GetName(), id.GetProject(), id.GetDomain(), cfg.IngressAppsDomain))
-		url := scheme + "://" + host
-		if cfg.IngressAppsPort != 0 {
-			url += fmt.Sprintf(":%d", cfg.IngressAppsPort)
-		}
-		return &flyteapp.Ingress{PublicUrl: url}
-	}
 	if cfg.BaseDomain == "" {
 		return nil
 	}

--- a/app/internal/service/internal_app_service_test.go
+++ b/app/internal/service/internal_app_service_test.go
@@ -76,8 +76,8 @@ func (m *mockAppK8sClient) Watch(ctx context.Context, project, domain, appName s
 
 func testCfg() *appconfig.InternalAppConfig {
 	return &appconfig.InternalAppConfig{
-		Enabled:           true,
-		IngressAppsDomain: "example.com",
+		Enabled:               true,
+		BaseDomain:            "example.com",
 		Scheme:                "https",
 		DefaultRequestTimeout: 5 * time.Minute,
 		MaxRequestTimeout:     time.Hour,
@@ -184,7 +184,7 @@ func TestCreate_IngressWithPort(t *testing.T) {
 func TestCreate_NoBaseDomain_NoIngress(t *testing.T) {
 	k8s := &mockAppK8sClient{}
 	cfg := testCfg()
-	cfg.IngressAppsDomain = ""
+	cfg.BaseDomain = ""
 	svc := NewInternalAppService(k8s, cfg)
 
 	app := testApp()

--- a/charts/flyte-devbox/templates/proxy/traefik-config.yaml
+++ b/charts/flyte-devbox/templates/proxy/traefik-config.yaml
@@ -14,14 +14,6 @@ spec:
         transport:
           respondingTimeouts:
             readTimeout: 0
-      apps:
-        port: 30081
-        nodePort: 30081
-        expose:
-          default: true
-        transport:
-          respondingTimeouts:
-            readTimeout: 0
       websecure:
         expose: false
     providers:

--- a/charts/flyte-devbox/values.yaml
+++ b/charts/flyte-devbox/values.yaml
@@ -69,10 +69,8 @@ flyte-binary:
       manager:
         internalApps:
           enabled: true
-          baseDomain: "local.flyte.app"
+          baseDomain: "localhost"
           scheme: "http"
-          ingressEntryPoint: "apps"
-          ingressAppsDomain: "localhost"
           ingressAppsPort: 30081
           defaultEnvVars:
             - FLYTE_AWS_ENDPOINT: 'http://rustfs.{{ .Release.Namespace }}:9000'

--- a/docker/devbox-bundled/Makefile
+++ b/docker/devbox-bundled/Makefile
@@ -74,7 +74,7 @@ build-gpu: build
 # 30001 - DB
 # 30002 - RustFS
 # 30080 - Flyte Proxy
-# 30081 - Flyte Apps
+# 30081 - Kourier (Knative apps)
 .PHONY: start
 start: FLYTE_DEVBOX_IMAGE := flyte-devbox:latest
 start: FLYTE_DEV := False
@@ -126,7 +126,9 @@ setup-knative:
 	kubectl patch configmap/config-network -n knative-serving --type merge \
 		--patch '{"data":{"domain-template":"{{.Name}}-{{.Namespace}}.{{.Domain}}"}}'
 	kubectl patch configmap/config-domain -n knative-serving --type merge \
-		--patch '{"data":{"local.flyte.app":""}}'
+		--patch '{"data":{"local.flyte.app":null,"localhost":""}}'
+	kubectl patch svc/kourier -n kourier-system --type merge \
+		--patch '{"spec":{"type":"NodePort","ports":[{"name":"http2","port":80,"targetPort":8080,"nodePort":30081}]}}'
 
 .PHONY: stop
 stop:

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -538,25 +538,15 @@ data:
   100-inline-config.yaml: |
     manager:
       internalApps:
-        baseDomain: local.flyte.app
+        baseDomain: localhost
         defaultEnvVars:
-        - name: FLYTE_AWS_ENDPOINT
-          value: http://rustfs.flyte:9000
-        - name: FLYTE_AWS_ACCESS_KEY_ID
-          value: rustfs
-        - name: FLYTE_AWS_SECRET_ACCESS_KEY
-          value: rustfsstorage
-        - name: _U_EP_OVERRIDE
-          value: flyte-binary-http.flyte:8090
-        - name: _U_INSECURE
-          value: "true"
-        - name: _U_USE_ACTIONS
-          value: "1"
+        - FLYTE_AWS_ENDPOINT: http://rustfs.flyte:9000
+        - FLYTE_AWS_ACCESS_KEY_ID: rustfs
+        - FLYTE_AWS_SECRET_ACCESS_KEY: rustfsstorage
+        - _U_EP_OVERRIDE: flyte-binary-http.flyte:8090
+        - _U_INSECURE: "true"
+        - _U_USE_ACTIONS: "1"
         enabled: true
-        ingressAppsDomain: localhost
-        ingressAppsPort: 30081
-        ingressEnabled: true
-        ingressEntryPoint: apps
         scheme: http
     plugins:
       k8s:
@@ -935,7 +925,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 709f0513c6d5a65b47f3e9d42696c92cecfdc3073acac33c7ad32340a645bef4
+        checksum/configuration: 67ff4767c65e0e994c1cdc6dc435705ad04f001488a986711b4c3704abea0404
         checksum/configuration-secret: e70194084619f4a1d4017093aac6367047167107fd0222513a32a61734629cac
       labels:
         app.kubernetes.io/component: flyte-binary
@@ -1163,14 +1153,6 @@ spec:
     ports:
       web:
         nodePort: 30080
-        transport:
-          respondingTimeouts:
-            readTimeout: 0
-      apps:
-        port: 30081
-        nodePort: 30081
-        expose:
-          default: true
         transport:
           respondingTimeouts:
             readTimeout: 0

--- a/docker/devbox-bundled/manifests/dev.yaml
+++ b/docker/devbox-bundled/manifests/dev.yaml
@@ -758,14 +758,6 @@ spec:
         transport:
           respondingTimeouts:
             readTimeout: 0
-      apps:
-        port: 30081
-        nodePort: 30081
-        expose:
-          default: true
-        transport:
-          respondingTimeouts:
-            readTimeout: 0
       websecure:
         expose: false
     providers:

--- a/manager/config.yaml
+++ b/manager/config.yaml
@@ -18,12 +18,10 @@ manager:
 
   internalApps:
     enabled: true
-    baseDomain: "local.flyte.app"
+    baseDomain: "localhost"
     scheme: "http"
     defaultRequestTimeout: 300s
     maxRequestTimeout: 3600s
-    ingressEntryPoint: "apps"
-    ingressAppsDomain: "localhost"
     ingressAppsPort: 30081
     defaultEnvVars:
       - FLYTE_AWS_ENDPOINT: "http://rustfs.flyte.svc.cluster.local:9000"


### PR DESCRIPTION
## Why are the changes needed?

Each app deploy was creating a per-app Traefik `IngressRoute` + `Middleware` (`deployIngress` in `app_client.go`) whose only job was to rewrite the `Host` header from our advertised URL (`<name>-<project>-<domain>.<IngressAppsDomain>`) to Knative's hostname (`<ksvc>-<ns>.<BaseDomain>`) so Kourier could route it.

For the devbox flow there is no reason to keep those two hostnames different. If we just make the advertised URL match Knative's default domain template, Kourier can serve the request directly — no per-app K8s objects, no Traefik middleware.

## What changes were proposed in this pull request?

- `app/internal/k8s/app_client.go`: delete `deployIngress` / `deleteIngress`, the Traefik GVKs, and all call sites in `Deploy` / `Delete`. Drop the now-unused `unstructured` and `schema` imports.
- `app/internal/service/internal_app_service.go` + `app_client.go` (`publicIngress`): when `IngressAppsDomain` is empty, fall back to `BaseDomain` and append `IngressAppsPort` so returned URLs include `:30081`. Service-layer and k8s-layer versions now behave identically.
- `charts/flyte-devbox/values.yaml` + `manager/config.yaml`: `baseDomain: localhost`, keep `ingressAppsPort: 30081`, drop `ingressEntryPoint` / `ingressAppsDomain`.
- `charts/flyte-devbox/templates/proxy/traefik-config.yaml`: remove the `apps` entrypoint — Traefik only serves 30080 now.
- `docker/devbox-bundled/Makefile`: `setup-knative` sets Knative's `config-domain` to `localhost` (removes `local.flyte.app`) and patches `svc/kourier` in `kourier-system` to `NodePort 30081`. Port-map comment updated.
- Regenerated `docker/devbox-bundled/manifests/{complete,dev}.yaml`.

Public URL shape is unchanged: `http://<name>-<project>-<domain>.localhost:30081`. Request path is now `browser → :30081 → Kourier → KService` with no Traefik hop.

## How was this patch tested?

- `go build ./app/...`
- `go test ./app/internal/k8s/... ./app/internal/service/...` — all pass.
- Manually: deploying a Streamlit app and hitting `http://streamlit-hello-v2-flytesnacks-development.localhost:30081/` loads the app.

### Labels

- **changed**

## Check all the applicable boxes

- [x] All new and existing tests passed.
- [x] All commits are signed-off.

* `main` <!-- branch-stack -->
  - \#6583
    - \#7197
      - **fix: serve apps directly via Kourier, drop Traefik IngressRoute** :point\_left:
