### PR TITLE
feat(tasklog): add runName and actionName template vars

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/tasklog/template.go
+++ b/flyteplugins/go/tasks/pluginmachinery/tasklog/template.go
@@ -49,6 +49,8 @@ type templateRegexes struct {
 	GeneratedName        *regexp.Regexp
 	AgentID              *regexp.Regexp
 	ConnectorID          *regexp.Regexp
+	RunName              *regexp.Regexp
+	ActionName           *regexp.Regexp
 }
 
 func initDefaultRegexes() templateRegexes {
@@ -78,6 +80,8 @@ func initDefaultRegexes() templateRegexes {
 		MustCreateRegex("generatedName"),
 		MustCreateRegex("agentID"),
 		MustCreateRegex("connectorID"),
+		MustCreateRegex("runName"),
+		MustCreateRegex("actionName"),
 	}
 }
 
@@ -174,6 +178,14 @@ func (input Input) templateVars() []TemplateVar {
 				TemplateVar{
 					defaultRegexes.ExecutionName,
 					taskExecutionIdentifier.NodeExecutionId.ExecutionId.Name,
+				},
+				TemplateVar{
+					defaultRegexes.RunName,
+					taskExecutionIdentifier.NodeExecutionId.ExecutionId.Name,
+				},
+				TemplateVar{
+					defaultRegexes.ActionName,
+					taskExecutionIdentifier.NodeExecutionId.NodeId,
 				},
 				TemplateVar{
 					defaultRegexes.ExecutionProject,

--- a/flyteplugins/go/tasks/pluginmachinery/tasklog/template_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/tasklog/template_test.go
@@ -32,6 +32,7 @@ func dummyTaskExecID() pluginCore.TaskExecutionID {
 			Org:          "my-task-org",
 		},
 		NodeExecutionId: &core.NodeExecutionIdentifier{
+			NodeId: "my-node-id",
 			ExecutionId: &core.WorkflowExecutionIdentifier{
 				Name:    "my-execution-name",
 				Project: "my-execution-project",
@@ -150,6 +151,8 @@ func Test_Input_templateVars(t *testing.T) {
 				{defaultRegexes.TaskProject, "my-task-project"},
 				{defaultRegexes.TaskDomain, "my-task-domain"},
 				{defaultRegexes.ExecutionName, "my-execution-name"},
+				{defaultRegexes.RunName, "my-execution-name"},
+				{defaultRegexes.ActionName, "my-node-id"},
 				{defaultRegexes.ExecutionProject, "my-execution-project"},
 				{defaultRegexes.ExecutionDomain, "my-execution-domain"},
 				{defaultRegexes.ExecutionOrg, "my-execution-org"},

--- a/flyteplugins/go/tasks/pluginmachinery/tasklog/template_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/tasklog/template_test.go
@@ -666,6 +666,22 @@ func TestTemplateLogPlugin_GeneratedName(t *testing.T) {
 			want: "https://example.com/logs/generated-name/view",
 		},
 		{
+			name: "runName and actionName substitute end-to-end",
+			plugin: TemplateLogPlugin{
+				TemplateURIs:  []TemplateURI{"https://example.com/org/{{.executionOrg}}/runs/{{.runName}}-{{.actionName}}/pod/{{.generatedName}}"},
+				MessageFormat: core.TaskLog_JSON,
+			},
+			input: Input{
+				LogName:              "main_logs",
+				TaskExecutionID:      dummyTaskExecID(),
+				PodRFC3339StartTime:  "1970-01-01T01:02:03+01:00",
+				PodRFC3339FinishTime: "1970-01-01T04:25:45+01:00",
+				PodUnixStartTime:     123,
+				PodUnixFinishTime:    12345,
+			},
+			want: "https://example.com/org/my-execution-org/runs/my-execution-name-my-node-id/pod/generated-name",
+		},
+		{
 			name: "generatedName with underscores are sanitized",
 			plugin: TemplateLogPlugin{
 				TemplateURIs:  []TemplateURI{"https://example.com/logs/{{.generatedName}}/view"},


### PR DESCRIPTION
## TL;DR
Restore the `runName` and `actionName` template variables that exist in v1's `tasklog` engine but were never ported to v2. User-supplied deeplink URLs that reference these placeholders (e.g. a wandb URL like `.../runs/{{.runName}}-{{.actionName}}`) currently pass through literally because v2 doesn't register them, leaving the link broken.

## Changes
- `flyteplugins/go/tasks/pluginmachinery/tasklog/template.go`
  - Add `RunName` and `ActionName` to `templateRegexes` and register their regexes in `initDefaultRegexes`.
  - Populate them in `templateVars()` when `TaskExecutionID.NodeExecutionId.ExecutionId` is set. `RunName` mirrors `executionName` (`NodeExecutionId.ExecutionId.Name`) for v1 compatibility; `ActionName` is `NodeExecutionId.NodeId`.
- `flyteplugins/go/tasks/pluginmachinery/tasklog/template_test.go`
  - Set `NodeId: "my-node-id"` in the fixture and assert the two new template vars in the existing `task execution happy path` case.

This mirrors the v1 implementation in `flyteplugins/go/tasks/pluginmachinery/tasklog/template.go` (variables introduced upstream for the v1 path).

## Type
- [x] Bug Fix
- [x] Feature

## Are all requirements met?
- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added