### PR TITLE
fix(flytestdlib): mark batch head item as processing in auto-refresh cache

### DIFF
--- a/flytestdlib/autorefreshcache/auto_refresh.go
+++ b/flytestdlib/autorefreshcache/auto_refresh.go
@@ -283,7 +283,7 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 	for _, batch := range batches {
 		b := batch
 		w.workqueue.AddRateLimited(&b)
-		for i := 1; i < len(b); i++ {
+		for i := 0; i < len(b); i++ {
 			w.processing.Store(b[i].GetID(), w.clock.Now())
 		}
 	}

--- a/flytestdlib/autorefreshcache/auto_refresh_test.go
+++ b/flytestdlib/autorefreshcache/auto_refresh_test.go
@@ -281,3 +281,24 @@ func TestInProcessing(t *testing.T) {
 	_, found := cache.processing.Load("test1")
 	assert.False(t, found)
 }
+
+// Regression: enqueueBatches marked only b[1:] as processing, skipping the batch
+// head b[0]. With the default SingleItemBatches every batch holds one item, so
+// nothing was ever marked and each resync re-enqueued items already in flight.
+func TestEnqueueBatches_MarksSingleItemBatchHead(t *testing.T) {
+	rateLimiter := workqueue.DefaultControllerRateLimiter()
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	c, err := newAutoRefreshCacheWithClock("head", syncFakeItem, rateLimiter, 5*time.Second, 10, 10,
+		promutils.NewTestScope(), fakeClock)
+	assert.NoError(t, err)
+	cache := c.(*autoRefresh)
+
+	_, err = cache.GetOrCreate("item-1", fakeCacheItem{val: 1})
+	assert.NoError(t, err)
+	// GetOrCreate marks on create; clear it to model a fresh resync tick where the
+	// item is cached but not in flight.
+	cache.processing.Delete("item-1")
+
+	assert.NoError(t, cache.enqueueBatches(context.Background()))
+	assert.True(t, cache.inProcessing("item-1"), "single-item batch head must be marked processing after enqueue")
+}

--- a/flytestdlib/cache/in_memory_auto_refresh.go
+++ b/flytestdlib/cache/in_memory_auto_refresh.go
@@ -291,7 +291,7 @@ func (w *InMemoryAutoRefresh) enqueueBatches(ctx context.Context) error {
 	for _, batch := range batches {
 		b := batch
 		w.workqueue.AddRateLimited(&b)
-		for i := 1; i < len(b); i++ {
+		for i := 0; i < len(b); i++ {
 			w.processing.Store(b[i].GetID(), w.clock.Now())
 		}
 	}

--- a/flytestdlib/cache/in_memory_auto_refresh_test.go
+++ b/flytestdlib/cache/in_memory_auto_refresh_test.go
@@ -342,3 +342,20 @@ func TestInProcessing(t *testing.T) {
 	_, found := cache.processing.Load("test1")
 	assert.False(t, found)
 }
+
+// Regression: enqueueBatches marked only b[1:] as processing, skipping the batch
+// head b[0]. With the default SingleItemBatches every batch holds one item, so
+// nothing was ever marked and each resync re-enqueued items already in flight.
+func TestEnqueueBatches_MarksSingleItemBatchHead(t *testing.T) {
+	rateLimiter := workqueue.DefaultControllerRateLimiter()
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	cache, err := NewInMemoryAutoRefresh("head", syncFakeItem, rateLimiter, 5*time.Second, 10, 10,
+		promutils.NewTestScope(), WithClock(fakeClock), WithSyncOnCreate(false))
+	assert.NoError(t, err)
+
+	_, err = cache.GetOrCreate("item-1", fakeCacheItem{val: 1})
+	assert.NoError(t, err)
+
+	assert.NoError(t, cache.enqueueBatches(context.Background()))
+	assert.True(t, cache.inProcessing("item-1"), "single-item batch head must be marked processing after enqueue")
+}


### PR DESCRIPTION
## Why are the changes needed?

The auto-refresh cache tracks which items a worker is currently syncing so the periodic resync does not enqueue an item again while it is still in flight. The first item of every enqueued batch was never recorded as in-flight, so the resync loop kept re-enqueueing items that were already being synced — the same key handled by multiple workers at once, duplicate `syncCb` calls, and wasted workqueue throughput. With the default single-item batching this affects every item the cache tracks.

## What changes were proposed in this pull request?

Record every item in an enqueued batch as in-flight, including the first one.

## How was this patch tested?

Added `TestEnqueueBatches_MarksSingleItemBatchHead` to both `flytestdlib/cache` and `flytestdlib/autorefreshcache`. It drives the real enqueue path with the default single-item batching and asserts the enqueued item is marked in-flight.

Reproduce:

```
go test ./flytestdlib/cache/ ./flytestdlib/autorefreshcache/ -run TestEnqueueBatches_MarksSingleItemBatchHead -v
```

Before:

```
--- FAIL: TestEnqueueBatches_MarksSingleItemBatchHead
    single-item batch head must be marked processing after enqueue
    Should be true
FAIL    github.com/flyteorg/flyte/v2/flytestdlib/cache
--- FAIL: TestEnqueueBatches_MarksSingleItemBatchHead
    single-item batch head must be marked processing after enqueue
    Should be true
FAIL    github.com/flyteorg/flyte/v2/flytestdlib/autorefreshcache
```

After:

```
--- PASS: TestEnqueueBatches_MarksSingleItemBatchHead
ok      github.com/flyteorg/flyte/v2/flytestdlib/cache
--- PASS: TestEnqueueBatches_MarksSingleItemBatchHead
ok      github.com/flyteorg/flyte/v2/flytestdlib/autorefreshcache
```

Both packages also pass with `-race`.

### Labels
fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
