### PR TITLE
ci: DCO remediation commit for v2 -> main integration

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,5 @@
+require:
+  members: false
+allowRemediationCommits:
+  individual: true
+  thirdParty: true


### PR DESCRIPTION
## Summary

- Adds `.github/dco.yml` enabling individual + third-party remediation commits (mirrors #7297, which lands the same config on `master` so the Probot DCO app actually picks it up).
- Adds a single third-party remediation commit signing off on behalf of the original authors for the **133 commits across \~20 contributors** flagged by the DCO check on the `v2 → main` integration PR (#6583).

## Why

The `v2 → main` PR fails DCO because many historical commits inherited into `v2` lack matching `Signed-off-by:` trailers (mostly GitHub `noreply` / personal email mismatches, plus a handful with no sign-off at all). Those underlying contributions were already merged through prior DCO-clean PRs to `master`, but the bot re-validates every commit in the PR. A blanket `git rebase --signoff` is not appropriate since I am not the author of these commits — third-party remediation is the correct mechanism.

## Mechanics

- The remediation commit body contains 133 lines of the form:
  `On behalf of <author> <email>, I, Haytham Abuelfutuh <haytham@afutuh.com>, hereby add my Signed-off-by to this commit: <full-sha>`
- Followed by a final `Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>` trailer.
- This is the format the Probot DCO app recognizes when `allowRemediationCommits.thirdParty: true` is set.

## Order of operations

1. Merge #7297 to `master` first (DCO config must be on the default branch for the bot to honor it).
2. Merge this PR into `v2`.
3. Re-run DCO on #6583 — the remediation commit will now be at the head of `v2` and should clear all 133 failures.

## Test plan

- [ ] Confirm #7297 has merged to `master` before merging this PR.
- [ ] After merge, re-run DCO check on #6583 and verify all 133 previously-failing commits are reported as remediated.

* `main` <!-- branch-stack -->
  - \#6583
    - **ci: DCO remediation commit for v2 -> main integration** :point\_left:
