### PR TITLE
add devbox CTA to v2 readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 > ## Flyte 2 Devbox is now available!
 >
 > Check out the guide [here](https://www.union.ai/docs/v2/flyte/user-guide/run-modes/running-devbox/) to get started.
+>
+> Looking for Flyte 1? Go to the [master](https://github.com/flyteorg/flyte/tree/master) branch, where Flyte 1 is now maintained.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+> [!IMPORTANT]
+> ## Flyte 2 Devbox is now available!
+>
+> Check out the guide [here](https://www.union.ai/docs/v2/flyte/user-guide/run-modes/running-devbox/) to get started.
+
+---
+
 # Flyte 2
 
 **Reliably orchestrate ML pipelines, models, and agents at scale — in pure Python.**


### PR DESCRIPTION
This PR should be merged on 4/27 for the Flyte 2 Devbox launch

- `main` <!-- branch-stack -->
  - \#6583
    - **\[DO NOT MERGE] add devbox CTA to v2 readme** :point\_left:
