### PR TITLE
fix(flytek8s): classify ImagePullBackOff caused by registry 429 as system error

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -1327,6 +1327,15 @@ func classifyWaitingContainer(waiting *v1.ContainerStateWaiting, c v1.PodConditi
 	case "ImagePullBackOff":
 		gracePeriod := config.GetK8sPluginConfig().ImagePullBackoffGracePeriod.Duration
 		if time.Since(t) >= gracePeriod {
+			if isRegistryRateLimited(waiting.Message) {
+				// Registry rate limiting (HTTP 429) is not caused by the user
+				// and is a transient infrastructure problem. Classify as a
+				// system-retryable failure so it does not consume the user's
+				// retry budget.
+				return pluginsCore.PhaseInfoSystemRetryableFailureWithCleanup(finalReason, GetMessageAfterGracePeriod(finalMessage, gracePeriod), &pluginsCore.TaskInfo{
+					OccurredAt: &t,
+				}), t
+			}
 			return pluginsCore.PhaseInfoRetryableFailureWithCleanup(finalReason, GetMessageAfterGracePeriod(finalMessage, gracePeriod), &pluginsCore.TaskInfo{
 				OccurredAt: &t,
 			}), t
@@ -1353,6 +1362,13 @@ func classifyWaitingContainer(waiting *v1.ContainerStateWaiting, c v1.PodConditi
 
 func GetMessageAfterGracePeriod(message string, gracePeriod time.Duration) string {
 	return fmt.Sprintf("Grace period [%s] exceeded|%s", gracePeriod, message)
+}
+
+// isRegistryRateLimited reports whether an ImagePullBackOff message indicates
+// the container runtime hit HTTP 429 Too Many Requests against the image
+// registry — a transient infrastructure failure outside the user's control.
+func isRegistryRateLimited(message string) bool {
+	return strings.Contains(message, "429 Too Many Requests")
 }
 
 func DemystifySuccess(status v1.PodStatus, info pluginsCore.TaskInfo) (pluginsCore.PhaseInfo, error) {

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -2575,6 +2575,29 @@ func TestDemystifyPending(t *testing.T) {
 		assert.True(t, taskStatus.CleanupOnFailure())
 	})
 
+	t.Run("ImagePullBackOffOutsideGracePeriod_RegistryRateLimited", func(t *testing.T) {
+		// HTTP 429 from the registry is a transient infrastructure failure,
+		// not a user error — it should surface as a system retryable failure.
+		s2 := *s.DeepCopy()
+		s2.Conditions[0].LastTransitionTime.Time = metav1.Now().Add(-config.GetK8sPluginConfig().ImagePullBackoffGracePeriod.Duration)
+		s2.ContainerStatuses = []v1.ContainerStatus{
+			{
+				Ready: false,
+				State: v1.ContainerState{
+					Waiting: &v1.ContainerStateWaiting{
+						Reason:  "ImagePullBackOff",
+						Message: `Back-off pulling image "registry.example.com/foo:bar": ErrImagePull: failed to pull and unpack image "registry.example.com/foo:bar": failed to copy: httpReadSeeker: failed open: unexpected status code https://registry.example.com/v2/foo/blobs/sha256:abc: 429 Too Many Requests`,
+					},
+				},
+			},
+		}
+		taskStatus, err := DemystifyPending(s2, pluginsCore.TaskInfo{})
+		assert.NoError(t, err)
+		assert.Equal(t, pluginsCore.PhaseRetryableFailure, taskStatus.Phase())
+		assert.Equal(t, core.ExecutionError_SYSTEM, taskStatus.Err().Kind)
+		assert.True(t, taskStatus.CleanupOnFailure())
+	})
+
 	t.Run("InvalidImageName", func(t *testing.T) {
 		s.ContainerStatuses = []v1.ContainerStatus{
 			{


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
Container runtimes surface registry rate limiting (HTTP 429 Too Many Requests) through the `ImagePullBackOff` waiting reason. Today, once the `ImagePullBackoffGracePeriod` elapses, `DemystifyPending` returns `PhaseInfoRetryableFailureWithCleanup`, which is classified as a **USER** error and consumes the user's retry budget.

429s from the registry are an infrastructure problem outside the user's control — typically transient throttling on the registry side. Misclassifying them as user errors means a transient registry rate-limit can exhaust a task's user retries even though the user did nothing wrong.

Example real-world pod waiting message:
```
Back-off pulling image "us-central1-docker.pkg.dev/.../internal-gnina:...": ErrImagePull: failed to pull and unpack image "...": failed to copy: httpReadSeeker: failed open: unexpected status code https://us-central1-docker.pkg.dev/v2/...: 429 Too Many Requests
```

## What changes were proposed in this pull request?
- `pod_helper.go`: in `classifyWaitingContainer`, after the `ImagePullBackOff` grace period, detect the `429 Too Many Requests` substring in the waiting message and return `PhaseInfoSystemRetryableFailureWithCleanup` instead of `PhaseInfoRetryableFailureWithCleanup`.
- Add small helper `isRegistryRateLimited(message string) bool`.
- All other `ImagePullBackOff` messages keep their existing user-error classification.

## How was this patch tested?
- New unit test `TestDemystifyPending/ImagePullBackOffOutsideGracePeriod_RegistryRateLimited` exercises a realistic 429 waiting message and asserts `core.ExecutionError_SYSTEM`.
- Existing `ImagePullBackOffOutsideGracePeriod` (non-429) test continues to pass, confirming the default classification is unchanged.
- `go test ./go/tasks/pluginmachinery/flytek8s/...` passes locally.

### Labels
- fixed

### Setup process
N/A

### Screenshots
N/A

## Check all the applicable boxes
- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
N/A

## Docs link
N/A