### PR TITLE
feat(copilot): preserve nested subdirectories in multipart blob uploads

### DIFF
--- a/flytecopilot/data/upload.go
+++ b/flytecopilot/data/upload.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"strings"
 
 	"github.com/golang/protobuf/proto" //nolint: staticcheck
 	"github.com/pkg/errors"
@@ -68,18 +69,22 @@ func (u Uploader) handleBlobType(ctx context.Context, localPath string, toPath s
 				return err
 			}
 			if info.IsDir() {
-				logger.Warnf(ctx, "Currently nested directories are not supported in multipart blob uploads, for directory @ %s", path)
-			} else {
-				ref, err := u.store.ConstructReference(ctx, toPath, info.Name())
-				if err != nil {
-					return err
-				}
-				files = append(files, dirFile{
-					path: path,
-					info: info,
-					ref:  ref,
-				})
+				return nil
 			}
+			rel, err := filepath.Rel(localPath, path)
+			if err != nil {
+				return err
+			}
+			keys := strings.Split(filepath.ToSlash(rel), "/")
+			ref, err := u.store.ConstructReference(ctx, toPath, keys...)
+			if err != nil {
+				return err
+			}
+			files = append(files, dirFile{
+				path: path,
+				info: info,
+				ref:  ref,
+			})
 			return nil
 		})
 		if err != nil {

--- a/flytecopilot/data/upload_test.go
+++ b/flytecopilot/data/upload_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,5 +64,69 @@ func TestUploader_RecursiveUpload(t *testing.T) {
 		b, err := io.ReadAll(r)
 		assert.NoError(t, err)
 		assert.Equal(t, string(data), string(b), "content dont match")
+	})
+
+	t.Run("upload-multipart-nested", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp(tmpFolderLocation, tmpPrefix)
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, os.RemoveAll(tmpDir))
+		}()
+
+		// A multipart blob output "x" whose directory contains a root file
+		// and files nested in subdirectories (including a basename collision
+		// across two different subdirs).
+		varDir := path.Join(tmpDir, "x")
+		assert.NoError(t, os.MkdirAll(path.Join(varDir, "nested"), os.ModePerm)) // #nosec G301
+		assert.NoError(t, os.MkdirAll(path.Join(varDir, "other"), os.ModePerm))  // #nosec G301
+		contents := map[string]string{
+			"root.txt":        "root",
+			"nested/deep.txt": "deep",
+			"nested/dup.txt":  "dup-in-nested",
+			"other/dup.txt":   "dup-in-other",
+		}
+		for rel, body := range contents {
+			assert.NoError(t, os.WriteFile(path.Join(varDir, rel), []byte(body), os.ModePerm)) // #nosec G306
+		}
+
+		vmap := &core.VariableMap{
+			Variables: []*core.VariableEntry{
+				{
+					Key: "x",
+					Value: &core.Variable{
+						Type: &core.LiteralType{Type: &core.LiteralType_Blob{Blob: &core.BlobType{Dimensionality: core.BlobType_MULTIPART}}},
+					},
+				},
+			},
+		}
+
+		store, err := storage.NewDataStore(&storage.Config{Type: storage.TypeMemory}, promutils.NewTestScope())
+		assert.NoError(t, err)
+
+		outputRef := storage.DataReference("output")
+		rawRef := storage.DataReference("raw")
+		u := NewUploader(context.TODO(), store, core.DataLoadingConfig_JSON, core.IOStrategy_UPLOAD_ON_EXIT, "error")
+		assert.NoError(t, u.RecursiveUpload(context.TODO(), vmap, tmpDir, outputRef, rawRef))
+
+		outputs := &core.LiteralMap{}
+		assert.NoError(t, store.ReadProtobuf(context.TODO(), outputRef, outputs))
+		assert.Len(t, outputs.GetLiterals(), 1)
+		blob := outputs.GetLiterals()["x"].GetScalar().GetBlob()
+		assert.NotNil(t, blob)
+		assert.Equal(t, core.BlobType_MULTIPART, blob.GetMetadata().GetType().GetDimensionality())
+
+		// Every file must land at a structure-preserving key under the blob
+		// prefix; the two dup.txt files must not collide.
+		base := storage.DataReference(blob.GetUri())
+		for rel, body := range contents {
+			ref, err := store.ConstructReference(context.TODO(), base, strings.Split(rel, "/")...)
+			assert.NoError(t, err)
+			r, err := store.ReadRaw(context.TODO(), ref)
+			assert.NoError(t, err, "%s does not exist", ref)
+			b, err := io.ReadAll(r)
+			assert.NoError(t, err)
+			assert.NoError(t, r.Close())
+			assert.Equal(t, body, string(b), "content mismatch for %s", rel)
+		}
 	})
 }


### PR DESCRIPTION
## Why are the changes needed?

Shell Glob matching in the SDK extras should work (pathlib.Path.glob supports **), [but Glob serializes to a Dir on the wire](https://github.com/flyteorg/flyte-sdk/blob/3c69976cd58820fad411c0e606b280e98ac7dc50/src/flyte/extras/shell/_runtime.py#L72), and in real remote execution flytecopilot uploads /var/outputs/<name>/ as a MULTIPART blob. This is because copilot's multipart uploader drops nested subdirectories. Glob and a bare Dir output fail identically here.

## What changes were proposed in this pull request?

Walk into directories and key each file by its relative path from the blob root (filepath.Rel + ConstructReference with the path segments), mirroring the download side, which already reconstructs nested keys. Top-level files are unaffected — their relative path is just the basename, so keys are unchanged.


## How was this patch tested?

Add an upload-multipart-nested test covering a root file, nested files, and a cross-subdir basename collision.

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
