### PR TITLE
fix(propeller/k8s): treat BadRequest / Invalid from apiserver as permanent failure

### DIFF
--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -262,8 +262,14 @@ func (e *PluginManager) launchResource(ctx context.Context, tCtx pluginsCore.Tas
 		} else if k8serrors.IsForbidden(err) {
 			return pluginsCore.DoTransition(pluginsCore.PhaseInfoRetryableFailure("RuntimeFailure", err.Error(), nil)), nil
 		} else if k8serrors.IsBadRequest(err) || k8serrors.IsInvalid(err) {
+			// BadRequest (HTTP 400) and Invalid (HTTP 422) errors are intrinsic
+			// to the request payload and not transient. The most common source
+			// is a validating admission webhook rejecting the pod spec; retrying
+			// with the same input will produce the same rejection. Treat as a
+			// permanent failure so the validation error surfaces to the user
+			// instead of exhausting the workflow's retry budget.
 			logger.Errorf(ctx, "Badly formatted resource for plugin [%s], err %s", e.id, err)
-			// return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("BadTaskFormat", err.Error(), nil)), nil
+			return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("BadTaskFormat", err.Error(), nil)), nil
 		} else if k8serrors.IsRequestEntityTooLargeError(err) {
 			logger.Errorf(ctx, "Badly formatted resource for plugin [%s], err %s", e.id, err)
 			return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("EntityTooLarge", err.Error(), nil)), nil

--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager_test.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager_test.go
@@ -408,6 +408,75 @@ func TestK8sTaskExecutor_Handle_LaunchResource(t *testing.T) {
 		assert.True(t, k8serrors.IsNotFound(err))
 	})
 
