### PR TITLE
[Flyte 7198] Enabling flyte plugins

### DIFF
--- a/executor/pkg/config/task_plugin_config.go
+++ b/executor/pkg/config/task_plugin_config.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	stdconfig "github.com/flyteorg/flyte/v2/flytestdlib/config"
+)
+
+const (
+	tasksSectionKey       = "tasks"
+	taskPluginsSectionKey = "task-plugins"
+)
+
+var (
+	defaultTaskPluginConfig = &TaskPluginConfig{}
+
+	tasksSection       = stdconfig.MustRegisterSection(tasksSectionKey, &TasksConfig{})
+	taskPluginsSection = tasksSection.MustRegisterSection(taskPluginsSectionKey, defaultTaskPluginConfig)
+)
+
+// TasksConfig is the top-level tasks configuration container.
+type TasksConfig struct{}
+
+// TaskPluginConfig holds the task plugin enablement and routing configuration,
+// read from the tasks.task-plugins config section.
+type TaskPluginConfig struct {
+	// EnabledPlugins is an allowlist of plugin executor IDs to load at startup.
+	// An empty slice loads all compiled-in plugins (default behaviour).
+	EnabledPlugins []string `json:"enabled-plugins"`
+
+	// DefaultForTaskTypes overrides which plugin handles a given task type.
+	// Key: task type string, Value: plugin ID string.
+	DefaultForTaskTypes map[string]string `json:"default-for-task-types"`
+}
+
+// GetTaskPluginConfig returns the parsed task plugin configuration from the
+// tasks.task-plugins config section.
+func GetTaskPluginConfig() *TaskPluginConfig {
+	return taskPluginsSection.GetConfig().(*TaskPluginConfig)
+}
+
+// SetTaskPluginConfig replaces the active task plugin configuration. Intended for use in tests.
+func SetTaskPluginConfig(cfg *TaskPluginConfig) error {
+	return taskPluginsSection.SetConfig(cfg)
+}

--- a/executor/pkg/plugin/registry.go
+++ b/executor/pkg/plugin/registry.go
@@ -3,13 +3,14 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 
+	executorConfig "github.com/flyteorg/flyte/v2/executor/pkg/config"
+	executorK8s "github.com/flyteorg/flyte/v2/executor/pkg/plugin/k8s"
 	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
 	k8sPlugin "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
-
-	executorK8s "github.com/flyteorg/flyte/v2/executor/pkg/plugin/k8s"
 )
 
 // PluginRegistryIface provides access to registered plugin entries.
@@ -42,6 +43,23 @@ func NewRegistry(setupCtx pluginsCore.SetupContext, pluginRegistry PluginRegistr
 	}
 }
 
