### PR TITLE
fix: sort actions ascending when seeding WatchActions tree

### DIFF
--- a/charts/flyte-devbox/values.yaml
+++ b/charts/flyte-devbox/values.yaml
@@ -71,7 +71,6 @@ flyte-binary:
           enabled: true
           baseDomain: "localhost"
           scheme: "http"
-          ingressAppsPort: 30081
           defaultEnvVars:
             - FLYTE_AWS_ENDPOINT: 'http://rustfs.{{ .Release.Namespace }}:9000'
             - FLYTE_AWS_ACCESS_KEY_ID: rustfs

--- a/gen/ts/package-lock.json
+++ b/gen/ts/package-lock.json
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
-      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/typescript": {

--- a/manager/config.yaml
+++ b/manager/config.yaml
@@ -22,7 +22,6 @@ manager:
     scheme: "http"
     defaultRequestTimeout: 300s
     maxRequestTimeout: 3600s
-    ingressAppsPort: 30081
     defaultEnvVars:
       - FLYTE_AWS_ENDPOINT: "http://rustfs.flyte.svc.cluster.local:9000"
       - FLYTE_AWS_ACCESS_KEY_ID: "rustfs"

--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -345,20 +345,22 @@ func TestListRuns(t *testing.T) {
 	assert.True(t, runNames["run-2"])
 	assert.True(t, runNames["run-3"])
 
-	// Pagination: page 1
+	// ListActions uses a keyset cursor: it returns up to Limit+1 rows so the
+	// caller can detect whether another page exists. Page 1 asks for Limit=2
+	// and gets all 3 rows back (limit+1 probe). The caller trims to Limit and
+	// uses the last kept row's created_at as the CursorToken for page 2.
 	runsPage1, err := actionRepo.ListActions(ctx, interfaces.ListResourceInput{
 		Filter: NewIsRootActionFilter(),
 		Limit:  2,
-		Offset: 0,
 	})
 	require.NoError(t, err)
-	assert.Len(t, runsPage1, 2)
+	assert.Len(t, runsPage1, 3)
 
-	// Pagination: page 2
+	page1 := runsPage1[:2]
 	runsPage2, err := actionRepo.ListActions(ctx, interfaces.ListResourceInput{
-		Filter: NewIsRootActionFilter(),
-		Limit:  2,
-		Offset: 2,
+		Filter:      NewIsRootActionFilter(),
+		Limit:       2,
+		CursorToken: page1[len(page1)-1].CreatedAt.UTC().Format(time.RFC3339Nano),
 	})
 	require.NoError(t, err)
 	assert.Len(t, runsPage2, 1)

--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -1303,10 +1303,16 @@ func (s *RunService) listAndSendAllActions(
 	const pageSize = 100
 	offset := 0
 	for {
+		// Sort ascending by created_at so parent actions are inserted into the
+		// run state manager before their children. insertAction requires the
+		// parent node to already exist in the tree when a child is processed.
 		batch, err := s.repo.ActionRepo().ListActions(ctx, interfaces.ListResourceInput{
 			Filter: impl.NewRunActionsFilter(runID),
 			Limit:  pageSize,
 			Offset: offset,
+			SortParameters: []interfaces.SortParameter{
+				impl.NewSortParameter("created_at", interfaces.SortOrderAscending),
+			},
 		})
 		if err != nil {
 			return err

--- a/runs/service/run_service_test.go
+++ b/runs/service/run_service_test.go
@@ -755,14 +755,18 @@ func TestListRuns(t *testing.T) {
 			&workflow.ListRunsResponse{Runs: []*workflow.Run{}, Token: ""},
 		},
 		{
+			// Service fetches Limit+1 rows to detect another page. With 3 rows
+			// returned for a limit of 2, the slice is trimmed to the first 2
+			// runs and the cursor token is the trimmed last row's created_at.
 			"list with limit 2 and token",
-			&common.ListRequest{Limit: 2, Token: "5"},
-			mockListRes{runs: sqlRes[5:7], err: nil},
-			&workflow.ListRunsResponse{Runs: runs[5:7], Token: "7"},
+			&common.ListRequest{Limit: 2, Token: sqlRes[5].CreatedAt.UTC().Format(time.RFC3339Nano)},
+			mockListRes{runs: sqlRes[5:8], err: nil},
+			&workflow.ListRunsResponse{Runs: runs[5:7], Token: sqlRes[6].CreatedAt.UTC().Format(time.RFC3339Nano)},
 		},
 		{
+			// Only 2 rows returned for limit 3 means no next page — token empty.
 			"list with limit 3 and token",
-			&common.ListRequest{Limit: 3, Token: "8"},
+			&common.ListRequest{Limit: 3, Token: sqlRes[8].CreatedAt.UTC().Format(time.RFC3339Nano)},
 			mockListRes{runs: sqlRes[8:10], err: nil},
 			&workflow.ListRunsResponse{Runs: runs[8:10], Token: ""},
 		},

--- a/runs/service/run_service_test.go
+++ b/runs/service/run_service_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow/workflowconnect"
+	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
 	repoMocks "github.com/flyteorg/flyte/v2/runs/repository/mocks"
 	"github.com/flyteorg/flyte/v2/runs/repository/models"
 )
@@ -777,6 +778,33 @@ func TestListRuns(t *testing.T) {
 			assert.Equal(t, tc.expect.Token, got.Msg.Token)
 		})
 	}
+}
+
+// TestListAndSendAllActionsUsesAscendingSort guards against regressing the
+// default repo sort order leaking into the WatchActions seed path. Children
+// have a later created_at than their parents; if ListActions returns rows in
+// descending order, the run state manager's insertAction fails because the
+// parent node is not yet in the tree. This test asserts we always pass an
+// ascending created_at sort parameter.
+func TestListAndSendAllActionsUsesAscendingSort(t *testing.T) {
+	actionRepo, _, svc := newTestService(t)
+
+	runID := &common.RunIdentifier{Project: "p", Domain: "d", Name: "run-1"}
+
+	var captured interfaces.ListResourceInput
+	actionRepo.On("ListActions", mock.Anything, mock.MatchedBy(func(input interfaces.ListResourceInput) bool {
+		captured = input
+		return true
+	})).Return([]*models.Action{}, nil).Once()
+
+	rsm, err := newRunStateManager(nil)
+	require.NoError(t, err)
+
+	err = svc.listAndSendAllActions(context.Background(), runID, rsm, nil)
+	require.NoError(t, err)
+
+	require.Len(t, captured.SortParameters, 1)
+	assert.Equal(t, "created_at ASC", captured.SortParameters[0].GetOrderExpr())
 }
 
 func TestGenerateRunName(t *testing.T) {


### PR DESCRIPTION
## Tracking issue

Related to #7192

## Why are the changes needed?

`WatchActions` currently fails during the initial tree seed with:

```
parent node [a0] not found for action [5jwxenorsaoevdvwpuz9dny93]
```

`listAndSendAllActions` calls `ActionRepo.ListActions` without any `SortParameters`, so it falls through to the repo default set in #7192: `ORDER BY phase ASC, created_at DESC`. Because children are created after their parents, `DESC` returns children first and the run state manager's `insertAction` looks up a parent that has not yet been inserted into `AllNodes`, returning an error and terminating the watch stream.

Cloud avoids this by passing an explicit `created_at ASC` sort parameter at the call site (`workflow/service/run_service.go:listAndSendAllActions`). OSS was missing the same override.

## What changes were proposed in this pull request?

- Pass `SortParameters: [{created_at ASC}]` in `listAndSendAllActions` so parents are always inserted into the run state manager before their children.

## How was this patch tested?

- `go build ./runs/...`
- Manually reproduced the failing `WatchActions` call against a run with child actions; with the fix the stream seeds without error and emits actions in parent-before-child order.

### Labels

fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

* `main` <!-- branch-stack -->
  - \#6583
    - **fix: sort actions ascending when seeding WatchActions tree** :point\_left:
