### PR TITLE
Fix incorrect "not found" error check.

### DIFF
--- a/flytectl/cmd/config/subcommand/matchable_attr_file_config_utils.go
+++ b/flytectl/cmd/config/subcommand/matchable_attr_file_config_utils.go
@@ -52,7 +52,7 @@ func DumpTaskResourceAttr(matchableAttrConfig interface{}, fileName string) erro
 		if err := WriteConfigToFile(matchableAttrConfig, fileName); err != nil {
 			return fmt.Errorf("error dumping in file due to %v", err)
 		}
-		fmt.Printf("wrote the config to file %v", fileName)
+		fmt.Printf("wrote the config to file %v\n", fileName)
 	} else {
 		fmt.Printf("%v", String(matchableAttrConfig))
 	}

--- a/flytectl/cmd/get/matchable_workflow_execution_config.go
+++ b/flytectl/cmd/get/matchable_workflow_execution_config.go
@@ -8,10 +8,9 @@ import (
 	sconfig "github.com/flyteorg/flyte/flytectl/cmd/config/subcommand"
 	"github.com/flyteorg/flyte/flytectl/cmd/config/subcommand/workflowexecutionconfig"
 	cmdCore "github.com/flyteorg/flyte/flytectl/cmd/core"
+	"github.com/flyteorg/flyte/flytectl/pkg/ext"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const (
@@ -141,7 +140,7 @@ func getWorkflowExecutionConfigFunc(ctx context.Context, args []string, cmdCtx c
 	// Updates the workflowExecutionConfigFileConfig with the fetched matchable attribute
 	if err := FetchAndUnDecorateMatchableAttr(ctx, project, domain, workflowName, cmdCtx.AdminFetcherExt(),
 		&workflowExecutionConfigFileConfig, admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG); err != nil {
-		if grpcError := status.Code(err); grpcError == codes.NotFound && workflowexecutionconfig.DefaultFetchConfig.Gen {
+		if ext.IsNotFoundError(err) && workflowexecutionconfig.DefaultFetchConfig.Gen {
 			fmt.Println("Generating a sample workflow execution config file")
 			workflowExecutionConfigFileConfig = getSampleWorkflowExecutionFileConfig(project, domain, workflowName)
 		} else {


### PR DESCRIPTION
## Why are the changes needed?

So far, the following command would fail:
```
$ flytectl get workflow-execution-config -p PROJECT -d DOMAIN --attrFile FILE --gen
Error: attribute not found
```

The attribute file is not written.

## What changes were proposed in this pull request?

The above command failed because the command line parsing code would check the error returned by `FetchAndUnDecorateMatchableAttr` for a gRPC "not found" error but `AdminFetcherExtClient` maps this gRPC code to an internal `NotFoundError` type: It is this error that we need to check for.

This PR adapts the error check, which unbreaks attribute file generation. (While at it, I also added a missing '\n' to a log message.)

## How was this patch tested?

I ran the above command again. It now works.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.