### PR TITLE
Add HTTP transport connection-pool settings to the storage client

### DIFF
--- a/flytestdlib/storage/config.go
+++ b/flytestdlib/storage/config.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"time"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/config"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
@@ -39,6 +40,11 @@ var (
 			Region:   "us-east-1",
 			AuthType: "iam",
 		},
+		DefaultHTTPClient: HTTPClientConfig{
+			MaxIdleConns:        1024,
+			MaxIdleConnsPerHost: 1024,
+			IdleConnTimeout:     config.Duration{Duration: 90 * time.Second},
+		},
 		MultiContainerEnabled: false,
 	}
 )
@@ -74,6 +80,11 @@ type SignedURLConfig struct {
 type HTTPClientConfig struct {
 	Headers map[string][]string `json:"headers" pflag:"-,Sets http headers to set on the http client."`
 	Timeout config.Duration     `json:"timeout" pflag:",Sets time out on the http client."`
+	// Zero values for the transport settings below fall back to the http.DefaultTransport values.
+	MaxIdleConns        int             `json:"maxIdleConns" pflag:",Maximum number of idle connections across all hosts. Zero means use the http.DefaultTransport value."`
+	MaxIdleConnsPerHost int             `json:"maxIdleConnsPerHost" pflag:",Maximum number of idle connections per host. Zero means use the http.DefaultTransport value."`
+	MaxConnsPerHost     int             `json:"maxConnsPerHost" pflag:",Maximum number of connections per host; new requests block at the limit. Zero means no limit."`
+	IdleConnTimeout     config.Duration `json:"idleConnTimeout" pflag:",Maximum amount of time an idle connection remains open. Zero means use the http.DefaultTransport value."`
 }
 
 // ConnectionConfig defines connection configurations.

--- a/flytestdlib/storage/config_flags.go
+++ b/flytestdlib/storage/config_flags.go
@@ -65,5 +65,9 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "cache.target_gc_percent"), defaultConfig.Cache.TargetGCPercent, "Sets the garbage collection target percentage.")
 	cmdFlags.Int64(fmt.Sprintf("%v%v", prefix, "limits.maxDownloadMBs"), defaultConfig.Limits.GetLimitMegabytes, "Maximum allowed download size (in MBs) per call.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultHttpClient.timeout"), defaultConfig.DefaultHTTPClient.Timeout.String(), "Sets time out on the http client.")
+	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "defaultHttpClient.maxIdleConns"), defaultConfig.DefaultHTTPClient.MaxIdleConns, "Maximum number of idle connections across all hosts. Zero means use the http.DefaultTransport value.")
+	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "defaultHttpClient.maxIdleConnsPerHost"), defaultConfig.DefaultHTTPClient.MaxIdleConnsPerHost, "Maximum number of idle connections per host. Zero means use the http.DefaultTransport value.")
+	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "defaultHttpClient.maxConnsPerHost"), defaultConfig.DefaultHTTPClient.MaxConnsPerHost, "Maximum number of connections per host; new requests block at the limit. Zero means no limit.")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultHttpClient.idleConnTimeout"), defaultConfig.DefaultHTTPClient.IdleConnTimeout.String(), "Maximum amount of time an idle connection remains open. Zero means use the http.DefaultTransport value.")
 	return cmdFlags
 }

--- a/flytestdlib/storage/config_flags_test.go
+++ b/flytestdlib/storage/config_flags_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-viper/mapstructure/v2"
+	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -303,6 +303,62 @@ func TestConfig_SetFlags(t *testing.T) {
 			cmdFlags.Set("defaultHttpClient.timeout", testValue)
 			if vString, err := cmdFlags.GetString("defaultHttpClient.timeout"); err == nil {
 				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.DefaultHTTPClient.Timeout)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_defaultHttpClient.maxIdleConns", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("defaultHttpClient.maxIdleConns", testValue)
+			if vInt, err := cmdFlags.GetInt("defaultHttpClient.maxIdleConns"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt), &actual.DefaultHTTPClient.MaxIdleConns)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_defaultHttpClient.maxIdleConnsPerHost", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("defaultHttpClient.maxIdleConnsPerHost", testValue)
+			if vInt, err := cmdFlags.GetInt("defaultHttpClient.maxIdleConnsPerHost"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt), &actual.DefaultHTTPClient.MaxIdleConnsPerHost)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_defaultHttpClient.maxConnsPerHost", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("defaultHttpClient.maxConnsPerHost", testValue)
+			if vInt, err := cmdFlags.GetInt("defaultHttpClient.maxConnsPerHost"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt), &actual.DefaultHTTPClient.MaxConnsPerHost)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_defaultHttpClient.idleConnTimeout", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := defaultConfig.DefaultHTTPClient.IdleConnTimeout.String()
+
+			cmdFlags.Set("defaultHttpClient.idleConnTimeout", testValue)
+			if vString, err := cmdFlags.GetString("defaultHttpClient.idleConnTimeout"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.DefaultHTTPClient.IdleConnTimeout)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/flytestdlib/storage/rawstores.go
+++ b/flytestdlib/storage/rawstores.go
@@ -41,18 +41,32 @@ func applyDefaultHeaders(r *http.Request, headers map[string][]string) {
 }
 
 func createHTTPClient(cfg HTTPClientConfig) *http.Client {
-	c := &http.Client{
-		Timeout: cfg.Timeout.Duration,
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if cfg.MaxIdleConns > 0 {
+		transport.MaxIdleConns = cfg.MaxIdleConns
+	}
+	if cfg.MaxIdleConnsPerHost > 0 {
+		transport.MaxIdleConnsPerHost = cfg.MaxIdleConnsPerHost
+	}
+	if cfg.MaxConnsPerHost > 0 {
+		transport.MaxConnsPerHost = cfg.MaxConnsPerHost
+	}
+	if cfg.IdleConnTimeout.Duration > 0 {
+		transport.IdleConnTimeout = cfg.IdleConnTimeout.Duration
 	}
 
+	var rt http.RoundTripper = transport
 	if len(cfg.Headers) > 0 {
-		c.Transport = &proxyTransport{
-			RoundTripper:   http.DefaultTransport,
+		rt = &proxyTransport{
+			RoundTripper:   transport,
 			defaultHeaders: cfg.Headers,
 		}
 	}
 
-	return c
+	return &http.Client{
+		Timeout:   cfg.Timeout.Duration,
+		Transport: rt,
+	}
 }
 
 type dataStoreMetrics struct {

--- a/flytestdlib/storage/rawstores_test.go
+++ b/flytestdlib/storage/rawstores_test.go
@@ -13,7 +13,31 @@ import (
 func Test_createHTTPClient(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		client := createHTTPClient(HTTPClientConfig{})
-		assert.Nil(t, client.Transport)
+
+		transport, casted := client.Transport.(*http.Transport)
+		assert.True(t, casted)
+		defaultTransport := http.DefaultTransport.(*http.Transport)
+		assert.NotSame(t, defaultTransport, transport)
+		assert.Equal(t, defaultTransport.MaxIdleConns, transport.MaxIdleConns)
+		assert.Equal(t, defaultTransport.MaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+		assert.Equal(t, defaultTransport.MaxConnsPerHost, transport.MaxConnsPerHost)
+		assert.Equal(t, defaultTransport.IdleConnTimeout, transport.IdleConnTimeout)
+	})
+
+	t.Run("Transport settings", func(t *testing.T) {
+		client := createHTTPClient(HTTPClientConfig{
+			MaxIdleConns:        512,
+			MaxIdleConnsPerHost: 256,
+			MaxConnsPerHost:     128,
+			IdleConnTimeout:     config.Duration{Duration: 30 * time.Second},
+		})
+
+		transport, casted := client.Transport.(*http.Transport)
+		assert.True(t, casted)
+		assert.Equal(t, 512, transport.MaxIdleConns)
+		assert.Equal(t, 256, transport.MaxIdleConnsPerHost)
+		assert.Equal(t, 128, transport.MaxConnsPerHost)
+		assert.Equal(t, 30*time.Second, transport.IdleConnTimeout)
 	})
 
 	t.Run("Some headers", func(t *testing.T) {
@@ -22,13 +46,17 @@ func Test_createHTTPClient(t *testing.T) {
 		}
 
 		client := createHTTPClient(HTTPClientConfig{
-			Headers: m,
+			Headers:             m,
+			MaxIdleConnsPerHost: 256,
 		})
 
 		assert.NotNil(t, client.Transport)
 		proxyTransport, casted := client.Transport.(*proxyTransport)
 		assert.True(t, casted)
 		assert.Equal(t, m, proxyTransport.defaultHeaders)
+		transport, casted := proxyTransport.RoundTripper.(*http.Transport)
+		assert.True(t, casted)
+		assert.Equal(t, 256, transport.MaxIdleConnsPerHost)
 	})
 
 	t.Run("Set empty timeout", func(t *testing.T) {


### PR DESCRIPTION
## Overview

The storage layer's HTTP client (`flytestdlib/storage`) relies on `http.DefaultTransport`, which keeps only **2 idle connections per host** (`MaxIdleConnsPerHost` default). All S3 traffic targets a single host (the bucket endpoint) over HTTP/1.1 — no multiplexing — so connection count equals request concurrency.

Under high-concurrency blob-store access (hundreds of concurrent S3 operations from one process), nearly every request dials a fresh connection, uses it once, fails to park it in the full idle pool, and the connection is closed — so the next request pays a full TLS handshake. CPU profiling under such load showed **~22% of total CPU in `net/http.(*persistConn).addTLS` / `crypto/tls.HandshakeContext`**, TLS handshake allocators (ML-KEM/x25519 key exchange, HKDF, new-connection bufio buffers) dominating the allocation delta at ~150 MB/s, and multi-second latency outliers on requests that landed on a cold connection.

This change:
- Clones `http.DefaultTransport` in `createHTTPClient` (preserving proxy, TLS, and HTTP/2 wiring) so the storage client gets its own tunable connection pool.
- Exposes `maxIdleConns`, `maxIdleConnsPerHost`, `maxConnsPerHost`, and `idleConnTimeout` via `HTTPClientConfig` (`Storage.defaultHttpClient.*`), regenerating the pflags.
- Defaults the idle pool to **1024 / 1024 idle connections, 90s idle timeout** so connections are reused instead of re-dialed at high concurrency. Idle connections are cheap (parked goroutines + FDs); 1024 covers peak concurrency with headroom.
- Leaves `maxConnsPerHost` **unset (0 = unlimited) by default**: a per-host connection cap blocks requests once reached (indefinitely, given the client `Timeout` defaults to 0), which is a worse failure mode than a transient dial burst. It is available as a config-tunable safety valve.
- Each knob is applied only when > 0, since zero values are meaningful to `net/http` (`MaxIdleConnsPerHost=0` silently means 2 again); zero-valued config falls back to the corresponding `http.DefaultTransport` value.

When headers are configured, the header-injecting `proxyTransport` now wraps the tuned transport instead of the shared `http.DefaultTransport`.

## Test Plan

- Unit tests added/updated in `rawstores_test.go`: transport settings are applied, an empty config preserves `http.DefaultTransport` behavior (fresh clone, same values), and configured headers wrap the tuned transport.
- `go test ./flytestdlib/storage/...` and `go vet` pass.
- **Live (2026-06-10):** ran in a combined leaseworker test build (`unionai/cloud` test branch, flyte2 fork carrying this commit) on a dogfood dataplane through two ~10–30k-lease burst rounds (fasttask fanout + high-rate sleep fanout). No regressions: blob reads/writes healthy throughout, config knobs wired and visible, defaults applied. **Caveat: that cluster is GCS-backed**, so the S3/`http.DefaultTransport` path this PR patches was not meaningfully exercised — call-graph inspection shows no TLS-handshake frames at all on the GCS path (the Google SDK uses its own pooled HTTP/2 transport, structurally immune to the `MaxIdleConnsPerHost=2` churn), and the `bufio` allocations in those profiles were later traced (on the S3 run below) to Connect RPC response decompression (`compressionPool.putDecompressor` → `gzip.Reset`), unrelated to this PR's transport.
- [x] **VALIDATED on an S3-backed dataplane (2026-06-10, dogfood, fasttask tree fanout, ~16k queued leases, 512 concurrent evaluations):**
  - **TLS-handshake CPU: gone.** Mid-burst 30s profile has zero `addTLS`/`HandshakeContext`/ML-KEM/x25519 frames (same-cluster control on the previous build, same morning: 9.2% + `dialConn` ~5%). The only TLS frames remaining are `Conn.Write`/`Conn.Read` record crypto on established connections (~4.5%) — i.e., connections are being reused.
  - **Handshake allocators: gone from the burst allocation delta** (no `mlkem`/`x25519`/`hkdf` entries; control had them dominating at ~150 MB/s). Remaining `bufio` allocations traced via peek to Connect RPC response decompression (`compressionPool.putDecompressor` → `gzip.Reset`) and aws-sdk XML decoding — unrelated to this transport.
  - Whole-process CPU at higher lease pressure dropped vs the same-cluster control (~3.2 vs ~4.75 cores), with the top profile frames now allocation/GC machinery from unrelated known work (fasttask status decode).

## Rollout Plan

- Merges to `main`; consuming services pick the change up on their next dependency bump/build. No config change is required — the new defaults take effect automatically.
- The pool can be tuned per deployment via `Storage.defaultHttpClient.{maxIdleConns,maxIdleConnsPerHost,maxConnsPerHost,idleConnTimeout}`.

## Rollback Plan

- Config-level rollback without a code change: set `maxIdleConns`, `maxIdleConnsPerHost`, and `idleConnTimeout` to 0 to restore the previous `http.DefaultTransport` pool behavior.
- Full rollback: revert this commit; the change is self-contained to `flytestdlib/storage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

