### PR TITLE
feat(flytestdlib): add namespaceutils package to v2

### DIFF
--- a/flytestdlib/namespaceutils/namespaceutils.go
+++ b/flytestdlib/namespaceutils/namespaceutils.go
@@ -1,7 +1,6 @@
 package namespaceutils
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -9,19 +8,16 @@ const orgTemplate = "{{ org }}"
 const projectTemplate = "{{ project }}"
 const domainTemplate = "{{ domain }}"
 
-const replaceAllInstancesOfString = -1
-
 // GetNamespaceName returns kubernetes namespace name according to user defined template from config
 func GetNamespaceName(template string, org, project, domain string) string {
-	var namespace = template
-	namespace = strings.Replace(namespace, orgTemplate, org, replaceAllInstancesOfString)
-	namespace = strings.Replace(namespace, projectTemplate, project, replaceAllInstancesOfString)
-	namespace = strings.Replace(namespace, domainTemplate, domain, replaceAllInstancesOfString)
-
-	return namespace
+	return strings.NewReplacer(
+		orgTemplate, org,
+		projectTemplate, project,
+		domainTemplate, domain,
+	).Replace(template)
 }
 
 // GetNameWithNamespacedPrefix returns a name with the given prefix prepended
 func GetNameWithNamespacedPrefix(prefix, name string) string {
-	return fmt.Sprintf("%s%s", prefix, name)
+	return prefix + name
 }

--- a/flytestdlib/namespaceutils/namespaceutils.go
+++ b/flytestdlib/namespaceutils/namespaceutils.go
@@ -1,0 +1,27 @@
+package namespaceutils
+
+import (
+	"fmt"
+	"strings"
+)
+
+const orgTemplate = "{{ org }}"
+const projectTemplate = "{{ project }}"
+const domainTemplate = "{{ domain }}"
+
+const replaceAllInstancesOfString = -1
+
+// GetNamespaceName returns kubernetes namespace name according to user defined template from config
+func GetNamespaceName(template string, org, project, domain string) string {
+	var namespace = template
+	namespace = strings.Replace(namespace, orgTemplate, org, replaceAllInstancesOfString)
+	namespace = strings.Replace(namespace, projectTemplate, project, replaceAllInstancesOfString)
+	namespace = strings.Replace(namespace, domainTemplate, domain, replaceAllInstancesOfString)
+
+	return namespace
+}
+
+// GetNameWithNamespacedPrefix returns a name with the given prefix prepended
+func GetNameWithNamespacedPrefix(prefix, name string) string {
+	return fmt.Sprintf("%s%s", prefix, name)
+}

--- a/flytestdlib/namespaceutils/namespaceutils_test.go
+++ b/flytestdlib/namespaceutils/namespaceutils_test.go
@@ -9,17 +9,20 @@ import (
 func TestGetNamespaceName(t *testing.T) {
 	testCases := []struct {
 		template string
+		org      string
 		project  string
 		domain   string
 		want     string
 	}{
-		{"prefix-{{ project }}-{{ domain }}", "flytesnacks", "production", "prefix-flytesnacks-production"},
-		{"{{ domain }}", "flytesnacks", "production", "production"},
-		{"{{ project }}", "flytesnacks", "production", "flytesnacks"},
+		{"prefix-{{ project }}-{{ domain }}", "", "flytesnacks", "production", "prefix-flytesnacks-production"},
+		{"{{ domain }}", "", "flytesnacks", "production", "production"},
+		{"{{ project }}", "", "flytesnacks", "production", "flytesnacks"},
+		{"{{ org }}-{{ project }}-{{ domain }}", "acme", "flytesnacks", "production", "acme-flytesnacks-production"},
+		{"{{ org }}", "acme", "flytesnacks", "production", "acme"},
 	}
 
 	for _, tc := range testCases {
-		got := GetNamespaceName(tc.template, "", tc.project, tc.domain)
+		got := GetNamespaceName(tc.template, tc.org, tc.project, tc.domain)
 		assert.Equal(t, tc.want, got)
 	}
 }

--- a/flytestdlib/namespaceutils/namespaceutils_test.go
+++ b/flytestdlib/namespaceutils/namespaceutils_test.go
@@ -1,0 +1,42 @@
+package namespaceutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNamespaceName(t *testing.T) {
+	testCases := []struct {
+		template string
+		project  string
+		domain   string
+		want     string
+	}{
+		{"prefix-{{ project }}-{{ domain }}", "flytesnacks", "production", "prefix-flytesnacks-production"},
+		{"{{ domain }}", "flytesnacks", "production", "production"},
+		{"{{ project }}", "flytesnacks", "production", "flytesnacks"},
+	}
+
+	for _, tc := range testCases {
+		got := GetNamespaceName(tc.template, "", tc.project, tc.domain)
+		assert.Equal(t, tc.want, got)
+	}
+}
+
+func TestGetNameWithNamespacedPrefix(t *testing.T) {
+	testCases := []struct {
+		prefix string
+		name   string
+		want   string
+	}{
+		{"project-domain-", "app", "project-domain-app"},
+		{"", "app", "app"},
+		{"prefix-", "", "prefix-"},
+	}
+
+	for _, tc := range testCases {
+		got := GetNameWithNamespacedPrefix(tc.prefix, tc.name)
+		assert.Equal(t, tc.want, got)
+	}
+}


### PR DESCRIPTION
## Why are the changes needed?

The `namespaceutils` package exists in v1 `flytestdlib` but is missing from v2. Downstream services that depend on v1 `flytestdlib/namespaceutils` cannot migrate to v2 without re-implementing or vendoring these utilities. This PR ports the package to v2 to enable a clean migration path.

## What changes were proposed in this pull request?

Adds `flytestdlib/namespaceutils/` to v2 with the same two functions as the v1 implementation:

- `GetNamespaceName(template, org, project, domain string) string` — builds a Kubernetes namespace name by substituting \`{{ org }}\`, \`{{ project }}\`, \`{{ domain }}\` placeholders in a template
- `GetNameWithNamespacedPrefix(prefix, name string) string` — concatenates a prefix and a name

The implementation is identical to the v1 package — just ported to the v2 module path.

## How was this patch tested?

The unit tests from v1 were ported alongside the source. Both functions are covered by table-driven tests:

- \`TestGetNamespaceName\`
- \`TestGetNameWithNamespacedPrefix\`

\`\`\`
$ go test ./flytestdlib/namespaceutils/
ok  	github.com/flyteorg/flyte/v2/flytestdlib/namespaceutils	0.300s
\`\`\`

### Labels

- **added**: new package in v2 flytestdlib

## Check all the applicable boxes

- [x] All new and existing tests passed.
- [x] All commits are signed-off.

* \#6583 <!-- branch-stack -->
  - **feat(flytestdlib): add namespaceutils package to v2** :point\_left:
