### PR TITLE
fix: populate App.Spec in Get/List/Watch responses so UI can render about, replicas, and resources 

### DIFF
--- a/app/internal/k8s/app_client.go
+++ b/app/internal/k8s/app_client.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"math"
@@ -36,6 +37,7 @@ const (
 
 	annotationSpecSHA = "flyte.org/spec-sha"
 	annotationAppID   = "flyte.org/app-id"
+	annotationSpec    = "flyte.org/spec"
 
 	maxScaleZero = "0"
 
@@ -53,9 +55,9 @@ type AppK8sClientInterface interface {
 	// is kept so the app can be restarted later.
 	Stop(ctx context.Context, appID *flyteapp.Identifier) error
 
-	// GetStatus reads the KService and maps its conditions to a DeploymentStatus.
+	// GetApp reads the KService and returns the full App including reconstructed Spec and live Status.
 	// Returns a not-found error (checkable with k8serrors.IsNotFound) if the KService does not exist.
-	GetStatus(ctx context.Context, appID *flyteapp.Identifier) (*flyteapp.Status, error)
+	GetApp(ctx context.Context, appID *flyteapp.Identifier) (*flyteapp.App, error)
 
 	// List returns apps for the given project/domain scope with optional pagination.
 	// limit=0 means no limit. token is the K8s continue token from a previous call.
@@ -419,8 +421,8 @@ func (c *AppK8sClient) kserviceEventToWatchResponse(ctx context.Context, event k
 	}
 }
 
-// GetStatus reads the KService and maps its conditions to a flyteapp.Status proto.
-func (c *AppK8sClient) GetStatus(ctx context.Context, appID *flyteapp.Identifier) (*flyteapp.Status, error) {
+// GetApp reads the KService and returns the full App including reconstructed Spec and live Status.
+func (c *AppK8sClient) GetApp(ctx context.Context, appID *flyteapp.Identifier) (*flyteapp.App, error) {
 	ns := appNamespace(appID.GetProject(), appID.GetDomain())
 	name := kserviceName(appID)
 	ksvc := &servingv1.Service{}
@@ -430,7 +432,25 @@ func (c *AppK8sClient) GetStatus(ctx context.Context, appID *flyteapp.Identifier
 		}
 		return nil, fmt.Errorf("failed to get KService %s: %w", name, err)
 	}
-	return c.kserviceToStatus(ctx, ksvc), nil
+	return c.kserviceToApp(ctx, ksvc)
+}
+
+// specFromAnnotation deserializes the Spec stored in the flyte.org/spec annotation.
+// Returns nil if the annotation is absent or malformed.
+func specFromAnnotation(ksvc *servingv1.Service) *flyteapp.Spec {
+	b64, ok := ksvc.Annotations[annotationSpec]
+	if !ok {
+		return nil
+	}
+	b, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil
+	}
+	spec := &flyteapp.Spec{}
+	if err := proto.Unmarshal(b, spec); err != nil {
+		return nil
+	}
+	return spec
 }
 
 // List returns apps for the given project/domain scope with optional pagination.
@@ -502,14 +522,19 @@ func kserviceName(id *flyteapp.Identifier) string {
 	return name[:maxKServiceNameLen-9] + "-" + suffix
 }
 
-// specSHA computes a SHA256 digest of the serialized App Spec proto.
-func specSHA(spec *flyteapp.Spec) (string, error) {
+// marshalSpec serializes the App Spec proto and returns the raw bytes.
+func marshalSpec(spec *flyteapp.Spec) ([]byte, error) {
 	b, err := proto.Marshal(spec)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal spec: %w", err)
+		return nil, fmt.Errorf("failed to marshal spec: %w", err)
 	}
-	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:8]), nil // 8 bytes = 16 hex chars, enough for change detection
+	return b, nil
+}
+
+// specSHA computes a SHA256 digest of the serialized App Spec proto.
+func specSHA(specBytes []byte) string {
+	sum := sha256.Sum256(specBytes)
+	return hex.EncodeToString(sum[:8]) // 8 bytes = 16 hex chars, enough for change detection
 }
 
 // buildKService constructs a Knative Service manifest from an App proto.
@@ -519,10 +544,11 @@ func (c *AppK8sClient) buildKService(app *flyteapp.App) (*servingv1.Service, err
 	name := kserviceName(appID)
 	ns := appNamespace(appID.GetProject(), appID.GetDomain())
 
-	sha, err := specSHA(spec)
+	specBytes, err := marshalSpec(spec)
 	if err != nil {
 		return nil, err
 	}
+	sha := specSHA(specBytes)
 
 	podSpec, err := buildPodSpec(spec)
 	if err != nil {
@@ -562,6 +588,7 @@ func (c *AppK8sClient) buildKService(app *flyteapp.App) (*servingv1.Service, err
 			Annotations: map[string]string{
 				annotationSpecSHA: sha,
 				annotationAppID:   fmt.Sprintf("%s/%s/%s", appID.GetProject(), appID.GetDomain(), appID.GetName()),
+				annotationSpec:    base64.StdEncoding.EncodeToString(specBytes),
 			},
 		},
 		Spec: servingv1.ServiceSpec{
@@ -763,6 +790,10 @@ func (c *AppK8sClient) kserviceToStatus(ctx context.Context, ksvc *servingv1.Ser
 		Namespace: ksvc.Namespace,
 	}
 
+	if !ksvc.CreationTimestamp.IsZero() {
+		status.CreatedAt = timestamppb.New(ksvc.CreationTimestamp.Time)
+	}
+
 	return status
 }
 
@@ -878,6 +909,7 @@ func (c *AppK8sClient) kserviceToApp(ctx context.Context, ksvc *servingv1.Servic
 		Metadata: &flyteapp.Meta{
 			Id: appID,
 		},
+		Spec:   specFromAnnotation(ksvc),
 		Status: c.kserviceToStatus(ctx, ksvc),
 	}, nil
 }

--- a/app/internal/k8s/app_client_test.go
+++ b/app/internal/k8s/app_client_test.go
@@ -177,16 +177,16 @@ func TestDelete_NotFound(t *testing.T) {
 	require.NoError(t, c.Delete(context.Background(), id))
 }
 
-func TestGetStatus_NotFound(t *testing.T) {
+func TestGetApp_NotFound(t *testing.T) {
 	c := testClient(t)
 	id := &flyteapp.Identifier{Project: "proj", Domain: "dev", Name: "missing"}
-	status, err := c.GetStatus(context.Background(), id)
+	app, err := c.GetApp(context.Background(), id)
 	require.Error(t, err)
 	assert.True(t, k8serrors.IsNotFound(err))
-	assert.Nil(t, status)
+	assert.Nil(t, app)
 }
 
-func TestGetStatus_Stopped(t *testing.T) {
+func TestGetApp_Stopped(t *testing.T) {
 	c := testClient(t)
 	app := testApp("proj", "dev", "myapp", "nginx:latest")
 	require.NoError(t, c.Deploy(context.Background(), app))
@@ -194,13 +194,13 @@ func TestGetStatus_Stopped(t *testing.T) {
 	id := &flyteapp.Identifier{Project: "proj", Domain: "dev", Name: "myapp"}
 	require.NoError(t, c.Stop(context.Background(), id))
 
-	status, err := c.GetStatus(context.Background(), id)
+	result, err := c.GetApp(context.Background(), id)
 	require.NoError(t, err)
-	require.Len(t, status.Conditions, 1)
-	assert.Equal(t, flyteapp.Status_DEPLOYMENT_STATUS_STOPPED, status.Conditions[0].DeploymentStatus)
+	require.Len(t, result.Status.Conditions, 1)
+	assert.Equal(t, flyteapp.Status_DEPLOYMENT_STATUS_STOPPED, result.Status.Conditions[0].DeploymentStatus)
 }
 
-func TestGetStatus_CurrentReplicas(t *testing.T) {
+func TestGetApp_CurrentReplicas(t *testing.T) {
 	s := testScheme(t)
 	// Pre-populate a KService with LatestReadyRevisionName already set in status,
 	// and the corresponding Revision with ActualReplicas=4.
@@ -234,9 +234,32 @@ func TestGetStatus_CurrentReplicas(t *testing.T) {
 	}
 
 	id := &flyteapp.Identifier{Project: "proj", Domain: "dev", Name: "myapp"}
-	status, err := c.GetStatus(context.Background(), id)
+	result, err := c.GetApp(context.Background(), id)
 	require.NoError(t, err)
-	assert.Equal(t, uint32(4), status.CurrentReplicas)
+	assert.Equal(t, uint32(4), result.Status.CurrentReplicas)
+}
+
+func TestGetApp_SpecRoundTrip(t *testing.T) {
+	c := testClient(t)
+	app := testApp("proj", "dev", "myapp", "nginx:latest")
+	app.Spec.Profile = &flyteapp.Profile{
+		Type:             "FastAPI",
+		Name:             "My App",
+		ShortDescription: "A test app",
+	}
+	app.Spec.Autoscaling = &flyteapp.AutoscalingConfig{
+		Replicas: &flyteapp.Replicas{Min: 1, Max: 5},
+	}
+	require.NoError(t, c.Deploy(context.Background(), app))
+
+	id := &flyteapp.Identifier{Project: "proj", Domain: "dev", Name: "myapp"}
+	result, err := c.GetApp(context.Background(), id)
+	require.NoError(t, err)
+	require.NotNil(t, result.Spec)
+	assert.Equal(t, "FastAPI", result.Spec.Profile.Type)
+	assert.Equal(t, "My App", result.Spec.Profile.Name)
+	assert.Equal(t, uint32(1), result.Spec.Autoscaling.Replicas.Min)
+	assert.Equal(t, uint32(5), result.Spec.Autoscaling.Replicas.Max)
 }
 
 func TestList(t *testing.T) {

--- a/app/internal/service/internal_app_service.go
+++ b/app/internal/service/internal_app_service.go
@@ -98,7 +98,7 @@ func (s *InternalAppService) Get(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("app_id is required"))
 	}
 
-	status, err := s.k8s.GetStatus(ctx, appID.AppId)
+	app, err := s.k8s.GetApp(ctx, appID.AppId)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
@@ -106,12 +106,7 @@ func (s *InternalAppService) Get(
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	return connect.NewResponse(&flyteapp.GetResponse{
-		App: &flyteapp.App{
-			Metadata: &flyteapp.Meta{Id: appID.AppId},
-			Status:   status,
-		},
-	}), nil
+	return connect.NewResponse(&flyteapp.GetResponse{App: app}), nil
 }
 
 // Update modifies an app's spec or desired state.
@@ -143,11 +138,11 @@ func (s *InternalAppService) Update(
 		}
 	}
 
-	status, err := s.k8s.GetStatus(ctx, appID)
+	freshApp, err := s.k8s.GetApp(ctx, appID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	app.Status = status
+	app.Status = freshApp.Status
 
 	return connect.NewResponse(&flyteapp.UpdateResponse{App: app}), nil
 }

--- a/app/internal/service/internal_app_service_test.go
+++ b/app/internal/service/internal_app_service_test.go
@@ -36,12 +36,12 @@ func (m *mockAppK8sClient) Delete(ctx context.Context, appID *flyteapp.Identifie
 	return m.Called(ctx, appID).Error(0)
 }
 
-func (m *mockAppK8sClient) GetStatus(ctx context.Context, appID *flyteapp.Identifier) (*flyteapp.Status, error) {
+func (m *mockAppK8sClient) GetApp(ctx context.Context, appID *flyteapp.Identifier) (*flyteapp.App, error) {
 	args := m.Called(ctx, appID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	return args.Get(0).(*flyteapp.Status), args.Error(1)
+	return args.Get(0).(*flyteapp.App), args.Error(1)
 }
 
 func (m *mockAppK8sClient) List(ctx context.Context, project, domain string, limit uint32, token string) ([]*flyteapp.App, string, error) {
@@ -99,10 +99,13 @@ func testApp() *flyteapp.App {
 	}
 }
 
-func testStatus(phase flyteapp.Status_DeploymentStatus) *flyteapp.Status {
-	return &flyteapp.Status{
-		Conditions: []*flyteapp.Condition{
-			{DeploymentStatus: phase},
+func testAppWithStatus(phase flyteapp.Status_DeploymentStatus) *flyteapp.App {
+	return &flyteapp.App{
+		Metadata: &flyteapp.Meta{Id: testAppID()},
+		Status: &flyteapp.Status{
+			Conditions: []*flyteapp.Condition{
+				{DeploymentStatus: phase},
+			},
 		},
 	}
 }
@@ -203,7 +206,7 @@ func TestGet_Success(t *testing.T) {
 	svc := NewInternalAppService(k8s, testCfg())
 
 	appID := testAppID()
-	k8s.On("GetStatus", mock.Anything, appID).Return(testStatus(flyteapp.Status_DEPLOYMENT_STATUS_ACTIVE), nil)
+	k8s.On("GetApp", mock.Anything, appID).Return(testAppWithStatus(flyteapp.Status_DEPLOYMENT_STATUS_ACTIVE), nil)
 
 	resp, err := svc.Get(context.Background(), connect.NewRequest(&flyteapp.GetRequest{
 		Identifier: &flyteapp.GetRequest_AppId{AppId: appID},
@@ -229,7 +232,7 @@ func TestUpdate_Deploy(t *testing.T) {
 
 	app := testApp()
 	k8s.On("Deploy", mock.Anything, app).Return(nil)
-	k8s.On("GetStatus", mock.Anything, app.Metadata.Id).Return(testStatus(flyteapp.Status_DEPLOYMENT_STATUS_DEPLOYING), nil)
+	k8s.On("GetApp", mock.Anything, app.Metadata.Id).Return(testAppWithStatus(flyteapp.Status_DEPLOYMENT_STATUS_DEPLOYING), nil)
 
 	resp, err := svc.Update(context.Background(), connect.NewRequest(&flyteapp.UpdateRequest{App: app}))
 	require.NoError(t, err)
@@ -244,7 +247,7 @@ func TestUpdate_Stop(t *testing.T) {
 	app := testApp()
 	app.Spec.DesiredState = flyteapp.Spec_DESIRED_STATE_STOPPED
 	k8s.On("Stop", mock.Anything, app.Metadata.Id).Return(nil)
-	k8s.On("GetStatus", mock.Anything, app.Metadata.Id).Return(testStatus(flyteapp.Status_DEPLOYMENT_STATUS_STOPPED), nil)
+	k8s.On("GetApp", mock.Anything, app.Metadata.Id).Return(testAppWithStatus(flyteapp.Status_DEPLOYMENT_STATUS_STOPPED), nil)
 
 	resp, err := svc.Update(context.Background(), connect.NewRequest(&flyteapp.UpdateRequest{App: app}))
 	require.NoError(t, err)


### PR DESCRIPTION
## Why are the changes needed?

The UI's About, Replicas, Requests, and Limits sections were all showing as undefined because App.Spec was never included in Get, List, or Watch responses — only Metadata and Status were returned.

## What changes were proposed in this pull request?

- Serialize the full App.Spec proto as a base64-encoded flyte.org/spec annotation on the KService at deploy time, so
  it survives the K8s round-trip
- Add specFromAnnotation() to deserialize it on read; kserviceToApp now includes Spec in every returned App
- Rename GetStatus → GetApp in AppK8sClientInterface, returning \*flyteapp.App instead of \*flyteapp.Status, so\
  callers get the full object
- Populate Status.CreatedAt from ksvc.CreationTimestamp in kserviceToStatus

## How was this patch tested?

- go test ./app/... passes — all existing tests updated for the new GetApp signature
- New TestGetApp\_SpecRoundTrip verifies that Profile and Autoscaling.Replicas written via Deploy are correctly recovered via GetApp
- Manual verification: deploy an app and confirm the UI's About (image, command, ports), Replicas (min/max), Requests,
  and Limits tabs populate correctly

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->

- `main` <!-- branch-stack -->
  - \#6583
    - \*\*fix: populate App.Spec in Get/List/Watch responses so UI can render about, replicas, and resources \*\* :point\_left:
