### PR TITLE
Compute template replacement values once per Render call

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/core/template/template.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/template/template.go
@@ -93,9 +93,24 @@ func Render(ctx context.Context, inputTemplate []string, params Parameters) ([]s
 	if params.Inputs == nil || params.OutputPath == nil {
 		return nil, fmt.Errorf("input reader and output path cannot be nil")
 	}
+
+	prevCheckpoint := params.OutputPath.GetPreviousCheckpointsPrefix().String()
+	if prevCheckpoint == "" {
+		prevCheckpoint = "\"\""
+	}
+	values := replacementValues{
+		inputFile:              params.Inputs.GetInputPath().String(),
+		inputPrefix:            params.Inputs.GetInputPrefixPath().String(),
+		outputPrefix:           params.OutputPath.GetOutputPrefixPath().String(),
+		rawOutputDataPrefix:    params.OutputPath.GetRawOutputPrefix().String(),
+		prevCheckpointPrefix:   prevCheckpoint,
+		checkpointOutputPrefix: params.OutputPath.GetCheckpointPrefix().String(),
+		perRetryUniqueKey:      perRetryUniqueKey,
+	}
+
 	res := make([]string, 0, len(inputTemplate))
 	for _, t := range inputTemplate {
-		updated, err := render(ctx, t, params, perRetryUniqueKey)
+		updated, err := render(ctx, t, params, values)
 		if err != nil {
 			return res, err
 		}
@@ -106,19 +121,27 @@ func Render(ctx context.Context, inputTemplate []string, params Parameters) ([]s
 	return res, nil
 }
 
-func render(ctx context.Context, inputTemplate string, params Parameters, perRetryKey string) (string, error) {
+// replacementValues holds the replacement values that are identical for every string of a single
+// Render call, so they are computed once per call rather than once per rendered string.
+type replacementValues struct {
+	inputFile              string
+	inputPrefix            string
+	outputPrefix           string
+	rawOutputDataPrefix    string
+	prevCheckpointPrefix   string
+	checkpointOutputPrefix string
+	perRetryUniqueKey      string
+}
 
-	val := inputFileRegex.ReplaceAllString(inputTemplate, params.Inputs.GetInputPath().String())
-	val = outputRegex.ReplaceAllString(val, params.OutputPath.GetOutputPrefixPath().String())
-	val = inputPrefixRegex.ReplaceAllString(val, params.Inputs.GetInputPrefixPath().String())
-	val = rawOutputDataPrefixRegex.ReplaceAllString(val, params.OutputPath.GetRawOutputPrefix().String())
-	prevCheckpoint := params.OutputPath.GetPreviousCheckpointsPrefix().String()
-	if prevCheckpoint == "" {
-		prevCheckpoint = "\"\""
-	}
-	val = prevCheckpointPrefixRegex.ReplaceAllString(val, prevCheckpoint)
-	val = currCheckpointPrefixRegex.ReplaceAllString(val, params.OutputPath.GetCheckpointPrefix().String())
-	val = perRetryUniqueKey.ReplaceAllString(val, perRetryKey)
+func render(ctx context.Context, inputTemplate string, params Parameters, values replacementValues) (string, error) {
+
+	val := inputFileRegex.ReplaceAllString(inputTemplate, values.inputFile)
+	val = outputRegex.ReplaceAllString(val, values.outputPrefix)
+	val = inputPrefixRegex.ReplaceAllString(val, values.inputPrefix)
+	val = rawOutputDataPrefixRegex.ReplaceAllString(val, values.rawOutputDataPrefix)
+	val = prevCheckpointPrefixRegex.ReplaceAllString(val, values.prevCheckpointPrefix)
+	val = currCheckpointPrefixRegex.ReplaceAllString(val, values.checkpointOutputPrefix)
+	val = perRetryUniqueKey.ReplaceAllString(val, values.perRetryUniqueKey)
 
 	// For Task template, we will replace only if there is a match. This is because, task template replacement
 	// may be expensive, as we may offload


### PR DESCRIPTION
## Overview

`template.Render` loops over every string in a task's command and calls `render()` for each. Each `render()` call rebuilt **all** of the replacement values from scratch — six of which are blob-store path constructions (`GetInputPath`, `GetOutputPrefixPath`, `GetInputPrefixPath`, `GetRawOutputPrefix`, `GetPreviousCheckpointsPrefix`, `GetCheckpointPrefix`) that do URL resolution and string building — even though the values are identical for every argument. A 5-argument command built the same six paths 5×, and they were computed unconditionally as `ReplaceAllString` arguments even when the command contained no such placeholder.

CPU profiling under a high-rate task-submission burst showed `template.Render` at **~34% of process CPU**, with the cost inside `render()` dominated by the path getters (`GetCheckpointPrefix` ~40%, `GetInputPath` ~33% — i.e. the replacement-value construction, not the regex matching), and `net/url.ResolveReference`/`url.parse`/`strings.Builder` among the top allocators.

This change hoists the per-call-constant replacement values into a struct computed **once per `Render` call**, mirroring how `perRetryUniqueKey` was already hoisted out of the loop. The per-string work is now just the regex replacements.

Notes on scope:
- All six hoisted getters are pure path construction (verified against the `ioutils` implementations), so moving them out of the loop cannot change behavior — including the `prevCheckpoint == "" → "\"\""` special case, which moves up intact.
- `TaskTemplatePath` (may offload/do I/O) and `Inputs.Get` (I/O) keep their existing lazy match-first behavior, unchanged.
- `Render`'s exported signature is unchanged; only the unexported `render()` signature changes.

## Test Plan

- Existing `template_test.go` suite exercises `Render` across all placeholder types and passes unchanged (`go test ./flyteplugins/go/tasks/pluginmachinery/core/template/...`), which is the right regression coverage for a pure refactor: identical inputs must produce identical outputs.
- `go vet` clean.
- **Live before/after (2026-06-10, leaseworker on a dogfood dataplane, same fasttask tree-fanout workload at ~10–30k leases):**
  - *Without this change* (control build, same day): the replacement-value construction family was the **top allocator group at ~40%** of a ~30 GB burst allocation delta — `net/url.(*URL).ResolveReference` 7.5 GB cum, `strings.(*Builder).WriteString` 4.3 GB, `net/url.parse` 3.4 GB, `ensureEndingPathSeparator` 1.8 GB — and `template.Render` was ~7% of burst CPU.
  - *With this change*: the path-construction family is **absent from the top allocators** across two burst rounds (t3m delta 13.7 GB and t9m delta 16.2 GB); the only remaining render cost is the per-argument regex replacement itself (~2.5 GB cum, expected — it must run per string), and `template.Render` fell **below the CPU profile's reporting threshold** in mid-burst 20s/30s captures.
  - Rendered outputs verified equivalent in practice: task submissions, log links, and input/output paths behaved identically across both builds.

## Rollout Plan

- Merges to `main`; consuming services pick the change up on their next dependency bump/build. No config involved.

## Rollback Plan

- Revert this commit; the change is self-contained to `template.go` and has no config, API, or persisted-state surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
