### PR TITLE
fix: Get rid of deprecated x/net/http2/h2c

### DIFF
--- a/flytestdlib/.golangci.yml
+++ b/flytestdlib/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   default: none
   enable:
     - copyloopvar
+    - depguard
     - dupl
     - errcheck
     - ginkgolinter
@@ -22,6 +23,12 @@ linters:
     - unparam
     - unused
   settings:
+    depguard:
+      rules:
+        no-h2c:
+          deny:
+            - pkg: golang.org/x/net/http2/h2c
+              desc: "deprecated: use net/http with http.Protocols.SetUnencryptedHTTP2(true)"
     revive:
       rules:
         - name: comment-spacings

--- a/flytestdlib/app/app.go
+++ b/flytestdlib/app/app.go
@@ -15,8 +15,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/config"
 	"github.com/flyteorg/flyte/v2/flytestdlib/config/viper"
@@ -118,8 +116,9 @@ func (a *App) serve(ctx context.Context) error {
 
 		addr := fmt.Sprintf("%s:%d", sc.Host, sc.Port)
 		server = &http.Server{
-			Addr:    addr,
-			Handler: h2c.NewHandler(handler, &http2.Server{}),
+			Addr:      addr,
+			Handler:   handler,
+			Protocols: httpProtocols(),
 		}
 
 		wg.Add(1)
@@ -197,17 +196,21 @@ func (a *App) serve(ctx context.Context) error {
 	return shutdownErr
 }
 
+func httpProtocols() *http.Protocols {
+	protocols := &http.Protocols{}
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+	return protocols
+}
+
 // requestGzipDecompressMiddleware pre-decompresses request bodies that carry
 // Content-Encoding: gzip before they reach the connect-rpc handler.
 //
 // Some HTTP clients (e.g. pyqwest used by the Python connectrpc SDK) compress
 // the request body at the application level and set Content-Encoding: gzip,
-// but also use chunked transfer encoding for larger payloads.  Go's h2c
-// framing delivers the body in chunks, so by the time connect-go calls
-// gzip.NewReader on the raw body stream the first bytes it receives may be a
-// chunk-size line rather than the gzip magic bytes, causing "gzip: invalid
-// header".  Pre-reading and fully decompressing the body here, before h2c
-// framing is involved, sidesteps the problem entirely.
+// but the stream may not begin with gzip magic bytes by the time connect-go
+// attempts to wrap it, causing "gzip: invalid header". Pre-reading and fully
+// decompressing the body here sidesteps the problem entirely.
 func requestGzipDecompressMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.EqualFold(r.Header.Get("Content-Encoding"), "gzip") {

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.37.0
 	go.opentelemetry.io/otel/trace v1.37.0
 	golang.org/x/exp v0.0.0-20251209150349-8475f28825e9
-	golang.org/x/net v0.54.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
@@ -206,6 +205,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/runs/test/api/setup_test.go
+++ b/runs/test/api/setup_test.go
@@ -12,8 +12,6 @@ import (
 
 	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
 	"github.com/jmoiron/sqlx"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/database"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/actions/actionsconnect"
@@ -136,8 +134,9 @@ func TestMain(m *testing.M) {
 
 	endpoint = fmt.Sprintf("http://localhost:%d", testPort)
 	testServer = &http.Server{
-		Addr:    fmt.Sprintf(":%d", testPort),
-		Handler: h2c.NewHandler(mux, &http2.Server{}),
+		Addr:      fmt.Sprintf(":%d", testPort),
+		Handler:   mux,
+		Protocols: httpProtocols(),
 	}
 
 	// Start server in background
@@ -171,6 +170,13 @@ func TestMain(m *testing.M) {
 
 	// Run tests
 	exitCode = m.Run()
+}
+
+func httpProtocols() *http.Protocols {
+	protocols := &http.Protocols{}
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+	return protocols
 }
 
 // waitForServer waits for the server to be ready


### PR DESCRIPTION
## Why are the changes needed?

Go 1.25 added native support for unencrypted HTTP/2 (h2c) directly in the standard `net/http`. This PR removes the dependency on the deprecated package `golang.org/x/net/http2/h2c`.

## What changes were proposed in this pull request?

1. Replaced `golang.org/x/net/http2/h2c` usage with the native Go 1.25 `http.Protocols` API in two places:
 - flytestdlib/app/app.go
 - runs/test/api/setup_test.go

2. Enabled the `depguard` linter in `flytestdlib/.golangci.yml` to prevent future regressions.

## How was this patch tested?

Both files compile cleanly with go build. The behavior is equivalent - the server continues to accept both HTTP/1.1 and unencrypted HTTP/2 connections.

```
curl -i --http2-prior-knowledge http://localhost:8090
```

### Labels

- **changed**

### Setup process

### Screenshots

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

## Stack

## Docs link

https://pkg.go.dev/golang.org/x/net/http2/h2c - deprecated package being replaced