### PR TITLE
fix: make copilot task metadata parsing nil-safe

### DIFF
--- a/executor/pkg/plugin/task_exec_metadata.go
+++ b/executor/pkg/plugin/task_exec_metadata.go
@@ -100,6 +100,7 @@ func NewTaskExecutionMetadata(ta *flyteorgv1.TaskAction) (pluginsCore.TaskExecut
 	generatedName := buildGeneratedName(ta)
 	retryAttempt := attemptToRetry(ta.Status.Attempts)
 	maxAttempts := maxAttemptsFromTaskTemplate(ta.Spec.TaskTemplate)
+	taskID := taskIDFromTaskTemplate(ta.Spec.TaskTemplate)
 
 	return &taskExecutionMetadata{
 		ownerID: types.NamespacedName{
@@ -118,6 +119,7 @@ func NewTaskExecutionMetadata(ta *flyteorgv1.TaskAction) (pluginsCore.TaskExecut
 					NodeId: ta.Spec.ActionName,
 				},
 				RetryAttempt: retryAttempt,
+				TaskId:       taskID,
 			},
 		},
 		namespace: ta.Namespace,
@@ -167,6 +169,20 @@ func maxAttemptsFromTaskTemplate(data []byte) uint32 {
 	}
 
 	return md.GetRetries().GetRetries() + 1
+}
+
+func taskIDFromTaskTemplate(data []byte) *core.Identifier {
+	if len(data) == 0 {
+		return nil
+	}
+	tmpl := &core.TaskTemplate{}
+	if err := proto.Unmarshal(data, tmpl); err != nil {
+		return nil
+	}
+	if tmpl.GetId() == nil {
+		return nil
+	}
+	return proto.Clone(tmpl.GetId()).(*core.Identifier)
 }
 
 // buildOverridesFromTaskTemplate deserializes the task template and extracts resource requirements.

--- a/executor/pkg/plugin/task_exec_metadata_test.go
+++ b/executor/pkg/plugin/task_exec_metadata_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 )
 
 func TestNewTaskExecutionMetadata_UsesProjectedRunContext(t *testing.T) {
@@ -53,4 +55,38 @@ func TestNewTaskExecutionMetadata_UserEnvVarsCannotClobberInternal(t *testing.T)
 	require.Equal(t, "run-name", env["RUN_NAME"])
 	require.Equal(t, "s3://bucket/run", env["_U_RUN_BASE"])
 	require.Equal(t, "allowed", env["USER_VAR"])
+}
+
+func TestNewTaskExecutionMetadata_UsesTaskTemplateID(t *testing.T) {
+	taskID := &core.Identifier{
+		ResourceType: core.ResourceType_TASK,
+		Project:      "project",
+		Domain:       "development",
+		Name:         "task-name",
+		Version:      "version",
+	}
+	taskTemplate, err := proto.Marshal(&core.TaskTemplate{Id: taskID})
+	require.NoError(t, err)
+
+	taskAction := &flyteorgv1.TaskAction{
+		Spec: flyteorgv1.TaskActionSpec{
+			Project:       "project",
+			Domain:        "development",
+			RunName:       "run-name",
+			ActionName:    "action-name",
+			RunOutputBase: "s3://bucket/run",
+			TaskTemplate:  taskTemplate,
+		},
+	}
+
+	meta, err := NewTaskExecutionMetadata(taskAction)
+	require.NoError(t, err)
+
+	got := meta.GetTaskExecutionID().GetID().GetTaskId()
+	require.NotNil(t, got)
+	require.Equal(t, taskID.GetResourceType(), got.GetResourceType())
+	require.Equal(t, taskID.GetProject(), got.GetProject())
+	require.Equal(t, taskID.GetDomain(), got.GetDomain())
+	require.Equal(t, taskID.GetName(), got.GetName())
+	require.Equal(t, taskID.GetVersion(), got.GetVersion())
 }

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -213,8 +213,8 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 		return nil
 	}
 
