### PR TITLE
feat(executor): configurable default service account for task pods

### DIFF
--- a/executor/pkg/config/config.go
+++ b/executor/pkg/config/config.go
@@ -79,6 +79,11 @@ type Config struct {
 	// Cluster is the cluster identifier attached to action events.
 	Cluster string `json:"cluster" pflag:",Cluster identifier for action events"`
 
+	// DefaultK8sServiceAccount is assigned to task pods when the task's security
+	// context does not specify one. Empty leaves the pod on the namespace's
+	// `default` ServiceAccount.
+	DefaultK8sServiceAccount string `json:"defaultK8sServiceAccount" pflag:",Default Kubernetes service account for task pods when the task does not set one"`
+
 	// MaxSystemFailures bounds consecutive system-level failures (Plugin.Handle Go
 	// errors and plugin-reported system-retryable failures) before a TaskAction is
 	// converted to a permanent failure.

--- a/executor/pkg/config/config.go
+++ b/executor/pkg/config/config.go
@@ -80,8 +80,8 @@ type Config struct {
 	Cluster string `json:"cluster" pflag:",Cluster identifier for action events"`
 
 	// DefaultK8sServiceAccount is assigned to task pods when the task's security
-	// context does not specify one. Empty leaves the pod on the namespace's
-	// `default` ServiceAccount.
+	// context does not specify one. Empty means no account is set, so Kubernetes
+	// assigns the `default` ServiceAccount of the pod's own namespace.
 	DefaultK8sServiceAccount string `json:"defaultK8sServiceAccount" pflag:",Default Kubernetes service account for task pods when the task does not set one"`
 
 	// MaxSystemFailures bounds consecutive system-level failures (Plugin.Handle Go

--- a/executor/pkg/config/config.go
+++ b/executor/pkg/config/config.go
@@ -87,7 +87,7 @@ type Config struct {
 	// MaxSystemFailures bounds consecutive system-level failures (Plugin.Handle Go
 	// errors and plugin-reported system-retryable failures) before a TaskAction is
 	// converted to a permanent failure.
-	MaxSystemFailures uint32 `json:"maxSystemFailures" pflag:",Max consecutive system-level failures before forcing permanent failure"`
+	MaxSystemFailures int32 `json:"maxSystemFailures" pflag:",Max consecutive system-level failures before forcing permanent failure"`
 
 	// GC configures the garbage collector for terminal TaskActions.
 	GC GCConfig `json:"gc" pflag:",Garbage collector configuration for terminal TaskActions"`

--- a/executor/pkg/config/config_flags.go
+++ b/executor/pkg/config/config_flags.go
@@ -63,6 +63,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "enableHTTP2"), defaultConfig.EnableHTTP2, "Enable HTTP/2 for metrics and webhook servers")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "EventsServiceURL"), defaultConfig.EventsServiceURL, "URL of the Event Service for action event updates")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cluster"), defaultConfig.Cluster, "Cluster identifier for action events")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultK8sServiceAccount"), defaultConfig.DefaultK8sServiceAccount, "Default Kubernetes service account for task pods when the task does not set one")
 	cmdFlags.Uint32(fmt.Sprintf("%v%v", prefix, "maxSystemFailures"), defaultConfig.MaxSystemFailures, "Max consecutive system-level failures before forcing permanent failure")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.interval"), defaultConfig.GC.Interval.String(), "How often the garbage collector runs. 0 disables GC.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.maxTTL"), defaultConfig.GC.MaxTTL.String(), "Time-to-live for terminal TaskActions before deletion.")

--- a/executor/pkg/config/config_flags.go
+++ b/executor/pkg/config/config_flags.go
@@ -62,9 +62,10 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "metricsCertKey"), defaultConfig.MetricsCertKey, "Name of the metrics server key file")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "enableHTTP2"), defaultConfig.EnableHTTP2, "Enable HTTP/2 for metrics and webhook servers")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "EventsServiceURL"), defaultConfig.EventsServiceURL, "URL of the Event Service for action event updates")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cacheServiceURL"), defaultConfig.CacheServiceURL, "URL of the cache service for task cache operations")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cluster"), defaultConfig.Cluster, "Cluster identifier for action events")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultK8sServiceAccount"), defaultConfig.DefaultK8sServiceAccount, "Default Kubernetes service account for task pods when the task does not set one")
-	cmdFlags.Uint32(fmt.Sprintf("%v%v", prefix, "maxSystemFailures"), defaultConfig.MaxSystemFailures, "Max consecutive system-level failures before forcing permanent failure")
+	cmdFlags.Int32(fmt.Sprintf("%v%v", prefix, "maxSystemFailures"), defaultConfig.MaxSystemFailures, "Max consecutive system-level failures before forcing permanent failure")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.interval"), defaultConfig.GC.Interval.String(), "How often the garbage collector runs. 0 disables GC.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.maxTTL"), defaultConfig.GC.MaxTTL.String(), "Time-to-live for terminal TaskActions before deletion.")
 	return cmdFlags

--- a/executor/pkg/config/config_flags_test.go
+++ b/executor/pkg/config/config_flags_test.go
@@ -281,6 +281,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_defaultK8sServiceAccount", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("defaultK8sServiceAccount", testValue)
+			if vString, err := cmdFlags.GetString("defaultK8sServiceAccount"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.DefaultK8sServiceAccount)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_gc.interval", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/executor/pkg/config/config_flags_test.go
+++ b/executor/pkg/config/config_flags_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -267,6 +267,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_cacheServiceURL", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("cacheServiceURL", testValue)
+			if vString, err := cmdFlags.GetString("cacheServiceURL"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.CacheServiceURL)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_cluster", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {
@@ -289,6 +303,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			cmdFlags.Set("defaultK8sServiceAccount", testValue)
 			if vString, err := cmdFlags.GetString("defaultK8sServiceAccount"); err == nil {
 				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.DefaultK8sServiceAccount)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_maxSystemFailures", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("maxSystemFailures", testValue)
+			if vInt32, err := cmdFlags.GetInt32("maxSystemFailures"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt32), &actual.MaxSystemFailures)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/executor/pkg/plugin/task_exec_metadata.go
+++ b/executor/pkg/plugin/task_exec_metadata.go
@@ -62,11 +62,11 @@ type taskExecutionMetadata struct {
 	serviceAccount  string
 }
 
-func resolveServiceAccount(securityContext *core.SecurityContext) string {
+func resolveServiceAccount(securityContext *core.SecurityContext, defaultSA string) string {
 	if sa := securityContext.GetRunAs().GetK8SServiceAccount(); sa != "" {
 		return sa
 	}
-	return executorconfig.GetConfig().DefaultK8sServiceAccount
+	return defaultSA
 }
 
 // NewTaskExecutionMetadata creates a TaskExecutionMetadata from a TaskAction.
@@ -146,7 +146,7 @@ func NewTaskExecutionMetadata(ta *flyteorgv1.TaskAction) (pluginsCore.TaskExecut
 		envVars:         envVars,
 		interruptible:   ta.Spec.Interruptible != nil && *ta.Spec.Interruptible,
 		securityContext: securityContext,
-		serviceAccount:  resolveServiceAccount(securityContext),
+		serviceAccount:  resolveServiceAccount(securityContext, executorconfig.GetConfig().DefaultK8sServiceAccount),
 	}, nil
 }
 

--- a/executor/pkg/plugin/task_exec_metadata.go
+++ b/executor/pkg/plugin/task_exec_metadata.go
@@ -62,11 +62,6 @@ type taskExecutionMetadata struct {
 	serviceAccount  string
 }
 
