### PR TITLE
chore(deps): add 5-day cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     # Skip the folder where your generated/dist code lives
     exclude-paths:
       - "gen/**"
+    cooldown:
+      default-days: 5
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -14,6 +16,8 @@ updates:
     # Skip the folder where your generated/dist code lives
     exclude-paths:
       - "gen/**"
+    cooldown:
+      default-days: 5
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -21,6 +25,8 @@ updates:
     # Skip the folder where your generated/dist code lives
     exclude-paths:
       - "gen/**"
+    cooldown:
+      default-days: 5
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
@@ -28,3 +34,5 @@ updates:
     # Skip the folder where your generated/dist code lives
     exclude-paths:
       - "gen/**"
+    cooldown:
+      default-days: 5


### PR DESCRIPTION
Add a 5-day default cooldown to all four dependabot ecosystems (github-actions, gomod, npm, uv) so freshly published versions get some bake time before dependabot proposes upgrades.