-	//nolint:protogetter
-	logger.Infof(ctx, "CoPilot Enabled for task [%s]", taskExecMetadata.GetTaskExecutionID().GetID().TaskId.GetName())
+	taskName := taskExecMetadata.GetTaskExecutionID().GetID().GetTaskId().GetName()
+	logger.Infof(ctx, "CoPilot Enabled for task [%s]", taskName)
 	if iFace != nil {
 		if iFace.Inputs != nil && len(iFace.Inputs.Variables) > 0 {
 			inPath := cfg.DefaultInputDataPath
@@ -224,7 +224,7 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 
 			// TODO we should calculate input volume size based on the size of the inputs which is known ahead of time. We should store that as part of the metadata
 			size := CalculateStorageSize(taskExecMetadata.GetOverrides().GetResources())
-			logger.Infof(ctx, "Adding Input path [%s] of Size [%d] for Task [%s]", inPath, size, taskExecMetadata.GetTaskExecutionID().GetID().TaskId.Name)
+			logger.Infof(ctx, "Adding Input path [%s] of Size [%v] for Task [%s]", inPath, size, taskName)
 			inputsVolumeMount := v1.VolumeMount{
 				Name:      cfg.InputVolumeName,
 				MountPath: inPath,
@@ -253,7 +253,7 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 			}
 
 			size := CalculateStorageSize(taskExecMetadata.GetOverrides().GetResources())
-			logger.Infof(ctx, "Adding Output path [%s] of size [%d] for Task [%s]", size, outPath, taskExecMetadata.GetTaskExecutionID().GetID().TaskId.Name)
+			logger.Infof(ctx, "Adding Output path [%s] of size [%v] for Task [%s]", outPath, size, taskName)
 
 			outputsVolumeMount := v1.VolumeMount{
 				Name:      cfg.OutputVolumeName,

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
@@ -528,6 +528,48 @@ func TestAddCoPilotToPod(t *testing.T) {
 		assertPodHasCoPilot(t, cfg, pilot, iface, &pod)
 	})
 
+	t.Run("nil-task-id", func(t *testing.T) {
+		pod := v1.PodSpec{}
+		iface := &core.TypedInterface{
+			Inputs: &core.VariableMap{
+				Variables: []*core.VariableEntry{
+					{Key: "x", Value: &core.Variable{Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_INTEGER}}}},
+				},
+			},
+			Outputs: &core.VariableMap{
+				Variables: []*core.VariableEntry{
+					{Key: "o", Value: &core.Variable{Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_INTEGER}}}},
+				},
+			},
+		}
+		pilot := &core.DataLoadingConfig{
+			Enabled:    true,
+			InputPath:  "in",
+			OutputPath: "out",
+		}
+		tID := &pluginsCoreMock.TaskExecutionID{}
+		tID.EXPECT().GetID().Return(&core.TaskExecutionIdentifier{})
+		metadata := &pluginsCoreMock.TaskExecutionMetadata{}
+		metadata.EXPECT().GetTaskExecutionID().Return(tID)
+		overrides := &pluginsCoreMock.TaskOverrides{}
+		overrides.EXPECT().GetResources().Return(resourceRequirements)
+		metadata.EXPECT().GetOverrides().Return(overrides)
+
+		inputPaths := &pluginsIOMock.InputFilePaths{}
+		inputPaths.EXPECT().GetInputPath().Return(storage.DataReference("/base/inputs/inputs.pb"))
+
+		outputPaths := &pluginsIOMock.OutputFilePaths{}
+		outputPaths.EXPECT().GetOutputPrefixPath().Return(storage.DataReference("/output"))
+		outputPaths.EXPECT().GetRawOutputPrefix().Return(storage.DataReference("/raw"))
+
+		var err error
+		assert.NotPanics(t, func() {
+			err = AddCoPilotToPod(ctx, cfg, &pod, iface, metadata, inputPaths, outputPaths, pilot)
+		})
+		assert.NoError(t, err)
+		assertPodHasCoPilot(t, cfg, pilot, iface, &pod)
+	})
+
 	t.Run("happy-nil-iface", func(t *testing.T) {
 		pod := v1.PodSpec{}
 		pilot := &core.DataLoadingConfig{


### PR DESCRIPTION
## Tracking issue

N/A

## Why are the changes needed?

Flyte v2 devbox could panic while reconciling a CoPilot-enabled `TaskAction`. The panic was caused by CoPilot logging dereferencing `TaskExecutionIdentifier.TaskId` directly when that field could be nil (`flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go:227`). The v2 executor metadata path now derives that task id from the inline task template instead of leaving it absent (`executor/pkg/plugin/task_exec_metadata.go`).

## What changes were proposed in this pull request?

- Populate `TaskExecutionIdentifier.TaskId` from the inline serialized `TaskTemplate.id`.
- Make CoPilot task-name logging nil-safe when task metadata is incomplete.
- Fix the CoPilot output log argument order.

## How was this patch tested?

Added focused unit coverage for:
- Task id propagation from `TaskTemplate.id` into executor metadata.
- CoPilot handling when `TaskExecutionIdentifier.TaskId` is nil.

Ran:

```bash
go test ./executor/pkg/plugin ./flyteplugins/go/tasks/pluginmachinery/flytek8s
```

Also built and imported a patched `flyte-binary-v2:sandbox` image into the local devbox containerd for manual validation.

### Labels

fixed

### Setup process

N/A

### Logs

Observed before the fix:

```text
{"json":{"src":"copilot.go:176"},"level":"info","msg":"Enabling CoPilot on main container [rtn8lvm8dnm6v6lmwppw-6rhn6rc8kwr6u1xzo28zwh14-0]","ts":"2026-05-07T14:21:06Z"}
{"json":{"src":"copilot.go:217"},"level":"info","msg":"CoPilot Enabled for task []","ts":"2026-05-07T14:21:06Z"}
2026-05-07T14:21:06Z    INFO    Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference        {"controller": "taskaction", "controllerGroup": "flyte.org", "controllerKind": "TaskAction", "TaskAction": {"name":"rtn8lvm8dnm6v6lmwppw-6rhn6rc8kwr6u1xzo28zwh14","namespace":"flyte"}, "namespace": "flyte", "name": "rtn8lvm8dnm6v6lmwppw-6rhn6rc8kwr6u1xzo28zwh14", "reconcileID": "72ea04c7-faf8-4fa6-9f55-6f8c8055c873"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x23f5150]

goroutine 594 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:116 +0x19c
panic({0x2ff96e0?, 0x6570f10?})
        /usr/local/go/src/runtime/panic.go:792 +0x124
github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s.AddCoPilotToPod({0x3f445a8, 0x400c07bcb0}, {{0x38754fa, 0xe}, {0x4000f32f30, 0x2a}, {0x387f12b, 0x11}, {0x388290d, 0x12}, ...}, ...)
        /flyteorg/build/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go:227 +0x440
github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s.ApplyFlytePodConfiguration({0x3f445a8, 0x400c07bcb0}, {0x3f6bb40, 0x400b9d15e0}, 0x400b9dcd88, 0x400c0f00f0, {0x400c0bc150, 0x2f})
        /flyteorg/build/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go:584 +0x9c0
github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/pod.plugin.BuildResource({}, {0x3f445a8, 0x400c07bcb0}, {0x3f6bb40, 0x400b9d15e0})
        /flyteorg/build/flyteplugins/go/tasks/plugins/k8s/pod/plugin.go:121 +0x7dc
github.com/flyteorg/flyte/v2/executor/pkg/plugin/k8s.(*PluginManager).launchResource(0x40000dc3c0, {0x3f445a8, 0x400c07bcb0}, {0x3f6bb40, 0x400b9d15e0})
        /flyteorg/build/executor/pkg/plugin/k8s/plugin_manager.go:100 +0x54
github.com/flyteorg/flyte/v2/executor/pkg/plugin/k8s.(*PluginManager).Handle(0x40000dc3c0, {0x3f445a8, 0x400c07bcb0}, {0x3f6bb40, 0x400b9d15e0})
        /flyteorg/build/executor/pkg/plugin/k8s/plugin_manager.go:222 +0x31c
github.com/flyteorg/flyte/v2/executor/pkg/controller.(*TaskActionReconciler).Reconcile(0x40011114a0, {0x3f445a8, 0x400c07bcb0}, {{{0x400b6f63d6?, 0x5?}, {0x400b6a0150?, 0x400bda1d08?}}})
        /flyteorg/build/executor/pkg/controller/taskaction_controller.go:312 +0x7d8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x3f54578?, {0x3f445a8?, 0x400c07bcb0?}, {{{0x400b6f63d6?, 0xb?}, {0x400b6a0150?, 0x0?}}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:119 +0x80
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0x4001111540, {0x3f445e0, 0x4000989b80}, {0x329b7c0, 0x400117bac0})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:316 +0x2c8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0x4001111540, {0x3f445e0, 0x4000989b80})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266 +0x150
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227 +0x70
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 561
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:223 +0x3fc

```

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] Relevant tests passed.
- [x] All commits are signed-off.

## Related PRs

N/A

## Stack

<!-- branch-stack -->

## Docs link

N/A