### PR TITLE
chore: bump nvidia-device-plugin to v0.19.1 in devbox bundled manifest

### DIFF
--- a/docker/devbox-bundled/nvidia-device-plugin.yaml
+++ b/docker/devbox-bundled/nvidia-device-plugin.yaml
@@ -28,7 +28,7 @@ spec:
       runtimeClassName: nvidia
       containers:
         - name: nvidia-device-plugin-ctr
-          image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.19.1
           env:
             - name: FAIL_ON_INIT_ERROR
               value: "false"


### PR DESCRIPTION
## Why are the changes needed?

Update the NVIDIA device plugin image used by the bundled devbox manifest from `v0.17.0` to `v0.19.1` to pick up upstream fixes and improvements.

## What changes were proposed in this pull request?

Bumps `nvcr.io/nvidia/k8s-device-plugin` from `v0.17.0` to `v0.19.1` in `docker/devbox-bundled/nvidia-device-plugin.yaml`.

## How was this patch tested?

Manually verified the bundled devbox stack starts and exposes GPUs with the new image.

### Labels

- **changed**

## Check all the applicable boxes

- [x] All commits are signed-off.

* `main` <!-- branch-stack -->
  - \#6583
    - **chore: bump nvidia-device-plugin to v0.19.1 in devbox bundled manifest** :point\_left:
