### PR TITLE
fix: run devbox docker-registry as root to write to hostPath PV

### DIFF
--- a/charts/flyte-devbox/values.yaml
+++ b/charts/flyte-devbox/values.yaml
@@ -12,6 +12,12 @@ docker-registry:
   service:
     type: NodePort
     nodePort: 30000
+  # Run as root so the registry can write to the hostPath PV mount, which
+  # is created as root:root 755 by the node and cannot be chowned via fsGroup.
+  securityContext:
+    runAsUser: 0
+  containerSecurityContext:
+    runAsUser: 0
 flyte-binary:
   fullnameOverride: flyte-binary
   enabled: true

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -8482,7 +8482,7 @@ spec:
           name: data
       securityContext:
         fsGroup: 1000
-        runAsUser: 1000
+        runAsUser: 0
       volumes:
       - configMap:
           name: docker-registry-config

--- a/docker/devbox-bundled/manifests/dev.yaml
+++ b/docker/devbox-bundled/manifests/dev.yaml
@@ -8174,7 +8174,7 @@ spec:
           name: data
       securityContext:
         fsGroup: 1000
-        runAsUser: 1000
+        runAsUser: 0
       volumes:
       - configMap:
           name: docker-registry-config


### PR DESCRIPTION
## Why are the changes needed?

The bundled `docker-registry` pod in the devbox runs as uid 1000 by
default (twuni chart default), but its hostPath PV at
`/var/lib/flyte/storage/registry` is created as `root:root 755` by the
node and cannot be chowned via `fsGroup` — `fsGroup` is ignored on
hostPath volumes.

As a result, every image push to `localhost:30000` fails with:

```
filesystem: mkdir /var/lib/registry/docker: permission denied
```

which surfaces in `flyte run` as:

```
error: unexpected status from POST request to http://localhost:30000/v2/<repo>/blobs/uploads/: 500 Internal Server Error
```

## What changes were proposed in this pull request?

Override the docker-registry chart's pod and container securityContext
to `runAsUser: 0` in `charts/flyte-devbox/values.yaml`, and regenerate
`docker/devbox-bundled/manifests/{complete,dev}.yaml`.

```yaml
docker-registry:
  ...
  securityContext:
    runAsUser: 0
  containerSecurityContext:
    runAsUser: 0
```

## How was this patch tested?

Manually: with the running devbox, after applying the equivalent patch
the registry pod could write to its mount and `flyte run` succeeded in
pushing the built image. Verified the regenerated bundled manifest only
changes the registry deployment's `securityContext.runAsUser` from 1000
to 0.

### Labels

- **fixed**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

* `main` <!-- branch-stack -->
  - \#6583
    - **fix: run devbox docker-registry as root to write to hostPath PV** :point\_left:
