### PR TITLE
ci: skip git-town job on PRs from forks

### DIFF
--- a/.github/workflows/git_town.yml
+++ b/.github/workflows/git_town.yml
@@ -9,6 +9,7 @@ jobs:
   git-town:
     name: Display the branch stack
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     permissions:
       contents: read

--- a/gen/ts/package-lock.json
+++ b/gen/ts/package-lock.json
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
-      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/typescript": {


### PR DESCRIPTION
## Why are the changes needed?

The `git-town` GitHub Actions job fails on pull requests opened from forks because the `git-town/action` requires write access to the repository (to post PR comments / update the branch stack), which is not granted to workflows triggered by fork PRs.

Example failing run: <https://github.com/flyteorg/flyte/actions/runs/24802528018/job/72588574953?pr=7249>

## What changes were proposed in this pull request?

Add an `if` guard to the `git-town` job so it only runs when the PR head repository matches the base repository (i.e. the branch lives in `flyteorg/flyte`, not in a contributor's fork).

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

## How was this patch tested?

Opened this PR from a fork (`pingsutw/flyte`) to verify the `git-town` job is skipped on fork PRs.

### Labels

- **fixed**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

* `main` <!-- branch-stack -->
  - \#6583
    - **ci: skip git-town job on PRs from forks** :point\_left:
