### PR TITLE
fix(runs): drop trailing slash from run output base to prevent "//" in SDK paths

### DIFF
--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -1694,8 +1694,10 @@ func literalMapToOutputs(m *core.LiteralMap) *task.Outputs {
 }
 
 // buildRunOutputBase generates the output base path for the run.
+// The returned path has no trailing slash so that callers that append
+// "/<segment>" produce a clean single-slash separator (avoiding "//").
 func buildRunOutputBase(storagePrefix, project, domain, name string) string {
-	return fmt.Sprintf("%s/%s/%s/%s/",
+	return fmt.Sprintf("%s/%s/%s/%s",
 		strings.TrimRight(storagePrefix, "/"),
 		project, domain, name)
 }

--- a/runs/service/utils_test.go
+++ b/runs/service/utils_test.go
@@ -277,3 +277,27 @@ func TestGenerateCacheKeyForTask(t *testing.T) {
 		assert.NotEmpty(t, key)
 	})
 }
+
+func TestBuildRunOutputBase(t *testing.T) {
+	t.Run("does not end with trailing slash", func(t *testing.T) {
+		// Regression: a trailing slash caused SDK consumers doing
+		// f"{run_output_base}/{action_name}/..." to produce a doubled slash like
+		// "s3://bucket/proj/dev/run//action/1/error.pb".
+		got := buildRunOutputBase("s3://flyte-data", "flytesnacks", "development", "r782")
+		assert.Equal(t, "s3://flyte-data/flytesnacks/development/r782", got)
+		assert.False(t, strings.HasSuffix(got, "/"), "run output base must not end in '/', got %q", got)
+	})
+
+	t.Run("storagePrefix with trailing slash is normalized", func(t *testing.T) {
+		got := buildRunOutputBase("s3://flyte-data/", "flytesnacks", "development", "r782")
+		assert.Equal(t, "s3://flyte-data/flytesnacks/development/r782", got)
+	})
+
+	t.Run("appending an action segment yields single slash separator", func(t *testing.T) {
+		base := buildRunOutputBase("s3://flyte-data", "flytesnacks", "development", "r782")
+		// Simulate the SDK's f-string construction: f"{run_output_base}/{action_name}/1/error.pb"
+		errorPath := base + "/action-0/1/error.pb"
+		rest := strings.TrimPrefix(errorPath, "s3://")
+		assert.NotContains(t, rest, "//", "constructed error path must not contain '//', got %q", errorPath)
+	})
+}


### PR DESCRIPTION
## Why are the changes needed?

`buildRunOutputBase` in `runs/service/run_service.go` emitted a path with a trailing `/`
(e.g. `s3://flyte-data/flytesnacks/development/r782/`). The Python SDK builds an error
file path as:

```python
error_path = io.error_path(f"{action.run_output_base}/{action.action_id.name}/1")
```

With the trailing slash that becomes `s3://flyte-data/.../r782//action-0/1/error.pb` —
a doubled slash that the SDK cannot load, so failed tasks never surface their real
error message and instead fall through to a generic runtime system error.

## What changes were proposed in this pull request?

- `buildRunOutputBase` now returns the path **without** a trailing `/`. Consumers
  appending `/<segment>` get a single-slash separator.
- `actionOutputURI` (the other consumer) already did `strings.TrimRight(runOutputBase, "/")`
  before appending, so it is unaffected.
- No proto or SDK changes — this is a pure server-side normalization.

## How was this patch tested?

- `go test ./runs/service/...` passes.
- Added `TestBuildRunOutputBase` (`runs/service/utils_test.go`) covering:
  - the returned path has no trailing slash,
  - a `storagePrefix` that already has a trailing slash is normalized,
  - appending an action segment (`base + "/action-0/1/error.pb"`) contains no `//`
    beyond the scheme delimiter — a direct regression guard against the original bug.

### Labels

fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

* `main` <!-- branch-stack -->
  - \#6583
    - **fix(runs): drop trailing slash from run output base to prevent "//" in SDK paths** :point\_left:
