### PR TITLE
refactor(executor): construct the executor metrics scope once

### DIFF
--- a/executor/setup.go
+++ b/executor/setup.go
@@ -109,7 +109,9 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		podNamespace = sc.Namespace
 	}
 
-	if err := webhookPkg.Setup(ctx, kubeClient, wCfg, podNamespace, promutils.NewScope("executor"), mgr); err != nil {
+	executorScope := promutils.NewScope("executor")
+
+	if err := webhookPkg.Setup(ctx, kubeClient, wCfg, podNamespace, executorScope.NewSubScope("webhook"), mgr); err != nil {
 		return fmt.Errorf("executor: webhook setup failed: %w", err)
 	}
 
@@ -121,7 +123,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	setupCtx := plugin.NewSetupContext(
 		mgr, nil, nil, nil, nil,
 		"TaskAction",
-		promutils.NewScope("executor"),
+		executorScope.NewSubScope("plugin"),
 	)
 	registry := plugin.NewRegistry(setupCtx, pluginmachinery.PluginRegistry())
 	if err := registry.Initialize(ctx); err != nil {


### PR DESCRIPTION
## Tracking issue
Closes #7456

## Why are the changes needed?
`executor/setup.go` constructed `promutils.NewScope("executor")` twice: once for the
webhook setup and once for the plugin setup context. Two independent scopes sharing
the same `executor:` prefix are a latent duplicate-registration panic on the default
Prometheus registry. If both ever register a like-named metric, `prometheus.Register`
returns `AlreadyRegisteredError` and the `MustNew*` helpers panic at startup.

## What changes were proposed in this pull request?
- Construct the base `executor` scope once (`executorScope := promutils.NewScope("executor")`).
- Give the webhook and plugin distinct sub-scopes derived from it:
  `executorScope.NewSubScope("webhook")` and `executorScope.NewSubScope("plugin")`
  (prefixes `executor:webhook:` and `executor:plugin:`).

Scoped to webhook + plugin per the issue. `executor:storage` and `executor:catalog`
already use distinct names, so they're collision-safe and left untouched. I'm happy to
fold those into the same base scope (emitted names unchanged) here or in a follow-up
if you'd prefer the file fully consistent.

## How was this patch tested?
No new unit test, since this is setup wiring with no new logic, and the issue's
criteria only require the executor to start cleanly and existing tests to pass.
Verified locally with `gofmt -l executor/setup.go`, `go build ./executor/...`, and
`go vet ./executor/...` (all clean). CI exercises `./executor/...`.

### Labels
- **changed**

### Setup process
N/A

### Screenshots
N/A

## Check all the applicable boxes
- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
N/A

## Docs link
N/A