### PR TITLE
[V2] ListRuns fallback to sort by field

### DIFF
--- a/runs/repository/impl/sorting.go
+++ b/runs/repository/impl/sorting.go
@@ -31,13 +31,20 @@ func NewSortParameter(field string, order interfaces.SortOrder) interfaces.SortP
 	}
 }
 
-// GetSortByFieldsV2 converts proto sort fields to our SortParameter interfaces with validation
+// GetSortByFieldsV2 converts proto sort fields to our SortParameter interfaces with validation.
+// It prefers sort_by_fields; if empty, it falls back to the deprecated sort_by field.
 func GetSortByFieldsV2(request *common.ListRequest, allowedSortColumns sets.Set[string]) ([]interfaces.SortParameter, error) {
-	if request == nil || request.GetSortByFields() == nil {
+	if request == nil {
 		return nil, nil
 	}
 
 	protoSortFields := request.GetSortByFields()
+	if len(protoSortFields) == 0 {
+		// Fall back to deprecated sort_by field.
+		if sortBy := request.GetSortBy(); sortBy != nil && sortBy.Key != "" {
+			protoSortFields = []*common.Sort{sortBy}
+		}
+	}
 	if len(protoSortFields) == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

Flyteconsole send request with `sort_by`. We should use this if `sort_by_fields` is not set.

## What changes were proposed in this pull request?

Fallback to sort by `sort_by` if `sort_by_fields` is not set.

## How was this patch tested?

Run on devbox and ensure runs are sorted by "created_at"

<img width="2912" height="1048" alt="image" src="https://github.com/user-attachments/assets/18a756dc-dc37-4a8c-8204-9fc505527def" />

The flyteconsole will send following request, and we expect runs to be sorted by "created_at"

```json
{
    "request": {
        "limit": 100,
        "sortBy": {
            "key": "created_at"
        },
        "filters": [
            {
                "function": "GREATER_THAN_OR_EQUAL",
                "field": "created_at",
                "values": [
                    "2026-04-21T05:31:32.214Z"
                ]
            }
        ]
    },
    "projectId": {
        "organization": "localhost",
        "domain": "development",
        "name": "flytesnacks"
    }
}
```



### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
