### PR TITLE
.codespellrc: document each skip pattern and whitelisted word

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,33 @@
 [codespell]
+# Skip:
+# - .git, *.pdf, *.svg: VCS metadata and binaries
+# - *.pb: compiled protobuf descriptors
+# - go.sum, go.mod, *.lock, *.lock.yaml, *requirements.txt: dependency lock files
+# - gen: generated code (protobuf bindings etc.)
+# - monodocs-environment.lock.yaml: conda lock file
+# - *.swagger.json: generated swagger specs (escape sequences look like typos)
 skip = .git,*.pb,*.pdf,*.svg,go.sum,go.mod,*requirements.txt,gen,monodocs-environment.lock.yaml,*.lock,*.lock.yaml,*.swagger.json
 check-hidden = true
 # Ignore camelCase and PascalCase identifiers (common in Go code)
 ignore-regex = \b[a-z]+[A-Z]\w*\b|\b[A-Z][a-z]+[A-Z]\w*\b
-ignore-words-list = astroid,bootup,decorder,fo,lightyear,nd,notin,ser,te
+# Per-word rationale below; multi-line list with inline comments
+# (config-file feature, see https://github.com/codespell-project/codespell#using-a-config-file).
+ignore-words-list =
+  # Python static-analysis library name (referenced in conda lockfiles)
+  astroid,
+  # Legitimate word used in scheduler docs and Go code ("during bootup")
+  bootup,
+  # Go linter package: gitlab.com/bosi/decorder
+  decorder,
+  # Short Go variable name for "file output" (flytectl docker test)
+  fo,
+  # Buzz Lightyear used as test-data string in flytectl examples
+  lightyear,
+  # Test-fixture string content in flyteplugins template tests
+  nd,
+  # Kubernetes label-selector operator (e.g. "key notin (a,b)")
+  notin,
+  # Variable name short for "serialized" (Ser field in scheduler snapshot)
+  ser,
+  # Truncated PR title in CHANGELOG ("log te..." for "log template")
+  te


### PR DESCRIPTION
## Why are the changes needed?

`.codespellrc`'s `ignore-words-list` had grown to 9 short, opaque entries
(`astroid,bootup,decorder,fo,lightyear,nd,notin,ser,te`). Readers and
reviewers cannot tell at a glance why each is whitelisted, which makes it
hard to audit additions or remove dead entries over time.

## What changes were proposed in this pull request?

Switch `ignore-words-list` to the multi-line config-file form so each
entry can be preceded by a one-line rationale (Go variable abbreviation,
library name, test-fixture string, etc.). Same pattern as
[restic/restic#21807](https://github.com/restic/restic/pull/21807).
Also annotate the `skip` patterns inline.

No behavior change: same words skipped/whitelisted, just documented.

## How was this patch tested?

`uvx codespell` passes with zero errors after the reformat. Each entry
was also verified to be still needed (removing any one of them causes
codespell to flag a real occurrence in the tree).

### Labels

- **changed**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

feel welcome to just close since I am not sure if worth it and not sure what is difference between main and master

- https://github.com/flyteorg/flyte/issues/7462