### PR TITLE
fix: persist devbox local docker registry across restarts

### DIFF
--- a/charts/flyte-devbox/templates/_helpers.tpl
+++ b/charts/flyte-devbox/templates/_helpers.tpl
@@ -89,6 +89,13 @@ Name of PersistentVolume and PersistentVolumeClaim for RustFS
 {{- printf "%s-rustfs-storage" .Release.Name -}}
 {{- end }}
 
+{{/*
+Name of PersistentVolume and PersistentVolumeClaim for Docker Registry
+*/}}
+{{- define "flyte-devbox.persistence.registryVolumeName" -}}
+{{- printf "%s-registry-storage" .Release.Name -}}
+{{- end }}
+
 
 {{/*
 Selector labels for console

--- a/charts/flyte-devbox/templates/storage/registry/pv.yaml
+++ b/charts/flyte-devbox/templates/storage/registry/pv.yaml
@@ -11,7 +11,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   capacity:
-    storage: 10Gi
+    storage: 20Gi
   hostPath:
     path: "/var/lib/flyte/storage/registry"
 {{- end }}

--- a/charts/flyte-devbox/templates/storage/registry/pv.yaml
+++ b/charts/flyte-devbox/templates/storage/registry/pv.yaml
@@ -1,0 +1,17 @@
+{{- if (index .Values "docker-registry" "enabled") }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "flyte-devbox.persistence.registryVolumeName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "flyte-devbox.labels" . | nindent 4 }}
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 10Gi
+  hostPath:
+    path: "/var/lib/flyte/storage/registry"
+{{- end }}

--- a/charts/flyte-devbox/templates/storage/registry/pvc.yaml
+++ b/charts/flyte-devbox/templates/storage/registry/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if (index .Values "docker-registry" "enabled") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "flyte-devbox.persistence.registryVolumeName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "flyte-devbox.labels" . | nindent 4 }}
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  volumeName: {{ include "flyte-devbox.persistence.registryVolumeName" . }}
+{{- end }}

--- a/charts/flyte-devbox/templates/storage/registry/pvc.yaml
+++ b/charts/flyte-devbox/templates/storage/registry/pvc.yaml
@@ -12,6 +12,6 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 20Gi
   volumeName: {{ include "flyte-devbox.persistence.registryVolumeName" . }}
 {{- end }}

--- a/charts/flyte-devbox/values.yaml
+++ b/charts/flyte-devbox/values.yaml
@@ -5,7 +5,8 @@ docker-registry:
     tag: sandbox
     pullPolicy: Never
   persistence:
-    enabled: false
+    enabled: true
+    existingClaim: flyte-devbox-registry-storage
   secrets:
     haSharedSecret: flytesandboxsecret
   service:

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -900,8 +900,49 @@ spec:
       - configMap:
           name: docker-registry-config
         name: docker-registry-config
-      - emptyDir: {}
-        name: data
+      - name: data
+        persistentVolumeClaim:
+          claimName: flyte-devbox-registry-storage
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  labels:
+    app.kubernetes.io/instance: flyte-devbox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: flyte-devbox
+    app.kubernetes.io/version: 1.16.1
+    helm.sh/chart: flyte-devbox-0.1.0
+  name: flyte-devbox-registry-storage
+  namespace: flyte
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 10Gi
+  hostPath:
+    path: /var/lib/flyte/storage/registry
+  storageClassName: manual
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: flyte-devbox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: flyte-devbox
+    app.kubernetes.io/version: 1.16.1
+    helm.sh/chart: flyte-devbox-0.1.0
+  name: flyte-devbox-registry-storage
+  namespace: flyte
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: manual
+  volumeName: flyte-devbox-registry-storage
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -919,7 +919,7 @@ spec:
   accessModes:
   - ReadWriteOnce
   capacity:
-    storage: 10Gi
+    storage: 20Gi
   hostPath:
     path: /var/lib/flyte/storage/registry
   storageClassName: manual
@@ -940,7 +940,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 20Gi
   storageClassName: manual
   volumeName: flyte-devbox-registry-storage
 ---

--- a/docker/devbox-bundled/manifests/dev.yaml
+++ b/docker/devbox-bundled/manifests/dev.yaml
@@ -600,8 +600,49 @@ spec:
       - configMap:
           name: docker-registry-config
         name: docker-registry-config
-      - emptyDir: {}
-        name: data
+      - name: data
+        persistentVolumeClaim:
+          claimName: flyte-devbox-registry-storage
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  labels:
+    app.kubernetes.io/instance: flyte-devbox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: flyte-devbox
+    app.kubernetes.io/version: 1.16.1
+    helm.sh/chart: flyte-devbox-0.1.0
+  name: flyte-devbox-registry-storage
+  namespace: flyte
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 10Gi
+  hostPath:
+    path: /var/lib/flyte/storage/registry
+  storageClassName: manual
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: flyte-devbox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: flyte-devbox
+    app.kubernetes.io/version: 1.16.1
+    helm.sh/chart: flyte-devbox-0.1.0
+  name: flyte-devbox-registry-storage
+  namespace: flyte
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: manual
+  volumeName: flyte-devbox-registry-storage
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/docker/devbox-bundled/manifests/dev.yaml
+++ b/docker/devbox-bundled/manifests/dev.yaml
@@ -619,7 +619,7 @@ spec:
   accessModes:
   - ReadWriteOnce
   capacity:
-    storage: 10Gi
+    storage: 20Gi
   hostPath:
     path: /var/lib/flyte/storage/registry
   storageClassName: manual
@@ -640,7 +640,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 20Gi
   storageClassName: manual
   volumeName: flyte-devbox-registry-storage
 ---


### PR DESCRIPTION
## Why are the changes needed?

The in-cluster `docker-registry` in the devbox used an `emptyDir` volume for `/var/lib/registry`. Every time the devbox container restarted, all pushed images were wiped and users had to rebuild and re-push their images. This is a significant friction point in the local dev loop.

## What changes were proposed in this pull request?

Back the registry with a hostPath-based PVC at `/var/lib/flyte/storage/registry`, which sits under the `VOLUME /var/lib/flyte/storage` declared in the devbox `Dockerfile` and therefore persists across container restarts — the same pattern already used by `rustfs` and `embedded-postgres`.

- `charts/flyte-devbox/values.yaml`: enable `docker-registry.persistence` with `existingClaim: flyte-devbox-registry-storage`.
- `charts/flyte-devbox/templates/_helpers.tpl`: add `flyte-devbox.persistence.registryVolumeName` helper.
- `charts/flyte-devbox/templates/storage/registry/{pv,pvc}.yaml`: new hostPath PV + PVC (10Gi, `manual` storage class) at `/var/lib/flyte/storage/registry`.
- `docker/devbox-bundled/manifests/{dev,complete}.yaml`: regenerated — registry Deployment now mounts the PVC instead of `emptyDir`, and the new PV/PVC resources are included.

## How was this patch tested?

Built the devbox image, pushed an image to the local registry, restarted the devbox container, and verified the previously pushed image was still present (no rebuild needed). Also confirmed the rendered manifests match `make -C docker/devbox-bundled manifests`.

### Labels

fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

* `main` <!-- branch-stack -->
  - \#6583
    - **fix: persist devbox local docker registry across restarts** :point\_left:
