### PR TITLE
feat: enable Embedded K8s secret manager in devbox webhook

### DIFF
--- a/charts/flyte-devbox/values.yaml
+++ b/charts/flyte-devbox/values.yaml
@@ -78,6 +78,13 @@ flyte-binary:
             - _U_EP_OVERRIDE: 'flyte-binary-http.{{ .Release.Namespace }}:8090'
             - _U_INSECURE: "true"
             - _U_USE_ACTIONS: "1"
+      webhook:
+        secretManagerTypes:
+          - Embedded
+        embeddedSecretManagerConfig:
+          type: K8s
+          k8sConfig:
+            namespace: '{{ .Release.Namespace }}'
     inlineConfigMap: '{{ include "flyte-devbox.configuration.inlineConfigMap" . }}'
   clusterResourceTemplates:
     inlineConfigMap: '{{ include "flyte-devbox.clusterResourceTemplates.inlineConfigMap" . }}'


### PR DESCRIPTION
## Why are the changes needed?

The devbox `flyte-binary-config` ConfigMap was missing the webhook
`secretManagerTypes` / `embeddedSecretManagerConfig` block that
`manager/config.yaml` uses by default. Without it, the webhook cannot
inject secrets stored by SecretService as K8s Secrets into pod specs in
the devbox environment, so any flow that exercises the Embedded K8s
secret manager fails locally.

## What changes were proposed in this pull request?

Adds the following to `flyte-binary.configuration.inline.webhook` in
`charts/flyte-devbox/values.yaml`:

```yaml
webhook:
  secretManagerTypes:
    - Embedded
  embeddedSecretManagerConfig:
    type: K8s
    k8sConfig:
      namespace: '{{ .Release.Namespace }}'
```

Using `.Release.Namespace` keeps the secret namespace in sync with the
manager's kubernetes namespace (where SecretService writes secrets).

## How was this patch tested?

Manually rendered the chart and verified the rendered ConfigMap contains
the new webhook block:

```bash
helm upgrade flyte-devbox charts/flyte-devbox -n flyte
kubectl get cm -n flyte flyte-binary-config -o yaml | grep -A6 secretManager
```

### Labels

- **added**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

* `main` <!-- branch-stack -->
  - \#6583
    - **feat: enable Embedded K8s secret manager in devbox webhook** :point\_left:
