### PR TITLE
ci: add devbox integration test running hello world via flyte CLI

### DIFF
--- a/.github/workflows/flyte-binary-v2.yml
+++ b/.github/workflows/flyte-binary-v2.yml
@@ -234,13 +234,6 @@ jobs:
         with:
           driver-opts: image=moby/buildkit:master
           buildkitd-flags: "--allow-insecure-entitlement security.insecure"
-      - name: Install helm and kustomize
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-          curl -fsSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-          sudo mv kustomize /usr/local/bin/
-      - name: Build devbox manifests
-        run: make -C docker/devbox-bundled manifests
       - name: Build devbox image (amd64, load into docker)
         uses: docker/build-push-action@v6
         env:

--- a/.github/workflows/flyte-binary-v2.yml
+++ b/.github/workflows/flyte-binary-v2.yml
@@ -246,11 +246,19 @@ jobs:
           build-args: FLYTE_DEVBOX_VERSION=${{ env.FLYTE_DEVBOX_VERSION }}
           load: true
           cache-from: type=gha,scope=demo-cpu
-      - name: Preload kernel modules for k3s/flannel
+      - name: Prepare host for k3s (legacy iptables + kernel modules)
         run: |
+          # Ubuntu runners default to nftables-backed iptables; flannel/kube-proxy
+          # inside k3s-in-docker hit silent rule failures (subnet.env never gets
+          # written). Pin to legacy iptables for both host and containers.
+          sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
+          sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
           sudo modprobe br_netfilter
           sudo modprobe overlay
-          sudo sysctl -w net.bridge.bridge-nf-call-iptables=1
+          sudo modprobe nf_conntrack
+          sudo modprobe iptable_nat || true
+          sudo modprobe iptable_filter || true
+          sudo sysctl -w net.bridge.bridge-nf-call-iptables=1 || true
           sudo sysctl -w net.ipv4.ip_forward=1
       - name: Start devbox cluster
         working-directory: docker/devbox-bundled

--- a/.github/workflows/flyte-binary-v2.yml
+++ b/.github/workflows/flyte-binary-v2.yml
@@ -218,3 +218,97 @@ jobs:
           push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
           cache-from: type=gha,scope=demo-gpu
           cache-to: type=gha,mode=max,scope=demo-gpu
+
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: [build-and-push-single-binary-image]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: single-binary-image
+          path: docker/devbox-bundled/images/tar
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: image=moby/buildkit:master
+          buildkitd-flags: "--allow-insecure-entitlement security.insecure"
+      - name: Install helm and kustomize
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          curl -fsSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+      - name: Build devbox manifests
+        run: make -C docker/devbox-bundled manifests
+      - name: Build devbox image (amd64, load into docker)
+        uses: docker/build-push-action@v6
+        env:
+          FLYTE_DEVBOX_VERSION: ${{ github.sha }}
+        with:
+          context: docker/devbox-bundled
+          allow: "security.insecure"
+          platforms: linux/amd64
+          tags: flyte-devbox:latest
+          build-args: FLYTE_DEVBOX_VERSION=${{ env.FLYTE_DEVBOX_VERSION }}
+          load: true
+          cache-from: type=gha,scope=demo-cpu
+      - name: Start devbox cluster
+        working-directory: docker/devbox-bundled
+        run: make start FLYTE_DEVBOX_IMAGE=flyte-devbox:latest
+      - name: Wait for flyte endpoint
+        run: |
+          echo "Waiting for flyte-proxy on :30080..."
+          for i in $(seq 1 120); do
+            if curl -fsS --max-time 2 http://localhost:30080/healthcheck >/dev/null 2>&1 \
+               || curl -fsS --max-time 2 http://localhost:30080 >/dev/null 2>&1; then
+              echo "endpoint is up"; exit 0
+            fi
+            sleep 5
+          done
+          echo "flyte endpoint did not become ready in time"
+          docker logs flyte-devbox | tail -200 || true
+          exit 1
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install flyte SDK
+        run: pip install flyte
+      - name: Write hello world task and config
+        run: |
+          mkdir -p /tmp/hello
+          cat > /tmp/hello/config.yaml <<'EOF'
+          admin:
+            endpoint: dns:///localhost:30080
+            insecure: true
+            authType: Pkce
+          EOF
+          cat > /tmp/hello/hello.py <<'EOF'
+          import asyncio
+          import flyte
+
+          env = flyte.TaskEnvironment(
+              name="hello_world_ci",
+              image=flyte.Image.from_debian_base(python_version=(3, 12)),
+          )
+
+          @env.task
+          def calculate(x: int) -> int:
+              return x * 2 + 5
+
+          @env.task
+          async def main(numbers: list[int]) -> float:
+              results = await asyncio.gather(*[calculate.aio(n) for n in numbers])
+              return sum(results) / len(results)
+          EOF
+      - name: Run hello world via flyte CLI
+        working-directory: /tmp/hello
+        run: flyte --config config.yaml run hello.py main --numbers '[1,2,3]'
+      - name: Dump devbox logs on failure
+        if: failure()
+        run: docker logs flyte-devbox | tail -500 || true
+      - name: Stop devbox
+        if: always()
+        working-directory: docker/devbox-bundled
+        run: make stop || true

