### PR TITLE
Inject INTERNAL_APP_ENDPOINT_PATTERN into KService pods for in-cluster app discovery

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -65,6 +65,11 @@ type InternalAppConfig struct {
 	// processes need to connect back to the Flyte manager.
 	DefaultEnvVars map[string]string `json:"defaultEnvVars" pflag:"-,Default env vars injected into every app pod"`
 
+	// NamespacedNamePrefixTemplate is the template for generating the INTERNAL_APP_ENDPOINT_PATTERN env var.
+	// Supported variables: {{ project }}, {{ domain }}, {{ org }}.
+	// Example: "{{ project }}-{{ domain }}-"
+	NamespacedNamePrefixTemplate string `json:"namespacedNamePrefixTemplate" pflag:",Template for internal app endpoint pattern (e.g., {{ project }}-{{ domain }}-)"`
+
 	// WatchBufferSize is the buffer size for each subscriber's event channel.
 	// A larger value reduces the chance of dropped events under burst load.
 	WatchBufferSize int `json:"watchBufferSize" pflag:",Buffer size for watch subscriber channels"`

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -65,10 +65,10 @@ type InternalAppConfig struct {
 	// processes need to connect back to the Flyte manager.
 	DefaultEnvVars map[string]string `json:"defaultEnvVars" pflag:"-,Default env vars injected into every app pod"`
 
-	// NamespacedNamePrefixTemplate is the template for generating the INTERNAL_APP_ENDPOINT_PATTERN env var.
-	// Supported variables: {{ project }}, {{ domain }}, {{ org }}.
-	// Example: "{{ project }}-{{ domain }}-"
-	NamespacedNamePrefixTemplate string `json:"namespacedNamePrefixTemplate" pflag:",Template for internal app endpoint pattern (e.g., {{ project }}-{{ domain }}-)"`
+	// NamespacedNameSuffixTemplate is the template for generating the INTERNAL_APP_ENDPOINT_PATTERN env var.
+	// Supported variables: {{ project }}, {{ domain }}.
+	// Example: "{{ project }}-{{ domain }}"
+	NamespacedNameSuffixTemplate string `json:"namespacedNameSuffixTemplate" pflag:",Template for internal app endpoint pattern (e.g., {{ project }}-{{ domain }})"`
 
 	// WatchBufferSize is the buffer size for each subscriber's event channel.
 	// A larger value reduces the chance of dropped events under burst load.
@@ -76,9 +76,10 @@ type InternalAppConfig struct {
 }
 
 var defaultInternalAppConfig = &InternalAppConfig{
-	DefaultRequestTimeout: 300 * time.Second,
-	MaxRequestTimeout:     3600 * time.Second,
-	WatchBufferSize:       100,
+	DefaultRequestTimeout:        300 * time.Second,
+	MaxRequestTimeout:            3600 * time.Second,
+	WatchBufferSize:              100,
+	NamespacedNameSuffixTemplate: "{{ project }}-{{ domain }}",
 }
 
 var internalAppConfigSection = config.MustRegisterSection(internalAppConfigSectionKey, defaultInternalAppConfig)

--- a/app/internal/k8s/app_client.go
+++ b/app/internal/k8s/app_client.go
@@ -494,6 +494,15 @@ func KServiceName(id *flyteapp.Identifier) string {
 	return prefix + "-" + suffix
 }
 
+// renderNamespacedSuffix substitutes {{ project }} and {{ domain }}
+// in a template string to produce the KService name suffix used in INTERNAL_APP_ENDPOINT_PATTERN.
+func renderNamespacedSuffix(tmpl, project, domain string) string {
+	return strings.NewReplacer(
+		"{{ project }}", strings.ToLower(project),
+		"{{ domain }}", strings.ToLower(domain),
+	).Replace(tmpl)
+}
+
 // marshalSpec serializes the App Spec proto and returns the raw bytes.
 func marshalSpec(spec *flyteapp.Spec) ([]byte, error) {
 	b, err := proto.Marshal(spec)
@@ -538,15 +547,13 @@ func (c *AppK8sClient) buildKService(app *flyteapp.App) (*servingv1.Service, err
 
 	// Inject INTERNAL_APP_ENDPOINT_PATTERN so app code can construct internal cluster URLs
 	// for other apps by substituting {app_fqdn} with the target app name.
-	// The pattern includes project and domain as a suffix to match the KService name format
+	// The suffix is rendered from NamespacedNamePrefixTemplate to match the KService name format
 	// {name}-{project}-{domain} used by KServiceName().
 	if len(podSpec.Containers) > 0 {
+		suffix := renderNamespacedSuffix(c.cfg.NamespacedNameSuffixTemplate, appID.GetProject(), appID.GetDomain())
 		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
-			Name: "INTERNAL_APP_ENDPOINT_PATTERN",
-			Value: fmt.Sprintf("http://{app_fqdn}-%s-%s.%s.svc.cluster.local",
-				strings.ToLower(appID.GetProject()),
-				strings.ToLower(appID.GetDomain()),
-				ns),
+			Name:  "INTERNAL_APP_ENDPOINT_PATTERN",
+			Value: fmt.Sprintf("http://{app_fqdn}-%s.%s.svc.cluster.local", suffix, ns),
 		})
 	}
 

--- a/app/internal/k8s/app_client.go
+++ b/app/internal/k8s/app_client.go
@@ -536,6 +536,20 @@ func (c *AppK8sClient) buildKService(app *flyteapp.App) (*servingv1.Service, err
 		podSpec.Containers[0].Env = append(defaults, podSpec.Containers[0].Env...)
 	}
 
+	// Inject INTERNAL_APP_ENDPOINT_PATTERN so app code can construct internal cluster URLs
+	// for other apps by substituting {app_fqdn} with the target app name.
+	// The pattern includes project and domain as a suffix to match the KService name format
+	// {name}-{project}-{domain} used by KServiceName().
+	if len(podSpec.Containers) > 0 {
+		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
+			Name: "INTERNAL_APP_ENDPOINT_PATTERN",
+			Value: fmt.Sprintf("http://{app_fqdn}-%s-%s.%s.svc.cluster.local",
+				strings.ToLower(appID.GetProject()),
+				strings.ToLower(appID.GetDomain()),
+				ns),
+		})
+	}
+
 	templateAnnotations := buildAutoscalingAnnotations(spec, c.cfg)
 
 	timeoutSecs := c.cfg.DefaultRequestTimeout.Seconds()

