### PR TITLE
ci: switch ci trigger to pull_request_target for check-generate workflow

### DIFF
--- a/.github/workflows/check-generate.yml
+++ b/.github/workflows/check-generate.yml
@@ -1,7 +1,7 @@
 name: Check Generated Files
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -11,11 +11,14 @@ jobs:
       contents: read
       actions: read
       packages: read
+      issues: read
     outputs:
       image: ${{ steps.docker-image.outputs.image }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Determine Docker image
         id: docker-image
@@ -52,10 +55,16 @@ jobs:
                 per_page: 10
               });
 
-              // Find the run for this PR
-              const prRun = runs.workflow_runs.find(run =>
-                run.head_sha === context.payload.pull_request.head.sha
-              );
+              // For pull_request_target from forks, run.pull_requests is always empty (GitHub API limitation).
+              // Fall back to matching by head_sha for fork PRs.
+              const prNumber = context.issue.number;
+              const prHeadSha = context.payload.pull_request.head.sha;
+              const prRun = runs.workflow_runs.find(run => {
+                if (Array.isArray(run.pull_requests) && run.pull_requests.length > 0) {
+                  return run.pull_requests.some(pr => pr.number === prNumber);
+                }
+                return run.head_sha === prHeadSha;
+              });
 
               if (prRun) {
                 console.log(`Found workflow run: ${prRun.html_url}`);
@@ -95,6 +104,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache cargo artifacts
         uses: actions/cache@v4
@@ -139,6 +150,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run go mod tidy and check
         run: |
@@ -158,6 +171,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run mockery and check
         run: |


### PR DESCRIPTION
## Tracking issue
Related to: (https://github.com/flyteorg/flyte/issues/6845)

## Why are the changes needed?

Because the fork PR doesn't have permission to push the ci image to ghcr.io when it is built with the related files are changed.
So change the workflow trigger to pull_request_target.

## What changes were proposed in this pull request?

`check-generate.yml`
- Changed the workflow trigger to pull_request_target in check-generate.yml.
- Add other method to find the pr and check if it is running.
- Add ref in check code to use the code from head repo.


## How was this patch tested?

Test by the workflow being trigger in ci process.

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

Original PR: #6952 #7040 

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
