### PR TITLE
fix: deflake ExampleNewAutoRefreshCache

### DIFF
--- a/flytestdlib/autorefreshcache/auto_refresh_example_test.go
+++ b/flytestdlib/autorefreshcache/auto_refresh_example_test.go
@@ -128,8 +128,8 @@ func ExampleNewAutoRefreshCache() {
 			break
 		}
 		if time.Now().After(deadline) {
-			fmt.Printf("Current status for item1 is %v", item.(*ExampleCacheItem).status)
-			break
+			cancel()
+			panic(fmt.Sprintf("timed out waiting for item1 to reach %v; last status=%v", ExampleStatusSucceeded, item.(*ExampleCacheItem).status))
 		}
 		time.Sleep(resyncPeriod)
 	}

--- a/flytestdlib/autorefreshcache/auto_refresh_example_test.go
+++ b/flytestdlib/autorefreshcache/auto_refresh_example_test.go
@@ -112,13 +112,26 @@ func ExampleNewAutoRefreshCache() {
 		fmt.Printf("unexpected error in create; err1: %v, err2: %v", err1, err2)
 	}
 
-	// wait for the cache to go through a few refresh cycles and then check status
-	time.Sleep(resyncPeriod * 10)
-	item, err := cache.Get(item1.ID())
-	if err != nil && errors.IsCausedBy(err, ErrNotFound) {
-		fmt.Printf("Item1 is no longer in the cache")
-	} else {
-		fmt.Printf("Current status for item1 is %v", item.(*ExampleCacheItem).status)
+	// Poll until the cache's background worker refreshes item1 to its terminal state. Polling against
+	// the expected condition (instead of sleeping a fixed duration) keeps this example deterministic
+	// even when the async worker is slow under load.
+	var item Item
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		item, err = cache.Get(item1.ID())
+		if err != nil && errors.IsCausedBy(err, ErrNotFound) {
+			fmt.Printf("Item1 is no longer in the cache")
+			break
+		}
+		if err == nil && item.(*ExampleCacheItem).status == ExampleStatusSucceeded {
+			fmt.Printf("Current status for item1 is %v", item.(*ExampleCacheItem).status)
+			break
+		}
+		if time.Now().After(deadline) {
+			fmt.Printf("Current status for item1 is %v", item.(*ExampleCacheItem).status)
+			break
+		}
+		time.Sleep(resyncPeriod)
 	}
 
 	// stop the cache

--- a/flytestdlib/autorefreshcache/auto_refresh_example_test.go
+++ b/flytestdlib/autorefreshcache/auto_refresh_example_test.go
@@ -116,7 +116,7 @@ func ExampleNewAutoRefreshCache() {
 	// the expected condition (instead of sleeping a fixed duration) keeps this example deterministic
 	// even when the async worker is slow under load.
 	var item Item
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for {
 		item, err = cache.Get(item1.ID())
 		if err != nil && errors.IsCausedBy(err, ErrNotFound) {

--- a/flytestdlib/autorefreshcache/auto_refresh_example_test.go
+++ b/flytestdlib/autorefreshcache/auto_refresh_example_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/flyteorg/flyte/v2/flytestdlib/errors"
 	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 )
 
@@ -112,43 +113,62 @@ func ExampleNewAutoRefreshCache() {
 		fmt.Printf("unexpected error in create; err1: %v, err2: %v", err1, err2)
 	}
 
-	// Poll until the cache's background worker refreshes item1 to its terminal state. Polling against
-	// the expected condition (instead of sleeping a fixed duration) keeps this example deterministic
-	// even when the async worker is slow under load.
-	var item Item
-	var lastStatus ExampleItemStatus = ExampleStatusNotStarted
-	deadline := time.Now().Add(10 * time.Second)
-	for {
-		item, err = cache.Get(item1.ID())
-		if err != nil {
-			if errors.IsCausedBy(err, ErrNotFound) {
-				fmt.Printf("Item1 is no longer in the cache")
-				break
-			}
-			cancel()
-			panic(fmt.Sprintf("unexpected error fetching item1: %v", err))
-		}
-
-		exItem, ok := item.(*ExampleCacheItem)
-		if !ok {
-			cancel()
-			panic(fmt.Sprintf("unexpected item type %T for item1", item))
-		}
-		lastStatus = exItem.status
-		if lastStatus == ExampleStatusSucceeded {
-			fmt.Printf("Current status for item1 is %v", lastStatus)
-			break
-		}
-		if time.Now().After(deadline) {
-			cancel()
-			panic(fmt.Sprintf("timed out waiting for item1 to reach %v; last status=%v", ExampleStatusSucceeded, lastStatus))
-		}
-		time.Sleep(resyncPeriod)
+	// The cache refreshes asynchronously in the background, so item1 transitions to its terminal
+	// status some time after it is created. Right after GetOrCreate it is already retrievable from
+	// the cache in its initial state. See TestNewAutoRefreshCache for verification that the
+	// background worker eventually advances item1 to its terminal status.
+	item, err := cache.Get(item1.ID())
+	if err != nil {
+		fmt.Printf("unexpected error getting item1: %v", err)
+	} else {
+		fmt.Printf("item1 is in the cache with id %q", item.(*ExampleCacheItem).ID())
 	}
 
 	// stop the cache
 	cancel()
 
 	// Output:
-	// Current status for item1 is Completed
+	// item1 is in the cache with id "item1"
+}
+
+// TestNewAutoRefreshCache verifies that the background worker eventually advances an item to its
+// terminal status. This lives in a test (rather than the example above) so that the wait can use
+// require.Eventually, which needs a *testing.T that example functions do not have.
+func TestNewAutoRefreshCache(t *testing.T) {
+	exampleService := newExampleService()
+
+	syncItemCb := func(ctx context.Context, batch []ItemWrapper) ([]ItemSyncResponse, error) {
+		updatedItems := make([]ItemSyncResponse, 0, len(batch))
+		for _, obj := range batch {
+			oldItem := obj.GetItem().(*ExampleCacheItem)
+			newItem := exampleService.getStatus(oldItem.ID())
+			if newItem.status != oldItem.status {
+				updatedItems = append(updatedItems, ItemSyncResponse{
+					ID:     oldItem.ID(),
+					Item:   newItem,
+					Action: Update,
+				})
+			}
+		}
+		return updatedItems, nil
+	}
+
+	resyncPeriod := time.Millisecond
+	rateLimiter := workqueue.DefaultControllerRateLimiter()
+	cache, err := NewAutoRefreshCache("my-cache", syncItemCb, rateLimiter, resyncPeriod, 10, 100, promutils.NewTestScope())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, cache.Start(ctx))
+
+	item1 := &ExampleCacheItem{status: ExampleStatusNotStarted, id: "item1"}
+	_, err = cache.GetOrCreate(item1.id, item1)
+	require.NoError(t, err)
+
+	// Poll until the background worker refreshes item1 to its terminal state.
+	require.Eventually(t, func() bool {
+		item, err := cache.Get(item1.ID())
+		return err == nil && item.(*ExampleCacheItem).status == ExampleStatusSucceeded
+	}, 3*time.Second, resyncPeriod, "expected item1 to reach terminal status %q", ExampleStatusSucceeded)
 }

--- a/flytestdlib/autorefreshcache/auto_refresh_example_test.go
+++ b/flytestdlib/autorefreshcache/auto_refresh_example_test.go
@@ -116,20 +116,32 @@ func ExampleNewAutoRefreshCache() {
 	// the expected condition (instead of sleeping a fixed duration) keeps this example deterministic
 	// even when the async worker is slow under load.
 	var item Item
+	var lastStatus ExampleItemStatus = ExampleStatusNotStarted
 	deadline := time.Now().Add(10 * time.Second)
 	for {
 		item, err = cache.Get(item1.ID())
-		if err != nil && errors.IsCausedBy(err, ErrNotFound) {
-			fmt.Printf("Item1 is no longer in the cache")
-			break
+		if err != nil {
+			if errors.IsCausedBy(err, ErrNotFound) {
+				fmt.Printf("Item1 is no longer in the cache")
+				break
+			}
+			cancel()
+			panic(fmt.Sprintf("unexpected error fetching item1: %v", err))
 		}
-		if err == nil && item.(*ExampleCacheItem).status == ExampleStatusSucceeded {
-			fmt.Printf("Current status for item1 is %v", item.(*ExampleCacheItem).status)
+
+		exItem, ok := item.(*ExampleCacheItem)
+		if !ok {
+			cancel()
+			panic(fmt.Sprintf("unexpected item type %T for item1", item))
+		}
+		lastStatus = exItem.status
+		if lastStatus == ExampleStatusSucceeded {
+			fmt.Printf("Current status for item1 is %v", lastStatus)
 			break
 		}
 		if time.Now().After(deadline) {
 			cancel()
-			panic(fmt.Sprintf("timed out waiting for item1 to reach %v; last status=%v", ExampleStatusSucceeded, item.(*ExampleCacheItem).status))
+			panic(fmt.Sprintf("timed out waiting for item1 to reach %v; last status=%v", ExampleStatusSucceeded, lastStatus))
 		}
 		time.Sleep(resyncPeriod)
 	}

--- a/flytestdlib/autorefreshcache/auto_refresh_example_test.go
+++ b/flytestdlib/autorefreshcache/auto_refresh_example_test.go
@@ -116,7 +116,7 @@ func ExampleNewAutoRefreshCache() {
 	// the expected condition (instead of sleeping a fixed duration) keeps this example deterministic
 	// even when the async worker is slow under load.
 	var item Item
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(3 * time.Second)
 	for {
 		item, err = cache.Get(item1.ID())
 		if err != nil && errors.IsCausedBy(err, ErrNotFound) {

--- a/flytestdlib/autorefreshcache/auto_refresh_example_test.go
+++ b/flytestdlib/autorefreshcache/auto_refresh_example_test.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/flyteorg/flyte/v2/flytestdlib/errors"
 	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 )
 
@@ -113,62 +112,48 @@ func ExampleNewAutoRefreshCache() {
 		fmt.Printf("unexpected error in create; err1: %v, err2: %v", err1, err2)
 	}
 
-	// The cache refreshes asynchronously in the background, so item1 transitions to its terminal
-	// status some time after it is created. Right after GetOrCreate it is already retrievable from
-	// the cache in its initial state. See TestNewAutoRefreshCache for verification that the
-	// background worker eventually advances item1 to its terminal status.
-	item, err := cache.Get(item1.ID())
-	if err != nil {
-		fmt.Printf("unexpected error getting item1: %v", err)
-	} else {
-		fmt.Printf("item1 is in the cache with id %q", item.(*ExampleCacheItem).ID())
+	// Poll until the cache's background worker refreshes item1 to its terminal state. Polling against
+	// the expected condition (instead of sleeping a fixed duration) keeps this example deterministic
+	// even when the async worker is slow under load.
+	//
+	// We hand-roll the wait loop instead of using require.Eventually because this is a runnable
+	// Example (verified via the "Output:" comment below), not a Test. Example functions take no
+	// arguments and so have no *testing.T, while require.Eventually requires a require.TestingT to
+	// report failures. The deadline below bounds the wait and panics on timeout to surface a hang.
+	var item Item
+	var lastStatus ExampleItemStatus = ExampleStatusNotStarted
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		item, err = cache.Get(item1.ID())
+		if err != nil {
+			if errors.IsCausedBy(err, ErrNotFound) {
+				fmt.Printf("Item1 is no longer in the cache")
+				break
+			}
+			cancel()
+			panic(fmt.Sprintf("unexpected error fetching item1: %v", err))
+		}
+
+		exItem, ok := item.(*ExampleCacheItem)
+		if !ok {
+			cancel()
+			panic(fmt.Sprintf("unexpected item type %T for item1", item))
+		}
+		lastStatus = exItem.status
+		if lastStatus == ExampleStatusSucceeded {
+			fmt.Printf("Current status for item1 is %v", lastStatus)
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			panic(fmt.Sprintf("timed out waiting for item1 to reach %v; last status=%v", ExampleStatusSucceeded, lastStatus))
+		}
+		time.Sleep(resyncPeriod)
 	}
 
 	// stop the cache
 	cancel()
 
 	// Output:
-	// item1 is in the cache with id "item1"
-}
-
-// TestNewAutoRefreshCache verifies that the background worker eventually advances an item to its
-// terminal status. This lives in a test (rather than the example above) so that the wait can use
-// require.Eventually, which needs a *testing.T that example functions do not have.
-func TestNewAutoRefreshCache(t *testing.T) {
-	exampleService := newExampleService()
-
-	syncItemCb := func(ctx context.Context, batch []ItemWrapper) ([]ItemSyncResponse, error) {
-		updatedItems := make([]ItemSyncResponse, 0, len(batch))
-		for _, obj := range batch {
-			oldItem := obj.GetItem().(*ExampleCacheItem)
-			newItem := exampleService.getStatus(oldItem.ID())
-			if newItem.status != oldItem.status {
-				updatedItems = append(updatedItems, ItemSyncResponse{
-					ID:     oldItem.ID(),
-					Item:   newItem,
-					Action: Update,
-				})
-			}
-		}
-		return updatedItems, nil
-	}
-
-	resyncPeriod := time.Millisecond
-	rateLimiter := workqueue.DefaultControllerRateLimiter()
-	cache, err := NewAutoRefreshCache("my-cache", syncItemCb, rateLimiter, resyncPeriod, 10, 100, promutils.NewTestScope())
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	require.NoError(t, cache.Start(ctx))
-
-	item1 := &ExampleCacheItem{status: ExampleStatusNotStarted, id: "item1"}
-	_, err = cache.GetOrCreate(item1.id, item1)
-	require.NoError(t, err)
-
-	// Poll until the background worker refreshes item1 to its terminal state.
-	require.Eventually(t, func() bool {
-		item, err := cache.Get(item1.ID())
-		return err == nil && item.(*ExampleCacheItem).status == ExampleStatusSucceeded
-	}, 3*time.Second, resyncPeriod, "expected item1 to reach terminal status %q", ExampleStatusSucceeded)
+	// Current status for item1 is Completed
 }


### PR DESCRIPTION
## Why are the changes needed?

`ExampleNewAutoRefreshCache` in `flytestdlib/autorefreshcache` is flaky in CI ([failing run](https://github.com/flyteorg/flyte/actions/runs/26675665878/job/78626794222)):

```
--- FAIL: ExampleNewAutoRefreshCache (0.01s)
got:
Current status for item1 is Not-started
want:
Current status for item1 is Completed
```

The example slept a fixed `resyncPeriod * 10` (10ms) and then asserted that `item1` had reached the terminal `Completed` status. That transition is performed by the cache's **async background refresh worker**, so 10ms is not guaranteed to be enough on a slow/contended CI runner — the item is still `Not-started` when the assertion runs. This is a classic fixed-duration-wait-for-async-work race.

## What changes were proposed in this pull request?

Replace the fixed `time.Sleep` with **condition-based polling**: poll `cache.Get` every `resyncPeriod` until `item1` reaches its terminal state (`Completed`), guarded by a 10s safety deadline. This removes the timing dependency while keeping the example's `// Output:` deterministic.

## How was this patch tested?

- `go build` / `go vet` of the package pass; `go test -race ./flytestdlib/autorefreshcache/` passes.
- Ran the example 200x via separate `go test` invocations under heavy CPU load (both before and after the change). **Note:** I was not able to reproduce the original CI flake locally even under load — the failure appears specific to the CI runner's scheduling. The change is therefore justified primarily by the root cause (a fixed 10ms wait for asynchronous work), not by a local repro.
  - Caveat worth knowing for reviewers: Go's `testing` package does **not** honor `-count` for `Example` functions (verified separately), so stressing an example requires repeated `go test` invocations rather than `-count=N`.

### Labels

- **fixed**: deflakes a CI example test.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.