-// resolveServiceAccount returns the Kubernetes service account for the task pod:
-// the one set on the task's security context if present, otherwise the executor's
-// configured default (DefaultK8sServiceAccount). Empty means no account is set, so
-// Kubernetes assigns the `default` ServiceAccount of the pod's own namespace. The
-// proto getters are nil-safe.
 func resolveServiceAccount(securityContext *core.SecurityContext) string {
 	if sa := securityContext.GetRunAs().GetK8SServiceAccount(); sa != "" {
 		return sa

--- a/executor/pkg/plugin/task_exec_metadata.go
+++ b/executor/pkg/plugin/task_exec_metadata.go
@@ -64,8 +64,9 @@ type taskExecutionMetadata struct {
 
 // resolveServiceAccount returns the Kubernetes service account for the task pod:
 // the one set on the task's security context if present, otherwise the executor's
-// configured default (DefaultK8sServiceAccount). Empty leaves the pod on the
-// namespace `default` ServiceAccount. The proto getters are nil-safe.
+// configured default (DefaultK8sServiceAccount). Empty means no account is set, so
+// Kubernetes assigns the `default` ServiceAccount of the pod's own namespace. The
+// proto getters are nil-safe.
 func resolveServiceAccount(securityContext *core.SecurityContext) string {
 	if sa := securityContext.GetRunAs().GetK8SServiceAccount(); sa != "" {
 		return sa

--- a/executor/pkg/plugin/task_exec_metadata.go
+++ b/executor/pkg/plugin/task_exec_metadata.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
+	executorconfig "github.com/flyteorg/flyte/v2/executor/pkg/config"
 	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	flytesecret "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret"
@@ -58,6 +59,18 @@ type taskExecutionMetadata struct {
 	envVars         map[string]string
 	interruptible   bool
 	securityContext *core.SecurityContext
+	serviceAccount  string
+}
+
+// resolveServiceAccount returns the Kubernetes service account for the task pod:
+// the one set on the task's security context if present, otherwise the executor's
+// configured default (DefaultK8sServiceAccount). Empty leaves the pod on the
+// namespace `default` ServiceAccount. The proto getters are nil-safe.
+func resolveServiceAccount(securityContext *core.SecurityContext) string {
+	if sa := securityContext.GetRunAs().GetK8SServiceAccount(); sa != "" {
+		return sa
+	}
+	return executorconfig.GetConfig().DefaultK8sServiceAccount
 }
 
 // NewTaskExecutionMetadata creates a TaskExecutionMetadata from a TaskAction.
@@ -137,6 +150,7 @@ func NewTaskExecutionMetadata(ta *flyteorgv1.TaskAction) (pluginsCore.TaskExecut
 		envVars:         envVars,
 		interruptible:   ta.Spec.Interruptible != nil && *ta.Spec.Interruptible,
 		securityContext: securityContext,
+		serviceAccount:  resolveServiceAccount(securityContext),
 	}, nil
 }
 
@@ -229,7 +243,7 @@ func (m *taskExecutionMetadata) GetOwnerReference() metav1.OwnerReference   { re
 func (m *taskExecutionMetadata) GetLabels() map[string]string               { return m.labels }
 func (m *taskExecutionMetadata) GetAnnotations() map[string]string          { return m.annotations }
 func (m *taskExecutionMetadata) GetMaxAttempts() uint32                     { return m.maxAttempts }
-func (m *taskExecutionMetadata) GetK8sServiceAccount() string               { return "" }
+func (m *taskExecutionMetadata) GetK8sServiceAccount() string               { return m.serviceAccount }
 func (m *taskExecutionMetadata) IsInterruptible() bool                      { return m.interruptible }
 func (m *taskExecutionMetadata) GetInterruptibleFailureThreshold() int32    { return 0 }
 func (m *taskExecutionMetadata) GetEnvironmentVariables() map[string]string { return m.envVars }

--- a/executor/pkg/plugin/task_exec_metadata_test.go
+++ b/executor/pkg/plugin/task_exec_metadata_test.go
@@ -7,18 +7,32 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
+	executorconfig "github.com/flyteorg/flyte/v2/executor/pkg/config"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 )
 
 func TestResolveServiceAccount(t *testing.T) {
-	// A service account set on the task's security context wins.
+	// A service account set on the task's security context always wins.
 	sc := &core.SecurityContext{RunAs: &core.Identity{K8SServiceAccount: "custom-sa"}}
 	require.Equal(t, "custom-sa", resolveServiceAccount(sc))
 
-	// With no run-specified account, it falls back to the executor config default
-	// (empty in tests, i.e. the namespace `default` ServiceAccount). Nil-safe.
+	// With no executor default and no run account, it resolves to empty (Kubernetes
+	// then uses the pod namespace's `default` ServiceAccount). Getters are nil-safe.
+	cfg := executorconfig.GetConfig()
+	prev := cfg.DefaultK8sServiceAccount
+	defer func() { cfg.DefaultK8sServiceAccount = prev }()
+
+	cfg.DefaultK8sServiceAccount = ""
 	require.Equal(t, "", resolveServiceAccount(nil))
 	require.Equal(t, "", resolveServiceAccount(&core.SecurityContext{}))
+
+	// When an executor default is configured, it is used as the fallback...
+	cfg.DefaultK8sServiceAccount = "config-default-sa"
+	require.Equal(t, "config-default-sa", resolveServiceAccount(nil))
+	require.Equal(t, "config-default-sa", resolveServiceAccount(&core.SecurityContext{}))
+
+	// ...but a run-specified account still takes precedence over it.
+	require.Equal(t, "custom-sa", resolveServiceAccount(sc))
 }
 
 func TestNewTaskExecutionMetadata_UsesProjectedRunContext(t *testing.T) {

--- a/executor/pkg/plugin/task_exec_metadata_test.go
+++ b/executor/pkg/plugin/task_exec_metadata_test.go
@@ -7,32 +7,20 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
-	executorconfig "github.com/flyteorg/flyte/v2/executor/pkg/config"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 )
 
 func TestResolveServiceAccount(t *testing.T) {
-	// A service account set on the task's security context always wins.
+	// A service account set on the task's security context always wins over the default.
 	sc := &core.SecurityContext{RunAs: &core.Identity{K8SServiceAccount: "custom-sa"}}
-	require.Equal(t, "custom-sa", resolveServiceAccount(sc))
+	require.Equal(t, "custom-sa", resolveServiceAccount(sc, "config-default-sa"))
 
-	// With no executor default and no run account, it resolves to empty (Kubernetes
-	// then uses the pod namespace's `default` ServiceAccount). Getters are nil-safe.
-	cfg := executorconfig.GetConfig()
-	prev := cfg.DefaultK8sServiceAccount
-	defer func() { cfg.DefaultK8sServiceAccount = prev }()
+	// With no run account, it falls back to the provided default. Getters are nil-safe.
+	require.Equal(t, "config-default-sa", resolveServiceAccount(nil, "config-default-sa"))
+	require.Equal(t, "config-default-sa", resolveServiceAccount(&core.SecurityContext{}, "config-default-sa"))
 
-	cfg.DefaultK8sServiceAccount = ""
-	require.Equal(t, "", resolveServiceAccount(nil))
-	require.Equal(t, "", resolveServiceAccount(&core.SecurityContext{}))
-
-	// When an executor default is configured, it is used as the fallback...
-	cfg.DefaultK8sServiceAccount = "config-default-sa"
-	require.Equal(t, "config-default-sa", resolveServiceAccount(nil))
-	require.Equal(t, "config-default-sa", resolveServiceAccount(&core.SecurityContext{}))
-
-	// ...but a run-specified account still takes precedence over it.
-	require.Equal(t, "custom-sa", resolveServiceAccount(sc))
+	// An empty default resolves to empty, so Kubernetes uses the pod namespace's `default`.
+	require.Equal(t, "", resolveServiceAccount(nil, ""))
 }
 
 func TestNewTaskExecutionMetadata_UsesProjectedRunContext(t *testing.T) {

--- a/executor/pkg/plugin/task_exec_metadata_test.go
+++ b/executor/pkg/plugin/task_exec_metadata_test.go
@@ -10,6 +10,17 @@ import (
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 )
 
+func TestResolveServiceAccount(t *testing.T) {
+	// A service account set on the task's security context wins.
+	sc := &core.SecurityContext{RunAs: &core.Identity{K8SServiceAccount: "custom-sa"}}
+	require.Equal(t, "custom-sa", resolveServiceAccount(sc))
+
+	// With no run-specified account, it falls back to the executor config default
+	// (empty in tests, i.e. the namespace `default` ServiceAccount). Nil-safe.
+	require.Equal(t, "", resolveServiceAccount(nil))
+	require.Equal(t, "", resolveServiceAccount(&core.SecurityContext{}))
+}
+
 func TestNewTaskExecutionMetadata_UsesProjectedRunContext(t *testing.T) {
 	interruptible := true
 	taskAction := &flyteorgv1.TaskAction{

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -170,7 +170,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	reconciler.CatalogClient = asyncCatalogClient
 	reconciler.Catalog = cacheClient
 	reconciler.Recorder = mgr.GetEventRecorderFor("taskaction-controller")
-	reconciler.MaxSystemFailures = cfg.MaxSystemFailures
+	reconciler.MaxSystemFailures = uint32(cfg.MaxSystemFailures)
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("executor: failed to setup controller: %w", err)
 	}

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -170,6 +170,9 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	reconciler.CatalogClient = asyncCatalogClient
 	reconciler.Catalog = cacheClient
 	reconciler.Recorder = mgr.GetEventRecorderFor("taskaction-controller")
+	if cfg.MaxSystemFailures < 0 {
+		return fmt.Errorf("executor: maxSystemFailures must be non-negative, got %d", cfg.MaxSystemFailures)
+	}
 	reconciler.MaxSystemFailures = uint32(cfg.MaxSystemFailures)
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("executor: failed to setup controller: %w", err)


### PR DESCRIPTION
## Tracking issue

<!-- none -->

## Why are the changes needed?

Task pods always ran as the namespace **`default`** ServiceAccount — the executor's
`GetK8sServiceAccount()` returned `""`, so Kubernetes assigned `default`. On EKS that
SA typically has no IRSA `eks.amazonaws.com/role-arn`, so task pods get no cloud
credentials and fail S3 operations (e.g. downloading the fast-register code bundle)
with `403 Forbidden`.

The auto-created `default` SA is awkward to annotate via Helm (it pre-exists and Helm
won't adopt an unowned resource), so being able to point task pods at an existing,
already-annotated ServiceAccount is a cleaner fix.

## What changes were proposed in this pull request?

- **`executor/pkg/config/config.go`** — add `defaultK8sServiceAccount` to the executor
  config. Also change `MaxSystemFailures` from `uint32` to `int32`: the pflags generator
  doesn't support `uint32`, so `config_flags.go` couldn't be regenerated and its flag
  entry had been hand-added. It's cast back to `uint32` at the reconciler boundary
  (`executor/setup.go`), where it's compared against the CRD's `Status.SystemFailures uint32`.
- **`executor/pkg/config/config_flags.go` / `config_flags_test.go`** — regenerated via
  `go generate ./executor/pkg/config/...` (genuine generator output now, including the new
  `defaultK8sServiceAccount` flag).
- **`executor/pkg/plugin/task_exec_metadata.go`** — `GetK8sServiceAccount()` now resolves:
  1. the ServiceAccount on the task's `SecurityContext.RunAs.K8SServiceAccount` if set,
  2. else `executor.defaultK8sServiceAccount`,
  3. else `""` → Kubernetes uses the `default` ServiceAccount of the pod's own namespace
     (unchanged behavior).

A deployment can now set e.g. `executor.defaultK8sServiceAccount: <flyte-binary SA>` so
task pods run as the chart's IRSA-annotated ServiceAccount.

> Note: pointing task pods at the server ServiceAccount grants task code that SA's IAM
> role and RBAC. Prefer a dedicated, least-privilege worker ServiceAccount in production;
> this option simply makes the account configurable.

## How was this patch tested?

- Unit test (`TestResolveServiceAccount`): a run-specified SA always wins; with no run SA
  it falls back to the executor config default (asserted with a non-empty configured
  value), and resolves to `""` when neither is set. Getters are nil-safe.
- `go generate ./executor/pkg/config/...`, `go build ./executor/...`, `go vet`, `gofmt`,
  and the `config` pflag tests all pass.
- Verified live on a dev cluster: with `defaultK8sServiceAccount` set to an
  IRSA-annotated SA, task pods assume that role and S3 access succeeds.

### Labels

added

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
