### PR TITLE
chore: regenerate devbox bundled manifest with webhook secret manager

### DIFF
--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -8351,6 +8351,26 @@ metadata:
     app.kubernetes.io/name: flyte-devbox
     app.kubernetes.io/version: 1.16.1
     helm.sh/chart: flyte-devbox-0.1.0
+  name: flyte-devbox-registry-storage
+  namespace: flyte
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 20Gi
+  hostPath:
+    path: /var/lib/flyte/storage/registry
+  storageClassName: manual
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  labels:
+    app.kubernetes.io/instance: flyte-devbox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: flyte-devbox
+    app.kubernetes.io/version: 1.16.1
+    helm.sh/chart: flyte-devbox-0.1.0
   name: flyte-devbox-rustfs-storage
   namespace: flyte
 spec:
@@ -8361,6 +8381,26 @@ spec:
   hostPath:
     path: /var/lib/flyte/storage/rustfs
   storageClassName: manual
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: flyte-devbox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: flyte-devbox
+    app.kubernetes.io/version: 1.16.1
+    helm.sh/chart: flyte-devbox-0.1.0
+  name: flyte-devbox-registry-storage
+  namespace: flyte
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: manual
+  volumeName: flyte-devbox-registry-storage
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -8450,46 +8490,6 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: flyte-devbox-registry-storage
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  labels:
-    app.kubernetes.io/instance: flyte-devbox
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: flyte-devbox
-    app.kubernetes.io/version: 1.16.1
-    helm.sh/chart: flyte-devbox-0.1.0
-  name: flyte-devbox-registry-storage
-  namespace: flyte
-spec:
-  accessModes:
-  - ReadWriteOnce
-  capacity:
-    storage: 20Gi
-  hostPath:
-    path: /var/lib/flyte/storage/registry
-  storageClassName: manual
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  labels:
-    app.kubernetes.io/instance: flyte-devbox
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: flyte-devbox
-    app.kubernetes.io/version: 1.16.1
-    helm.sh/chart: flyte-devbox-0.1.0
-  name: flyte-devbox-registry-storage
-  namespace: flyte
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 20Gi
-  storageClassName: manual
-  volumeName: flyte-devbox-registry-storage
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -7774,6 +7774,13 @@ data:
         ephemeralStorage: 0
         gpu: 0
         memory: 0
+    webhook:
+      embeddedSecretManagerConfig:
+        k8sConfig:
+          namespace: 'flyte'
+        type: K8s
+      secretManagerTypes:
+      - Embedded
 kind: ConfigMap
 metadata:
   labels:
@@ -8506,7 +8513,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 057bc8cd8f198da64d01b746859585efb371b57b3215ffea2e46a7b83ad7b820
+        checksum/configuration: 53ebdf49e3406c689b89d5bf7c25698f0c4f123ab016f51533e6331fe173a744
         checksum/configuration-secret: e70194084619f4a1d4017093aac6367047167107fd0222513a32a61734629cac
       labels:
         app.kubernetes.io/component: flyte-binary

--- a/docker/devbox-bundled/manifests/dev.yaml
+++ b/docker/devbox-bundled/manifests/dev.yaml
@@ -8043,6 +8043,26 @@ metadata:
     app.kubernetes.io/name: flyte-devbox
     app.kubernetes.io/version: 1.16.1
     helm.sh/chart: flyte-devbox-0.1.0
+  name: flyte-devbox-registry-storage
+  namespace: flyte
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 20Gi
+  hostPath:
+    path: /var/lib/flyte/storage/registry
+  storageClassName: manual
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  labels:
+    app.kubernetes.io/instance: flyte-devbox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: flyte-devbox
+    app.kubernetes.io/version: 1.16.1
+    helm.sh/chart: flyte-devbox-0.1.0
   name: flyte-devbox-rustfs-storage
   namespace: flyte
 spec:
@@ -8053,6 +8073,26 @@ spec:
   hostPath:
     path: /var/lib/flyte/storage/rustfs
   storageClassName: manual
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: flyte-devbox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: flyte-devbox
+    app.kubernetes.io/version: 1.16.1
+    helm.sh/chart: flyte-devbox-0.1.0
+  name: flyte-devbox-registry-storage
+  namespace: flyte
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: manual
+  volumeName: flyte-devbox-registry-storage
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -8142,46 +8182,6 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: flyte-devbox-registry-storage
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  labels:
-    app.kubernetes.io/instance: flyte-devbox
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: flyte-devbox
-    app.kubernetes.io/version: 1.16.1
-    helm.sh/chart: flyte-devbox-0.1.0
-  name: flyte-devbox-registry-storage
-  namespace: flyte
-spec:
-  accessModes:
-  - ReadWriteOnce
-  capacity:
-    storage: 20Gi
-  hostPath:
-    path: /var/lib/flyte/storage/registry
-  storageClassName: manual
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  labels:
-    app.kubernetes.io/instance: flyte-devbox
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: flyte-devbox
-    app.kubernetes.io/version: 1.16.1
-    helm.sh/chart: flyte-devbox-0.1.0
-  name: flyte-devbox-registry-storage
-  namespace: flyte
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 20Gi
-  storageClassName: manual
-  volumeName: flyte-devbox-registry-storage
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## Why are the changes needed?

Follow-up to #7279, which added the webhook `secretManagerTypes` /
`embeddedSecretManagerConfig` block to `charts/flyte-devbox/values.yaml`
but missed regenerating the bundled manifest baked into the devbox
image. Without this, devbox images built from the bundled manifest do
not pick up the Embedded K8s secret manager config.

## What changes were proposed in this pull request?

Re-renders `docker/devbox-bundled/manifests/complete.yaml` so the
`flyte-binary-config` ConfigMap contains:

```yaml
webhook:
  embeddedSecretManagerConfig:
    k8sConfig:
      namespace: 'flyte'
    type: K8s
  secretManagerTypes:
  - Embedded
```

`dev.yaml` is not affected (it does not include `flyte-binary`).

## How was this patch tested?

Diff inspection confirms only the `flyte-binary-config` ConfigMap and
its checksum annotation changed.

### Labels

- **changed**

## Related PRs

- \#7279

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

* `main` <!-- branch-stack -->
  - \#6583
    - **chore: regenerate devbox bundled manifest with webhook secret manager** :point\_left:
