### PR TITLE
perf(devbox): support buildx remote cache in devbox-bundled Makefile

### DIFF
--- a/.github/workflows/flyte-binary-v2.yml
+++ b/.github/workflows/flyte-binary-v2.yml
@@ -82,6 +82,8 @@ jobs:
             FLYTE_VERSION=${{ env.FLYTE_VERSION }}
           file: Dockerfile
           outputs: type=docker,dest=docker/devbox-bundled/images/tar/arm64/flyte-binary.tar
+          cache-from: type=gha,scope=flyte-binary-arm64
+          cache-to: type=gha,mode=max,scope=flyte-binary-arm64
       - name: Export AMD64 Image
         uses: docker/build-push-action@v6
         with:
@@ -93,6 +95,8 @@ jobs:
             FLYTE_VERSION=${{ env.FLYTE_VERSION }}
           file: Dockerfile
           outputs: type=docker,dest=docker/devbox-bundled/images/tar/amd64/flyte-binary.tar
+          cache-from: type=gha,scope=flyte-binary-amd64
+          cache-to: type=gha,mode=max,scope=flyte-binary-amd64
       - name: Upload single binary image
         uses: actions/upload-artifact@v4
         with:
@@ -117,6 +121,9 @@ jobs:
             FLYTE_VERSION=${{ env.FLYTE_VERSION }}
           file: Dockerfile
           push: true
+          cache-from: |
+            type=gha,scope=flyte-binary-arm64
+            type=gha,scope=flyte-binary-amd64
 
   build-and-push-devbox-bundled-image:
     runs-on: ubuntu-latest

--- a/docker/devbox-bundled/Makefile
+++ b/docker/devbox-bundled/Makefile
@@ -1,26 +1,58 @@
-# Optional buildx remote cache configuration. Values are passed verbatim to
-# `docker buildx build --cache-from/--cache-to`. Examples:
+# Buildx remote cache configuration.
 #
+# Defaults (can be overridden by setting BUILDX_CACHE_FROM / BUILDX_CACHE_TO):
+#   - Inside GitHub Actions ($(GITHUB_ACTIONS) == true): use `type=gha`, so the
+#     build cache is persisted in the Actions cache service across runs.
+#   - Locally: use `type=local` under $(BUILDX_CACHE_DIR) so repeated local
+#     builds reuse the previous build's layers.
+#
+# Override examples:
 #   # Registry-backed cache (works anywhere):
 #   make build \
 #     BUILDX_CACHE_FROM="type=registry,ref=ghcr.io/<org>/flyte-devbox-cache:buildcache" \
 #     BUILDX_CACHE_TO="type=registry,ref=ghcr.io/<org>/flyte-devbox-cache:buildcache,mode=max"
 #
-#   # GitHub Actions cache:
-#   make build BUILDX_CACHE_FROM=type=gha BUILDX_CACHE_TO=type=gha,mode=max
+#   # Disable caching entirely:
+#   make build BUILDX_CACHE_FROM= BUILDX_CACHE_TO=
 #
-# Leaving these empty preserves the previous no-cache behavior.
-#
-# Note: the flyte-binary build runs once per arch (amd64 and arm64) using the
-# same flags, so a shared registry cache ref will have the later arch overwrite
-# the earlier one. For CI that caches both arches, either run each arch in a
-# separate job or include an arch-specific suffix in the ref you pass.
-BUILDX_CACHE_FROM ?=
-BUILDX_CACHE_TO ?=
+# Note: the flyte-binary build runs once per arch (amd64 and arm64); we
+# auto-scope each arch's cache separately so amd64 and arm64 don't clobber
+# each other. Custom overrides apply as-is and do not get arch scoping.
+BUILDX_CACHE_DIR ?= $(HOME)/.cache/flyte-devbox-buildx
+
+ifeq ($(GITHUB_ACTIONS),true)
+  _DEVBOX_CACHE_FROM := type=gha,scope=flyte-devbox
+  _DEVBOX_CACHE_TO   := type=gha,scope=flyte-devbox,mode=max
+  _BINARY_CACHE_FROM  = type=gha,scope=flyte-binary-$(1)
+  _BINARY_CACHE_TO    = type=gha,scope=flyte-binary-$(1),mode=max
+else
+  _DEVBOX_CACHE_FROM := type=local,src=$(BUILDX_CACHE_DIR)/devbox
+  _DEVBOX_CACHE_TO   := type=local,dest=$(BUILDX_CACHE_DIR)/devbox,mode=max
+  _BINARY_CACHE_FROM  = type=local,src=$(BUILDX_CACHE_DIR)/flyte-binary-$(1)
+  _BINARY_CACHE_TO    = type=local,dest=$(BUILDX_CACHE_DIR)/flyte-binary-$(1),mode=max
+endif
+
+# Track whether the user overrode the cache knobs (command line / environment)
+# so we can keep per-arch scoping for the binary build when they haven't.
+_CACHE_FROM_USER_SET := $(filter command environment override,$(origin BUILDX_CACHE_FROM))
+_CACHE_TO_USER_SET   := $(filter command environment override,$(origin BUILDX_CACHE_TO))
+
+BUILDX_CACHE_FROM ?= $(_DEVBOX_CACHE_FROM)
+BUILDX_CACHE_TO   ?= $(_DEVBOX_CACHE_TO)
 
 BUILDX_CACHE_FLAGS = \
 	$(if $(BUILDX_CACHE_FROM),--cache-from=$(BUILDX_CACHE_FROM)) \
 	$(if $(BUILDX_CACHE_TO),--cache-to=$(BUILDX_CACHE_TO))
+
+# Per-arch cache flags for the flyte-binary build. User overrides apply as-is;
+# otherwise the arch-scoped defaults keep amd64 and arm64 caches separate.
+binary_cache_flags = \
+	$(if $(_CACHE_FROM_USER_SET),\
+		$(if $(BUILDX_CACHE_FROM),--cache-from=$(BUILDX_CACHE_FROM)),\
+		--cache-from=$(call _BINARY_CACHE_FROM,$(1))) \
+	$(if $(_CACHE_TO_USER_SET),\
+		$(if $(BUILDX_CACHE_TO),--cache-to=$(BUILDX_CACHE_TO)),\
+		--cache-to=$(call _BINARY_CACHE_TO,$(1)))
 
 define FLYTE_BINARY_BUILD
 mkdir -p images/tar/$(1)
@@ -30,7 +62,7 @@ docker buildx build \
 	--builder flyte-devbox \
 	--platform linux/$(1) \
 	--tag flyte-binary-v2:sandbox \
-	$(BUILDX_CACHE_FLAGS) \
+	$(call binary_cache_flags,$(1)) \
 	--output type=docker,dest=images/tar/$(1)/flyte-binary.tar \
 	../..
 

--- a/docker/devbox-bundled/Makefile
+++ b/docker/devbox-bundled/Makefile
@@ -1,3 +1,27 @@
+# Optional buildx remote cache configuration. Values are passed verbatim to
+# `docker buildx build --cache-from/--cache-to`. Examples:
+#
+#   # Registry-backed cache (works anywhere):
+#   make build \
+#     BUILDX_CACHE_FROM="type=registry,ref=ghcr.io/<org>/flyte-devbox-cache:buildcache" \
+#     BUILDX_CACHE_TO="type=registry,ref=ghcr.io/<org>/flyte-devbox-cache:buildcache,mode=max"
+#
+#   # GitHub Actions cache:
+#   make build BUILDX_CACHE_FROM=type=gha BUILDX_CACHE_TO=type=gha,mode=max
+#
+# Leaving these empty preserves the previous no-cache behavior.
+#
+# Note: the flyte-binary build runs once per arch (amd64 and arm64) using the
+# same flags, so a shared registry cache ref will have the later arch overwrite
+# the earlier one. For CI that caches both arches, either run each arch in a
+# separate job or include an arch-specific suffix in the ref you pass.
+BUILDX_CACHE_FROM ?=
+BUILDX_CACHE_TO ?=
+
+BUILDX_CACHE_FLAGS = \
+	$(if $(BUILDX_CACHE_FROM),--cache-from=$(BUILDX_CACHE_FROM)) \
+	$(if $(BUILDX_CACHE_TO),--cache-to=$(BUILDX_CACHE_TO))
+
 define FLYTE_BINARY_BUILD
 mkdir -p images/tar/$(1)
 
@@ -6,6 +30,7 @@ docker buildx build \
 	--builder flyte-devbox \
 	--platform linux/$(1) \
 	--tag flyte-binary-v2:sandbox \
+	$(BUILDX_CACHE_FLAGS) \
 	--output type=docker,dest=images/tar/$(1)/flyte-binary.tar \
 	../..
 
@@ -58,11 +83,13 @@ sync-crds:
 .PHONY: build
 build: sync-crds flyte dep_update manifests
 	docker buildx build --builder flyte-devbox --allow security.insecure --load \
+		$(BUILDX_CACHE_FLAGS) \
 		--tag flyte-devbox:latest .
 
 .PHONY: build-gpu
 build-gpu: build
 	docker buildx build --builder flyte-devbox --allow security.insecure --load \
+		$(BUILDX_CACHE_FLAGS) \
 		--file Dockerfile.gpu \
 		--build-context base=docker-image://flyte-devbox:latest \
 		--build-arg BASE_IMAGE=base \


### PR DESCRIPTION
## Why are the changes needed?

`docker/devbox-bundled/Makefile` invokes `docker buildx build` three times (the per-arch flyte-binary build, the main devbox image, and the GPU variant) without any `--cache-from` / `--cache-to` flags. `.github/workflows/flyte-binary-v2.yml`'s `Export ARM64 Image` / `Export AMD64 Image` steps were also uncached. As a result, fresh checkouts, CI runners, and repeated local builds always start cold — the expensive stages in the Dockerfile (image preloading, bootstrap compilation, embedded-postgres fetch, frontend bundle) are recomputed from scratch every time.

## What changes were proposed in this pull request?

Three linked changes:

1. **Makefile pass-through knobs** — expose `BUILDX_CACHE_FROM` / `BUILDX_CACHE_TO` that append `--cache-from` / `--cache-to` to every `docker buildx build` invocation (per-arch flyte-binary, `build`, `build-gpu`). Leaving them unset disables caching.
2. **Smart defaults** — detect the execution environment:
   - `$(GITHUB_ACTIONS) == true` → default to `type=gha` with scope `flyte-devbox` for the image and `flyte-binary-<arch>` for each per-arch binary build.
   - Otherwise → default to `type=local` under `$(BUILDX_CACHE_DIR)` (defaults to `$HOME/.cache/flyte-devbox-buildx`), with per-arch subdirectories for the binary build.
   - User overrides via command line or environment (detected with `$(origin ...)`) take precedence uniformly across all three buildx calls.
3. **CI workflow** — add `cache-from` / `cache-to: type=gha` with per-arch scopes (`flyte-binary-arm64`, `flyte-binary-amd64`) to the `Export ARM64 Image`, `Export AMD64 Image`, and final multi-arch push steps in `flyte-binary-v2.yml`. `docker/setup-buildx-action` is already present and propagates the required `ACTIONS_CACHE_URL` / `ACTIONS_RUNTIME_TOKEN` automatically.

The per-arch binary build runs twice per invocation (amd64, then arm64). Auto-scoping each arch separately prevents the second build from clobbering the first's cache.

## How was this patch tested?

`make -n` verified flag rendering in four modes: GHA default, local default, custom override, and disabled.

### GHA benchmark on this PR branch (real runs)

Measured on GitHub-hosted `ubuntu-latest` runners. Baseline is the average of the last 6 successful `v2` push runs. "Cold fill" = first run on this PR (empty gha scopes; cache upload overhead). "Warm hit" = re-run of the same workflow after scopes are populated.

| Job | v2 baseline (avg, 6 runs) | PR cold-fill | PR warm-hit |
|---|---:|---:|---:|
| `test-bootstrap` | ~50 s | 30 s | 28 s |
| `build-and-push-single-binary-image` | **5.8 min** | 9.3 min | **35 s** |
| `build-and-push-devbox-bundled-image` | 2–13 min (bimodal; existing `demo-cpu`/`demo-gpu` cache) | n/a (transient GitHub cache-service 500 on pre-existing `demo-gpu` step) | 1.5 min |

- `build-and-push-single-binary-image` goes from **5.8 min → 35 s** on a warm run (~10×). Cold fill is ~3.5 min slower than baseline (one-time cost to upload cache); breaks even after a single reuse.
- `build-and-push-devbox-bundled-image` already had `type=gha` cache before this PR, so no regression there.

### Local benchmark (Makefile defaults, `type=local` cache)

Both runs executed on this branch via `make build` in `docker/devbox-bundled/`. BuildKit's in-container cache is pruned between runs so the external `type=local` cache is the only reuse path.

| Run | Local cache dir | Wall-clock |
|---|---|---:|
| cold-fill | empty | **7 min 18 s** |
| warm-hit | populated by cold-fill | **2 min 17 s** |

**~3.2× speedup** / 5 min 1 s saved per subsequent local build after any `docker buildx prune`.

### Labels

changed

## Check all the applicable boxes

- [x] All commits are signed-off.