### PR TITLE
fix(flyte-binary): route ClusterService through the gRPC ingress

### DIFF
--- a/charts/flyte-binary/templates/_helpers.tpl
+++ b/charts/flyte-binary/templates/_helpers.tpl
@@ -197,6 +197,8 @@ Get the Flyte API paths for ingress.
 - /flyteidl2.workflow.TranslatorService/*
 - /flyteidl2.dataproxy.DataProxyService
 - /flyteidl2.dataproxy.DataProxyService/*
+- /flyteidl2.cluster.ClusterService
+- /flyteidl2.cluster.ClusterService/*
 - /flyteidl2.secret.SecretService
 - /flyteidl2.secret.SecretService/*
 - /flyteidl2.project.ProjectService


### PR DESCRIPTION
## Tracking issue

<!-- none -->

## Why are the changes needed?

The dataproxy **`ClusterService`** (`flyteidl2.cluster.ClusterService`) is served by the
binary (`dataproxy/setup.go` mounts `NewClusterServiceHandler`), but it was missing from
the ingress `grpcPaths`. As a result the ALB returns **HTTP 404** for
`/flyteidl2.cluster.ClusterService/*`.

Any client that calls `SelectCluster` is broken by this. In particular the SDK calls
`SelectCluster` with `operation=OPERATION_CREATE_UPLOAD_LOCATION` *before* uploading task
inputs, so it fails with:

```
RuntimeError: SelectCluster failed for operation=1: Not Found
```

## What changes were proposed in this pull request?

- **`templates/_helpers.tpl`** — add `/flyteidl2.cluster.ClusterService` and
  `/flyteidl2.cluster.ClusterService/*` to `flyte-binary.ingress.grpcPaths`, alongside the
  other `flyteidl2.*` services (next to `DataProxyService`, since `ClusterService` lives in
  the dataproxy package). The path points at the same HTTP/gRPC backend as the other
  services.

## How was this patch tested?

- `helm template --set ingress.create=true --set ingress.separateGrpcIngress=true` now
  renders the two `ClusterService` paths in the gRPC ingress.
- `helm lint charts/flyte-binary` passes.
- Verified live on a dev cluster: before the change `POST /flyteidl2.cluster.ClusterService/SelectCluster`
  returned `404`; after adding the routes it returns `200` and the SDK's upload path succeeds.

### Labels

fixed

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
