### PR TITLE
Cache image-pull-secret reads in webhook via controller-runtime informer

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/secret/secrets_injector.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/secrets_injector.go
@@ -6,6 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret/config"
@@ -62,8 +63,27 @@ func newSecretsInjector(
 			return nil, fmt.Errorf("failed to add core v1 to scheme: %w", err)
 		}
 
+		secretInformerCache, err := ctrlcache.New(kubeConfig, ctrlcache.Options{
+			Scheme: ctrlRuntimeScheme,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create informer cache: %w", err)
+		}
+
+		go func() {
+			if err := secretInformerCache.Start(ctx); err != nil {
+				logger.Errorf(ctx, "secret informer cache stopped: %v", err)
+			}
+		}()
+		if !secretInformerCache.WaitForCacheSync(ctx) {
+			return nil, fmt.Errorf("secret informer cache failed to sync")
+		}
+
 		ctrlRuntimeClient, err := client.New(kubeConfig, client.Options{
 			Scheme: ctrlRuntimeScheme,
+			Cache: &client.CacheOptions{
+				Reader: secretInformerCache,
+			},
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create controller-runtime client: %w", err)


### PR DESCRIPTION
## Tracking issue

<!-- N/A -->

## Why are the changes needed?

The embedded secret manager's mutating webhook (`flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go`) issues two synchronous `kube-apiserver` `Get` calls per pod admission to resolve image pull secrets when `EmbeddedSecretManagerConfig.ImagePullSecrets.Enabled` is set:

1. `findAndAddImagePullSecret` reads the reference `corev1.Secret` from the configured reference namespace.
2. `addImagePullSecretToPod` reads the mirrored `corev1.Secret` from the pod's namespace (and creates it on first sight).

The controller-runtime client used for these reads is constructed via bare `client.New(...)`, which is a direct (non-cached) client. Every admission round-trips to the API server, which is unnecessary load at scale (high pod churn across many namespaces).

## What changes were proposed in this pull request?

Replace the bare `client.New` in `flyteplugins/go/tasks/pluginmachinery/secret/secrets_injector.go` with a cache-backed delegating client:

- A `controller-runtime` informer cache is created and started for the lifetime of the webhook.
- The cache watches Secrets cluster-wide; reads served from the informer, writes (the `Create` of the mirrored secret) still go through the API server.
- `WaitForCacheSync` blocks startup until the informer is ready, so the first admission isn't a guaranteed cache miss.

The existing in-process `SecretValue` cache (`stdlibCache`) is unrelated and is left unchanged — it caches values pulled from external secret managers (AWS / GCP / Azure / Vault), not the k8s `Secret` objects that back the image pull.

## How was this patch tested?

- `go build ./flyteplugins/go/tasks/pluginmachinery/secret/... ./executor/...` — clean.
- `go vet ./flyteplugins/go/tasks/pluginmachinery/secret/... ./executor/...` — clean.
- `go test ./flyteplugins/go/tasks/pluginmachinery/secret/... -count=1` — all pass.

Manual verification of the runtime path (informer behavior under list/watch on Secrets, `WaitForCacheSync` blocking startup, informer-driven invalidation when reference secrets change) is recommended in a staging cluster before promoting.

### Labels

- **changed**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

Companion PR in the v1 fork: unionai/flyte#969