+	t.Run("jobBadRequest", func(t *testing.T) {
+		// BadRequest (HTTP 400) errors — typically from a validating admission
+		// webhook — are intrinsic to the request payload and not transient.
+		// Retrying with the same input will produce the same rejection.
+		// They should be treated as a permanent failure (PhasePermanentFailure)
+		// rather than the default retryable system error, so workflows surface
+		// the validation error to the user instead of exhausting their retry
+		// budget. See https://github.com/flyteorg/flyte/issues/6531.
+		tctx := getMockTaskContext(PluginPhaseNotStarted, PluginPhaseNotStarted)
+		mockResourceHandler := &pluginsk8sMock.Plugin{}
+		mockResourceHandler.EXPECT().GetProperties().Return(k8s.PluginProperties{})
+		mockResourceHandler.EXPECT().BuildResource(mock.Anything, mock.Anything).Return(&v1.Pod{}, nil)
+		fakeClient := extendedFakeClient{
+			Client:      fake.NewClientBuilder().WithRuntimeObjects().Build(),
+			CreateError: k8serrors.NewBadRequest("admission webhook \"deny.example.com\" denied the request: invalid pod spec"),
+		}
+		mockClientset := k8sfake.NewSimpleClientset()
+
+		pluginManager, err := NewPluginManager(ctx, dummySetupContext(fakeClient), k8s.PluginEntry{
+			ID:              "x",
+			ResourceToWatch: &v1.Pod{},
+			Plugin:          mockResourceHandler,
+		}, NewResourceMonitorIndex(), mockClientset)
+		assert.NoError(t, err)
+
+		transition, err := pluginManager.Handle(ctx, tctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, transition)
+		transitionInfo := transition.Info()
+		assert.NotNil(t, transitionInfo)
+		assert.Equal(t, pluginsCore.PhasePermanentFailure, transitionInfo.Phase())
+		assert.Equal(t, "BadTaskFormat", transitionInfo.Err().GetCode())
+	})
+
+	t.Run("jobInvalid", func(t *testing.T) {
+		// Invalid (HTTP 422) errors indicate the request was well-formed but
+		// the object failed validation (e.g. an invalid field value). Like
+		// BadRequest, this is intrinsic to the payload and not transient, so
+		// it should be a permanent failure.
+		tctx := getMockTaskContext(PluginPhaseNotStarted, PluginPhaseNotStarted)
+		mockResourceHandler := &pluginsk8sMock.Plugin{}
+		mockResourceHandler.EXPECT().GetProperties().Return(k8s.PluginProperties{})
+		mockResourceHandler.EXPECT().BuildResource(mock.Anything, mock.Anything).Return(&v1.Pod{}, nil)
+		fakeClient := extendedFakeClient{
+			Client: fake.NewClientBuilder().WithRuntimeObjects().Build(),
+			CreateError: k8serrors.NewInvalid(
+				schema.GroupKind{Group: "", Kind: "Pod"},
+				"test-pod",
+				nil,
+			),
+		}
+		mockClientset := k8sfake.NewSimpleClientset()
+
+		pluginManager, err := NewPluginManager(ctx, dummySetupContext(fakeClient), k8s.PluginEntry{
+			ID:              "x",
+			ResourceToWatch: &v1.Pod{},
+			Plugin:          mockResourceHandler,
+		}, NewResourceMonitorIndex(), mockClientset)
+		assert.NoError(t, err)
+
+		transition, err := pluginManager.Handle(ctx, tctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, transition)
+		transitionInfo := transition.Info()
+		assert.NotNil(t, transitionInfo)
+		assert.Equal(t, pluginsCore.PhasePermanentFailure, transitionInfo.Phase())
+		assert.Equal(t, "BadTaskFormat", transitionInfo.Err().GetCode())
+	})
+
 	t.Run("Insufficient resource blocking pod creation for the first time", func(t *testing.T) {
 		tctx := getMockTaskContext(PluginPhaseNotStarted, PluginPhaseNotStarted)
 		var tmpl *core.TaskTemplate

--- a/go.mod
+++ b/go.mod
@@ -5,21 +5,14 @@ go 1.26.0
 require (
 	github.com/flyteorg/flyte/datacatalog v0.0.0-00010101000000-000000000000
 	github.com/flyteorg/flyte/flyteadmin v0.0.0-00010101000000-000000000000
-	github.com/flyteorg/flyte/flyteidl v0.0.0-00010101000000-000000000000
-	github.com/flyteorg/flyte/flyteplugins v0.0.0-00010101000000-000000000000
 	github.com/flyteorg/flyte/flytepropeller v0.0.0-00010101000000-000000000000
 	github.com/flyteorg/flyte/flytestdlib v0.0.0-00010101000000-000000000000
 	github.com/golang/glog v1.2.5
-	github.com/kubeflow/spark-operator v0.0.0-20250325114751-1905be6e1dbd
 	github.com/prometheus/client_golang v1.23.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10
-	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.20.0
-	google.golang.org/protobuf v1.36.11
 	gorm.io/driver/postgres v1.5.3
-	k8s.io/api v0.34.1
-	k8s.io/apimachinery v0.34.1
 	sigs.k8s.io/controller-runtime v0.22.4
 )
 
@@ -89,6 +82,8 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/flyteorg/flyte/flyteidl v0.0.0-00010101000000-000000000000 // indirect
+	github.com/flyteorg/flyte/flyteplugins v0.0.0-00010101000000-000000000000 // indirect
 	github.com/flyteorg/stow v0.3.12 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
@@ -143,6 +138,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/kubeflow/spark-operator v0.0.0-20250325114751-1905be6e1dbd // indirect
 	github.com/kubeflow/training-operator v1.8.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
@@ -199,6 +195,7 @@ require (
 	github.com/spf13/viper v1.21.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
@@ -243,6 +240,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/grpc v1.80.0 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
@@ -256,7 +254,9 @@ require (
 	gorm.io/driver/sqlite v1.5.4 // indirect
 	gorm.io/gorm v1.25.4 // indirect
 	gorm.io/plugin/opentelemetry v0.1.4 // indirect
+	k8s.io/api v0.34.1 // indirect
 	k8s.io/apiextensions-apiserver v0.34.1 // indirect
+	k8s.io/apimachinery v0.34.1 // indirect
 	k8s.io/client-go v0.34.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250814151709-d7b6acb124c3 // indirect


### PR DESCRIPTION
## Tracking issue

Closes #6531

## Why

When propeller creates a task pod and the apiserver rejects it with HTTP 400 (`BadRequest`) or HTTP 422 (`Invalid`) — typically a validating admission webhook saying no, or an invalid field caught by the apiserver — the failure path falls through to the default branch and surfaces as a retryable system error. The workflow then burns through its retry budget making the exact same request, with the exact same outcome.

These errors are intrinsic to the request payload. Retrying with the same input produces the same rejection. Neighboring `EntityTooLarge` is already handled this way.

The right transition was already written but commented out since #1 (2019) with no documented rationale. Uncommenting and adding a regression test.

## What changed

- `flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go`: uncomment the `PhaseInfoFailure("BadTaskFormat", ...)` transition so BadRequest / Invalid produce a permanent failure instead of falling through to the system-error path. Added a short comment so this doesn't get re-commented in the future.

## How was this patch tested?

Added two sub-tests to `TestK8sTaskExecutor_Handle_LaunchResource` — `jobBadRequest` (using `k8serrors.NewBadRequest`) and `jobInvalid` (using `k8serrors.NewInvalid`). Both assert `pluginsCore.PhasePermanentFailure` with error code `BadTaskFormat`. Both fail on master and pass with this PR; the full `plugin_manager_test.go` suite stays green.

```
ok  	github.com/flyteorg/flyte/flytepropeller/pkg/controller/nodes/task/k8s	1.724s
```

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.