### PR TITLE
fix(dataproxy): GetActionData returns empty inputs for sub-actions

### DIFF
--- a/dataproxy/service/dataproxy_service.go
+++ b/dataproxy/service/dataproxy_service.go
@@ -492,11 +492,7 @@ func (s *Service) GetActionData(
 
 	if urisResp.Msg.GetInputsUri() != "" {
 		group.Go(func() error {
-			baseRef := storage.DataReference(urisResp.Msg.GetInputsUri())
-			inputRef, err := s.dataStore.ConstructReference(groupCtx, baseRef, "inputs.pb")
-			if err != nil {
-				return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to construct input ref: %w", err))
-			}
+			inputRef := storage.DataReference(urisResp.Msg.GetInputsUri())
 			logger.Infof(groupCtx, "GetActionData: reading inputs from %s", inputRef)
 			if err := s.dataStore.ReadProtobuf(groupCtx, inputRef, resp.Inputs); err != nil {
 				if !storage.IsNotFound(err) {

--- a/dataproxy/service/dataproxy_service_test.go
+++ b/dataproxy/service/dataproxy_service_test.go
@@ -544,14 +544,14 @@ func TestGetActionData(t *testing.T) {
 	}{
 		{
 			name:             "success with both inputs and outputs",
-			inputsURI:        "s3://test-bucket/inputs-dir",
+			inputsURI:        "s3://test-bucket/inputs-dir/inputs.pb",
 			outputsURI:       "s3://test-bucket/outputs/outputs.pb",
 			expectInputsLen:  1,
 			expectOutputsLen: 1,
 		},
 		{
 			name:             "success with only inputs",
-			inputsURI:        "s3://test-bucket/inputs-dir",
+			inputsURI:        "s3://test-bucket/inputs-dir/inputs.pb",
 			outputsURI:       "",
 			expectInputsLen:  1,
 			expectOutputsLen: 0,
@@ -577,7 +577,7 @@ func TestGetActionData(t *testing.T) {
 		},
 		{
 			name:          "read inputs error propagates",
-			inputsURI:     "s3://test-bucket/inputs-dir",
+			inputsURI:     "s3://test-bucket/inputs-dir/inputs.pb",
 			readInputsErr: assertErr("read failed"),
 			wantErr:       true,
 		},
@@ -605,7 +605,7 @@ func TestGetActionData(t *testing.T) {
 			mockComposedStore := storageMocks.NewComposedProtobufStore(t)
 
 			if tt.inputsURI != "" {
-				expectedInputRef := storage.DataReference(tt.inputsURI + "/inputs.pb")
+				expectedInputRef := storage.DataReference(tt.inputsURI)
 				call := mockComposedStore.On("ReadProtobuf", mock.Anything, expectedInputRef, mock.Anything)
 				if tt.readInputsErr != nil {
 					call.Return(tt.readInputsErr).Maybe()

--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -316,7 +316,7 @@ func (s *RunService) persistRunModel(
 	triggerType string,
 ) (*models.Run, error) {
 	// Store task spec and compute digest
-	info := &workflow.RunInfo{InputsUri: inputPrefix}
+	info := &workflow.RunInfo{InputsUri: inputPrefix + "/inputs.pb"}
 	taskSpecModel, err := models.NewTaskSpecModel(ctx, taskSpec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create task spec model: %w", err)

--- a/runs/service/run_service_test.go
+++ b/runs/service/run_service_test.go
@@ -1407,7 +1407,7 @@ func TestCreateRun_WithOffloadedInputData(t *testing.T) {
 	actionRepo.On("CreateAction", mock.Anything, mock.MatchedBy(func(m *models.Run) bool {
 		var info workflow.RunInfo
 		_ = proto.Unmarshal(m.DetailedInfo, &info)
-		return info.InputsUri == offloadedURI
+		return info.InputsUri == offloadedURI+"/inputs.pb"
 	}), mock.Anything).Return(expectedRun, nil).Once()
 	actionsClient.On("Enqueue", mock.MatchedBy(func(_ context.Context) bool { return true }), mock.MatchedBy(func(req *connect.Request[actions.EnqueueRequest]) bool {
 		return req.Msg.Action.InputUri == offloadedURI


### PR DESCRIPTION
## Tracking issue

n/a

## Why are the changes needed?

`GetActionData` works for root actions but returns empty inputs for sub-actions. Verified against a live cluster:

- Root action stored `RunInfo.InputsUri = s3://flyte-data/uploads/.../offloaded-inputs/<hash>` (prefix only).
- Sub-action stored `RunInfo.InputsUri = s3://flyte-data/.../<sub>/inputs.pb` (full path).

`dataproxy.GetActionData` unconditionally appended `inputs.pb` to the stored URI:

```go
baseRef := storage.DataReference(urisResp.Msg.GetInputsUri())
inputRef, _ := s.dataStore.ConstructReference(groupCtx, baseRef, "inputs.pb")
```

For root that resolved to the real file; for sub-actions it produced `.../inputs.pb/inputs.pb` and 404'd silently.

## What changes were proposed in this pull request?

Normalize on storing the full file path in `RunInfo.InputsUri` and let the dataproxy read it verbatim:

- `runs/service/run_service.go`: `persistRunModel` now stores `inputPrefix + "/inputs.pb"`, matching what sub-actions already store via `recordSingleAction`.
- `dataproxy/service/dataproxy_service.go`: drop the `ConstructReference(..., "inputs.pb")` and read `InputsUri` directly.

## How was this patch tested?

- Updated unit tests in `dataproxy/service/dataproxy_service_test.go` and `runs/service/run_service_test.go` to reflect the new contract.
- `go test ./dataproxy/service/... ./runs/service/...` passes.
- Verified the bug end-to-end against a local cluster (DB + RustFS) before the fix.

### Labels

fixed

## Check all the applicable boxes

- [x] I updated the documentation accordingly. (n/a)
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
