### PR TITLE
fix(spark): populate timestamp fields in log template input

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -394,6 +394,14 @@ func getEventInfoForSpark(pluginContext k8s.PluginContext, sj *sparkOp.SparkAppl
 	taskLogs := make([]*core.TaskLog, 0, 3)
 	taskExecID := pluginContext.TaskExecutionMetadata().GetTaskExecutionID()
 
+	startTime := sj.CreationTimestamp.Unix()
+	var finishTime int64
+	isTerminal := sj.Status.AppState.State == sparkOp.ApplicationStateCompleted ||
+		sj.Status.AppState.State == sparkOp.ApplicationStateFailed
+	if isTerminal && !sj.Status.TerminationTime.IsZero() {
+		finishTime = sj.Status.TerminationTime.Unix()
+	}
+
 	if sj.Status.DriverInfo.PodName != "" {
 		p, err := logs.InitializeLogPlugins(&sparkConfig.LogConfig.Mixed)
 		if err != nil {
@@ -402,11 +410,15 @@ func getEventInfoForSpark(pluginContext k8s.PluginContext, sj *sparkOp.SparkAppl
 
 		if p != nil {
 			o, err := p.GetTaskLogs(tasklog.Input{
-				PodName:         sj.Status.DriverInfo.PodName,
-				Namespace:       sj.Namespace,
-				LogName:         "(Driver Logs)",
-				TaskExecutionID: taskExecID,
-				TaskTemplate:    taskTemplate,
+				PodName:              sj.Status.DriverInfo.PodName,
+				Namespace:            sj.Namespace,
+				LogName:              "(Driver Logs)",
+				PodRFC3339StartTime:  time.Unix(startTime, 0).Format(time.RFC3339),
+				PodRFC3339FinishTime: time.Unix(finishTime, 0).Format(time.RFC3339),
+				PodUnixStartTime:     startTime,
+				PodUnixFinishTime:    finishTime,
+				TaskExecutionID:      taskExecID,
+				TaskTemplate:         taskTemplate,
 			})
 
 			if err != nil {
@@ -424,10 +436,14 @@ func getEventInfoForSpark(pluginContext k8s.PluginContext, sj *sparkOp.SparkAppl
 
 	if p != nil {
 		o, err := p.GetTaskLogs(tasklog.Input{
-			PodName:         sj.Status.DriverInfo.PodName,
-			Namespace:       sj.Namespace,
-			LogName:         "(User Logs)",
-			TaskExecutionID: taskExecID,
+			PodName:              sj.Status.DriverInfo.PodName,
+			Namespace:            sj.Namespace,
+			LogName:              "(User Logs)",
+			PodRFC3339StartTime:  time.Unix(startTime, 0).Format(time.RFC3339),
+			PodRFC3339FinishTime: time.Unix(finishTime, 0).Format(time.RFC3339),
+			PodUnixStartTime:     startTime,
+			PodUnixFinishTime:    finishTime,
+			TaskExecutionID:      taskExecID,
 		})
 
 		if err != nil {
@@ -444,10 +460,14 @@ func getEventInfoForSpark(pluginContext k8s.PluginContext, sj *sparkOp.SparkAppl
 
 	if p != nil {
 		o, err := p.GetTaskLogs(tasklog.Input{
-			PodName:         sj.Name,
-			Namespace:       sj.Namespace,
-			LogName:         "(System Logs)",
-			TaskExecutionID: taskExecID,
+			PodName:              sj.Name,
+			Namespace:            sj.Namespace,
+			LogName:              "(System Logs)",
+			PodRFC3339StartTime:  time.Unix(startTime, 0).Format(time.RFC3339),
+			PodRFC3339FinishTime: time.Unix(finishTime, 0).Format(time.RFC3339),
+			PodUnixStartTime:     startTime,
+			PodUnixFinishTime:    finishTime,
+			TaskExecutionID:      taskExecID,
 		})
 
 		if err != nil {
@@ -464,10 +484,14 @@ func getEventInfoForSpark(pluginContext k8s.PluginContext, sj *sparkOp.SparkAppl
 
 	if p != nil {
 		o, err := p.GetTaskLogs(tasklog.Input{
-			PodName:         sj.Name,
-			Namespace:       sj.Namespace,
-			LogName:         "(Spark-Submit/All User Logs)",
-			TaskExecutionID: taskExecID,
+			PodName:              sj.Name,
+			Namespace:            sj.Namespace,
+			LogName:              "(Spark-Submit/All User Logs)",
+			PodRFC3339StartTime:  time.Unix(startTime, 0).Format(time.RFC3339),
+			PodRFC3339FinishTime: time.Unix(finishTime, 0).Format(time.RFC3339),
+			PodUnixStartTime:     startTime,
+			PodUnixFinishTime:    finishTime,
+			TaskExecutionID:      taskExecID,
 		})
 
 		if err != nil {

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	sparkOp "github.com/kubeflow/spark-operator/api/v1beta2"
 	"github.com/stretchr/testify/assert"
@@ -171,6 +172,88 @@ func TestGetEventInfo(t *testing.T) {
 	}
 
 	assert.Equal(t, expectedLinks, generatedLinks)
+}
+
+func TestGetEventInfoTimestamps(t *testing.T) {
+	assert.NoError(t, setSparkConfig(&Config{
+		LogConfig: LogConfig{
+			Mixed: logs.LogConfig{
+				IsCloudwatchEnabled:   true,
+				CloudwatchTemplateURI: "https://logs.example.com/{{ .podName }}?start={{ .podUnixStartTime }}&end={{ .podUnixFinishTime }}&rfc3339start={{ .podRFC3339StartTime }}",
+			},
+		},
+	}))
+
+	creationTime := v1.NewTime(v1.Now().Add(-10 * time.Minute))
+	terminationTime := v1.NewTime(v1.Now().Add(-1 * time.Minute))
+
+	t.Run("running app has start time but no finish time", func(t *testing.T) {
+		app := &sparkOp.SparkApplication{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "spark-app-name",
+				Namespace:         "spark-namespace",
+				CreationTimestamp: creationTime,
+			},
+			Status: sparkOp.SparkApplicationStatus{
+				SparkApplicationID: "app-id",
+				AppState: sparkOp.ApplicationState{
+					State: sparkOp.ApplicationStateRunning,
+				},
+				DriverInfo: sparkOp.DriverInfo{
+					PodName:             "spark-pod",
+					WebUIIngressAddress: sparkUIAddress,
+				},
+				ExecutionAttempts: 1,
+			},
+		}
+
+		taskTemplate := dummySparkTaskTemplateContainer("blah-1", dummySparkConf)
+		taskCtx := dummySparkTaskContext(taskTemplate, false, k8s.PluginState{})
+		info, err := getEventInfoForSpark(taskCtx, app, taskTemplate)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, info.Logs)
+
+		driverLogURI := info.Logs[0].GetUri()
+		expectedStart := strconv.FormatInt(creationTime.Unix(), 10)
+		assert.Contains(t, driverLogURI, "start="+expectedStart)
+		assert.NotContains(t, driverLogURI, "start=0")
+		assert.Contains(t, driverLogURI, "end=0")
+	})
+
+	t.Run("completed app has start and finish time from TerminationTime", func(t *testing.T) {
+		app := &sparkOp.SparkApplication{
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "spark-app-name",
+				Namespace:         "spark-namespace",
+				CreationTimestamp: creationTime,
+			},
+			Status: sparkOp.SparkApplicationStatus{
+				SparkApplicationID: "app-id",
+				AppState: sparkOp.ApplicationState{
+					State: sparkOp.ApplicationStateCompleted,
+				},
+				TerminationTime: terminationTime,
+				DriverInfo: sparkOp.DriverInfo{
+					PodName:             "spark-pod",
+					WebUIIngressAddress: sparkUIAddress,
+				},
+				ExecutionAttempts: 1,
+			},
+		}
+
+		taskTemplate := dummySparkTaskTemplateContainer("blah-1", dummySparkConf)
+		taskCtx := dummySparkTaskContext(taskTemplate, false, k8s.PluginState{})
+		info, err := getEventInfoForSpark(taskCtx, app, taskTemplate)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, info.Logs)
+
+		driverLogURI := info.Logs[0].GetUri()
+		expectedStart := strconv.FormatInt(creationTime.Unix(), 10)
+		expectedFinish := strconv.FormatInt(terminationTime.Unix(), 10)
+		assert.Contains(t, driverLogURI, "start="+expectedStart)
+		assert.Contains(t, driverLogURI, "end="+expectedFinish)
+		assert.NotContains(t, driverLogURI, "end=0")
+	})
 }
 
 func TestGetTaskPhase(t *testing.T) {


### PR DESCRIPTION
## Summary

The Spark plugin's `getEventInfoForSpark` constructs `tasklog.Input` without populating any timestamp fields (`PodUnixStartTime`, `PodUnixFinishTime`, `PodRFC3339StartTime`, `PodRFC3339FinishTime`). This causes log template URIs referencing `{{ .podUnixStartTime }}` to render as `0`, making it impossible to construct time-bounded log links for external logging services like Grafana Loki or Kibana.

The standard K8s plugin (`logging_utils.go`) and kfoperators (`common_operator.go`) already populate these fields from the resource's `CreationTimestamp`. This change applies the same pattern to all four `tasklog.Input` structs in `getEventInfoForSpark`.

### Changes

- Compute `startTime` from `sj.CreationTimestamp.Unix()` (always available)
- Compute `finishTime` from `sj.Status.TerminationTime` only when the app is in a terminal state (`Completed` or `Failed`) and `TerminationTime` is non-zero — otherwise `finishTime` remains `0`
- Populate `PodUnixStartTime`, `PodUnixFinishTime`, `PodRFC3339StartTime`, and `PodRFC3339FinishTime` in all four `tasklog.Input` structs (Driver, User, System, and All-User logs)
- Added `TestGetEventInfoTimestamps` test with two subtests:
  - **Running app**: verifies start time is populated and finish time is `0`
  - **Completed app**: verifies both start and finish times are populated from `CreationTimestamp` and `TerminationTime` respectively

### Testing

- All existing Spark plugin tests pass
- New test verifies that a log template URI containing `{{ .podUnixStartTime }}` renders the actual creation timestamp rather than `0`
- New test verifies that finish time is only populated for terminal states using the CRD's `TerminationTime`
- Manually tested against a Flyte Binary deployment with Grafana Loki log links using `{{ .podUnixStartTime }}000` for epoch-ms time ranges

Fixes #6328