### PR TITLE
fix(flyteadmin): populate ErrorKind/ErrorCode columns for accept-time execution failures

### DIFF
--- a/flyteadmin/pkg/repositories/transformers/execution.go
+++ b/flyteadmin/pkg/repositories/transformers/execution.go
@@ -112,6 +112,17 @@ func CreateExecutionModel(input CreateExecutionModelInput) (*models.Execution, e
 
 	activeExecution := int32(admin.ExecutionState_EXECUTION_ACTIVE)
 
+	// Populate the top-level ErrorKind/ErrorCode columns at create time so executions that
+	// fail before the propeller event path (e.g. accept-time validation failures) are
+	// queryable without deserializing the closure (mirrors UpdateExecutionModelState).
+	var errorKind, errorCode *string
+	if execErr := closure.GetError(); execErr != nil {
+		kind := execErr.GetKind().String()
+		code := execErr.GetCode()
+		errorKind = &kind
+		errorCode = &code
+	}
+
 	executionModel := &models.Execution{
 		ExecutionKey: models.ExecutionKey{
 			Project: input.WorkflowExecutionID.GetProject(),
@@ -132,6 +143,8 @@ func CreateExecutionModel(input CreateExecutionModelInput) (*models.Execution, e
 		User:                  requestSpec.GetMetadata().GetPrincipal(),
 		State:                 &activeExecution,
 		LaunchEntity:          strings.ToLower(input.LaunchEntity.String()),
+		ErrorKind:             errorKind,
+		ErrorCode:             errorCode,
 	}
 	// A reference launch entity can be one of either or a task OR launch plan. Traditionally, workflows are executed
 	// with a reference launch plan which is why this behavior is the default below.

--- a/flyteadmin/pkg/repositories/transformers/execution_test.go
+++ b/flyteadmin/pkg/repositories/transformers/execution_test.go
@@ -113,6 +113,8 @@ func TestCreateExecutionModel(t *testing.T) {
 		expectedSpecBytes, _ := proto.Marshal(expectedSpec)
 		assert.Equal(t, expectedSpecBytes, execution.Spec)
 		assert.Equal(t, execution.User, principal)
+		assert.Nil(t, execution.ErrorKind)
+		assert.Nil(t, execution.ErrorCode)
 
 		expectedCreatedAt, _ := ptypes.TimestampProto(createdAt)
 		expectedClosure, _ := proto.Marshal(&admin.ExecutionClosure{
@@ -172,6 +174,10 @@ func TestCreateExecutionModel(t *testing.T) {
 		expectedSpecBytes, _ := proto.Marshal(expectedSpec)
 		assert.Equal(t, expectedSpecBytes, execution.Spec)
 		assert.Equal(t, execution.User, principal)
+		assert.NotNil(t, execution.ErrorKind)
+		assert.Equal(t, core.ExecutionError_SYSTEM.String(), *execution.ErrorKind)
+		assert.NotNil(t, execution.ErrorCode)
+		assert.Equal(t, "Unknown", *execution.ErrorCode)
 
 		expectedCreatedAt, _ := ptypes.TimestampProto(createdAt)
 		expectedClosure, _ := proto.Marshal(&admin.ExecutionClosure{
@@ -238,6 +244,10 @@ func TestCreateExecutionModel(t *testing.T) {
 		expectedSpecBytes, _ := proto.Marshal(expectedSpec)
 		assert.Equal(t, expectedSpecBytes, execution.Spec)
 		assert.Equal(t, execution.User, principal)
+		assert.NotNil(t, execution.ErrorKind)
+		assert.Equal(t, core.ExecutionError_USER.String(), *execution.ErrorKind)
+		assert.NotNil(t, execution.ErrorCode)
+		assert.Equal(t, codes.InvalidArgument.String(), *execution.ErrorCode)
 
 		expectedCreatedAt, _ := ptypes.TimestampProto(createdAt)
 		expectedClosure, _ := proto.Marshal(&admin.ExecutionClosure{
@@ -304,6 +314,10 @@ func TestCreateExecutionModel(t *testing.T) {
 		expectedSpecBytes, _ := proto.Marshal(expectedSpec)
 		assert.Equal(t, expectedSpecBytes, execution.Spec)
 		assert.Equal(t, execution.User, principal)
+		assert.NotNil(t, execution.ErrorKind)
+		assert.Equal(t, core.ExecutionError_SYSTEM.String(), *execution.ErrorKind)
+		assert.NotNil(t, execution.ErrorCode)
+		assert.Equal(t, codes.Internal.String(), *execution.ErrorCode)
 
 		expectedCreatedAt, _ := ptypes.TimestampProto(createdAt)
 		expectedClosure, _ := proto.Marshal(&admin.ExecutionClosure{


### PR DESCRIPTION
## Why are the changes needed?

FlyteAdmin keeps an execution's error kind and code in dedicated indexed columns so operators can query and alert on failures without unpacking each closure blob. The event path fills them — but an execution that fails at *creation* time, when the workflow executor rejects it before it starts, lands as `FAILED` with the error only inside the closure. Any alert that filters on the error-kind column silently misses those.

## What changes were proposed in this pull request?

Populate the error-kind and error-code columns when an execution is created already-failed, matching what the event path does. Successful executions leave them empty as before.

## How was this patch tested?

Extended `TestCreateExecutionModel` — success leaves the columns nil; the unknown / invalid-argument / internal cases assert they match the failure's kind and code. Also end-to-end against a running flyteadmin with the executor pointed at an unreachable cluster so creation fails at accept time: the stock binary leaves `error_kind`/`error_code` `NULL` on the failed row, this PR writes `SYSTEM` / `Internal`.

### Labels
fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
