### PR TITLE
feat(flyte-binary): manage the task-pod default ServiceAccount

### DIFF
--- a/charts/flyte-binary/templates/task-serviceaccount.yaml
+++ b/charts/flyte-binary/templates/task-serviceaccount.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.taskServiceAccount.create }}
+{{- /*
+The executor runs task pods as the namespace `default` ServiceAccount
+(executor returns an empty service account name, so Kubernetes uses `default`).
+This manages that ServiceAccount so it can carry annotations such as an IRSA
+role-arn, giving task pods cloud credentials (e.g. S3 access).
+*/}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.taskServiceAccount.name | default "default" }}
+  namespace: {{ .Values.taskServiceAccount.namespace | default .Release.Namespace | quote }}
+  labels: {{- include "flyte-binary.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- tpl ( .Values.commonLabels | toYaml ) . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.taskServiceAccount.labels }}
+    {{- tpl ( .Values.taskServiceAccount.labels | toYaml ) . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.commonAnnotations .Values.taskServiceAccount.annotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- tpl ( .Values.commonAnnotations | toYaml ) . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.taskServiceAccount.annotations }}
+    {{- tpl ( .Values.taskServiceAccount.annotations | toYaml ) . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -460,6 +460,23 @@ serviceAccount:
   # imagePullSecrets Secrets to use for fetching images from private registries
   imagePullSecrets: []
 
+# taskServiceAccount Configure the ServiceAccount that task pods run as.
+# The executor launches task pods with an empty service account name, so they
+# use the namespace `default` ServiceAccount. Enable this to manage that
+# ServiceAccount's annotations — e.g. an IRSA `eks.amazonaws.com/role-arn` so
+# task pods get cloud credentials (S3, etc.).
+taskServiceAccount:
+  # create Manage the task ServiceAccount (annotate the default SA)
+  create: false
+  # name Name of the task ServiceAccount (task pods use `default`)
+  name: default
+  # namespace Namespace of the task ServiceAccount (defaults to the release namespace)
+  namespace: ""
+  # labels Add labels to the task ServiceAccount
+  labels: {}
+  # annotations Add annotations to the task ServiceAccount (e.g. IRSA role-arn)
+  annotations: {}
+
 # flyteconnector Configure Flyte Connector objects
 flyteconnector:
   # enable Flag to enable bundled Flyte Connector


### PR DESCRIPTION
## Tracking issue

<!-- none -->

## Why are the changes needed?

Task pods run as the namespace **`default`** ServiceAccount — the executor returns an
empty service account name (`executor/pkg/plugin/task_exec_metadata.go`,
`GetK8sServiceAccount() string { return "" }`), so Kubernetes assigns `default`.

The chart had no way to put annotations on that ServiceAccount. On EKS this means task
pods can't be given an IRSA role (`eks.amazonaws.com/role-arn`), so they run without
cloud credentials and fail S3 operations with `403 Forbidden` (e.g. downloading the
fast-register code bundle).

## What changes were proposed in this pull request?

- **`templates/task-serviceaccount.yaml`** (new) — manages the task ServiceAccount
  (`default`, configurable) in the release namespace so it can carry annotations/labels.
- **`values.yaml`** — adds a `taskServiceAccount` block, **disabled by default**
  (`create: false`); set `create: true` and `annotations` to attach an IRSA role:
  ```yaml
  taskServiceAccount:
    create: true
    name: default
    annotations:
      eks.amazonaws.com/role-arn: "arn:aws:iam::<acct>:role/<worker-role>"
  ```

Note: because Kubernetes auto-creates the `default` ServiceAccount, an existing one
must carry Helm ownership metadata (`app.kubernetes.io/managed-by: Helm`,
`meta.helm.sh/release-name`/`-namespace`) for Helm to adopt it on upgrade.

## How was this patch tested?

- `helm template --show-only templates/task-serviceaccount.yaml` renders the `default`
  ServiceAccount with the configured IRSA annotation when enabled, and nothing when
  `create: false`.
- `helm lint` passes.
- Verified live on a dev cluster: a task pod using the annotated `default` SA assumes
  the worker IRSA role and the previously-403'ing `HEAD` on the code bundle returns 200.

### Labels

added

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
