### PR TITLE
perf(devbox): parallelize image preload in devbox-bundled build

### DIFF
--- a/docker/devbox-bundled/images/preload
+++ b/docker/devbox-bundled/images/preload
@@ -1,19 +1,37 @@
 #!/bin/sh
 
-set -ex
+set -e
 
 __save_image() {
   local dest="$1"
   local tar="$(echo ${dest} | cut -d: -f1 | tr / -).tar"
   local src="$( [ -n "$2" ] && echo "$2" || echo ${dest} )"
-  podman pull --arch ${TARGETARCH} ${src}
-  podman tag ${src} ${dest}
-  podman save -o ${tar} ${dest}
+  local log="${tar}.log"
+  if ! ( podman pull --arch ${TARGETARCH} ${src} && \
+         podman tag ${src} ${dest} && \
+         podman save -o ${tar} ${dest} ) >"${log}" 2>&1; then
+    echo "=== FAILED: ${dest} ===" >&2
+    cat "${log}" >&2
+    return 1
+  fi
+  echo "=== OK: ${dest} ===" >&2
 }
 
 MANIFEST="$(realpath "$1")"
 mkdir -p images
 cd images
+
+PIDS=""
 while read line; do
-  __save_image $(echo ${line} | tr = ' ')
+  [ -z "$line" ] && continue
+  __save_image $(echo ${line} | tr = ' ') &
+  PIDS="$PIDS $!"
 done < ${MANIFEST}
+
+FAIL=0
+for pid in $PIDS; do
+  wait "$pid" || FAIL=1
+done
+
+rm -f *.log
+exit $FAIL


### PR DESCRIPTION
## Why are the changes needed?

The `preload` stage in `docker/devbox-bundled/Dockerfile` pulls, tags, and saves the container images listed in `images/manifest.txt` one at a time. With 8 images in the manifest, cold builds spend most of the stage's wall time waiting on serial registry round-trips even though the operations are independent.

## What changes were proposed in this pull request?

Rewrite `docker/devbox-bundled/images/preload` to run `podman pull`/`tag`/`save` for every manifest entry concurrently and then `wait` for them all:

- All entries launch in parallel as background jobs; the script exits non-zero if any job fails.
- Each image's stdout/stderr is buffered to a per-image `.log` file and only emitted on failure, so successful runs stay readable and failed ones clearly identify which image broke.
- Behavior and output artifacts (per-image `.tar` files under `images/`) are unchanged.

Net effect: preload runtime drops from roughly the sum of per-image pull times to roughly the max.

## How was this patch tested?

- `sh -n docker/devbox-bundled/images/preload` — syntax check passes.
- Local `make build` in `docker/devbox-bundled/` completes successfully with a visibly shorter preload stage.

### Labels

changed

## Check all the applicable boxes

- [x] All commits are signed-off.

* `main` <!-- branch-stack -->
  - \#6583
    - **perf(devbox): parallelize image preload in devbox-bundled build** :point\_left:
