### PR TITLE
fix: stop Knative apps privately + keep UI state accurate after stop/start

### DIFF
--- a/app/internal/k8s/app_client.go
+++ b/app/internal/k8s/app_client.go
@@ -52,7 +52,11 @@ const (
 	annotationAppOrg  = "flyte.org/app-org"
 	annotationSpec    = "flyte.org/spec"
 
-	maxScaleZero = "0"
+	labelAppStopped        = "flyte.org/app-stopped"
+	labelKnativeVisibility = "networking.knative.dev/visibility"
+	visibilityClusterLocal = "cluster-local"
+
+	scaleZero = "0"
 
 	// maxKServiceNameLen is the Kubernetes DNS label limit.
 	maxKServiceNameLen = 63
@@ -64,8 +68,8 @@ type AppK8sClientInterface interface {
 	// the update if the spec SHA annotation is unchanged.
 	Deploy(ctx context.Context, app *flyteapp.App) error
 
-	// Stop scales the KService to zero by setting max-scale=0. The KService CRD
-	// is kept so the app can be restarted later.
+	// Stop scales the KService to zero and makes it cluster-local (not published to external gateway).
+	// The KService CRD is kept so the app can be restarted later.
 	Stop(ctx context.Context, appID *flyteapp.Identifier) error
 
 	// GetApp reads the KService and returns the full App including reconstructed Spec and live Status.
@@ -165,7 +169,13 @@ func (c *AppK8sClient) Deploy(ctx context.Context, app *flyteapp.App) error {
 		return fmt.Errorf("failed to get KService %s: %w", name, err)
 	}
 
-	if existing.Annotations[annotationSpecSHA] == ksvc.Annotations[annotationSpecSHA] {
+	// Always update when the existing KService is in stopped state,
+	// even if the spec SHA is unchanged. Stop() marks the KService with a label
+	// without touching the spec SHA annotation, so an unchanged spec would
+	// otherwise cause Deploy() to skip the update and leave it stopped.
+	existingStopped := existing.Labels != nil && existing.Labels[labelAppStopped] == "true"
+
+	if !existingStopped && existing.Annotations[annotationSpecSHA] == ksvc.Annotations[annotationSpecSHA] {
 		logger.Debugf(ctx, "KService %s/%s spec unchanged, skipping update", ns, name)
 		return nil
 	}
@@ -180,6 +190,9 @@ func (c *AppK8sClient) Deploy(ctx context.Context, app *flyteapp.App) error {
 	for k, v := range ksvc.Labels {
 		existing.Labels[k] = v
 	}
+	// Deploy implies "start": clear stop/private labels applied by Stop().
+	delete(existing.Labels, labelAppStopped)
+	delete(existing.Labels, labelKnativeVisibility)
 	if existing.Annotations == nil {
 		existing.Annotations = make(map[string]string)
 	}
@@ -193,22 +206,47 @@ func (c *AppK8sClient) Deploy(ctx context.Context, app *flyteapp.App) error {
 	return nil
 }
 
-// Stop sets max-scale=0 on the KService, scaling it to zero without deleting it.
+// Stop makes the app unreachable from the public gateway and scales it to zero without deleting the KService.
 func (c *AppK8sClient) Stop(ctx context.Context, appID *flyteapp.Identifier) error {
 	ns := AppNamespace
 	name := KServiceName(appID)
-	patch := []byte(`{"spec":{"template":{"metadata":{"annotations":{"autoscaling.knative.dev/max-scale":"0"}}}}}`)
+	// Make the Service cluster-local so it is not published to the external gateway,
+	// and set initial/min scale to zero so it converges to 0 pods.
+	// initial-scale=0 requires allow-zero-initial-scale=true in config-autoscaler.
+	patch := []byte(fmt.Sprintf(
+		`{"metadata":{"labels":{"%s":"true","%s":"%s"}},"spec":{"template":{"metadata":{"annotations":{"autoscaling.knative.dev/min-scale":"%s","autoscaling.knative.dev/initial-scale":"%s"}}}}}`,
+		labelAppStopped,
+		labelKnativeVisibility,
+		visibilityClusterLocal,
+		scaleZero,
+		scaleZero,
+	))
 	ksvc := &servingv1.Service{}
 	ksvc.Name = name
 	ksvc.Namespace = ns
 	if err := c.k8sClient.Patch(ctx, ksvc, client.RawPatch(types.MergePatchType, patch)); err != nil {
 		if k8serrors.IsNotFound(err) {
-			// Already stopped/deleted — treat as success.
 			return nil
 		}
 		return fmt.Errorf("failed to patch KService %s to stop: %w", name, err)
 	}
-	logger.Infof(ctx, "Stopped KService %s/%s (max-scale=0)", ns, name)
+
+	// The patch above updates the revision template, which creates a new Revision.
+	// To ensure running pods are terminated immediately (instead of waiting for the
+	// stable window with no traffic), delete the latest ready Revision.
+	current := &servingv1.Service{}
+	if err := c.k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: ns}, current); err == nil {
+		if revName := current.Status.LatestReadyRevisionName; revName != "" {
+			rev := &servingv1.Revision{}
+			rev.Name = revName
+			rev.Namespace = ns
+			if delErr := c.k8sClient.Delete(ctx, rev); delErr != nil && !k8serrors.IsNotFound(delErr) {
+				logger.Warnf(ctx, "Failed to delete Revision %s/%s to stop: %v", ns, revName, delErr)
+			}
+		}
+	}
+
+	logger.Infof(ctx, "Stopped KService %s/%s (cluster-local, scaled to zero)", ns, name)
 	return nil
 }
 
@@ -748,16 +786,14 @@ func knativeCondToAppCondition(kCond knativeapis.Condition, serviceReady, servic
 // kserviceToStatus maps a KService's conditions to a flyteapp.Status proto.
 // It fetches the latest ready Revision to read the accurate ActualReplicas count.
 func (c *AppK8sClient) kserviceToStatus(ctx context.Context, ksvc *servingv1.Service) *flyteapp.Status {
-	// Check if max-scale=0 is set — explicitly stopped by the control plane.
-	if ann := ksvc.Spec.Template.Annotations; ann != nil {
-		if ann["autoscaling.knative.dev/max-scale"] == maxScaleZero {
-			return &flyteapp.Status{
-				Conditions: []*flyteapp.Condition{{
-					DeploymentStatus:   flyteapp.Status_DEPLOYMENT_STATUS_STOPPED,
-					Message:            "App scaled to zero",
-					LastTransitionTime: timestamppb.Now(),
-				}},
-			}
+	// Check if the Service is explicitly stopped by the control plane.
+	if ksvc.Labels != nil && ksvc.Labels[labelAppStopped] == "true" {
+		return &flyteapp.Status{
+			Conditions: []*flyteapp.Condition{{
+				DeploymentStatus:   flyteapp.Status_DEPLOYMENT_STATUS_STOPPED,
+				Message:            "App scaled to zero",
+				LastTransitionTime: timestamppb.Now(),
+			}},
 		}
 	}
 
@@ -766,7 +802,13 @@ func (c *AppK8sClient) kserviceToStatus(ctx context.Context, ksvc *servingv1.Ser
 	serviceFailed := readyCond != nil && readyCond.IsFalse()
 	var conditions []*flyteapp.Condition
 	for i := range ksvc.Status.Conditions {
-		if cond := knativeCondToAppCondition(ksvc.Status.Conditions[i], serviceReady, serviceFailed); cond != nil {
+		kCond := ksvc.Status.Conditions[i]
+		// Knative condition sets may surface both RoutesReady=Unknown and Ready=Unknown.
+		// Emit only the overall Ready in this case, since it's what the UI cares about.
+		if kCond.Type == servingv1.ServiceConditionRoutesReady && kCond.Status == corev1.ConditionUnknown {
+			continue
+		}
+		if cond := knativeCondToAppCondition(kCond, serviceReady, serviceFailed); cond != nil {
 			conditions = append(conditions, cond)
 		}
 	}

--- a/app/internal/k8s/app_client.go
+++ b/app/internal/k8s/app_client.go
@@ -973,11 +973,16 @@ func (c *AppK8sClient) kserviceToApp(ctx context.Context, ksvc *servingv1.Servic
 		Name:    parts[2],
 	}
 
+	spec := specFromAnnotation(ksvc)
+	if spec != nil && ksvc.Labels[labelAppStopped] == "true" {
+		spec.DesiredState = flyteapp.Spec_DESIRED_STATE_STOPPED
+	}
+
 	return &flyteapp.App{
 		Metadata: &flyteapp.Meta{
 			Id: appID,
 		},
-		Spec:   specFromAnnotation(ksvc),
+		Spec:   spec,
 		Status: c.kserviceToStatus(ctx, ksvc),
 	}, nil
 }

--- a/app/internal/k8s/app_client_test.go
+++ b/app/internal/k8s/app_client_test.go
@@ -732,6 +732,19 @@ func testKsvc(name, ns, rv string) *servingv1.Service {
 
 // --- Status message format tests ---
 
+func TestKserviceToApp_StoppedDesiredState(t *testing.T) {
+	c := testClient(t)
+	app := testApp("proj", "dev", "myapp", "nginx:latest")
+
+	require.NoError(t, c.Deploy(context.Background(), app))
+	require.NoError(t, c.Stop(context.Background(), app.Metadata.Id))
+
+	got, err := c.GetApp(context.Background(), app.Metadata.Id)
+	require.NoError(t, err)
+	assert.Equal(t, flyteapp.Spec_DESIRED_STATE_STOPPED, got.GetSpec().GetDesiredState(),
+		"stopped app should have DesiredState=STOPPED in the returned spec")
+}
+
 func TestKserviceToStatus_Messages(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/app/internal/k8s/app_client_test.go
+++ b/app/internal/k8s/app_client_test.go
@@ -134,6 +134,34 @@ func TestDeploy_SkipUpdateWhenUnchanged(t *testing.T) {
 	assert.Equal(t, initialRV, ksvc.ResourceVersion, "resource version should not change on no-op deploy")
 }
 
+func TestDeploy_AfterStop_ClearsStoppedLabels(t *testing.T) {
+	// Regression: Deploy() was skipping the update when the spec SHA was unchanged,
+	// even if Stop() had marked the KService as stopped. Clicking "Start App" in the UI sends
+	// the same spec, so the SHA matched and the app could never restart.
+	c := testClient(t)
+	app := testApp("proj", "dev", "myapp", "nginx:latest")
+	require.NoError(t, c.Deploy(context.Background(), app))
+
+	id := &flyteapp.Identifier{Project: "proj", Domain: "dev", Name: "myapp"}
+	require.NoError(t, c.Stop(context.Background(), id))
+
+	ksvc := &servingv1.Service{}
+	require.NoError(t, c.k8sClient.Get(context.Background(),
+		client.ObjectKey{Name: "myapp-proj-dev", Namespace: AppNamespace}, ksvc))
+	assert.Equal(t, "true", ksvc.Labels[labelAppStopped], "app-stopped label should be set after Stop")
+	assert.Equal(t, visibilityClusterLocal, ksvc.Labels[labelKnativeVisibility], "service should be cluster-local after Stop")
+
+	// Deploy same spec (as "Start App" would) — must not skip due to SHA match.
+	require.NoError(t, c.Deploy(context.Background(), app))
+
+	require.NoError(t, c.k8sClient.Get(context.Background(),
+		client.ObjectKey{Name: "myapp-proj-dev", Namespace: AppNamespace}, ksvc))
+	_, stopped := ksvc.Labels[labelAppStopped]
+	assert.False(t, stopped, "app-stopped label must be cleared after Deploy following a Stop")
+	_, visibility := ksvc.Labels[labelKnativeVisibility]
+	assert.False(t, visibility, "visibility label must be cleared after Deploy following a Stop")
+}
+
 func TestStop(t *testing.T) {
 	c := testClient(t)
 	app := testApp("proj", "dev", "myapp", "nginx:latest")
@@ -145,7 +173,10 @@ func TestStop(t *testing.T) {
 	ksvc := &servingv1.Service{}
 	require.NoError(t, c.k8sClient.Get(context.Background(),
 		client.ObjectKey{Name: "myapp-proj-dev", Namespace: AppNamespace}, ksvc))
-	assert.Equal(t, "0", ksvc.Spec.Template.Annotations["autoscaling.knative.dev/max-scale"])
+	assert.Equal(t, "true", ksvc.Labels[labelAppStopped])
+	assert.Equal(t, visibilityClusterLocal, ksvc.Labels[labelKnativeVisibility])
+	assert.Equal(t, "0", ksvc.Spec.Template.Annotations["autoscaling.knative.dev/min-scale"])
+	assert.Equal(t, "0", ksvc.Spec.Template.Annotations["autoscaling.knative.dev/initial-scale"])
 }
 
 func TestStop_NotFound(t *testing.T) {
@@ -153,6 +184,66 @@ func TestStop_NotFound(t *testing.T) {
 	id := &flyteapp.Identifier{Project: "proj", Domain: "dev", Name: "missing"}
 	// Should succeed silently — already gone.
 	require.NoError(t, c.Stop(context.Background(), id))
+}
+
+func TestStop_DeletesLatestReadyRevision(t *testing.T) {
+	// When a KService has a LatestReadyRevisionName, Stop() must delete that
+	// Revision so its Deployment and pods are immediately terminated.
+	// Updating the KService template alone is not sufficient — it does not immediately terminate existing pods.
+	// for the autoscaler and does not kill running pods; they only scale down after
+	// the stable window (~60s) with no traffic.
+	s := testScheme(t)
+	ksvc := &servingv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myapp-proj-dev",
+			Namespace: AppNamespace,
+			Labels: map[string]string{
+				labelAppManaged: "true",
+				labelProject:    "proj",
+				labelDomain:     "dev",
+				labelAppName:    "myapp",
+			},
+			Annotations: map[string]string{
+				annotationAppID: "proj/dev/myapp",
+			},
+		},
+	}
+	ksvc.Status.LatestReadyRevisionName = "myapp-proj-dev-00001"
+
+	rev := &servingv1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myapp-proj-dev-00001",
+			Namespace: AppNamespace,
+		},
+	}
+
+	fc := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(ksvc, rev).
+		WithStatusSubresource(ksvc).
+		Build()
+	c := &AppK8sClient{
+		k8sClient: fc,
+		cfg:       &config.InternalAppConfig{},
+	}
+
+	id := &flyteapp.Identifier{Project: "proj", Domain: "dev", Name: "myapp"}
+	require.NoError(t, c.Stop(context.Background(), id))
+
+	// KService must be marked stopped so Deploy can reliably clear the stopped state.
+	gotKsvc := &servingv1.Service{}
+	require.NoError(t, fc.Get(context.Background(),
+		client.ObjectKey{Name: "myapp-proj-dev", Namespace: AppNamespace}, gotKsvc))
+	assert.Equal(t, "true", gotKsvc.Labels[labelAppStopped],
+		"KService must carry the app-stopped label after Stop")
+	assert.Equal(t, visibilityClusterLocal, gotKsvc.Labels[labelKnativeVisibility],
+		"KService must be cluster-local after Stop")
+
+	// LatestReadyRevision must be deleted so its pods are terminated immediately.
+	gotRev := &servingv1.Revision{}
+	err := fc.Get(context.Background(),
+		client.ObjectKey{Name: "myapp-proj-dev-00001", Namespace: AppNamespace}, gotRev)
+	assert.True(t, k8serrors.IsNotFound(err), "LatestReadyRevision must be deleted after Stop")
 }
 
 func TestDelete(t *testing.T) {
@@ -582,7 +673,6 @@ func TestSubscribe_ReceivesEvent(t *testing.T) {
 	}
 }
 
-
 func TestSubscribe_AppSpecificDoesNotReceiveOtherApps(t *testing.T) {
 	c := testClient(t)
 	ch := c.Subscribe("app1")
@@ -712,10 +802,10 @@ func TestKserviceToStatus_Messages(t *testing.T) {
 			name: "stopped",
 			ksvc: func() *servingv1.Service {
 				ksvc := testKsvc("myapp", AppNamespace, "1")
-				if ksvc.Spec.Template.Annotations == nil {
-					ksvc.Spec.Template.Annotations = map[string]string{}
+				if ksvc.Labels == nil {
+					ksvc.Labels = map[string]string{}
 				}
-				ksvc.Spec.Template.Annotations["autoscaling.knative.dev/max-scale"] = "0"
+				ksvc.Labels[labelAppStopped] = "true"
 				return ksvc
 			},
 			wantConditions: []struct {

--- a/app/service/app_service.go
+++ b/app/service/app_service.go
@@ -69,10 +69,29 @@ func (s *AppService) Get(
 	if err != nil {
 		return nil, err
 	}
-	if ok && appID.AppId != nil && s.cache != nil {
+	if ok && appID.AppId != nil && s.cache != nil && !isTransitionalState(resp.Msg.GetApp()) {
 		s.cache.Add(cacheKey(appID.AppId), resp.Msg.GetApp())
 	}
 	return resp, nil
+}
+
+// isTransitionalState returns true when the app has a non-stopped desired state
+// but is currently reporting a stopped status. This happens in the window between
+// a Start action and K8s actually bringing the pod up; caching in that window
+// would lock the UI into showing "stopped" for the full TTL on every poll cycle.
+func isTransitionalState(app *flyteapp.App) bool {
+	if app == nil {
+		return false
+	}
+	if app.GetSpec().GetDesiredState() == flyteapp.Spec_DESIRED_STATE_STOPPED {
+		return false
+	}
+	for _, cond := range app.GetStatus().GetConditions() {
+		if cond.GetDeploymentStatus() == flyteapp.Status_DEPLOYMENT_STATUS_STOPPED {
+			return true
+		}
+	}
+	return false
 }
 
 // Update forwards to InternalAppService and invalidates the cache entry.

--- a/app/service/app_service_test.go
+++ b/app/service/app_service_test.go
@@ -161,6 +161,88 @@ func TestGet_CacheExpired_CallsInternal(t *testing.T) {
 	internal.AssertExpectations(t)
 }
 
+func TestGet_TransitionalState_SkipsCache(t *testing.T) {
+	// Simulate the Start-App bug: after clicking Start, K8s hasn't brought the
+	// pod up yet so InternalAppService still returns STOPPED. The cache must NOT
+	// be populated in this state, otherwise every poll for the full TTL window
+	// returns stale "stopped" and the UI appears stuck.
+	internal := &mockInternalClient{}
+	svc := NewAppService(internal, 30*time.Second)
+
+	appID := testAppID()
+	// App desired=ACTIVE but status=STOPPED (transitional: just started).
+	stoppedApp := &flyteapp.App{
+		Metadata: &flyteapp.Meta{Id: appID},
+		Spec: &flyteapp.Spec{
+			AppPayload: &flyteapp.Spec_Container{
+				Container: &flytecoreapp.Container{Image: "nginx:latest"},
+			},
+			DesiredState: flyteapp.Spec_DESIRED_STATE_ACTIVE,
+		},
+		Status: &flyteapp.Status{
+			Conditions: []*flyteapp.Condition{
+				{DeploymentStatus: flyteapp.Status_DEPLOYMENT_STATUS_STOPPED},
+			},
+		},
+	}
+
+	// Internal is called twice because the response is never cached.
+	internal.On("Get", mock.Anything, mock.Anything).Return(
+		connect.NewResponse(&flyteapp.GetResponse{App: stoppedApp}), nil,
+	).Times(2)
+
+	req := connect.NewRequest(&flyteapp.GetRequest{
+		Identifier: &flyteapp.GetRequest_AppId{AppId: appID},
+	})
+	_, err := svc.Get(context.Background(), req)
+	require.NoError(t, err)
+	_, err = svc.Get(context.Background(), req)
+	require.NoError(t, err)
+
+	_, hit := svc.cache.Get(cacheKey(appID))
+	assert.False(t, hit, "transitional state must not be cached")
+	internal.AssertExpectations(t)
+}
+
+func TestGet_StoppedWithDesiredStopped_Caches(t *testing.T) {
+	// Stable stopped state (user explicitly stopped it) should be cached normally.
+	internal := &mockInternalClient{}
+	svc := NewAppService(internal, 30*time.Second)
+
+	appID := testAppID()
+	stoppedApp := &flyteapp.App{
+		Metadata: &flyteapp.Meta{Id: appID},
+		Spec: &flyteapp.Spec{
+			AppPayload: &flyteapp.Spec_Container{
+				Container: &flytecoreapp.Container{Image: "nginx:latest"},
+			},
+			DesiredState: flyteapp.Spec_DESIRED_STATE_STOPPED,
+		},
+		Status: &flyteapp.Status{
+			Conditions: []*flyteapp.Condition{
+				{DeploymentStatus: flyteapp.Status_DEPLOYMENT_STATUS_STOPPED},
+			},
+		},
+	}
+
+	// Internal called once; second call served from cache.
+	internal.On("Get", mock.Anything, mock.Anything).Return(
+		connect.NewResponse(&flyteapp.GetResponse{App: stoppedApp}), nil,
+	).Once()
+
+	req := connect.NewRequest(&flyteapp.GetRequest{
+		Identifier: &flyteapp.GetRequest_AppId{AppId: appID},
+	})
+	_, err := svc.Get(context.Background(), req)
+	require.NoError(t, err)
+	_, err = svc.Get(context.Background(), req)
+	require.NoError(t, err)
+
+	_, hit := svc.cache.Get(cacheKey(appID))
+	assert.True(t, hit, "stable stopped state should be cached")
+	internal.AssertExpectations(t)
+}
+
 // --- Create / Update / Delete invalidate cache ---
 
 func TestCreate_InvalidatesCache(t *testing.T) {

--- a/docker/devbox-bundled/Makefile
+++ b/docker/devbox-bundled/Makefile
@@ -190,6 +190,8 @@ setup-knative:
 		--patch '{"data":{"domain-template":"{{.Name}}.{{.Domain}}"}}'
 	kubectl patch configmap/config-domain -n knative-serving --type merge \
 		--patch '{"data":{"local.flyte.app":null,"localhost":""}}'
+	kubectl patch configmap/config-autoscaler -n knative-serving --type merge \
+		--patch '{"data":{"allow-zero-initial-scale":"true"}}'
 	kubectl patch svc/kourier -n kourier-system --type merge \
 		--patch '{"spec":{"type":"NodePort","ports":[{"name":"http2","port":80,"targetPort":8080,"nodePort":30081}]}}'
 

--- a/docker/devbox-bundled/kustomize/complete/kustomization.yaml
+++ b/docker/devbox-bundled/kustomize/complete/kustomization.yaml
@@ -57,6 +57,14 @@ patches:
       registries-skipping-tag-resolving: "localhost:30000,kind-registry:5000"
       allow-http-registry: "true"
 - patch: |-
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-autoscaler
+      namespace: knative-serving
+    data:
+      allow-zero-initial-scale: "true"
+- patch: |-
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:

--- a/docker/devbox-bundled/kustomize/dev/kustomization.yaml
+++ b/docker/devbox-bundled/kustomize/dev/kustomization.yaml
@@ -47,6 +47,14 @@ patches:
       registries-skipping-tag-resolving: "localhost:30000,kind-registry:5000"
       allow-http-registry: "true"
 - patch: |-
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-autoscaler
+      namespace: knative-serving
+    data:
+      allow-zero-initial-scale: "true"
+- patch: |-
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -7832,6 +7832,7 @@ metadata:
 ---
 apiVersion: v1
 data:
+  allow-zero-initial-scale: "true"
   max-scale: "1"
 kind: ConfigMap
 metadata:

--- a/docker/devbox-bundled/manifests/dev.yaml
+++ b/docker/devbox-bundled/manifests/dev.yaml
@@ -7548,6 +7548,7 @@ metadata:
 ---
 apiVersion: v1
 data:
+  allow-zero-initial-scale: "true"
   max-scale: "1"
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
## Why are the changes needed?

Users expect “Stop App” to (1) scale the app down to zero and (2) make the public ingress inaccessible. The prior approach relied on `autoscaling.knative.dev/max-scale: "0"` as a stop signal, but in Knative that value represents “unlimited” upper bound, so it didn’t reliably enforce the intended stop semantics. Separately, the UI polls/Get calls can briefly show stale “stopped” state during stop→start transitions because the control plane can cache transitional responses while the data plane is still converging.


## What changes were proposed in this pull request?
 - Replaced the incorrect max-scale=0 stop semantics with Knative-native behavior:
 - Stop() labels the Knative Service `networking.knative.dev/visibility=cluster-local` so it is not published to the external gateway (public ingress becomes inaccessible).
 - Stop() marks the Service with `flyte.org/app-stopped=true` as the control-plane source of truth for STOPPED state.
 - Stop() sets `autoscaling.knative.dev/min-scale="0"` and `autoscaling.knative.dev/initial-scale="0"` to converge cleanly to zero pods.
 - Stop() deletes the latest ready Revision so existing pods terminate immediately (no waiting for the stable window).
 - Deploy() (“Start”) clears the stopped/private labels so the service becomes externally routable again.
 - Status mapping now treats STOPPED based on `flyte.org/app-stopped` (not max-scale).
 
### Devbox / cluster configuration
 - Enabled `config-autoscaler.allow-zero-initial-scale="true"` in devbox-bundled kustomize overlays and rendered manifests.
 - Updated `docker/devbox-bundled/Makefile` setup-knative to also patch config-autoscaler so the “manual install” path matches the bundled manifests behavior.

### UI correctness / control-plane behavior
 - Added a small TTL cache in the control-plane AppService for Get responses to reduce cross-plane chatter, while explicitly avoiding caching “transitional” stop/start windows (desired state running, but status still stopped) so the UI doesn’t get stuck showing STOPPED after clicking Start.

## How was this patch tested?
 - Unit tests:
   - go test ./app/internal/k8s
   - go test ./app/service
   - Manual verification (devbox / cluster):
       - Create app → confirm public URL reachable.
       - Stop app → confirm pods scale to 0 and public URL is not reachable (service is cluster-local).
       - Start app → confirm visibility label cleared, service becomes publicly reachable again, and UI
      transitions to ACTIVE without being stuck in STOPPED due to caching.
  

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
