### PR TITLE
ci: add PR labeler workflow for main/master branches

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+flyte2:
+  - base-branch: ['^main$']
+
+flyte:
+  - base-branch: ['^master$']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: "Pull Request Labeler"
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false


### PR DESCRIPTION
## Why are the changes needed?

The repo maintains two active lines of development on different default branches (`main` for Flyte 2 and `master` for Flyte 1). Triagers currently have to manually label PRs to distinguish which line they target, which is easy to miss.

## What changes were proposed in this pull request?

Adds an `actions/labeler@v5` workflow that automatically labels PRs based on their base branch:
- PRs targeting `main` get the `flyte2` label
- PRs targeting `master` get the `flyte` label

Files added:
- `.github/labeler.yml` — labeler configuration using `base-branch` regex matching
- `.github/workflows/labeler.yml` — workflow triggered on PR open/reopen/sync, with `pull-requests: write` permission

`sync-labels: false` so the action only adds labels and never removes user-applied ones.

## How was this patch tested?

Workflow will run on this PR itself — expect the `flyte2` label to be applied automatically once merged, since this PR targets `main`.

Note: the `flyte` and `flyte2` labels need to exist in the repo's label set for the action to apply them.

## Check all the applicable boxes

- [x] All commits are signed-off.