### PR TITLE
[Devbox] update rustfs endpoint

### DIFF
--- a/charts/flyte-devbox/values.yaml
+++ b/charts/flyte-devbox/values.yaml
@@ -83,7 +83,7 @@ flyte-binary:
         scheme: "http"
         ingressAppsPort: 30081
         defaultEnvVars:
-          - FLYTE_AWS_ENDPOINT: 'http://rustfs.{{ .Release.Namespace }}:9000'
+          - FLYTE_AWS_ENDPOINT: 'http://rustfs-svc.{{ .Release.Namespace }}:9000'
           - FLYTE_AWS_ACCESS_KEY_ID: rustfs
           - FLYTE_AWS_SECRET_ACCESS_KEY: rustfsstorage
           - _U_EP_OVERRIDE: 'flyte-binary-http.{{ .Release.Namespace }}:8090'

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -7792,7 +7792,7 @@ data:
     internalApps:
       baseDomain: localhost
       defaultEnvVars:
-      - FLYTE_AWS_ENDPOINT: http://rustfs.flyte:9000
+      - FLYTE_AWS_ENDPOINT: http://rustfs-svc.flyte:9000
       - FLYTE_AWS_ACCESS_KEY_ID: rustfs
       - FLYTE_AWS_SECRET_ACCESS_KEY: rustfsstorage
       - _U_EP_OVERRIDE: flyte-binary-http.flyte:8090
@@ -8612,7 +8612,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 06269249f6e0df4e5df3c3f62e2f5bd703a127730dbcd6a68627557d343227af
+        checksum/configuration: d2aec94f19fbf15dce1dd1e0530da68a0c2de5043a3a89155daa31eb212fbacb
         checksum/configuration-secret: 800f306f43701bd39e3b42e0d756f4627643cf3cee6dbd050a5a57a08052c280
       labels:
         app.kubernetes.io/component: flyte-binary


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

We will get following error when running app. The reason is that rustfs endpoint is incorrect, should be  `http://rustfs-svc.flyte:9000/`

<img width="2958" height="484" alt="image" src="https://github.com/user-attachments/assets/b34c1054-c01d-4d0c-916b-cb52ff1c5532" />


```sh
GenericError: Generic S3 error: Error performing HEAD http://rustfs.flyte:9000/flyte-data/uploads/flytesnacks/development/UP7YFHXZHWAKZEMGOQV4VUZJFI%3D%3D%3D%3D%3D%3D/fasted9093529269a3674ea395c464883d33.tar.gz in 18.744430729s, after 3 retries, max_retries: 3, retry_timeout: 180s  - HTTP error: error sending request

Debug source:
Generic {
    store: "S3",
    source: RetryError(
        RetryErrorImpl {
            method: HEAD,
            uri: Some(
                http://rustfs.flyte:9000/flyte-data/uploads/flytesnacks/development/UP7YFHXZHWAKZEMGOQV4VUZJFI%3D%3D%3D%3D%3D%3D/fasted9093529269a3674ea395c464883d33.tar.gz,
            ),
            retries: 3,
            max_retries: 3,
            elapsed: 18.744430729s,
            retry_timeout: 180s,
            inner: Http(
                HttpError {
                    kind: Connect,
                    source: reqwest::Error {
                        kind: Request,
                        source: hyper_util::client::legacy::Error(
                            Connect,
                            ConnectError(
                                "dns error",
                                Custom {
                                    kind: Uncategorized,
                                    error: "failed to lookup address information: Name or service not known",
                                },
                            ),
                        ),
                    },
                },
            ),
        },
    ),
}
```

## What changes were proposed in this pull request?

Update `FLYTE_AWS_ENDPOINT` to `'http://rustfs-svc.{{ .Release.Namespace }}:9000'`


## How was this patch tested?

Run devbox locally:

1. `make devbox-build`
2. `make devbox-run`
3. deploy app here: https://www.union.ai/docs/v2/flyte/user-guide/build-apps/single-script-apps/#plain-python-http-server
4. We can see app is deployed successfully

```sh
❯ python plain_python_server.py
  > Building 1 image...
    > Building image flyte for environment plain-python-server
    i Image ghcr.io/flyteorg/flyte:py3.12-v2.4.0 already exists, skipping build
  ✓ Built image for environment plain-python-server: ghcr.io/flyteorg/flyte:py3.12-v2.4.0
  ✓ Code bundle found in cache, skipping upload
VERSION: 0d5b715eec56966d1afa1c0eed424445
  > Deploying app plain-python-server, with image ghcr.io/flyteorg/flyte:py3.12-v2.4.0 version 0d5b715eec56966d1afa1c0eed424445 with args ['python', 'plain_python_server.py', '--server']
09:30:29.008552 WARNING   _serve.py:712 - Deployed App plain-python-server, you can check the console at http://localhost:30080/v2/domain/development/project/flytesnacks/apps/plain-python-server
App URL: http://localhost:30080/v2/domain/development/project/flytesnacks/apps/plain-python-server
```

<img width="2004" height="236" alt="image" src="https://github.com/user-attachments/assets/0e79f902-b837-4655-adc6-ccc39069f134" />

<img width="2124" height="230" alt="image" src="https://github.com/user-attachments/assets/abd9959c-82f6-4421-95d2-6f5ce199a929" />


### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