+type PluginsConfigMeta struct {
+	EnabledPlugins []string
+}
+
+func GetEnabledPlugins() *PluginsConfigMeta {
+	return &PluginsConfigMeta{
+		EnabledPlugins: executorConfig.GetTaskPluginConfig().EnabledPlugins,
+	}
+}
+
+func (pcm *PluginsConfigMeta) isAllowed(id string) bool {
+	if len(pcm.EnabledPlugins) == 0 {
+		return true
+	}
+	return slices.Contains(pcm.EnabledPlugins, id)
+}
+
 // Initialize loads all registered plugins. Must be called once during startup.
 func (r *Registry) Initialize(ctx context.Context) error {
 	r.mu.Lock()
@@ -51,8 +69,14 @@ func (r *Registry) Initialize(ctx context.Context) error {
 		return nil
 	}
 
+	pluginMeta := GetEnabledPlugins()
 	// Load k8s plugins
 	for _, entry := range r.pluginRegistry.GetK8sPlugins() {
+		if !pluginMeta.isAllowed(entry.ID) {
+			logger.Infof(ctx, "Skipping k8s plugin [%s]: not in enabled-plugins allowlist", entry.ID)
+			continue
+		}
+
 		pm := executorK8s.NewPluginManager(
 			entry.ID,
 			entry.Plugin,
@@ -83,6 +107,11 @@ func (r *Registry) Initialize(ctx context.Context) error {
 
 	// Load core plugins
 	for _, entry := range r.pluginRegistry.GetCorePlugins() {
+		if !pluginMeta.isAllowed(entry.ID) {
+			logger.Infof(ctx, "Skipping core plugin [%s]: not in enabled-plugins allowlist", entry.ID)
+			continue
+		}
+
 		plugin, err := pluginsCore.LoadPlugin(ctx, r.setupCtx, entry)
 		if err != nil {
 			return fmt.Errorf("failed to load core plugin %s: %w", entry.ID, err)
@@ -101,6 +130,24 @@ func (r *Registry) Initialize(ctx context.Context) error {
 		}
 
 		logger.Infof(ctx, "Registered core plugin [%s] for task types %v", entry.ID, entry.RegisteredTaskTypes)
+	}
+
+	// Apply defaultForTaskTypes overrides from config. Runs after all plugins are
+	// loaded so any plugin ID (k8s or core) can be referenced.
+	for taskType, pluginID := range executorConfig.GetTaskPluginConfig().DefaultForTaskTypes {
+		var found pluginsCore.Plugin
+		for _, pm := range r.plugins {
+			if pm.GetID() == pluginID {
+				found = pm
+				break
+			}
+		}
+		if found != nil {
+			r.plugins[taskType] = found
+			logger.Infof(ctx, "Overriding task type %q to use plugin %q (from default-for-task-types config)", taskType, pluginID)
+		} else {
+			logger.Warnf(ctx, "default-for-task-types: plugin %q not found for task type %q override", pluginID, taskType)
+		}
 	}
 
 	r.initialized = true

--- a/executor/pkg/plugin/registry_test.go
+++ b/executor/pkg/plugin/registry_test.go
@@ -1,0 +1,261 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	executorConfig "github.com/flyteorg/flyte/v2/executor/pkg/config"
+	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
+	k8sPlugin "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
+)
+
+// mockCorePlugin is a minimal pluginsCore.Plugin for use in tests.
+type mockCorePlugin struct{ id string }
+
+func (m *mockCorePlugin) GetID() string { return m.id }
+func (m *mockCorePlugin) GetProperties() pluginsCore.PluginProperties {
+	return pluginsCore.PluginProperties{}
+}
+func (m *mockCorePlugin) Handle(_ context.Context, _ pluginsCore.TaskExecutionContext) (pluginsCore.Transition, error) {
+	return pluginsCore.Transition{}, nil
+}
+func (m *mockCorePlugin) Abort(_ context.Context, _ pluginsCore.TaskExecutionContext) error {
+	return nil
+}
+func (m *mockCorePlugin) Finalize(_ context.Context, _ pluginsCore.TaskExecutionContext) error {
+	return nil
+}
+
+// mockPluginRegistry implements PluginRegistryIface with configurable entries.
+type mockPluginRegistry struct {
+	corePlugins []pluginsCore.PluginEntry
+	k8sPlugins  []k8sPlugin.PluginEntry
+}
+
+func (m *mockPluginRegistry) GetCorePlugins() []pluginsCore.PluginEntry { return m.corePlugins }
+func (m *mockPluginRegistry) GetK8sPlugins() []k8sPlugin.PluginEntry    { return m.k8sPlugins }
+
+// coreEntry builds a PluginEntry backed by a mockCorePlugin.
+func coreEntry(id string, taskTypes ...string) pluginsCore.PluginEntry {
+	p := &mockCorePlugin{id: id}
+	return pluginsCore.PluginEntry{
+		ID:                  id,
+		RegisteredTaskTypes: taskTypes,
+		LoadPlugin: func(_ context.Context, _ pluginsCore.SetupContext) (pluginsCore.Plugin, error) {
+			return p, nil
+		},
+	}
+}
+
+func newTestRegistry(reg PluginRegistryIface) *Registry {
+	setupCtx := NewSetupContext(nil, nil, nil, nil, nil, "TaskAction", promutils.NewTestScope())
+	return NewRegistry(setupCtx, reg)
+}
+
+func resetConfig(t *testing.T, enabled []string) {
+	t.Helper()
+	require.NoError(t, executorConfig.SetTaskPluginConfig(&executorConfig.TaskPluginConfig{
+		EnabledPlugins: enabled,
+	}))
+	t.Cleanup(func() {
+		_ = executorConfig.SetTaskPluginConfig(&executorConfig.TaskPluginConfig{})
+	})
+}
+
+func TestPluginsConfigMeta(t *testing.T) {
+	tests := []struct {
+		name           string
+		configPlugins  []string
+		checkAllowed   string
+		wantAllowed    bool
+		checkGetConfig bool
+		wantGetPlugins []string
+	}{
+		{
+			name:           "GetEnabledPlugins reflects config",
+			configPlugins:  []string{"container", "spark"},
+			checkGetConfig: true,
+			wantGetPlugins: []string{"container", "spark"},
+		},
+		{
+			name:           "GetEnabledPlugins empty config",
+			configPlugins:  nil,
+			checkGetConfig: true,
+			wantGetPlugins: nil,
+		},
+		{
+			name:          "empty EnabledPlugins allows any id",
+			configPlugins: nil,
+			checkAllowed:  "anything",
+			wantAllowed:   true,
+		},
+		{
+			name:          "empty EnabledPlugins allows empty string",
+			configPlugins: nil,
+			checkAllowed:  "",
+			wantAllowed:   true,
+		},
+		{
+			name:          "listed id is allowed",
+			configPlugins: []string{"container", "spark"},
+			checkAllowed:  "container",
+			wantAllowed:   true,
+		},
+		{
+			name:          "unlisted id is blocked",
+			configPlugins: []string{"container"},
+			checkAllowed:  "ray",
+			wantAllowed:   false,
+		},
+		{
+			name:          "empty string blocked when list non-empty",
+			configPlugins: []string{"container"},
+			checkAllowed:  "",
+			wantAllowed:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resetConfig(t, tc.configPlugins)
+			if tc.checkGetConfig {
+				meta := GetEnabledPlugins()
+				assert.Equal(t, tc.wantGetPlugins, meta.EnabledPlugins)
+				return
+			}
+			pcm := &PluginsConfigMeta{EnabledPlugins: tc.configPlugins}
+			assert.Equal(t, tc.wantAllowed, pcm.isAllowed(tc.checkAllowed))
+		})
+	}
+}
+
+// 3.1 Empty allowlist loads all plugins.
+func TestRegistry_EmptyAllowlist_LoadsAll(t *testing.T) {
+	resetConfig(t, nil)
+
+	reg := &mockPluginRegistry{
+		corePlugins: []pluginsCore.PluginEntry{
+			coreEntry("container", "container"),
+			coreEntry("sidecar", "sidecar"),
+		},
+	}
+	r := newTestRegistry(reg)
+	require.NoError(t, r.Initialize(context.Background()))
+
+	p, err := r.ResolvePlugin("container")
+	require.NoError(t, err)
+	assert.Equal(t, "container", p.GetID())
+
+	p, err = r.ResolvePlugin("sidecar")
+	require.NoError(t, err)
+	assert.Equal(t, "sidecar", p.GetID())
+}
+
+// 3.2 Non-empty allowlist filters out plugins not in the list.
+func TestRegistry_Allowlist_FiltersPlugins(t *testing.T) {
+	resetConfig(t, []string{"container"})
+
+	reg := &mockPluginRegistry{
+		corePlugins: []pluginsCore.PluginEntry{
+			coreEntry("container", "container"),
+			coreEntry("ray", "ray"),
+		},
+	}
+	r := newTestRegistry(reg)
+	require.NoError(t, r.Initialize(context.Background()))
+
+	p, err := r.ResolvePlugin("container")
+	require.NoError(t, err)
+	assert.Equal(t, "container", p.GetID())
+
+	// "ray" was filtered out — no default plugin, so ResolvePlugin should error
+	_, err = r.ResolvePlugin("ray")
+	assert.Error(t, err)
+}
+
+// 3.3 ResolvePlugin returns error for task types belonging to filtered plugins.
+func TestRegistry_ResolvePlugin_ErrorForFilteredTaskType(t *testing.T) {
+	resetConfig(t, []string{"container"})
+
+	reg := &mockPluginRegistry{
+		corePlugins: []pluginsCore.PluginEntry{
+			coreEntry("container", "container"),
+			coreEntry("spark", "spark"),
+		},
+	}
+	r := newTestRegistry(reg)
+	require.NoError(t, r.Initialize(context.Background()))
+
+	_, err := r.ResolvePlugin("spark")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "spark")
+}
+
+// 3.4 Allowlist with unknown ID does not affect loading of other plugins.
+func TestRegistry_Allowlist_UnknownIDIgnored(t *testing.T) {
+	resetConfig(t, []string{"container", "nonexistent-plugin"})
+
+	reg := &mockPluginRegistry{
+		corePlugins: []pluginsCore.PluginEntry{
+			coreEntry("container", "container"),
+		},
+	}
+	r := newTestRegistry(reg)
+	require.NoError(t, r.Initialize(context.Background()))
+
+	p, err := r.ResolvePlugin("container")
+	require.NoError(t, err)
+	assert.Equal(t, "container", p.GetID())
+}
+
+// 3.5 DefaultForTaskTypes routes a task type to a different loaded plugin.
+func TestRegistry_DefaultForTaskTypes_Override(t *testing.T) {
+	require.NoError(t, executorConfig.SetTaskPluginConfig(&executorConfig.TaskPluginConfig{
+		DefaultForTaskTypes: map[string]string{"sidecar": "container"},
+	}))
+	t.Cleanup(func() { _ = executorConfig.SetTaskPluginConfig(&executorConfig.TaskPluginConfig{}) })
+
+	reg := &mockPluginRegistry{
+		corePlugins: []pluginsCore.PluginEntry{
+			coreEntry("container", "container"),
+			coreEntry("sidecar", "sidecar"),
+		},
+	}
+	r := newTestRegistry(reg)
+	require.NoError(t, r.Initialize(context.Background()))
+
+	// sidecar task type must now resolve to the container plugin
+	p, err := r.ResolvePlugin("sidecar")
+	require.NoError(t, err)
+	assert.Equal(t, "container", p.GetID())
+
+	// container task type is unaffected
+	p, err = r.ResolvePlugin("container")
+	require.NoError(t, err)
+	assert.Equal(t, "container", p.GetID())
+}
+
+// 3.6 DefaultForTaskTypes with an unknown plugin ID does not panic and leaves routing unchanged.
+func TestRegistry_DefaultForTaskTypes_UnknownPluginID(t *testing.T) {
+	require.NoError(t, executorConfig.SetTaskPluginConfig(&executorConfig.TaskPluginConfig{
+		DefaultForTaskTypes: map[string]string{"container": "nonexistent-plugin"},
+	}))
+	t.Cleanup(func() { _ = executorConfig.SetTaskPluginConfig(&executorConfig.TaskPluginConfig{}) })
+
+	reg := &mockPluginRegistry{
+		corePlugins: []pluginsCore.PluginEntry{
+			coreEntry("container", "container"),
+		},
+	}
+	r := newTestRegistry(reg)
+	require.NoError(t, r.Initialize(context.Background()))
+
+	// routing for container must remain as the original container plugin
+	p, err := r.ResolvePlugin("container")
+	require.NoError(t, err)
+	assert.Equal(t, "container", p.GetID())
+}

--- a/executor/plugins/loader.go
+++ b/executor/plugins/loader.go
@@ -1,0 +1,10 @@
+package plugins
+
+import (
+	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/dask"
+	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/kfoperators/mpi"
+	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch"
+	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow"
+	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/ray"
+	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/spark"
+)

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -32,8 +32,7 @@ import (
 	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow/workflowconnect"
 
-	// Plugin registrations — blank imports trigger init() which registers
-	// plugins with the global registry.
+	_ "github.com/flyteorg/flyte/v2/executor/plugins"
 	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/clustered"
 	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/pod"
 )
@@ -57,6 +56,17 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	cfg := config.GetConfig()
+
+	taskPluginCfg := config.GetTaskPluginConfig()
+	enabledPlugins := make(map[string]bool, len(taskPluginCfg.EnabledPlugins))
+	for _, id := range taskPluginCfg.EnabledPlugins {
+		enabledPlugins[id] = true
+	}
+	for _, reg := range pluginmachinery.PluginRegistry().GetSchemeRegisters() {
+		if len(enabledPlugins) == 0 || enabledPlugins[reg.ID] {
+			utilruntime.Must(reg.AddToScheme(scheme))
+		}
+	}
 
 	var tlsOpts []func(*tls.Config)
 	if !cfg.EnableHTTP2 {

--- a/flyteplugins/go/tasks/pluginmachinery/registry.go
+++ b/flyteplugins/go/tasks/pluginmachinery/registry.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/webapi"
@@ -12,10 +14,17 @@ import (
 	internalRemote "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/internal/webapi"
 )
 
+// SchemeRegistration associates a plugin ID with its AddToScheme function.
+type SchemeRegistration struct {
+	ID          string
+	AddToScheme func(*runtime.Scheme) error
+}
+
 type taskPluginRegistry struct {
-	m          sync.Mutex
-	k8sPlugin  []k8s.PluginEntry
-	corePlugin []core.PluginEntry
+	m               sync.Mutex
+	k8sPlugin       []k8s.PluginEntry
+	corePlugin      []core.PluginEntry
+	schemeRegisters []SchemeRegistration
 }
 
 // A singleton variable that maintains a registry of all plugins. The framework uses this to access all plugins
@@ -88,6 +97,20 @@ func (p *taskPluginRegistry) RegisterCorePlugin(info core.PluginEntry) {
 	p.corePlugin = append(p.corePlugin, info)
 }
 
+// RegisterScheme registers an AddToScheme function for a plugin's CRD types.
+func (p *taskPluginRegistry) RegisterScheme(id string, addToScheme func(*runtime.Scheme) error) {
+	p.m.Lock()
+	defer p.m.Unlock()
+	p.schemeRegisters = append(p.schemeRegisters, SchemeRegistration{ID: id, AddToScheme: addToScheme})
+}
+
+// GetSchemeRegisters returns a snapshot of all registered SchemeRegistrations.
+func (p *taskPluginRegistry) GetSchemeRegisters() []SchemeRegistration {
+	p.m.Lock()
+	defer p.m.Unlock()
+	return append(p.schemeRegisters[:0:0], p.schemeRegisters...)
+}
+
 // Returns a snapshot of all the registered core plugins.
 func (p *taskPluginRegistry) GetCorePlugins() []core.PluginEntry {
 	p.m.Lock()
@@ -106,6 +129,8 @@ type TaskPluginRegistry interface {
 	RegisterK8sPlugin(info k8s.PluginEntry)
 	RegisterCorePlugin(info core.PluginEntry)
 	RegisterRemotePlugin(info webapi.PluginEntry)
+	RegisterScheme(id string, addToScheme func(*runtime.Scheme) error)
 	GetCorePlugins() []core.PluginEntry
 	GetK8sPlugins() []k8s.PluginEntry
+	GetSchemeRegisters() []SchemeRegistration
 }

--- a/flyteplugins/go/tasks/plugins/k8s/dask/dask.go
+++ b/flyteplugins/go/tasks/plugins/k8s/dask/dask.go
@@ -553,6 +553,8 @@ func init() {
 		panic(err)
 	}
 
+	pluginmachinery.PluginRegistry().RegisterScheme(daskTaskType, daskAPI.AddToScheme)
+
 	pluginmachinery.PluginRegistry().RegisterK8sPlugin(
 		k8s.PluginEntry{
 			ID:                  daskTaskType,

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/mpi/mpi.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/mpi/mpi.go
@@ -249,6 +249,8 @@ func init() {
 		panic(err)
 	}
 
+	pluginmachinery.PluginRegistry().RegisterScheme(common.MPITaskType, kubeflowv1.AddToScheme)
+
 	pluginmachinery.PluginRegistry().RegisterK8sPlugin(
 		k8s.PluginEntry{
 			ID:                  common.MPITaskType,

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
@@ -310,6 +310,8 @@ func init() {
 		panic(err)
 	}
 
+	pluginmachinery.PluginRegistry().RegisterScheme(common.PytorchTaskType, kubeflowv1.AddToScheme)
+
 	pluginmachinery.PluginRegistry().RegisterK8sPlugin(
 		k8s.PluginEntry{
 			ID:                  common.PytorchTaskType,

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow.go
@@ -247,6 +247,8 @@ func init() {
 		panic(err)
 	}
 
+	pluginmachinery.PluginRegistry().RegisterScheme(common.TensorflowTaskType, kubeflowv1.AddToScheme)
+
 	pluginmachinery.PluginRegistry().RegisterK8sPlugin(
 		k8s.PluginEntry{
 			ID:                  common.TensorflowTaskType,

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -807,6 +807,8 @@ func init() {
 		panic(err)
 	}
 
+	pluginmachinery.PluginRegistry().RegisterScheme(rayTaskType, rayv1.AddToScheme)
+
 	pluginmachinery.PluginRegistry().RegisterK8sPlugin(
 		k8s.PluginEntry{
 			ID:                  rayTaskType,

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -629,6 +629,8 @@ func init() {
 		panic(err)
 	}
 
+	pluginmachinery.PluginRegistry().RegisterScheme(sparkTaskType, sparkOp.AddToScheme)
+
 	pluginmachinery.PluginRegistry().RegisterK8sPlugin(
 		k8s.PluginEntry{
 			ID:                  sparkTaskType,


### PR DESCRIPTION
## Tracking issue

Close #7198

## Why are the changes needed?

Flyte v2 OSS won't trigger ray, dask, spark, torch, tensorflow and mpi plugins

## What changes were proposed in this pull request?

1. Register CRD
2. Initialize informer and client for operate CRD
3. Filtering unset plugins

## How was this patch tested?

1. make sandbox-build && make sandbox-run FLYTE\_DEV=True
2. Installing crd opreators <img width="1599" height="93" alt="image" src="https://github.com/user-attachments/assets/852e27e9-931d-47aa-a9a3-c4ceceefeefc" />
3. make -C manager run

### Labels

- **added**: For new features.

This is important to improve the readability of release notes.

### Setup process
1. Update complete.yaml
```yaml
enabled_plugins:
  tasks:
    task-plugins:
        enabled-plugins:
          - container
          - sidecar
          - connector-service
          - echo
          - ray
          - spark
          - dask
          - pytorch
          - tensorflow
          - mpi
        default-for-task-types:
          container: container
          sidecar: sidecar
          container_array: k8s-array
```
2. make devbox-start
3. Installing crd opreators <img width="1599" height="93" alt="image" src="https://github.com/user-attachments/assets/852e27e9-931d-47aa-a9a3-c4ceceefeefc" />

spark\_role.yaml
```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: spark
  namespace: flyte
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: spark-testproject-development
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: edit
subjects:
  - kind: ServiceAccount
    name: spark
    namespace: flyte
```

### Screenshots

1. spark <img width="1635" height="653" alt="image" src="https://github.com/user-attachments/assets/86735a59-d61c-49cc-ab73-93751adc803b" />
2. ray <img width="1632" height="620" alt="image" src="https://github.com/user-attachments/assets/9ce5c27a-95ad-4a1b-af6a-8493175d2907" />
3. dask <img width="1711" height="657" alt="image" src="https://github.com/user-attachments/assets/6f614d43-5c5b-4830-81a6-08115d4066ff" />
5. torch <img width="1683" height="464" alt="image" src="https://github.com/user-attachments/assets/23862688-557c-41bd-8007-250c19bf5fb4" />

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->

- `main` <!-- branch-stack -->
  - \#6583
    - **\[Flyte 7198] Enabling flyte plugins** :point\_left:
