### PR TITLE
Fix: return error when update affects zero rows in execution repo

### DIFF
--- a/flyteadmin/pkg/repositories/gormimpl/execution_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/execution_repo.go
@@ -70,9 +70,16 @@ func (r *ExecutionRepo) Update(ctx context.Context, execution models.Execution) 
 	timer := r.metrics.UpdateDuration.Start()
 	tx := r.db.WithContext(ctx).Model(&models.Execution{}).Where(getIDFilter(execution.ID)).Updates(execution)
 	timer.Stop()
+
 	if err := tx.Error; err != nil {
 		return r.errorTransformer.ToFlyteAdminError(err)
 	}
+
+	
+	if tx.RowsAffected == 0 {
+		return adminErrors.GetMissingEntityError("execution", nil)
+	}
+
 	return nil
 }
 

--- a/flyteadmin/pkg/repositories/gormimpl/node_execution_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/node_execution_repo.go
@@ -100,8 +100,13 @@ func (r *NodeExecutionRepo) Update(ctx context.Context, nodeExecution *models.No
 	tx := r.db.WithContext(ctx).Model(&models.NodeExecution{}).Where(getIDFilter(nodeExecution.ID)).Updates(nodeExecution)
 	timer.Stop()
 	if err := tx.Error; err != nil {
-		return r.errorTransformer.ToFlyteAdminError(err)
-	}
+    return r.errorTransformer.ToFlyteAdminError(err)
+}
+
+if tx.RowsAffected == 0 {
+    return adminErrors.GetMissingEntityError("node execution", nil)
+}
+
 	return nil
 }
 

--- a/flyteadmin/pkg/repositories/gormimpl/task_execution_repo.go
+++ b/flyteadmin/pkg/repositories/gormimpl/task_execution_repo.go
@@ -88,6 +88,13 @@ func (r *TaskExecutionRepo) Update(ctx context.Context, execution models.TaskExe
 	if err := tx.Error; err != nil {
 		return r.errorTransformer.ToFlyteAdminError(err)
 	}
+
+
+	if tx.RowsAffected == 0 {
+		return flyteAdminDbErrors.GetMissingEntityError("task execution", nil)
+	}
+
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes #7257

This PR ensures that Update operations in ExecutionRepo return an error when no rows are affected.

Previously, updates silently succeeded even if no matching record existed, which could lead to hidden data issues.

This change adds a check on RowsAffected and returns a not found error when no rows are updated.