### PR TITLE
[Fix] make CI only runs on main branch

### DIFF
--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -8,6 +8,8 @@ on:
       - 'gen.Dockerfile'
       - '.github/workflows/build-ci-image.yml'
   pull_request_target:
+    branches:
+      - main
     paths:
       - 'gen.Dockerfile'
       - '.github/workflows/build-ci-image.yml'

--- a/.github/workflows/check-generate.yml
+++ b/.github/workflows/check-generate.yml
@@ -3,6 +3,8 @@ name: Check Generated Files
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+    branches:
+      - main
 
 jobs:
   setup:


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

We discovered some CI in main branch running in the PR that's merging into master, which blocks the PR from being merged: https://github.com/flyteorg/flyte/actions/runs/25786689725/job/75741746463?pr=7369

## What changes were proposed in this pull request?

As mentioned in docs: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target, when using `pull_request_target`, it will run the CI defined in the default branch rather than the base repository.

> This event runs in the context of the default branch of the base repository, rather than in the context of the merge commit, as the pull_request event does

This PR adds `branches` filter to ensure they only execute on `main` branch

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
