### PR TITLE
propagate ContainerError.Kind to ExecutionError.Recoverability in ReadError

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/ioutils/remote_file_output_reader.go
+++ b/flyteplugins/go/tasks/pluginmachinery/ioutils/remote_file_output_reader.go
@@ -66,6 +66,12 @@ func (r RemoteFileOutputReader) ReadError(ctx context.Context) (io.ExecutionErro
 			Code:    errorDoc.Error.Code,
 			Message: errorDoc.Error.Message,
 			Kind:    errorDoc.Error.Origin,
+			// Propagate the container's recoverability so downstream services
+			// (e.g. a retry decision in the execution engine) can honor
+			// NonRecoverableError without re-reading error.pb. The Go-level
+			// IsRecoverable flag below is set in parallel for in-process
+			// callers; both must agree.
+			Recoverability: errorDoc.Error.Kind,
 		},
 	}
 

--- a/flyteplugins/go/tasks/pluginmachinery/ioutils/remote_file_output_reader_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/ioutils/remote_file_output_reader_test.go
@@ -74,6 +74,10 @@ func TestReadOrigin(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, core.ExecutionError_USER, ee.Kind)
 		assert.False(t, ee.IsRecoverable)
+		// Proto-level Recoverability mirrors the container's kind so the bit
+		// travels on the wire to downstream services. Without this, all errors
+		// surface as the proto3 zero (NON_RECOVERABLE) regardless of intent.
+		assert.Equal(t, core.ContainerError_NON_RECOVERABLE, ee.GetRecoverability())
 		exists, err := r.DeckExists(ctx)
 		assert.NoError(t, err)
 		assert.True(t, exists)
@@ -105,5 +109,6 @@ func TestReadOrigin(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, core.ExecutionError_SYSTEM, ee.Kind)
 		assert.True(t, ee.IsRecoverable)
+		assert.Equal(t, core.ContainerError_RECOVERABLE, ee.GetRecoverability())
 	})
 }


### PR DESCRIPTION
## Summary

`RemoteFileOutputReader.ReadError` already populates the Go-level `io.ExecutionError.IsRecoverable` bool from `ContainerError.Kind`, but it does not populate the proto-level `core.ExecutionError.Recoverability` field on the wrapped `*core.ExecutionError`. Since the Go bool is dropped during proto encoding, any downstream service that consumes the `ExecutionError` over the wire sees the proto3 zero (`NON_RECOVERABLE`) for every failure regardless of the container's intent.

Set `Recoverability` from `errorDoc.Error.Kind` so the bit travels intact. The Go bool continues to be set in parallel for in-process callers; both agree.

## Motivation

In our setup, the leasor reads `ExecutionError.Recoverability` off the wire to honor `NonRecoverableError` from the SDK without re-reading `error.pb`. Without this fix, `NonRecoverableError` is indistinguishable from a recoverable failure on the wire, defeating the SDK-side contract that NonRecoverableError consumes no retries.

This is a strict superset behavior change — `Recoverability` was previously zero (NON_RECOVERABLE) for both recoverable and non-recoverable error.pb contents, so the field was useless. Now both cases set it correctly.

## Tests

Existing `TestReadOrigin` extended:
- `user` sub-test (NON_RECOVERABLE) now also asserts `ee.GetRecoverability() == ContainerError_NON_RECOVERABLE`
- `system` sub-test (RECOVERABLE) now also asserts `ee.GetRecoverability() == ContainerError_RECOVERABLE`

## Test plan
- [x] `go test ./flyteplugins/go/tasks/pluginmachinery/ioutils/...`