### PR TITLE
feat: add clustered-task plugin for JobSet-based distributed training

### DIFF
--- a/executor/setup.go
+++ b/executor/setup.go
@@ -34,6 +34,7 @@ import (
 
 	// Plugin registrations — blank imports trigger init() which registers
 	// plugins with the global registry.
+	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/clustered"
 	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/pod"
 )
 

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/build.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/build.go
@@ -45,7 +45,9 @@ func (clusteredResourceHandler) BuildResource(ctx context.Context, taskCtx plugi
 
 	podSpec = applyInterconnect(ctx, spec.GetInterconnect(), podSpec)
 
-	// Find the primary container and splice in the entrypoint + runtime env vars.
+	// The SDK is responsible for setting container.Command to the entrypoint module
+	// (python -m flyte.distributed._entrypoint) at serde time. The plugin stays
+	// module-path-agnostic so SDK renames do not require a backend release.
 	primaryIdx := -1
 	for i, c := range podSpec.Containers {
 		if c.Name == primaryContainerName {
@@ -58,11 +60,6 @@ func (clusteredResourceHandler) BuildResource(ctx context.Context, taskCtx plugi
 	}
 
 	container := &podSpec.Containers[primaryIdx]
-
-	// Move original command + args into args-only (passed through to torchrun → a0).
-	originalArgs := append(container.Command, container.Args...)
-	container.Command = []string{"python", "-m", "flyte.distributed._entrypoint"}
-	container.Args = originalArgs
 
 	injectTorchRunEnv(container, &spec)
 
@@ -100,10 +97,11 @@ func (clusteredResourceHandler) BuildResource(ctx context.Context, taskCtx plugi
 			Name:      jobSetName,
 			Namespace: taskCtx.TaskExecutionMetadata().GetNamespace(),
 			Labels: map[string]string{
-				"flyte.org/execution": taskCtx.TaskExecutionMetadata().GetTaskExecutionID().GetID().GetNodeExecutionId().GetExecutionId().GetName(),
+				"flyte.org/execution": sanitizeLabelValue(taskCtx.TaskExecutionMetadata().GetTaskExecutionID().GetID().GetNodeExecutionId().GetExecutionId().GetName()),
 			},
 			Annotations: map[string]string{
-				"flyte.org/task-type": taskType,
+				"flyte.org/task-type":      taskType,
+				primaryContainerAnnotation: primaryContainerName,
 			},
 		},
 		Spec: jobsetv1alpha2.JobSetSpec{
@@ -116,7 +114,7 @@ func (clusteredResourceHandler) BuildResource(ctx context.Context, taskCtx plugi
 			FailurePolicy: failurePolicy,
 			ReplicatedJobs: []jobsetv1alpha2.ReplicatedJob{
 				{
-					Name:     "workers",
+					Name:     workersReplicatedJobName,
 					Replicas: replicatedJobReplicas,
 					Template: batchv1.JobTemplateSpec{
 						Spec: jobSpec,

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/build.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/build.go
@@ -2,6 +2,7 @@ package clustered
 
 import (
 	"context"
+	"math"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,13 @@ func (clusteredResourceHandler) BuildResource(ctx context.Context, taskCtx plugi
 	var spec clusteredpb.ClusteredTaskSpec
 	if err = utils.UnmarshalStruct(taskTemplate.GetCustom(), &spec); err != nil { //nolint:staticcheck
 		return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "invalid ClusteredTaskSpec: %v", err)
+	}
+
+	if spec.GetReplicas() < 1 {
+		return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "replicas must be >= 1, got %d", spec.GetReplicas())
+	}
+	if spec.GetNprocPerNode() < 1 {
+		return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "nproc_per_node must be >= 1, got %d", spec.GetNprocPerNode())
 	}
 
 	podSpec, objectMeta, primaryContainerName, err := flytek8s.ToK8sPodSpec(ctx, taskCtx)
@@ -119,7 +127,11 @@ func (clusteredResourceHandler) BuildResource(ctx context.Context, taskCtx plugi
 	}
 
 	if ttl := spec.GetTtlSecondsAfterFinished(); ttl != nil {
-		ttlVal := int32(ttl.GetValue())
+		v := ttl.GetValue()
+		if v > math.MaxInt32 {
+			return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "ttl_seconds_after_finished %d exceeds maximum allowed value", v)
+		}
+		ttlVal := int32(v)
 		jobSet.Spec.TTLSecondsAfterFinished = &ttlVal
 	}
 

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/build.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/build.go
@@ -1,0 +1,127 @@
+package clustered
+
+import (
+	"context"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+
+	flyteerr "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/errors"
+	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/utils"
+	clusteredpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/plugins"
+)
+
+func (clusteredResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext) (client.Object, error) {
+	taskTemplate, err := taskCtx.TaskReader().Read(ctx)
+	if err != nil {
+		return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "unable to fetch task template: %v", err)
+	}
+	if taskTemplate == nil {
+		return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "nil task template")
+	}
+
+	var spec clusteredpb.ClusteredTaskSpec
+	if err = utils.UnmarshalStruct(taskTemplate.GetCustom(), &spec); err != nil { //nolint:staticcheck
+		return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "invalid ClusteredTaskSpec: %v", err)
+	}
+
+	podSpec, objectMeta, primaryContainerName, err := flytek8s.ToK8sPodSpec(ctx, taskCtx)
+	if err != nil {
+		return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "failed to build pod spec: %v", err)
+	}
+
+	podSpec = applyInterconnect(ctx, spec.GetInterconnect(), podSpec)
+
+	// Find the primary container and splice in the entrypoint + runtime env vars.
+	primaryIdx := -1
+	for i, c := range podSpec.Containers {
+		if c.Name == primaryContainerName {
+			primaryIdx = i
+			break
+		}
+	}
+	if primaryIdx == -1 {
+		return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "primary container %q not found in pod spec", primaryContainerName)
+	}
+
+	container := &podSpec.Containers[primaryIdx]
+
+	// Move original command + args into args-only (passed through to torchrun → a0).
+	originalArgs := append(container.Command, container.Args...)
+	container.Command = []string{"python", "-m", "flyte.distributed._entrypoint"}
+	container.Args = originalArgs
+
+	injectTorchRunEnv(container, &spec)
+
+	podSpec.RestartPolicy = corev1.RestartPolicyNever
+	if podSpec.Subdomain == "" {
+		podSpec.Subdomain = taskCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName()
+	}
+
+	replicas := spec.GetReplicas()
+	completionMode := batchv1.IndexedCompletion
+	backoffLimit := int32(0)
+	jobSpec := batchv1.JobSpec{
+		Parallelism:    &replicas,
+		Completions:    &replicas,
+		CompletionMode: &completionMode,
+		BackoffLimit:   &backoffLimit,
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: *objectMeta,
+			Spec:       *podSpec,
+		},
+	}
+
+	failurePolicy := buildFailurePolicy(&spec)
+
+	jobSetName := taskCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName()
+	enableDNSHostnames := true
+	replicatedJobReplicas := int32(1)
+
+	jobSet := &jobsetv1alpha2.JobSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "JobSet",
+			APIVersion: jobsetv1alpha2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobSetName,
+			Namespace: taskCtx.TaskExecutionMetadata().GetNamespace(),
+			Labels: map[string]string{
+				"flyte.org/execution": taskCtx.TaskExecutionMetadata().GetTaskExecutionID().GetID().GetNodeExecutionId().GetExecutionId().GetName(),
+			},
+			Annotations: map[string]string{
+				"flyte.org/task-type": taskType,
+			},
+		},
+		Spec: jobsetv1alpha2.JobSetSpec{
+			Network: &jobsetv1alpha2.Network{
+				EnableDNSHostnames: &enableDNSHostnames,
+			},
+			SuccessPolicy: &jobsetv1alpha2.SuccessPolicy{
+				Operator: jobsetv1alpha2.OperatorAll,
+			},
+			FailurePolicy: failurePolicy,
+			ReplicatedJobs: []jobsetv1alpha2.ReplicatedJob{
+				{
+					Name:     "workers",
+					Replicas: replicatedJobReplicas,
+					Template: batchv1.JobTemplateSpec{
+						Spec: jobSpec,
+					},
+				},
+			},
+		},
+	}
+
+	if ttl := spec.GetTtlSecondsAfterFinished(); ttl != nil {
+		ttlVal := int32(ttl.GetValue())
+		jobSet.Spec.TTLSecondsAfterFinished = &ttlVal
+	}
+
+	return jobSet, nil
+}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/build.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/build.go
@@ -64,8 +64,12 @@ func (clusteredResourceHandler) BuildResource(ctx context.Context, taskCtx plugi
 	injectTorchRunEnv(container, &spec)
 
 	podSpec.RestartPolicy = corev1.RestartPolicyNever
+	// JobSet name doubles as the headless service / pod subdomain; both must be
+	// RFC 1123 subdomain-compatible. GeneratedName isn't guaranteed to be, so
+	// sanitize once and use the same value for both.
+	jobSetName := utils.ConvertToDNS1123SubdomainCompatibleString(taskCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName())
 	if podSpec.Subdomain == "" {
-		podSpec.Subdomain = taskCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName()
+		podSpec.Subdomain = jobSetName
 	}
 
 	replicas := spec.GetReplicas()
@@ -82,9 +86,11 @@ func (clusteredResourceHandler) BuildResource(ctx context.Context, taskCtx plugi
 		},
 	}
 