--- a/.github/workflows/flyte-binary-v2.yml
+++ b/.github/workflows/flyte-binary-v2.yml
@@ -246,6 +246,12 @@ jobs:
           build-args: FLYTE_DEVBOX_VERSION=${{ env.FLYTE_DEVBOX_VERSION }}
           load: true
           cache-from: type=gha,scope=demo-cpu
+      - name: Preload kernel modules for k3s/flannel
+        run: |
+          sudo modprobe br_netfilter
+          sudo modprobe overlay
+          sudo sysctl -w net.bridge.bridge-nf-call-iptables=1
+          sudo sysctl -w net.ipv4.ip_forward=1
       - name: Start devbox cluster
         working-directory: docker/devbox-bundled
         run: make start FLYTE_DEVBOX_IMAGE=flyte-devbox:latest

--- a/.github/workflows/flyte-binary-v2.yml
+++ b/.github/workflows/flyte-binary-v2.yml
@@ -250,9 +250,11 @@ jobs:
         run: |
           # Ubuntu runners default to nftables-backed iptables; flannel/kube-proxy
           # inside k3s-in-docker hit silent rule failures (subnet.env never gets
-          # written). Pin to legacy iptables for both host and containers.
+          # written). Pin to legacy iptables for both host and containers, then
+          # restart docker so the daemon picks up the new backend.
           sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
           sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+          sudo systemctl restart docker
           sudo modprobe br_netfilter
           sudo modprobe overlay
           sudo modprobe nf_conntrack

--- a/.github/workflows/flyte-binary-v2.yml
+++ b/.github/workflows/flyte-binary-v2.yml
@@ -220,7 +220,10 @@ jobs:
           cache-to: type=gha,mode=max,scope=demo-gpu
 
   integration-test:
-    runs-on: ubuntu-latest
+    # k3s-in-docker + flannel is fragile on Ubuntu 24.04 GH runners (flannel
+    # silently fails to populate /run/flannel/subnet.env). Pin to 22.04 where
+    # the kernel + iptables combo is known to work.
+    runs-on: ubuntu-22.04
     needs: [build-and-push-single-binary-image]
     steps:
       - name: Checkout


### PR DESCRIPTION
## Why are the changes needed?

We don't currently exercise the devbox image end-to-end in CI. A PR can
successfully build the devbox bundled image yet still produce a cluster
that can't actually execute a task. This adds a smoke test that boots
the freshly built devbox and runs a hello-world task against it.

## What changes were proposed in this pull request?

Adds an `integration-test` job to `.github/workflows/flyte-binary-v2.yml`:

- Reuses the `single-binary-image` artifact from
  `build-and-push-single-binary-image` (no flyte-binary rebuild).
- Builds the devbox image for the current branch (`linux/amd64`, `--load`
  as `flyte-devbox:latest`), pulling from the existing `demo-cpu` GHA
  buildx cache.
- Boots the cluster with `make -C docker/devbox-bundled start` and waits
  for the flyte endpoint on `:30080`.
- Installs the `flyte` SDK, writes a minimal hello-world task + a config
  pointing at `dns:///localhost:30080` with `insecure: true`, and runs
  `flyte --config config.yaml run hello.py main --numbers '[1,2,3]'`.
  `flyte run` blocks on the remote run and exits non-zero on failure, so
  the job fails automatically if the task doesn't succeed.
- Dumps `docker logs flyte-devbox` on failure and always stops the
  container.

### Labels

added

## How was this patch tested?

Will be validated by CI on this PR.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

* `main` <!-- branch-stack -->
  - \#6583
    - **ci: add devbox integration test running hello world via flyte CLI** :point\_left:
