### PR TITLE
handle azure Gen2 storage path when parsing ref

### DIFF
--- a/flytestdlib/storage/storage.go
+++ b/flytestdlib/storage/storage.go
@@ -165,13 +165,13 @@ func (r DataReference) Split() (scheme, container, key string, err error) {
 		return "", "", "", err
 	}
 
-	// Handle storage URLs that use @ to separate container/bucket name from the storage endpoint.
-	// When url.Parse encounters the @ symbol, it treats the part before @ as User and the part after as Host.
-	// Example: Azure ADLS Gen2 uses abfs://container@storageaccount.dfs.core.windows.net/path format.
-	if u.User != nil && u.User.Username() != "" {
+	// Azure ADLS Gen2 encodes the filesystem in the userinfo position:
+	// abfs[s]://container@storageaccount.dfs.core.windows.net/path. url.Parse puts "container" in
+	// u.User and the storage account in u.Host, so pull the container from userinfo for these schemes.
+	// Other schemes keep using u.Host so URLs like s3://accessKey:secret@bucket/key still parse correctly.
+	container = u.Host
+	if (u.Scheme == "abfs" || u.Scheme == "abfss") && u.User != nil && u.User.Username() != "" {
 		container = u.User.Username()
-	} else {
-		container = u.Host
 	}
 
 	return u.Scheme, container, strings.Trim(u.Path, "/"), nil

--- a/flytestdlib/storage/storage.go
+++ b/flytestdlib/storage/storage.go
@@ -165,7 +165,16 @@ func (r DataReference) Split() (scheme, container, key string, err error) {
 		return "", "", "", err
 	}
 
-	return u.Scheme, u.Host, strings.Trim(u.Path, "/"), nil
+	// Handle storage URLs that use @ to separate container/bucket name from the storage endpoint.
+	// When url.Parse encounters the @ symbol, it treats the part before @ as User and the part after as Host.
+	// Example: Azure ADLS Gen2 uses abfs://container@storageaccount.dfs.core.windows.net/path format.
+	if u.User != nil && u.User.Username() != "" {
+		container = u.User.Username()
+	} else {
+		container = u.Host
+	}
+
+	return u.Scheme, container, strings.Trim(u.Path, "/"), nil
 }
 
 func (r DataReference) String() string {

--- a/flytestdlib/storage/storage_test.go
+++ b/flytestdlib/storage/storage_test.go
@@ -20,13 +20,45 @@ func TestDataReference_New(t *testing.T) {
 }
 
 func TestDataReference_Split(t *testing.T) {
-	input := DataReference("s3://container/path/to/file")
-	scheme, container, key, err := input.Split()
+	t.Run("S3 URL", func(t *testing.T) {
+		input := DataReference("s3://container/path/to/file")
+		scheme, container, key, err := input.Split()
 
-	assert.NoError(t, err)
-	assert.Equal(t, "s3", scheme)
-	assert.Equal(t, "container", container)
-	assert.Equal(t, "path/to/file", key)
+		assert.NoError(t, err)
+		assert.Equal(t, "s3", scheme)
+		assert.Equal(t, "container", container)
+		assert.Equal(t, "path/to/file", key)
+	})
+
+	t.Run("Azure ADLS Gen2 URL with storage account", func(t *testing.T) {
+		input := DataReference("abfs://mycontainer@mystorageaccount.dfs.core.windows.net/path/to/file")
+		scheme, container, key, err := input.Split()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "abfs", scheme)
+		assert.Equal(t, "mycontainer", container)
+		assert.Equal(t, "path/to/file", key)
+	})
+
+	t.Run("Azure ADLS Gen2 URL without path", func(t *testing.T) {
+		input := DataReference("abfs://mycontainer@mystorageaccount.dfs.core.windows.net")
+		scheme, container, key, err := input.Split()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "abfs", scheme)
+		assert.Equal(t, "mycontainer", container)
+		assert.Equal(t, "", key)
+	})
+
+	t.Run("GCS URL", func(t *testing.T) {
+		input := DataReference("gs://bucket/path/to/object")
+		scheme, container, key, err := input.Split()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "gs", scheme)
+		assert.Equal(t, "bucket", container)
+		assert.Equal(t, "path/to/object", key)
+	})
 }
 
 func ExampleNewDataStore() {

--- a/flytestdlib/storage/storage_test.go
+++ b/flytestdlib/storage/storage_test.go
@@ -59,6 +59,26 @@ func TestDataReference_Split(t *testing.T) {
 		assert.Equal(t, "bucket", container)
 		assert.Equal(t, "path/to/object", key)
 	})
+
+	t.Run("Azure ADLS Gen2 URL with abfss scheme", func(t *testing.T) {
+		input := DataReference("abfss://mycontainer@mystorageaccount.dfs.core.windows.net/path/to/file")
+		scheme, container, key, err := input.Split()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "abfss", scheme)
+		assert.Equal(t, "mycontainer", container)
+		assert.Equal(t, "path/to/file", key)
+	})
+
+	t.Run("S3 URL with userinfo keeps host as container", func(t *testing.T) {
+		input := DataReference("s3://accessKey:secret@bucket/path/to/file")
+		scheme, container, key, err := input.Split()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "s3", scheme)
+		assert.Equal(t, "bucket", container)
+		assert.Equal(t, "path/to/file", key)
+	})
 }
 
 func ExampleNewDataStore() {


### PR DESCRIPTION
## Summary
- Cherry-picks the ABFS Gen2 path-parsing fix from the legacy `flytestdlib` repo (original PR: https://github.com/flyteorg/flytestdlib/pull/841) onto `main`.
- Fixes `DataReference.Split` for Azure ADLS Gen2 (`abfs://container@account.dfs.core.windows.net/path`) URLs, where `url.Parse` puts the container in the `User` field instead of `Host`.
- Scopes the `u.User.Username()` override to `abfs`/`abfss` so `s3://accessKey:secret@bucket/key`-style URLs still return `bucket` as the container.
- Adds a regression test for the S3-with-userinfo case and an `abfss` test.

## Test plan
- [x] `go test ./flytestdlib/storage/... -run TestDataReference`

🤖 Generated with [Claude Code](https://claude.com/claude-code)