-	failurePolicy := buildFailurePolicy(&spec)
+	failurePolicy, err := buildFailurePolicy(&spec)
+	if err != nil {
+		return nil, err
+	}
 
-	jobSetName := taskCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName()
 	enableDNSHostnames := true
 	replicatedJobReplicas := int32(1)
 

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
@@ -1,0 +1,409 @@
+package clustered
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+
+	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
+	coreMocks "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core/mocks"
+	pluginIOMocks "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/io/mocks"
+	k8smocks "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s/mocks"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/utils"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
+	clusteredpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/plugins"
+)
+
+const (
+	testImage   = "test-image:latest"
+	testJobName = "f-abc123"
+	testNS      = "my-project-development"
+)
+
+// buildTaskTemplate builds a TaskTemplate with the given ClusteredTaskSpec packed into Custom.
+func buildTaskTemplate(spec *clusteredpb.ClusteredTaskSpec) *core.TaskTemplate {
+	custom, err := utils.MarshalObjToStruct(spec) //nolint:staticcheck
+	if err != nil {
+		panic(err)
+	}
+	return &core.TaskTemplate{
+		Type:            taskType,
+		TaskTypeVersion: 1,
+		Target: &core.TaskTemplate_Container{
+			Container: &core.Container{
+				Image:   testImage,
+				Command: []string{"a0"},
+				Args:    []string{"a0", "--inputs", "s3://bucket/in"},
+			},
+		},
+		Custom: custom,
+	}
+}
+
+// dummyTaskCtx builds a minimal task execution context suitable for BuildResource tests.
+func dummyTaskCtx(taskTemplate *core.TaskTemplate) *coreMocks.TaskExecutionContext {
+	taskCtx := &coreMocks.TaskExecutionContext{}
+
+	inputReader := &pluginIOMocks.InputReader{}
+	inputReader.EXPECT().GetInputPrefixPath().Return("/input/prefix")
+	inputReader.EXPECT().GetInputPath().Return("/input")
+	inputReader.EXPECT().Get(mock.Anything).Return(&core.LiteralMap{}, nil)
+	taskCtx.EXPECT().InputReader().Return(inputReader)
+
+	outputWriter := &pluginIOMocks.OutputWriter{}
+	outputWriter.EXPECT().GetOutputPath().Return("/data/outputs.pb")
+	outputWriter.EXPECT().GetOutputPrefixPath().Return("/data/")
+	outputWriter.EXPECT().GetRawOutputPrefix().Return("")
+	outputWriter.EXPECT().GetCheckpointPrefix().Return("/checkpoint")
+	outputWriter.EXPECT().GetPreviousCheckpointsPrefix().Return("/prev")
+	taskCtx.EXPECT().OutputWriter().Return(outputWriter)
+
+	taskReader := &coreMocks.TaskReader{}
+	taskReader.EXPECT().Read(mock.Anything).Return(taskTemplate, nil)
+	taskCtx.EXPECT().TaskReader().Return(taskReader)
+
+	tID := &coreMocks.TaskExecutionID{}
+	tID.EXPECT().GetID().Return(&core.TaskExecutionIdentifier{
+		NodeExecutionId: &core.NodeExecutionIdentifier{
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Name:    "my-exec",
+				Project: "my-project",
+				Domain:  "development",
+			},
+		},
+	})
+	tID.EXPECT().GetGeneratedName().Return(testJobName)
+	tID.EXPECT().GetUniqueNodeID().Return("node-id")
+
+	overrides := &coreMocks.TaskOverrides{}
+	overrides.EXPECT().GetResources().Return(&corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("8"),
+			corev1.ResourceMemory: resource.MustParse("32Gi"),
+		},
+	})
+	overrides.EXPECT().GetExtendedResources().Return(nil)
+	overrides.EXPECT().GetContainerImage().Return("")
+	overrides.EXPECT().GetPodTemplate().Return(nil)
+
+	meta := &coreMocks.TaskExecutionMetadata{}
+	meta.EXPECT().GetTaskExecutionID().Return(tID)
+	meta.EXPECT().GetNamespace().Return(testNS)
+	meta.EXPECT().GetAnnotations().Return(map[string]string{})
+	meta.EXPECT().GetLabels().Return(map[string]string{})
+	meta.EXPECT().GetOwnerReference().Return(metav1.OwnerReference{Kind: "node", Name: "n1"})
+	meta.EXPECT().IsInterruptible().Return(false)
+	meta.EXPECT().GetOverrides().Return(overrides)
+	meta.EXPECT().GetK8sServiceAccount().Return("")
+	meta.EXPECT().GetPlatformResources().Return(&corev1.ResourceRequirements{})
+	meta.EXPECT().GetEnvironmentVariables().Return(nil)
+	meta.EXPECT().GetConsoleURL().Return("")
+	taskCtx.EXPECT().TaskExecutionMetadata().Return(meta)
+
+	return taskCtx
+}
+
+// --- BuildResource tests ---
+
+func TestBuildResource_HappyPath(t *testing.T) {
+	spec := &clusteredpb.ClusteredTaskSpec{
+		Replicas:     4,
+		NprocPerNode: 8,
+		Runtime: &clusteredpb.Runtime{
+			Kind: &clusteredpb.Runtime_Torchrun{
+				Torchrun: &clusteredpb.TorchRuntime{
+					RdzvBackend: clusteredpb.RdzvBackend_STATIC,
+					MaxRestarts: 0,
+				},
+			},
+		},
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 3},
+	}
+	taskTemplate := buildTaskTemplate(spec)
+	taskCtx := dummyTaskCtx(taskTemplate)
+
+	handler := clusteredResourceHandler{}
+	obj, err := handler.BuildResource(context.Background(), taskCtx)
+	assert.NoError(t, err)
+	assert.NotNil(t, obj)
+
+	jobSet, ok := obj.(*jobsetv1alpha2.JobSet)
+	assert.True(t, ok, "expected *JobSet")
+
+	assert.Equal(t, testJobName, jobSet.Name)
+	assert.Equal(t, testNS, jobSet.Namespace)
+	assert.True(t, *jobSet.Spec.Network.EnableDNSHostnames)
+	assert.Equal(t, jobsetv1alpha2.OperatorAll, jobSet.Spec.SuccessPolicy.Operator)
+	assert.Equal(t, int32(3), jobSet.Spec.FailurePolicy.MaxRestarts)
+	assert.Len(t, jobSet.Spec.ReplicatedJobs, 1)
+	assert.Equal(t, "workers", jobSet.Spec.ReplicatedJobs[0].Name)
+	assert.Equal(t, int32(1), jobSet.Spec.ReplicatedJobs[0].Replicas)
+
+	jobSpec := jobSet.Spec.ReplicatedJobs[0].Template.Spec
+	assert.Equal(t, int32(4), *jobSpec.Parallelism)
+	assert.Equal(t, int32(4), *jobSpec.Completions)
+	assert.Equal(t, batchv1.IndexedCompletion, *jobSpec.CompletionMode)
+	assert.Equal(t, int32(0), *jobSpec.BackoffLimit)
+}
+
+func TestBuildResource_EntrypointSplice(t *testing.T) {
+	spec := &clusteredpb.ClusteredTaskSpec{
+		Replicas:     2,
+		NprocPerNode: 1,
+		Runtime: &clusteredpb.Runtime{
+			Kind: &clusteredpb.Runtime_Torchrun{
+				Torchrun: &clusteredpb.TorchRuntime{},
+			},
+		},
+	}
+	taskTemplate := buildTaskTemplate(spec)
+	taskCtx := dummyTaskCtx(taskTemplate)
+
+	handler := clusteredResourceHandler{}
+	obj, err := handler.BuildResource(context.Background(), taskCtx)
+	assert.NoError(t, err)
+
+	jobSet := obj.(*jobsetv1alpha2.JobSet)
+	podSpec := jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec
+
+	assert.NotEmpty(t, podSpec.Containers)
+	// The first (and only) container is the primary — check it was spliced.
+	primary := &podSpec.Containers[0]
+	assert.Equal(t, []string{"python", "-m", "flyte.distributed._entrypoint"}, primary.Command)
+	// Original command + args should be moved to args.
+	assert.Contains(t, primary.Args, "a0")
+}
+
+// --- injectTorchRunEnv tests ---
+
+func TestInjectTorchRunEnv_Static(t *testing.T) {
+	spec := &clusteredpb.ClusteredTaskSpec{
+		Replicas:     4,
+		NprocPerNode: 8,
+		Runtime: &clusteredpb.Runtime{
+			Kind: &clusteredpb.Runtime_Torchrun{
+				Torchrun: &clusteredpb.TorchRuntime{RdzvBackend: clusteredpb.RdzvBackend_STATIC},
+			},
+		},
+	}
+	container := &corev1.Container{}
+	injectTorchRunEnv(container, spec)
+
+	envMap := make(map[string]string)
+	for _, e := range container.Env {
+		if e.Value != "" {
+			envMap[e.Name] = e.Value
+		}
+	}
+	assert.Equal(t, "4", envMap["NNODES"])
+	assert.Equal(t, "8", envMap["NPROC_PER_NODE"])
+	assert.Equal(t, "29500", envMap["MASTER_PORT"])
+	assert.Equal(t, "static", envMap["RDZV_BACKEND"])
+
+	// Downward API env vars should be present.
+	names := make(map[string]bool)
+	for _, e := range container.Env {
+		names[e.Name] = true
+	}
+	assert.True(t, names["JOBSET_NAME"])
+	assert.True(t, names["JOBSET_RESTART_ATTEMPT"])
+	assert.True(t, names["POD_NAMESPACE"])
+}
+
+func TestInjectTorchRunEnv_C10D(t *testing.T) {
+	spec := &clusteredpb.ClusteredTaskSpec{
+		Replicas:     2,
+		NprocPerNode: 4,
+		Runtime: &clusteredpb.Runtime{
+			Kind: &clusteredpb.Runtime_Torchrun{
+				Torchrun: &clusteredpb.TorchRuntime{RdzvBackend: clusteredpb.RdzvBackend_C10D},
+			},
+		},
+	}
+	container := &corev1.Container{}
+	injectTorchRunEnv(container, spec)
+
+	for _, e := range container.Env {
+		if e.Name == "RDZV_BACKEND" {
+			assert.Equal(t, "c10d", e.Value)
+			return
+		}
+	}
+	t.Fatal("RDZV_BACKEND not found")
+}
+
+// --- buildFailurePolicy tests ---
+
+func TestBuildFailurePolicy_MaxRestarts(t *testing.T) {
+	spec := &clusteredpb.ClusteredTaskSpec{
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 3},
+	}
+	fp := buildFailurePolicy(spec)
+	assert.NotNil(t, fp)
+	assert.Equal(t, int32(3), fp.MaxRestarts)
+}
+
+func TestBuildFailurePolicy_Zero(t *testing.T) {
+	spec := &clusteredpb.ClusteredTaskSpec{
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 0},
+	}
+	fp := buildFailurePolicy(spec)
+	assert.Nil(t, fp)
+}
+
+func TestBuildFailurePolicy_Nil(t *testing.T) {
+	spec := &clusteredpb.ClusteredTaskSpec{}
+	fp := buildFailurePolicy(spec)
+	assert.Nil(t, fp)
+}
+
+// --- GetTaskPhase tests ---
+
+func makeJobSet(condType jobsetv1alpha2.JobSetConditionType, status metav1.ConditionStatus, suspend bool) *jobsetv1alpha2.JobSet {
+	js := &jobsetv1alpha2.JobSet{
+		ObjectMeta: metav1.ObjectMeta{Name: testJobName, Namespace: testNS},
+		Spec: jobsetv1alpha2.JobSetSpec{
+			Suspend: &suspend,
+			ReplicatedJobs: []jobsetv1alpha2.ReplicatedJob{
+				{
+					Name:     "workers",
+					Replicas: 1,
+					Template: batchv1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{
+							Parallelism: func() *int32 { v := int32(2); return &v }(),
+						},
+					},
+				},
+			},
+		},
+	}
+	if condType != "" {
+		js.Status.Conditions = []metav1.Condition{
+			{
+				Type:               string(condType),
+				Status:             status,
+				LastTransitionTime: metav1.NewTime(time.Now()),
+				Reason:             "test",
+				Message:            "test message",
+			},
+		}
+	}
+	return js
+}
+
+func dummyPluginCtx(taskTemplate *core.TaskTemplate) *k8smocks.PluginContext {
+	pCtx := &k8smocks.PluginContext{}
+
+	taskReader := &coreMocks.TaskReader{}
+	taskReader.EXPECT().Read(mock.Anything).Return(taskTemplate, nil)
+	pCtx.EXPECT().TaskReader().Return(taskReader)
+
+	tID := &coreMocks.TaskExecutionID{}
+	tID.EXPECT().GetID().Return(&core.TaskExecutionIdentifier{
+		NodeExecutionId: &core.NodeExecutionIdentifier{
+			ExecutionId: &core.WorkflowExecutionIdentifier{Name: "exec"},
+		},
+	})
+	tID.EXPECT().GetGeneratedName().Return(testJobName)
+	tID.EXPECT().GetUniqueNodeID().Return("node-id").Maybe()
+
+	meta := &coreMocks.TaskExecutionMetadata{}
+	meta.EXPECT().GetTaskExecutionID().Return(tID)
+	pCtx.EXPECT().TaskExecutionMetadata().Return(meta)
+
+	pluginStateReader := &coreMocks.PluginStateReader{}
+	pluginStateReader.EXPECT().Get(mock.Anything).Return(uint8(0), nil)
+	pCtx.EXPECT().PluginStateReader().Return(pluginStateReader)
+
+	return pCtx
+}
+
+func TestGetTaskPhase_Initializing(t *testing.T) {
+	suspend := false
+	js := makeJobSet("", "", suspend)
+
+	spec := &clusteredpb.ClusteredTaskSpec{Replicas: 2, NprocPerNode: 1}
+	pCtx := dummyPluginCtx(buildTaskTemplate(spec))
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseInitializing, phase.Phase())
+}
+
+func TestGetTaskPhase_Success(t *testing.T) {
+	js := makeJobSet(jobsetv1alpha2.JobSetCompleted, metav1.ConditionTrue, false)
+
+	spec := &clusteredpb.ClusteredTaskSpec{Replicas: 2, NprocPerNode: 1}
+	pCtx := dummyPluginCtx(buildTaskTemplate(spec))
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseSuccess, phase.Phase())
+}
+
+func TestGetTaskPhase_Failure(t *testing.T) {
+	js := makeJobSet(jobsetv1alpha2.JobSetFailed, metav1.ConditionTrue, false)
+
+	spec := &clusteredpb.ClusteredTaskSpec{Replicas: 2, NprocPerNode: 1}
+	pCtx := dummyPluginCtx(buildTaskTemplate(spec))
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRetryableFailure, phase.Phase())
+}
+
+func TestGetTaskPhase_Running(t *testing.T) {
+	suspend := false
+	js := makeJobSet("", "", suspend)
+	// An active condition with an unrecognized type → falls through to Running.
+	js.Status.Conditions = []metav1.Condition{
+		{
+			Type:               "SomeActiveCondition",
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(time.Now()),
+		},
+	}
+
+	spec := &clusteredpb.ClusteredTaskSpec{Replicas: 2, NprocPerNode: 1}
+	pCtx := dummyPluginCtx(buildTaskTemplate(spec))
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRunning, phase.Phase())
+}
+
+// --- IsTerminal / GetCompletionTime ---
+
+func TestIsTerminal(t *testing.T) {
+	handler := clusteredResourceHandler{}
+
+	js := makeJobSet(jobsetv1alpha2.JobSetCompleted, metav1.ConditionTrue, false)
+	ok, err := handler.IsTerminal(context.Background(), js)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	js2 := makeJobSet("", "", false)
+	ok2, err := handler.IsTerminal(context.Background(), js2)
+	assert.NoError(t, err)
+	assert.False(t, ok2)
+}
+
+func TestGetCompletionTime(t *testing.T) {
+	handler := clusteredResourceHandler{}
+	js := makeJobSet(jobsetv1alpha2.JobSetCompleted, metav1.ConditionTrue, false)
+	ts, err := handler.GetCompletionTime(js)
+	assert.NoError(t, err)
+	assert.False(t, ts.IsZero())
+}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
@@ -154,7 +154,11 @@ func TestBuildResource_HappyPath(t *testing.T) {
 	assert.Equal(t, int32(0), *jobSpec.BackoffLimit)
 }
 
-func TestBuildResource_EntrypointSplice(t *testing.T) {
+func TestBuildResource_PrimaryContainerPreserved(t *testing.T) {
+	// The plugin no longer rewrites container.Command — the SDK does that at
+	// serde time (design §3.2 / §3.8). Here we assert the plugin passes the
+	// TaskTemplate's container through unchanged and stamps the primary
+	// container name onto the JobSet via annotation for status-time recovery.
 	spec := &clusteredpb.ClusteredTaskSpec{
 		Replicas:     2,
 		NprocPerNode: 1,
@@ -175,11 +179,14 @@ func TestBuildResource_EntrypointSplice(t *testing.T) {
 	podSpec := jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec
 
 	assert.NotEmpty(t, podSpec.Containers)
-	// The first (and only) container is the primary — check it was spliced.
 	primary := &podSpec.Containers[0]
-	assert.Equal(t, []string{"python", "-m", "flyte.distributed._entrypoint"}, primary.Command)
-	// Original command + args should be moved to args.
-	assert.Contains(t, primary.Args, "a0")
+
+	// Command + args from the TaskTemplate must reach the pod untouched.
+	assert.Equal(t, []string{"a0"}, primary.Command)
+	assert.Equal(t, []string{"a0", "--inputs", "s3://bucket/in"}, primary.Args)
+
+	// Primary container name must be retrievable from the JobSet at status time.
+	assert.Equal(t, primary.Name, jobSet.Annotations[primaryContainerAnnotation])
 }
 
 // --- injectTorchRunEnv tests ---

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
@@ -253,7 +253,8 @@ func TestBuildFailurePolicy_MaxRestarts(t *testing.T) {
 	spec := &clusteredpb.ClusteredTaskSpec{
 		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 3},
 	}
-	fp := buildFailurePolicy(spec)
+	fp, err := buildFailurePolicy(spec)
+	assert.NoError(t, err)
 	assert.NotNil(t, fp)
 	assert.Equal(t, int32(3), fp.MaxRestarts)
 }
@@ -262,13 +263,24 @@ func TestBuildFailurePolicy_Zero(t *testing.T) {
 	spec := &clusteredpb.ClusteredTaskSpec{
 		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 0},
 	}
-	fp := buildFailurePolicy(spec)
+	fp, err := buildFailurePolicy(spec)
+	assert.NoError(t, err)
 	assert.Nil(t, fp)
 }
 
 func TestBuildFailurePolicy_Nil(t *testing.T) {
 	spec := &clusteredpb.ClusteredTaskSpec{}
-	fp := buildFailurePolicy(spec)
+	fp, err := buildFailurePolicy(spec)
+	assert.NoError(t, err)
+	assert.Nil(t, fp)
+}
+
+func TestBuildFailurePolicy_Negative(t *testing.T) {
+	spec := &clusteredpb.ClusteredTaskSpec{
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: -1},
+	}
+	fp, err := buildFailurePolicy(spec)
+	assert.Error(t, err)
 	assert.Nil(t, fp)
 }
 

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/failure.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/failure.go
@@ -1,0 +1,20 @@
+package clustered
+
+import (
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+
+	clusteredpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/plugins"
+)
+
+// buildFailurePolicy returns the JobSet failurePolicy from the SDK spec.
+// restart_on_host_maintenance (eviction free-restart via RestartJobSetAndIgnoreMaxRestarts) is deferred to PR 4.
+func buildFailurePolicy(spec *clusteredpb.ClusteredTaskSpec) *jobsetv1alpha2.FailurePolicy {
+	fp := spec.GetFailurePolicy()
+	if fp == nil || fp.GetMaxRestarts() == 0 {
+		return nil
+	}
+	maxRestarts := fp.GetMaxRestarts()
+	return &jobsetv1alpha2.FailurePolicy{
+		MaxRestarts: maxRestarts,
+	}
+}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/failure.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/failure.go
@@ -3,18 +3,22 @@ package clustered
 import (
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
+	flyteerr "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/errors"
 	clusteredpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/plugins"
 )
 
 // buildFailurePolicy returns the JobSet failurePolicy from the SDK spec.
 // restart_on_host_maintenance (eviction free-restart via RestartJobSetAndIgnoreMaxRestarts) is deferred to PR 4.
