### PR TITLE
ci: add flyteidl-release workflow to main

### DIFF
--- a/.github/workflows/flyteidl-release.yml
+++ b/.github/workflows/flyteidl-release.yml
@@ -1,0 +1,78 @@
+name: Release flyteidl
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "version. Do *not* use the `flyteidl/` prefix, e.g. `flyteidl/v1.2.3`, instead use only `v1.2.3` (including the `v`)"
+        required: true
+
+jobs:
+  push-flyteidl-tag:
+    name: Push git tag containing the `flyteidl/` prefix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.FLYTE_BOT_PAT }}
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/flyteidl/${{ github.event.inputs.version }}`,
+              sha: context.sha
+            })
+  deploy-to-pypi:
+    needs:
+      - push-flyteidl-tag
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: flyteidl
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python -m build
+          twine upload dist/*
+  deploy-to-npm:
+    needs:
+      - push-flyteidl-tag
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: flyteidl
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Set version in npm package
+        run: |
+          # v1.2.3 get 1.2.3
+          VERSION=$(echo ${{ inputs.version }} | sed 's#.*v##')
+          VERSION=$VERSION make update_npmversion
+        shell: bash
+      - run: |
+          npm install
+      - run: |
+          npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/flyteidl-release.yml
+++ b/.github/workflows/flyteidl-release.yml
@@ -1,3 +1,4 @@
+# This workflow is triggered manually and only releases the v1 flyteidl package.
 name: Release flyteidl
 
 on:


### PR DESCRIPTION
## Tracking issue

N/A

## Why are the changes needed?

The `Release flyteidl` workflow (`.github/workflows/flyteidl-release.yml`) only exists on the `master` branch. Since `main` is now the default branch, `workflow_dispatch` does not surface this workflow in the Actions UI, and `gh workflow run` cannot find it either. As a result, the flyteidl release pipeline cannot be triggered.

## What changes were proposed in this pull request?

Copy `.github/workflows/flyteidl-release.yml` from `master` to `main` verbatim. Once merged, the workflow becomes dispatchable from the default branch, and can be run against any ref (e.g. `master`):

```
gh workflow run flyteidl-release.yml --ref master -f version=v1.2.3
```

## How was this patch tested?

No functional change — workflow file copied unchanged from `master`. Will be exercised the next time we cut a flyteidl release.

### Labels

- **added**

## Check all the applicable boxes

- [x] I updated the documentation accordingly. (N/A — CI-only)
- [x] All new and existing tests passed. (N/A — workflow file copy)
- [x] All commits are signed-off.