### PR TITLE
[flytecopilot] Bind timeout and start-timeout flags to separate variables

### DIFF
--- a/flytecopilot/cmd/sidecar.go
+++ b/flytecopilot/cmd/sidecar.go
@@ -130,11 +130,20 @@ func NewUploadCommand(opts *RootOptions) *cobra.Command {
 		RootOptions: opts,
 	}
 
+	var deprecatedStartTimeout time.Duration
+
 	// deleteCmd represents the delete command
 	uploadCmd := &cobra.Command{
 		Use:   "sidecar <opts>",
 		Short: "uploads flyteData from the localpath to a remote dir.",
 		Long:  `Currently it looks at the outputs.pb and creates one file per variable.`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// --timeout has priority over --start-timeout
+			if cmd.Flags().Changed("start-timeout") && !cmd.Flags().Changed("timeout") {
+				uploadOptions.timeout = deprecatedStartTimeout
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return uploadOptions.Sidecar(context.Background())
 		},
@@ -148,7 +157,7 @@ func NewUploadCommand(opts *RootOptions) *cobra.Command {
 	uploadCmd.Flags().StringVarP(&uploadOptions.metaOutputName, "meta-output-name", "", "outputs.pb", "The key name under the remoteOutputPrefix that should be return to provide meta information about the outputs on successful execution")
 	uploadCmd.Flags().DurationVarP(&uploadOptions.timeout, "timeout", "t", time.Hour*1, "Max time to allow for uploads to complete, default is 1H")
 	uploadCmd.Flags().BytesBase64VarP(&uploadOptions.typedInterface, "interface", "i", nil, "Typed Interface - core.TypedInterface, base64 encoded string of the serialized protobuf")
-	uploadCmd.Flags().DurationVarP(&uploadOptions.timeout, "start-timeout", "", 0, "Deprecated: Use --timeout instead. Specifies the maximum duration to allow uploads to complete. Retained for backward compatibility.")
+	uploadCmd.Flags().DurationVar(&deprecatedStartTimeout, "start-timeout", 0, "Deprecated: Use --timeout instead. Specifies the maximum duration to allow uploads to complete. Retained for backward compatibility.")
 	uploadCmd.Flags().StringVarP(&uploadOptions.startWatcherType, "start-watcher-type", "", containerwatcher.WatcherTypeSignal, fmt.Sprintf("Sidecar will wait for container before starting upload process. Watcher type makes the type configurable. Available Type %+v", containerwatcher.AllWatcherTypes))
 	uploadCmd.Flags().StringVarP(&uploadOptions.exitWatcherType, "exit-watcher-type", "", containerwatcher.WatcherTypeSignal, fmt.Sprintf("Sidecar will wait for completion of the container before starting upload process. Watcher type makes the type configurable. Available Type %+v", containerwatcher.AllWatcherTypes))
 	return uploadCmd


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?

There is a bug where if none of `--timeout, --start-timeout` are set, flytecopilot uses a timeout of 0 rather than the intended `1h`.

## What changes were proposed in this pull request?

Do not bind both flags to the same variable. Use `deprecatedStartTimeout` to store the value of the deprecated `start-timeout` flag.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