-func buildFailurePolicy(spec *clusteredpb.ClusteredTaskSpec) *jobsetv1alpha2.FailurePolicy {
+func buildFailurePolicy(spec *clusteredpb.ClusteredTaskSpec) (*jobsetv1alpha2.FailurePolicy, error) {
 	fp := spec.GetFailurePolicy()
 	if fp == nil || fp.GetMaxRestarts() == 0 {
-		return nil
+		return nil, nil
 	}
 	maxRestarts := fp.GetMaxRestarts()
+	if maxRestarts < 0 {
+		return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "failure_policy.max_restarts must be >= 0, got %d", maxRestarts)
+	}
 	return &jobsetv1alpha2.FailurePolicy{
 		MaxRestarts: maxRestarts,
-	}
+	}, nil
 }

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/interconnect.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/interconnect.go
@@ -1,0 +1,19 @@
+package clustered
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
+	clusteredpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/plugins"
+)
+
+// applyInterconnect mutates the pod spec for the requested interconnect fabric.
+// Phase 3 will implement EFA, InfiniBand, and RoCE mutations.
+func applyInterconnect(ctx context.Context, interconnect clusteredpb.Interconnect, podSpec *corev1.PodSpec) *corev1.PodSpec {
+	if interconnect != clusteredpb.Interconnect_TCP {
+		logger.Warningf(ctx, "interconnect %v is not yet implemented; falling back to TCP", interconnect)
+	}
+	return podSpec
+}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/logs.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/logs.go
@@ -1,0 +1,68 @@
+package clustered
+
+import (
+	"fmt"
+	"time"
+
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/logs"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/tasklog"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
+)
+
+// getTaskLogs synthesizes per-rank log URLs.
+// Pod name pattern: <jobsetName>-workers-0-<podIdx>
+func getTaskLogs(pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet) ([]*core.TaskLog, error) {
+	taskTemplate, err := pluginContext.TaskReader().Read(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	logPlugin, err := logs.InitializeLogPlugins(logs.GetLogConfig(), taskTemplate)
+	if err != nil {
+		return nil, err
+	}
+	if logPlugin == nil {
+		return nil, nil
+	}
+
+	startTime := jobSet.CreationTimestamp.Unix()
+	finishTime := time.Now().Unix()
+	startTimeRFC3339 := time.Unix(startTime, 0).Format(time.RFC3339)
+	finishTimeRFC3339 := time.Unix(finishTime, 0).Format(time.RFC3339)
+	taskExecID := pluginContext.TaskExecutionMetadata().GetTaskExecutionID()
+
+	var totalReplicas int32
+	for _, rj := range jobSet.Spec.ReplicatedJobs {
+		if rj.Name == "workers" {
+			if rj.Template.Spec.Parallelism != nil {
+				totalReplicas = *rj.Template.Spec.Parallelism
+			}
+			break
+		}
+	}
+
+	taskLogs := make([]*core.TaskLog, 0, int(totalReplicas))
+	for podIdx := int32(0); podIdx < totalReplicas; podIdx++ {
+		podName := fmt.Sprintf("%s-workers-0-%d", jobSet.Name, podIdx)
+		output, err := logPlugin.GetTaskLogs(tasklog.Input{
+			PodName:              podName,
+			Namespace:            jobSet.Namespace,
+			LogName:              fmt.Sprintf("rank-%d", podIdx),
+			PodRFC3339StartTime:  startTimeRFC3339,
+			PodRFC3339FinishTime: finishTimeRFC3339,
+			PodUnixStartTime:     startTime,
+			PodUnixFinishTime:    finishTime,
+			TaskExecutionID:      taskExecID,
+			TaskTemplate:         taskTemplate,
+			ContainerName:        "primary",
+		})
+		if err != nil {
+			return nil, err
+		}
+		taskLogs = append(taskLogs, output.TaskLogs...)
+	}
+	return taskLogs, nil
+}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/logs.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/logs.go
@@ -14,7 +14,14 @@ import (
 )
 
 // getTaskLogs synthesizes per-rank log URLs.
-// Pod name pattern: <jobsetName>-workers-0-<podIdx>
+//
+// JobSet pod-name pattern: <jobsetName>-<replicatedJob>-<jobIdx>-<podIdx>.
+// We declare a single ReplicatedJob named "workers" with Replicas=1, so jobIdx
+// is always 0; podIdx == JOB_COMPLETION_INDEX == NODE_RANK in [0, totalReplicas).
+//
+// The primary container name is recovered from the annotation written at
+// BuildResource time so we don't depend on TaskExecutionID equaling the
+// container name (which it isn't, in general).
 func getTaskLogs(ctx context.Context, pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet) ([]*core.TaskLog, error) {
 	taskTemplate, err := pluginContext.TaskReader().Read(ctx)
 	if err != nil {
@@ -37,7 +44,7 @@ func getTaskLogs(ctx context.Context, pluginContext k8s.PluginContext, jobSet *j
 
 	var totalReplicas int32
 	for _, rj := range jobSet.Spec.ReplicatedJobs {
-		if rj.Name == "workers" {
+		if rj.Name == workersReplicatedJobName {
 			if rj.Template.Spec.Parallelism != nil {
 				totalReplicas = *rj.Template.Spec.Parallelism
 			}
@@ -45,9 +52,11 @@ func getTaskLogs(ctx context.Context, pluginContext k8s.PluginContext, jobSet *j
 		}
 	}
 
+	primaryContainerName := jobSet.Annotations[primaryContainerAnnotation]
+
 	taskLogs := make([]*core.TaskLog, 0, int(totalReplicas))
 	for podIdx := int32(0); podIdx < totalReplicas; podIdx++ {
-		podName := fmt.Sprintf("%s-workers-0-%d", jobSet.Name, podIdx)
+		podName := fmt.Sprintf("%s-%s-0-%d", jobSet.Name, workersReplicatedJobName, podIdx)
 		output, err := logPlugin.GetTaskLogs(tasklog.Input{
 			PodName:              podName,
 			Namespace:            jobSet.Namespace,
@@ -58,7 +67,7 @@ func getTaskLogs(ctx context.Context, pluginContext k8s.PluginContext, jobSet *j
 			PodUnixFinishTime:    finishTime,
 			TaskExecutionID:      taskExecID,
 			TaskTemplate:         taskTemplate,
-			ContainerName:        pluginContext.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(),
+			ContainerName:        primaryContainerName,
 		})
 		if err != nil {
 			return nil, err

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/logs.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/logs.go
@@ -1,6 +1,7 @@
 package clustered
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -14,8 +15,8 @@ import (
 
 // getTaskLogs synthesizes per-rank log URLs.
 // Pod name pattern: <jobsetName>-workers-0-<podIdx>
-func getTaskLogs(pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet) ([]*core.TaskLog, error) {
-	taskTemplate, err := pluginContext.TaskReader().Read(nil)
+func getTaskLogs(ctx context.Context, pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet) ([]*core.TaskLog, error) {
+	taskTemplate, err := pluginContext.TaskReader().Read(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +58,7 @@ func getTaskLogs(pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet)
 			PodUnixFinishTime:    finishTime,
 			TaskExecutionID:      taskExecID,
 			TaskTemplate:         taskTemplate,
-			ContainerName:        "primary",
+			ContainerName:        pluginContext.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(),
 		})
 		if err != nil {
 			return nil, err

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/phase.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/phase.go
@@ -1,0 +1,76 @@
+package clustered
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+
+	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/utils"
+)
+
+func (clusteredResourceHandler) GetTaskPhase(ctx context.Context, pluginContext k8s.PluginContext, resource client.Object) (pluginsCore.PhaseInfo, error) {
+	jobSet, ok := resource.(*jobsetv1alpha2.JobSet)
+	if !ok {
+		return pluginsCore.PhaseInfoUndefined, fmt.Errorf("unexpected resource type %T", resource)
+	}
+
+	taskLogs, err := getTaskLogs(pluginContext, jobSet)
+	if err != nil {
+		return pluginsCore.PhaseInfoUndefined, err
+	}
+
+	occurredAt := time.Now()
+	statusDetails, _ := utils.MarshalObjToStruct(jobSet.Status) //nolint:staticcheck
+	taskInfo := pluginsCore.TaskInfo{
+		Logs:       taskLogs,
+		OccurredAt: &occurredAt,
+		CustomInfo: statusDetails,
+	}
+
+	condition := extractCurrentCondition(jobSet.Status.Conditions)
+	if condition == nil {
+		// JobSet exists, not suspended, no terminal condition yet.
+		return pluginsCore.PhaseInfoInitializing(occurredAt, pluginsCore.DefaultPhaseVersion, "pods scheduling / DNS resolving", &taskInfo), nil
+	}
+
+	switch jobsetv1alpha2.JobSetConditionType(condition.Type) {
+	case jobsetv1alpha2.JobSetCompleted:
+		return pluginsCore.PhaseInfoSuccess(&taskInfo), nil
+
+	case jobsetv1alpha2.JobSetFailed:
+		return pluginsCore.PhaseInfoRetryableFailure(condition.Reason, condition.Message, &taskInfo), nil
+	}
+
+	phaseInfo := pluginsCore.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion, &taskInfo)
+
+	if err := k8s.MaybeUpdatePhaseVersionFromPluginContext(&phaseInfo, &pluginContext); err != nil {
+		return phaseInfo, err
+	}
+	return phaseInfo, nil
+}
+
+// extractCurrentCondition returns the most recently transitioned condition with Status=True, or nil.
+// Ported from kfoperators/common/common_operator.go — not imported to avoid the dependency.
+func extractCurrentCondition(conditions []metav1.Condition) *metav1.Condition {
+	if len(conditions) == 0 {
+		return nil
+	}
+	sorted := make([]metav1.Condition, len(conditions))
+	copy(sorted, conditions)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].LastTransitionTime.After(sorted[j].LastTransitionTime.Time)
+	})
+	for i := range sorted {
+		if sorted[i].Status == metav1.ConditionTrue {
+			return &sorted[i]
+		}
+	}
+	return nil
+}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/phase.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/phase.go
@@ -21,7 +21,7 @@ func (clusteredResourceHandler) GetTaskPhase(ctx context.Context, pluginContext 
 		return pluginsCore.PhaseInfoUndefined, fmt.Errorf("unexpected resource type %T", resource)
 	}
 
-	taskLogs, err := getTaskLogs(pluginContext, jobSet)
+	taskLogs, err := getTaskLogs(ctx, pluginContext, jobSet)
 	if err != nil {
 		return pluginsCore.PhaseInfoUndefined, err
 	}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/phase.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/phase.go
@@ -13,6 +13,7 @@ import (
 	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/utils"
+	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 )
 
 func (clusteredResourceHandler) GetTaskPhase(ctx context.Context, pluginContext k8s.PluginContext, resource client.Object) (pluginsCore.PhaseInfo, error) {
@@ -27,7 +28,10 @@ func (clusteredResourceHandler) GetTaskPhase(ctx context.Context, pluginContext 
 	}
 
 	occurredAt := time.Now()
-	statusDetails, _ := utils.MarshalObjToStruct(jobSet.Status) //nolint:staticcheck
+	statusDetails, err := utils.MarshalObjToStruct(jobSet.Status) //nolint:staticcheck
+	if err != nil {
+		logger.Warnf(ctx, "failed to marshal JobSet status for task info: %v", err)
+	}
 	taskInfo := pluginsCore.TaskInfo{
 		Logs:       taskLogs,
 		OccurredAt: &occurredAt,

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/plugin.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/plugin.go
@@ -32,7 +32,8 @@ func (clusteredResourceHandler) IsTerminal(_ context.Context, resource client.Ob
 	}
 	for _, cond := range jobSet.Status.Conditions {
 		t := jobsetv1alpha2.JobSetConditionType(cond.Type)
-		if t == jobsetv1alpha2.JobSetCompleted || t == jobsetv1alpha2.JobSetFailed {
+		if (t == jobsetv1alpha2.JobSetCompleted || t == jobsetv1alpha2.JobSetFailed) &&
+			cond.Status == metav1.ConditionTrue {
 			return true, nil
 		}
 	}
@@ -46,7 +47,8 @@ func (clusteredResourceHandler) GetCompletionTime(resource client.Object) (time.
 	}
 	for _, cond := range jobSet.Status.Conditions {
 		t := jobsetv1alpha2.JobSetConditionType(cond.Type)
-		if t == jobsetv1alpha2.JobSetCompleted || t == jobsetv1alpha2.JobSetFailed {
+		if (t == jobsetv1alpha2.JobSetCompleted || t == jobsetv1alpha2.JobSetFailed) &&
+			cond.Status == metav1.ConditionTrue {
 			if !cond.LastTransitionTime.IsZero() {
 				return cond.LastTransitionTime.Time, nil
 			}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/plugin.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/plugin.go
@@ -1,0 +1,80 @@
+package clustered
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery"
+	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
+)
+
+const taskType = "clustered-task"
+
+type clusteredResourceHandler struct{}
+
+var _ k8s.Plugin = clusteredResourceHandler{}
+
+func (clusteredResourceHandler) GetProperties() k8s.PluginProperties {
+	return k8s.PluginProperties{}
+}
+
+func (clusteredResourceHandler) IsTerminal(_ context.Context, resource client.Object) (bool, error) {
+	jobSet, ok := resource.(*jobsetv1alpha2.JobSet)
+	if !ok {
+		return false, fmt.Errorf("unexpected resource type %T", resource)
+	}
+	for _, cond := range jobSet.Status.Conditions {
+		t := jobsetv1alpha2.JobSetConditionType(cond.Type)
+		if t == jobsetv1alpha2.JobSetCompleted || t == jobsetv1alpha2.JobSetFailed {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (clusteredResourceHandler) GetCompletionTime(resource client.Object) (time.Time, error) {
+	jobSet, ok := resource.(*jobsetv1alpha2.JobSet)
+	if !ok {
+		return time.Time{}, fmt.Errorf("unexpected resource type %T", resource)
+	}
+	for _, cond := range jobSet.Status.Conditions {
+		t := jobsetv1alpha2.JobSetConditionType(cond.Type)
+		if t == jobsetv1alpha2.JobSetCompleted || t == jobsetv1alpha2.JobSetFailed {
+			if !cond.LastTransitionTime.IsZero() {
+				return cond.LastTransitionTime.Time, nil
+			}
+		}
+	}
+	return jobSet.CreationTimestamp.Time, nil
+}
+
+func (clusteredResourceHandler) BuildIdentityResource(_ context.Context, _ pluginsCore.TaskExecutionMetadata) (client.Object, error) {
+	return &jobsetv1alpha2.JobSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "JobSet",
+			APIVersion: jobsetv1alpha2.SchemeGroupVersion.String(),
+		},
+	}, nil
+}
+
+func init() {
+	if err := jobsetv1alpha2.AddToScheme(scheme.Scheme); err != nil {
+		panic(err)
+	}
+
+	pluginmachinery.PluginRegistry().RegisterK8sPlugin(
+		k8s.PluginEntry{
+			ID:                  taskType,
+			RegisteredTaskTypes: []pluginsCore.TaskType{taskType},
+			ResourceToWatch:     &jobsetv1alpha2.JobSet{},
+			Plugin:              clusteredResourceHandler{},
+			IsDefault:           false,
+		})
+}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/runtime_torch.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/runtime_torch.go
@@ -8,7 +8,10 @@ import (
 	clusteredpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/plugins"
 )
 
-// injectTorchRunEnv appends the env vars that _entrypoint.py and torchrun need.
+// injectTorchRunEnv upserts the env vars that _entrypoint.py and torchrun need.
+// Plugin-owned names overwrite any user-provided entries with the same name —
+// duplicate Env entries have undefined precedence in Kubernetes and would
+// confuse torchrun/_entrypoint.
 // JOB_COMPLETION_INDEX is injected automatically by kubelet for Indexed Jobs.
 func injectTorchRunEnv(container *corev1.Container, spec *clusteredpb.ClusteredTaskSpec) {
 	rdzvBackend := "static"
@@ -21,12 +24,12 @@ func injectTorchRunEnv(container *corev1.Container, spec *clusteredpb.ClusteredT
 		}
 	}
 
-	container.Env = append(container.Env,
-		corev1.EnvVar{Name: "NNODES", Value: strconv.Itoa(int(spec.GetReplicas()))},
-		corev1.EnvVar{Name: "NPROC_PER_NODE", Value: strconv.Itoa(int(spec.GetNprocPerNode()))},
-		corev1.EnvVar{Name: "MASTER_PORT", Value: "29500"},
-		corev1.EnvVar{Name: "RDZV_BACKEND", Value: rdzvBackend},
-		corev1.EnvVar{
+	pluginEnv := []corev1.EnvVar{
+		{Name: "NNODES", Value: strconv.Itoa(int(spec.GetReplicas()))},
+		{Name: "NPROC_PER_NODE", Value: strconv.Itoa(int(spec.GetNprocPerNode()))},
+		{Name: "MASTER_PORT", Value: "29500"},
+		{Name: "RDZV_BACKEND", Value: rdzvBackend},
+		{
 			Name: "JOBSET_NAME",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
@@ -34,7 +37,7 @@ func injectTorchRunEnv(container *corev1.Container, spec *clusteredpb.ClusteredT
 				},
 			},
 		},
-		corev1.EnvVar{
+		{
 			Name: "JOBSET_RESTART_ATTEMPT",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
@@ -42,7 +45,7 @@ func injectTorchRunEnv(container *corev1.Container, spec *clusteredpb.ClusteredT
 				},
 			},
 		},
-		corev1.EnvVar{
+		{
 			Name: "POD_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
@@ -50,5 +53,24 @@ func injectTorchRunEnv(container *corev1.Container, spec *clusteredpb.ClusteredT
 				},
 			},
 		},
-	)
+	}
+
+	container.Env = upsertEnv(container.Env, pluginEnv)
+}
+
+// upsertEnv replaces existing entries with the same name and appends new ones.
+func upsertEnv(existing []corev1.EnvVar, updates []corev1.EnvVar) []corev1.EnvVar {
+	idx := make(map[string]int, len(existing))
+	for i, e := range existing {
+		idx[e.Name] = i
+	}
+	for _, u := range updates {
+		if i, ok := idx[u.Name]; ok {
+			existing[i] = u
+		} else {
+			existing = append(existing, u)
+			idx[u.Name] = len(existing) - 1
+		}
+	}
+	return existing
 }

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/runtime_torch.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/runtime_torch.go
@@ -1,0 +1,54 @@
+package clustered
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+
+	clusteredpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/plugins"
+)
+
+// injectTorchRunEnv appends the env vars that _entrypoint.py and torchrun need.
+// JOB_COMPLETION_INDEX is injected automatically by kubelet for Indexed Jobs.
+func injectTorchRunEnv(container *corev1.Container, spec *clusteredpb.ClusteredTaskSpec) {
+	rdzvBackend := "static"
+	if tr := spec.GetRuntime().GetTorchrun(); tr != nil {
+		switch tr.GetRdzvBackend() {
+		case clusteredpb.RdzvBackend_C10D:
+			rdzvBackend = "c10d"
+		default:
+			rdzvBackend = "static"
+		}
+	}
+
+	container.Env = append(container.Env,
+		corev1.EnvVar{Name: "NNODES", Value: strconv.Itoa(int(spec.GetReplicas()))},
+		corev1.EnvVar{Name: "NPROC_PER_NODE", Value: strconv.Itoa(int(spec.GetNprocPerNode()))},
+		corev1.EnvVar{Name: "MASTER_PORT", Value: "29500"},
+		corev1.EnvVar{Name: "RDZV_BACKEND", Value: rdzvBackend},
+		corev1.EnvVar{
+			Name: "JOBSET_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.labels['jobset.sigs.k8s.io/jobset-name']",
+				},
+			},
+		},
+		corev1.EnvVar{
+			Name: "JOBSET_RESTART_ATTEMPT",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.annotations['jobset.sigs.k8s.io/restart-attempt']",
+				},
+			},
+		},
+		corev1.EnvVar{
+			Name: "POD_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			},
+		},
+	)
+}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/util.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/util.go
@@ -1,0 +1,43 @@
+package clustered
+
+import "regexp"
+
+// Name of the sole ReplicatedJob in the JobSet. Pod names follow the pattern
+// <jobsetName>-<replicatedJob>-<jobIdx>-<podIdx>; we run a single ReplicatedJob
+// with Replicas=1, so jobIdx is always 0 and podIdx == JOB_COMPLETION_INDEX == NODE_RANK.
+const workersReplicatedJobName = "workers"
+
+// Annotation set at build time so status-time code (logs, demystify) can recover
+// the primary container name without re-running flytek8s.ToK8sPodSpec.
+const primaryContainerAnnotation = "flyte.org/primary-container"
+
+// (kueue): Gang admission via Kueue is not yet wired.
+
+var (
+	labelSanitizeRE = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+	labelLeadingRE  = regexp.MustCompile(`^[^a-zA-Z0-9]`)
+	labelTrailingRE = regexp.MustCompile(`[^a-zA-Z0-9]$`)
+)
+
+// sanitizeLabelValue coerces an arbitrary string into a valid Kubernetes label
+// value (≤63 chars, alphanumeric start/end, [a-zA-Z0-9._-] in between).
+// Used for human-supplied identifiers like execution names.
+func sanitizeLabelValue(value string) string {
+	if value == "" {
+		return "none"
+	}
+	s := labelSanitizeRE.ReplaceAllString(value, "-")
+	if labelLeadingRE.MatchString(s) {
+		s = "x" + s[1:]
+	}
+	if labelTrailingRE.MatchString(s) {
+		s = s[:len(s)-1] + "x"
+	}
+	if len(s) > 63 {
+		s = s[:63]
+		if labelTrailingRE.MatchString(s) {
+			s = s[:len(s)-1] + "x"
+		}
+	}
+	return s
+}

--- a/go.mod
+++ b/go.mod
@@ -175,6 +175,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncw/swift v1.0.53 // indirect
+	github.com/open-policy-agent/cert-controller v0.12.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
@@ -228,6 +229,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	knative.dev/networking v0.0.0-20240116081125-ce0738abf051 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
+	sigs.k8s.io/jobset v0.5.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	knative.dev/pkg v0.0.0-20240116073220-b488e7be5902
 	knative.dev/serving v0.40.2
 	sigs.k8s.io/controller-runtime v0.22.4
+	sigs.k8s.io/jobset v0.5.2
 )
 
 require (
@@ -175,7 +176,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncw/swift v1.0.53 // indirect
-	github.com/open-policy-agent/cert-controller v0.12.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
@@ -229,7 +229,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	knative.dev/networking v0.0.0-20240116081125-ce0738abf051 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
-	sigs.k8s.io/jobset v0.5.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -338,8 +338,6 @@ github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg
 github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=
 github.com/onsi/gomega v1.36.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
-github.com/open-policy-agent/cert-controller v0.12.0 h1:RKXlBafMcCh+++I1geJetXo77tAjyb4542DQc/+aZIw=
-github.com/open-policy-agent/cert-controller v0.12.0/go.mod h1:N5bCFXdAXMYx0PdS6ZQ9lrDQQMz+F6deoChym6VleXw=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/go.sum
+++ b/go.sum
@@ -338,6 +338,8 @@ github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg
 github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=
 github.com/onsi/gomega v1.36.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+github.com/open-policy-agent/cert-controller v0.12.0 h1:RKXlBafMcCh+++I1geJetXo77tAjyb4542DQc/+aZIw=
+github.com/open-policy-agent/cert-controller v0.12.0/go.mod h1:N5bCFXdAXMYx0PdS6ZQ9lrDQQMz+F6deoChym6VleXw=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
@@ -623,6 +625,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUo
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.16.3 h1:2TuvuokmfXvDUamSx1SuAOO3eTyye+47mJCigwG62c4=
 sigs.k8s.io/controller-runtime v0.16.3/go.mod h1:j7bialYoSn142nv9sCOJmQgDXQXxnroFU4VnX/brVJ0=
+sigs.k8s.io/jobset v0.5.2 h1:276q5Pi/ErLYj+GQ0ydEXR6tx3LwBhEzHLQv+k8bYF4=
+sigs.k8s.io/jobset v0.5.2/go.mod h1:Vg99rj/6OoGvy1uvywGEHOcVLCWWJYkJtisKqdWzcFw=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=


### PR DESCRIPTION
## Why are the changes needed?

The existing PyTorch/Kubeflow Training Operator plugin is brittle and upstream Kubeflow is moving toward JobSet. This plugin provides a cleaner, Kubernetes-native approach to distributed training using sigs.k8s.io/jobset.

## What changes were proposed in this pull request?

- Adds `flyteplugins/go/tasks/plugins/k8s/clustered/` — a new k8s plugin that reads a ClusteredTaskSpec proto and emits a jobset.x-k8s.io/v1alpha2 JobSet
- Splices `python -m flyte.distributed._entrypoint` as the container command and injects torchrun env vars (`NNODES, NPROC_PER_NODE, MASTER_PORT, RDZV_BACKEND`, plus downward API vars for JobSet `name/restart-attempt/namespace`)
- Maps JobSet status conditions to Flyte PhaseInfo (initializing → running → success/retryable failure)
- Registers the plugin via a blank import in `executor/setup.go`; adds sigs.k8s.io/jobset v0.5.2 to go.mod

## How was this patch tested?

- Unit tests cover BuildResource golden output, entrypoint splicing, env var injection, failure policy construction, and all GetTaskPhase condition mappings
- Run: `go test ./flyteplugins/go/tasks/plugins/k8s/clustered/... -v`
- All 13 tests pass

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

- `main` <!-- branch-stack -->
  - **feat: add clustered-task plugin for JobSet-based distributed training** :point\_left:
    - \#7418

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
