### PR TITLE
fix(otelutils): avoid resource.Merge schema URL conflict panic

### DIFF
--- a/flytestdlib/otelutils/factory.go
+++ b/flytestdlib/otelutils/factory.go
@@ -90,17 +90,20 @@ func RegisterTracerProviderWithContext(ctx context.Context, serviceName string, 
 		return fmt.Errorf("unknown otel exporter type [%v]", config.ExporterType)
 	}
 
-	telemetryResource, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String(serviceName),
-			semconv.ServiceVersionKey.String(version.Version),
-		),
+	// Carry over the attributes from resource.Default() (telemetry.sdk.*,
+	// OTEL_RESOURCE_ATTRIBUTES / OTEL_SERVICE_NAME env vars, host info) but
+	// stamp them with semconv.SchemaURL instead of calling resource.Merge.
+	// Merge panics when the two sides declare different schema URLs, which
+	// happens whenever the installed otel/sdk's internal semconv version
+	// drifts apart from the semconv version imported above.
+	defaultAttrs := resource.Default().Attributes()
+	attrs := make([]attribute.KeyValue, 0, len(defaultAttrs)+2)
+	attrs = append(attrs, defaultAttrs...)
+	attrs = append(attrs,
+		semconv.ServiceNameKey.String(serviceName),
+		semconv.ServiceVersionKey.String(version.Version),
 	)
-	if err != nil {
-		return err
-	}
+	telemetryResource := resource.NewWithAttributes(semconv.SchemaURL, attrs...)
 
 	var sampler trace.Sampler
 	switch config.SamplerConfig.ParentSampler {


### PR DESCRIPTION
## Tracking issue
<!-- No open issue — discovered while debugging a production crash loop downstream. -->

## Why are the changes needed?

`flytestdlib/otelutils.RegisterTracerProviderWithContext` was crashing on startup with:

```
panic: failed to register tracer provider:
  conflicting Schema URL: https://opentelemetry.io/schemas/1.40.0
  and https://opentelemetry.io/schemas/1.34.0
```

The crash is reproducible whenever the OTel SDK version moves ahead of the semconv version imported by this file. The current code builds the tracer resource with:

```go
telemetryResource, err := resource.Merge(
    resource.Default(),
    resource.NewWithAttributes(semconv.SchemaURL, ...),
)
```

`resource.Merge` panics when the two sides declare different OpenTelemetry schema URLs. That happens here because:

- `resource.Default()` carries whichever semconv schema URL the installed `go.opentelemetry.io/otel/sdk` is built against (e.g. `1.40` in `otel/sdk@v1.43.0`).
- The custom resource uses the `semconv` package this file imports directly.

As `otel/sdk` gets bumped over time these drift apart and `resource.Merge` deterministically panics.

## What changes were proposed in this pull request?

Build the telemetry resource directly with `resource.NewWithAttributes` instead of going through `resource.Merge`. To preserve current behavior, the attributes from `resource.Default()` (which include `telemetry.sdk.name/language/version`, anything from `OTEL_RESOURCE_ATTRIBUTES` / `OTEL_SERVICE_NAME` env vars, and host info) are copied over and re-stamped with the configured `semconv.SchemaURL` from this file. The final span resource is identical to what `Merge` would have produced when schema URLs aligned, but it no longer panics when they don't.

```go
defaultAttrs := resource.Default().Attributes()
attrs := make([]attribute.KeyValue, 0, len(defaultAttrs)+2)
attrs = append(attrs, defaultAttrs...)
attrs = append(attrs,
    semconv.ServiceNameKey.String(serviceName),
    semconv.ServiceVersionKey.String(version.Version),
)
telemetryResource := resource.NewWithAttributes(semconv.SchemaURL, attrs...)
```

## How was this patch tested?

- `go build ./otelutils/...` — clean
- `go test ./otelutils/...` — passes (existing tests green)
- Verified that downstream binaries that previously CrashLoopBackOff'd on `RegisterTracerProviderWithContext` start cleanly with this patch applied.

### Labels
- **fixed**

### Setup process
N/A

### Screenshots
N/A

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

- unionai/flyte#979 — equivalent fix in the Flyte v1 fork.