--- a/app/internal/k8s/app_client_test.go
+++ b/app/internal/k8s/app_client_test.go
@@ -487,6 +487,25 @@ func TestKServiceName(t *testing.T) {
 	}
 }
 
+func TestRenderNamespacedSuffix(t *testing.T) {
+	tests := []struct {
+		tmpl    string
+		project string
+		domain  string
+		want    string
+	}{
+		{"{{ project }}-{{ domain }}", "myproject", "dev", "myproject-dev"},
+		{"{{ project }}-{{ domain }}", "MyProject", "Dev", "myproject-dev"},
+		{"{{ project }}-{{ domain }}", "proj", "prod", "proj-prod"},
+		{"custom-{{ domain }}", "proj", "dev", "custom-dev"},
+		{"", "proj", "dev", ""},
+	}
+	for _, tt := range tests {
+		got := renderNamespacedSuffix(tt.tmpl, tt.project, tt.domain)
+		assert.Equal(t, tt.want, got)
+	}
+}
+
 func TestPodDeploymentStatus(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/app/internal/k8s/app_client_test.go
+++ b/app/internal/k8s/app_client_test.go
@@ -100,6 +100,27 @@ func TestDeploy_Create(t *testing.T) {
 	assert.Equal(t, "proj/dev/myapp", ksvc.Annotations[annotationAppID])
 }
 
+func TestDeploy_InjectsInternalAppEndpointPattern(t *testing.T) {
+	c := testClient(t)
+	c.cfg.NamespacedNameSuffixTemplate = "{{ project }}-{{ domain }}"
+	app := testApp("proj", "dev", "myapp", "nginx:latest")
+	require.NoError(t, c.Deploy(context.Background(), app))
+
+	ksvc := &servingv1.Service{}
+	require.NoError(t, c.k8sClient.Get(context.Background(),
+		client.ObjectKey{Name: "myapp-proj-dev", Namespace: AppNamespace}, ksvc))
+
+	envVars := ksvc.Spec.Template.Spec.Containers[0].Env
+	var pattern string
+	for _, e := range envVars {
+		if e.Name == "INTERNAL_APP_ENDPOINT_PATTERN" {
+			pattern = e.Value
+			break
+		}
+	}
+	assert.Equal(t, "http://{app_fqdn}-proj-dev.flyte.svc.cluster.local", pattern)
+}
+
 func TestDeploy_UpdateOnSpecChange(t *testing.T) {
 	c := testClient(t)
 	app := testApp("proj", "dev", "myapp", "nginx:1.0")


### PR DESCRIPTION
## Why are the changes needed?
When multiple Flyte apps run in the same cluster (e.g. a Gradio app calling a vLLM model-serving app), apps need to call each other via the internal Kubernetes service URL (*.flyte.svc.cluster.local). Previouly the `INTERNAL_APP_ENDPOINT_PATTERN` env var — which the Flyte SDK's `AppEndpoint` uses to resolve internal URLs — was never injected into KService pods. This meant `AppEndpoint(app_name="...")` had no pattern to resolve against, and developers had to manually construct and hardcode the full internal cluster URL.

## What changes were proposed in this pull request?

 - Inject `INTERNAL_APP_ENDPOINT_PATTERN` into every KService container at deploy time  in buildKService. The value is a URL template with an {app_fqdn} placeholder that the SDK substitutes at runtime with the target app's name:                         
                                                                  
  `http://{app_fqdn}-{project}-{domain}.flyte.svc.cluster.local`
                                                                                     
 - The project and domain are baked in as a suffix to match Flyte's KService naming convention ({name}-{project}-{domain}). When the SDK resolves AppEndpoint(app_name="gemma4-26b") in project flytesnacks / domain development, it produces:                                                       
                                                          
  `http://gemma4-26b-flytesnacks-development.flyte.svc.cluster.local`

 - No auth is required on this path (bypasses ingress), and traffic stays in-cluster

### Code Changes                                                                                         
  - `app/config/config.go` — adds `NamespacedNameSuffixTemplate` field to `InternalAppConfig` 
  - `app/internal/k8s/app_client.go` — injects `INTERNAL_APP_ENDPOINT_PATTERN` in `buildKService`   

## How was this patch tested?

 Verified using the `app_calling_app` SDK example (`examples/apps/app_calling_app/app.py`). After this change, hitting `app2-calls-app1.../greeting/world` correctly proxies through to app1 via the internal cluster URL

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
