### PR TITLE
ci: add DCO config to allow remediation commits

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,5 @@
+require:
+  members: false
+allowRemediationCommits:
+  individual: true
+  thirdParty: true


### PR DESCRIPTION
## Summary

- Adds `.github/dco.yml` configuring the [Probot DCO app](https://github.com/dcoapp/app) to allow remediation commits.
- Enables both `individual` (a contributor signing off their own past commits) and `thirdParty` (someone else signing off on a contributor's behalf) remediation modes.

## Why

The Probot DCO app reads its config from the **default branch**, so this needs to land on `master` first before remediation commits on other branches will be honored. The immediate motivation is the `v2 → main` integration PR (#6583), which has 133 commits across ~20 authors flagged for missing/mismatched sign-offs and cannot be cleanly resolved by `git rebase --signoff` (the default fix the bot suggests works only when the PR author is the sole contributor).

## Behavior

- New PRs to any branch still require `Signed-off-by:` per commit (default strict check unchanged for normal flow).
- A separate "remediation" commit can now be added to backfill sign-offs for prior commits without rewriting history.

## Test plan

- [ ] After merge, re-run DCO check on PR #6583 once a remediation commit is pushed and confirm the bot honors it.