### PR TITLE
Allow HTTP registry for Knative Serving in devbox

### DIFF
--- a/docker/devbox-bundled/kustomize/complete/kustomization.yaml
+++ b/docker/devbox-bundled/kustomize/complete/kustomization.yaml
@@ -48,6 +48,15 @@ patches:
     data:
       "localhost": ""
 - patch: |-
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-deployment
+      namespace: knative-serving
+    data:
+      registries-skipping-tag-resolving: "localhost:30000,kind-registry:5000"
+      allow-http-registry: "true"
+- patch: |-
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:

--- a/docker/devbox-bundled/kustomize/dev/kustomization.yaml
+++ b/docker/devbox-bundled/kustomize/dev/kustomization.yaml
@@ -38,6 +38,15 @@ patches:
     data:
       "localhost": ""
 - patch: |-
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-deployment
+      namespace: knative-serving
+    data:
+      registries-skipping-tag-resolving: "localhost:30000,kind-registry:5000"
+      allow-http-registry: "true"
+- patch: |-
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -7873,7 +7873,9 @@ metadata:
 ---
 apiVersion: v1
 data:
+  allow-http-registry: "true"
   queue-sidecar-image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:d0be939fdfb469e52e999eb65f39466d18f029984a782affa26322c9fec6db78
+  registries-skipping-tag-resolving: localhost:30000,kind-registry:5000
 kind: ConfigMap
 metadata:
   annotations:

--- a/docker/devbox-bundled/manifests/dev.yaml
+++ b/docker/devbox-bundled/manifests/dev.yaml
@@ -7589,7 +7589,9 @@ metadata:
 ---
 apiVersion: v1
 data:
+  allow-http-registry: "true"
   queue-sidecar-image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:d0be939fdfb469e52e999eb65f39466d18f029984a782affa26322c9fec6db78
+  registries-skipping-tag-resolving: localhost:30000,kind-registry:5000
 kind: ConfigMap
 metadata:
   annotations:


### PR DESCRIPTION
## Why are the changes needed?

When using a local HTTP registry (e.g. `localhost:30000`) in the devbox, Python task pods can pull images successfully but Knative Serving revisions fail. By default, Knative's controller resolves image tags to digests via the registry over HTTPS, which fails for the local HTTP registry, blocking revision creation.

## What changes were proposed in this pull request?

Patch the `config-deployment` ConfigMap in the `knative-serving` namespace via the devbox kustomization:

- `registries-skipping-tag-resolving: "localhost:30000,kind-registry:5000"` — skip tag→digest resolution for the local registry.
- `allow-http-registry: "true"` — allow the controller to talk to the registry over HTTP.

## How was this patch tested?

Built the devbox bundle and verified Knative Service revisions can pull images from the local HTTP registry.

### Labels

- fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.