### PR TITLE
feat(connector): handle TaskExecution_RETRYABLE_FAILED phase

### DIFF
--- a/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
@@ -92,7 +92,7 @@ type ResourceWrapper struct {
 
 // IsTerminal is used to avoid making network calls to the connector service if the resource is already in a terminal state.
 func (r ResourceWrapper) IsTerminal() bool {
-	return r.Phase == flyteIdl.TaskExecution_SUCCEEDED || r.Phase == flyteIdl.TaskExecution_FAILED || r.Phase == flyteIdl.TaskExecution_ABORTED
+	return r.Phase == flyteIdl.TaskExecution_SUCCEEDED || r.Phase == flyteIdl.TaskExecution_FAILED || r.Phase == flyteIdl.TaskExecution_RETRYABLE_FAILED || r.Phase == flyteIdl.TaskExecution_ABORTED
 }
 
 type ResourceMetaWrapper struct {
@@ -362,6 +362,8 @@ func (p *Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phas
 		return core.PhaseInfoFailure(errorCode, "failed to run the job with aborted phase.", taskInfo), nil
 	case flyteIdl.TaskExecution_FAILED:
 		return core.PhaseInfoFailure(errorCode, fmt.Sprintf("failed to run the job: %s", resource.Message), taskInfo), nil
+	case flyteIdl.TaskExecution_RETRYABLE_FAILED:
+		return core.PhaseInfoRetryableFailure(errorCode, fmt.Sprintf("failed to run the job: %s", resource.Message), taskInfo), nil
 	}
 	// The default phase is undefined.
 	return core.PhaseInfoUndefined, pluginErrors.Errorf(core.SystemErrorCode, "unknown execution phase [%v].", resource.Phase)

--- a/flyteplugins/go/tasks/plugins/webapi/connector/plugin_test.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/plugin_test.go
@@ -252,6 +252,25 @@ func TestPlugin(t *testing.T) {
 		assert.Equal(t, pluginsCore.PhasePermanentFailure, phase.Phase())
 	})
 
+	t.Run("test TaskExecution_RETRYABLE_FAILED Status", func(t *testing.T) {
+		taskContext := new(webapiPlugin.StatusContext)
+		taskContext.On("Resource").Return(ResourceWrapper{
+			Phase:    flyteIdlCore.TaskExecution_RETRYABLE_FAILED,
+			Outputs:  nil,
+			Message:  "transient",
+			LogLinks: []*flyteIdlCore.TaskLog{{Uri: "http://localhost:3000/log", Name: "Log Link"}},
+		})
+
+		mockTaskMetadata := &pluginCoreMocks.TaskExecutionMetadata{}
+		mockTaskMetadata.On("GetTaskExecutionID").Return(&pluginCoreMocks.TaskExecutionID{})
+		taskContext.On("TaskExecutionMetadata").Return(mockTaskMetadata)
+
+		phase, err := plugin.Status(context.Background(), taskContext)
+		assert.NoError(t, err)
+		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phase.Phase())
+		assert.Equal(t, "failed to run the job: transient", phase.Err().GetMessage())
+	})
+
 	// Verifies that when the connector plugin recorded an endpoint on the
 	// ResourceWrapper, Status surfaces it through TaskInfo.LogContext.Connector
 	// so downstream consumers (action events → dataproxy log streaming) can
@@ -352,5 +371,29 @@ func TestInitializeConnectorRegistry(t *testing.T) {
 
 	for _, key := range expectedKeys {
 		assert.Contains(t, connectorRegistryKeys, key)
+	}
+}
+
+func TestResourceWrapper_IsTerminal(t *testing.T) {
+	cases := []struct {
+		phase    flyteIdlCore.TaskExecution_Phase
+		terminal bool
+	}{
+		{flyteIdlCore.TaskExecution_UNDEFINED, false},
+		{flyteIdlCore.TaskExecution_QUEUED, false},
+		{flyteIdlCore.TaskExecution_RUNNING, false},
+		{flyteIdlCore.TaskExecution_SUCCEEDED, true},
+		{flyteIdlCore.TaskExecution_FAILED, true},
+		{flyteIdlCore.TaskExecution_RETRYABLE_FAILED, true},
+		{flyteIdlCore.TaskExecution_ABORTED, true},
+		{flyteIdlCore.TaskExecution_INITIALIZING, false},
+		{flyteIdlCore.TaskExecution_WAITING_FOR_RESOURCES, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.phase.String(), func(t *testing.T) {
+			r := ResourceWrapper{Phase: tc.phase}
+			assert.Equal(t, tc.terminal, r.IsTerminal())
+		})
 	}
 }


### PR DESCRIPTION
## Tracking issue

<!-- Remove if not applicable -->

## Why are the changes needed?

The webapi connector plugin currently only handles `TaskExecution_FAILED` and `TaskExecution_ABORTED` as failure phases. The `TaskExecution_RETRYABLE_FAILED` phase (value `8` in `flyteidl2/core/execution.proto`) is silently ignored, falling through to the default branch which returns an "unknown execution phase" system error. As a result, a connector that legitimately reports a retryable failure surfaces as a system error to propeller and the task's retry policy is never honored.

## What changes were proposed in this pull request?

In `flyteplugins/go/tasks/plugins/webapi/connector/plugin.go`:

1. `ResourceWrapper.IsTerminal()` now treats `TaskExecution_RETRYABLE_FAILED` as terminal alongside `SUCCEEDED`/`FAILED`/`ABORTED`, so the framework skips an extra `Get` round-trip to the connector once it has returned this phase.
2. The phase switch in `Status` maps `TaskExecution_RETRYABLE_FAILED` to `core.PhaseInfoRetryableFailure(...)`, so propeller retries per the task's retry policy instead of marking the node as permanently failed.

## How was this patch tested?

Built locally with `go build ./flyteplugins/go/tasks/plugins/webapi/connector/...`. No existing tests covered the previous default-branch behavior; happy to add a unit test for both `IsTerminal()` and the phase mapping if reviewers prefer.

### Labels

- **added**

### Setup process

N/A

### Screenshots

N/A

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->