### PR TITLE
Don't panic when receiving status in k8s resolver

### DIFF
--- a/flytestdlib/resolver/k8s_resolver.go
+++ b/flytestdlib/resolver/k8s_resolver.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -10,7 +11,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/resolver"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -165,7 +166,8 @@ func (k *kResolver) run() {
 			"k8s resolver: failed to create watcher for target [%s]: service namespace: [%s], service name: [%s], "+"error [%v]",
 			k.target, k.target.serviceNamespace, k.target.serviceName, err,
 		)
-		if statusErr, ok := err.(*errors.StatusError); ok {
+		var statusErr *k8serrors.StatusError
+		if errors.As(err, &statusErr) {
 			logger.Errorf(k.ctx, "k8s resolver: status error details: %v", statusErr.ErrStatus)
 		}
 
@@ -187,7 +189,22 @@ func (k *kResolver) run() {
 			if event.Object == nil {
 				continue
 			}
-			k.resolve(event.Object.(*v1.Endpoints))
+
+			endpoints, isEndpoints := event.Object.(*v1.Endpoints)
+
+			if isEndpoints {
+				k.resolve(endpoints)
+				continue
+			}
+
+			status, isStatus := event.Object.(*metav1.Status)
+			if isStatus {
+				logger.Warnf(k.ctx, "k8s resolver: status error details: %v", status)
+				continue
+			}
+
+			logger.Errorf(k.ctx, "k8s resolver: unknown event type: %T", event.Object)
+
 		}
 	}
 }

--- a/flytestdlib/resolver/k8s_resolver_test.go
+++ b/flytestdlib/resolver/k8s_resolver_test.go
@@ -13,7 +13,9 @@ import (
 	"gotest.tools/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8swatch "k8s.io/apimachinery/pkg/watch"
 	testclient "k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
 )
 
 func parseTarget(target string) resolver.Target {
@@ -55,7 +57,7 @@ func (*fakeConn) NewServiceConfig(serviceConfig string) {
 }
 
 func TestBuilder(t *testing.T) {
-	k8sClient := testclient.NewSimpleClientset()
+	k8sClient := testclient.NewClientset()
 	builder := NewBuilder(context.Background(), k8sClient, "test")
 	fc := &fakeConn{
 		cmp: make(chan struct{}),
@@ -96,6 +98,64 @@ func TestBuilder(t *testing.T) {
 	assert.Equal(t, fc.found[0], "10.0.0.1:8000")
 
 	k8sResolver.Close()
+}
+
+func TestBuilderIgnoresStatusEvents(t *testing.T) {
+	k8sClient := testclient.NewClientset()
+	fakeWatcher := k8swatch.NewFakeWithChanSize(2, false)
+	watchStarted := make(chan struct{})
+	k8sClient.PrependWatchReactor("endpoints", func(action clientgotesting.Action) (bool, k8swatch.Interface, error) {
+		close(watchStarted)
+		return true, fakeWatcher, nil
+	})
+
+	builder := NewBuilder(context.Background(), k8sClient, "test")
+	fc := &fakeConn{
+		cmp: make(chan struct{}),
+	}
+	k8sResolver, err := builder.Build(parseTarget("test://flyteagent.flyte.svc.cluster.local:8000"), fc, resolver.BuildOptions{})
+	assert.NilError(t, err)
+	defer k8sResolver.Close()
+
+	select {
+	case <-watchStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for endpoints watch to start")
+	}
+
+	fakeWatcher.Error(&metav1.Status{
+		Status: metav1.StatusFailure,
+		Reason: metav1.StatusReasonExpired,
+	})
+	fakeWatcher.Add(&v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flyteagent",
+			Namespace: "flyte",
+		},
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: []v1.EndpointAddress{
+					{
+						IP: "10.0.0.2",
+					},
+				},
+				Ports: []v1.EndpointPort{
+					{
+						Name: "grpc",
+						Port: 8000,
+					},
+				},
+			},
+		},
+	})
+
+	select {
+	case <-fc.cmp:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for resolver state update")
+	}
+	assert.Equal(t, len(fc.found), 1)
+	assert.Equal(t, fc.found[0], "10.0.0.2:8000")
 }
 
 func TestParseResolverTargets(t *testing.T) {


### PR DESCRIPTION
## Why are the changes needed?

The resolver panics when the k8s resolver watcher receives a `*v1.Status` messages instead of a `v1.Endpoints`. 

```
panic: interface conversion: runtime.Object is *v1.Status, not *v1.Endpoints [recovered, repanicked]

goroutine 310 [running]:
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x36d4520, 0x208a036b6310}, {0x2ee8d20, 0x208ec806eab0}, {0x0, 0x0, 0x208a44769b38?})
  /go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/runtime/runtime.go:114 +0x1a9
k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0x36d4520, 0x208a036b6310}, {0x0, 0x0, 0x0})
  /go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/runtime/runtime.go:78 +0x55
panic({0x2ee8d20?, 0x208ec806eab0?})
  /usr/local/go/src/runtime/panic.go:860 +0x13a
github.com/flyteorg/flyte/flytestdlib/resolver.(*kResolver).run(0x208a0239f300)
  /go/src/github.com/flyteorg/flytestdlib/resolver/k8s_resolver.go:190 +0x8de
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1({0x0?, 0x7f1b6cc3c000?})
  /go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/wait/backoff.go:233 +0x13
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x36d4520?, 0x208a036b6310?}, 0x42532f?)
  /go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/wait/backoff.go:255 +0x51
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x36d4520, 0x208a036b6310}, 0x208a44769f50, {0x3694840, 0x208a02fa4090}, 0x1)
  /go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/wait/backoff.go:256 +0xe5
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x208a02c888a0?, {0x3694840?, 0x208a02fa4090?}, 0x50?, 0x0?)
  /go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/wait/backoff.go:233 +0x46
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x208a036a1040, 0x0, 0x0, 0x1, 0x208a036b6310)
  /go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/wait/backoff.go:210 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
  /go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/wait/backoff.go:163
created by github.com/flyteorg/flyte/flytestdlib/resolver.(*kubeBuilder).Build in goroutine 308
  /go/src/github.com/flyteorg/flytestdlib/resolver/k8s_resolver.go:106 +0x2f8
  ```

## What changes were proposed in this pull request?

Instead of unconditionally casting to endpoints check if the cast was successful. 

## How was this patch tested?

Tested in our production environment

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
