### PR TITLE
fix(executor): wire previous checkpoint path for in-place retries

### DIFF
--- a/executor/pkg/plugin/task_exec_context.go
+++ b/executor/pkg/plugin/task_exec_context.go
@@ -145,7 +145,17 @@ func NewTaskExecutionContext(
 		return nil, err
 	}
 	rawOutputPaths := ioutils.NewRawOutputPaths(ctx, outputPrefix)
-	outputFilePaths := ioutils.NewCheckpointRemoteFilePaths(ctx, dataStore, outputPrefix, rawOutputPaths, "")
+
+	var prevCheckpointPath storage.DataReference
+	if taskAction.Status.Attempts >= 2 {
+		prevOutputPrefix, err := ComputeActionOutputPath(ctx, taskAction.Namespace, taskAction.Name, taskAction.Spec.RunOutputBase, taskAction.Spec.ActionName, attempt-1)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute previous checkpoint path: %w", err)
+		}
+		prevCheckpointPath = ioutils.ConstructCheckpointPath(dataStore, prevOutputPrefix)
+	}
+
+	outputFilePaths := ioutils.NewCheckpointRemoteFilePaths(ctx, dataStore, outputPrefix, rawOutputPaths, prevCheckpointPath)
 	outputWriter := ioutils.NewRemoteFileOutputWriter(ctx, dataStore, outputFilePaths)
 
 	// Task execution metadata

--- a/executor/pkg/plugin/task_exec_context.go
+++ b/executor/pkg/plugin/task_exec_context.go
@@ -146,6 +146,8 @@ func NewTaskExecutionContext(
 	}
 	rawOutputPaths := ioutils.NewRawOutputPaths(ctx, outputPrefix)
 
+	// Attempts is 1-indexed, so the first attempt has nothing to resume from.
+	// Only set a previous checkpoint path from attempt 2 onward.
 	var prevCheckpointPath storage.DataReference
 	if taskAction.Status.Attempts >= 2 {
 		prevOutputPrefix, err := ComputeActionOutputPath(ctx, taskAction.Namespace, taskAction.Name, taskAction.Spec.RunOutputBase, taskAction.Spec.ActionName, attempt-1)

--- a/executor/pkg/plugin/task_exec_context_test.go
+++ b/executor/pkg/plugin/task_exec_context_test.go
@@ -1,0 +1,99 @@
+package plugin
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
+	"github.com/flyteorg/flyte/v2/flytestdlib/contextutils"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils/labeled"
+	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
+)
+
+func TestMain(m *testing.M) {
+	labeled.SetMetricKeys(
+		contextutils.ProjectKey,
+		contextutils.DomainKey,
+		contextutils.WorkflowIDKey,
+		contextutils.TaskIDKey,
+	)
+	os.Exit(m.Run())
+}
+
+func newTestDataStore(t *testing.T) *storage.DataStore {
+	t.Helper()
+	ds, err := storage.NewDataStore(&storage.Config{Type: storage.TypeMemory}, promutils.NewTestScope())
+	require.NoError(t, err)
+	return ds
+}
+
+func minimalTaskAction(namespace, name, runOutputBase, actionName string, attempts uint32) *flyteorgv1.TaskAction {
+	return &flyteorgv1.TaskAction{
+		Spec: flyteorgv1.TaskActionSpec{
+			RunOutputBase: runOutputBase,
+			ActionName:    actionName,
+			InputURI:      runOutputBase + "/inputs.pb",
+		},
+		Status: flyteorgv1.TaskActionStatus{
+			Attempts: attempts,
+		},
+	}
+}
+
+// TestNewTaskExecutionContext_FirstAttempt_NoPreviousCheckpoint verifies that
+// when Attempts is unset (0), no previous checkpoint path is set — there is
+// nothing to resume from on the very first execution.
+func TestNewTaskExecutionContext_FirstAttempt_NoPreviousCheckpoint(t *testing.T) {
+	ds := newTestDataStore(t)
+	ta := minimalTaskAction("flyte", "my-action-abc", "s3://bucket/run", "action-0", 0)
+
+	tCtx, err := NewTaskExecutionContext(ta, ds, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	prev := string(tCtx.OutputWriter().GetPreviousCheckpointsPrefix())
+	assert.Empty(t, prev, "first attempt must have no previous checkpoint path")
+}
+
+// TestNewTaskExecutionContext_Retry_PreviousCheckpointSet verifies that on a
+// retry (Attempts == 2), the previous checkpoint path points to the attempt-1
+// output directory and ends with the checkpoint suffix.
+func TestNewTaskExecutionContext_Retry_PreviousCheckpointSet(t *testing.T) {
+	ds := newTestDataStore(t)
+	ta := minimalTaskAction("flyte", "my-action-abc", "s3://bucket/run", "action-0", 2)
+
+	tCtx, err := NewTaskExecutionContext(ta, ds, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	prev := string(tCtx.OutputWriter().GetPreviousCheckpointsPrefix())
+	require.NotEmpty(t, prev, "retry must have a previous checkpoint path")
+	assert.True(t, strings.HasSuffix(prev, "/_flytecheckpoints"),
+		"previous checkpoint path must end with /_flytecheckpoints; got %q", prev)
+	assert.True(t, strings.HasPrefix(prev, "s3://bucket/"),
+		"previous checkpoint path must be under the RunOutputBase bucket; got %q", prev)
+}
+
+// TestNewTaskExecutionContext_Retry_PreviousAndCurrentDontCollide verifies that
+// the previous and current checkpoint paths are distinct and both live under
+// the same RunOutputBase — retries must not overwrite prior checkpoints.
+func TestNewTaskExecutionContext_Retry_PreviousAndCurrentDontCollide(t *testing.T) {
+	ds := newTestDataStore(t)
+	ta := minimalTaskAction("flyte", "my-action-abc", "s3://bucket/run", "action-0", 2)
+
+	tCtx, err := NewTaskExecutionContext(ta, ds, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	ow := tCtx.OutputWriter()
+	prev := string(ow.GetPreviousCheckpointsPrefix())
+	curr := string(ow.GetCheckpointPrefix())
+
+	assert.NotEqual(t, prev, curr, "previous and current checkpoint paths must not collide")
+	assert.True(t, strings.HasPrefix(prev, "s3://bucket/"),
+		"previous checkpoint must live under RunOutputBase bucket; got %q", prev)
+	assert.True(t, strings.HasPrefix(curr, "s3://bucket/"),
+		"current checkpoint must live under RunOutputBase bucket; got %q", curr)
+}


### PR DESCRIPTION
## Why are the changes needed?

On retries (`Status.Attempts >= 2`), `NewTaskExecutionContext` passed "" as the previous checkpoint path to `NewCheckpointRemoteFilePaths`. As a result, `{{.PrevCheckpointPrefix}}` substituted to empty in pod args, `checkpoint.load_sync()` always returned `None`, and tasks restarted from scratch on every retry.

Mirrors the worker-side fix from unionai/cloud#15143.


## What changes were proposed in this pull request?

When `Status.Attempts >= 2`, derive the previous checkpoint path via `ComputeActionOutputPath(..., attempt-1) + ConstructCheckpointPath` and pass it through.

## How was this patch tested?
  - `go test ./executor/pkg/plugin/... ./executor/pkg/controller/...`
  - End-to-end sdk example: `examples/checkpoint/generic_data_checkpoint.py` succeeds on attempt 4

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
