### PR TITLE
ci(build-ci-image): use pull_request_target so fork PRs can access DEPOT_PROJECT_ID

### DIFF
--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -7,7 +7,11 @@ on:
     paths:
       - 'gen.Dockerfile'
       - '.github/workflows/build-ci-image.yml'
-  pull_request:
+  # SECURITY: pull_request_target runs in the BASE repo context so repo
+  # variables (vars.DEPOT_PROJECT_ID) are available for fork PRs. The
+  # checkout below pins to the PR head SHA so fork-authored Dockerfile
+  # content is what gets built. Image push tag is namespaced to pr-<N>.
+  pull_request_target:
     paths:
       - 'gen.Dockerfile'
       - '.github/workflows/build-ci-image.yml'
@@ -38,6 +42,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
       - name: Validate Depot project id
         run: |
@@ -77,7 +84,7 @@ jobs:
       - name: Set image tag output
         id: set-tag
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
+          if [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "pull_request_target" ]; then
             echo "tag=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" == "refs/heads/v2" ]; then
             echo "tag=v2" >> $GITHUB_OUTPUT
@@ -106,7 +113,7 @@ jobs:
         run: echo "Image built with digest ${{ steps.build.outputs.digest }}"
 
       - name: Comment on PR with image tag
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -7,10 +7,6 @@ on:
     paths:
       - 'gen.Dockerfile'
       - '.github/workflows/build-ci-image.yml'
-  # SECURITY: pull_request_target runs in the BASE repo context so repo
-  # variables (vars.DEPOT_PROJECT_ID) are available for fork PRs. The
-  # checkout below pins to the PR head SHA so fork-authored Dockerfile
-  # content is what gets built. Image push tag is namespaced to pr-<N>.
   pull_request_target:
     paths:
       - 'gen.Dockerfile'

--- a/.github/workflows/check-generate.yml
+++ b/.github/workflows/check-generate.yml
@@ -48,6 +48,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 workflow_id: 'build-ci-image.yml',
+                event: 'pull_request_target',
                 per_page: 10
               });
 

--- a/.github/workflows/check-generate.yml
+++ b/.github/workflows/check-generate.yml
@@ -48,7 +48,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 workflow_id: 'build-ci-image.yml',
-                event: 'pull_request',
                 per_page: 10
               });
 


### PR DESCRIPTION
## Why

Same root cause as #7320 (which fixed \`flyte-binary-v2.yml\`): the \`Build and Publish CI Docker Image\` workflow validates and uses \`vars.DEPOT_PROJECT_ID\`, but GitHub does **not** pass repository variables to workflows triggered by \`pull_request\` events from forks. As a result, the \`Validate Depot project id\` step fails on every fork PR (e.g. PR #7326 from \`Sovietaced/flyte\`):

\`\`\`
##[error]DEPOT_PROJECT_ID repo variable is not set.
\`\`\`

## What changed

- \`pull_request\` → \`pull_request_target\` so \`vars.*\` is available.
- \`actions/checkout@v4\` pinned to \`github.event.pull_request.head.sha || github.sha\` with \`persist-credentials: false\` so the workflow builds the PR's Dockerfile (default for \`pull_request_target\` would be the base ref) without leaking the base-repo \`GITHUB_TOKEN\` into fork-controlled code.
- \`event_name == 'pull_request'\` checks updated to also match \`pull_request_target\`.

## Security considerations

- The image push tag is namespaced to \`pr-<N>\`, so fork PRs can only push to their own PR-scoped tag, not overwrite \`latest\`/\`v2\`.
- The PR comment step is also bounded to the triggering PR.
- The base-repo value exposed to fork code is \`vars.DEPOT_PROJECT_ID\` (a public Depot project id, not a credential). Auth to Depot uses OIDC.

## Test plan

- [ ] In-repo branches still build and push.
- [ ] After merge, fork PR #7326 re-runs and \`Validate Depot project id\` passes.
- [ ] Fork PR builds publish under \`pr-<N>\` tag, no overwrite of \`latest\`.