### PR TITLE
flytestdlib/cache: support config-driven Redis TLS (UseTLS)

### DIFF
--- a/flytestdlib/cache/config.go
+++ b/flytestdlib/cache/config.go
@@ -162,8 +162,18 @@ type RedisOptions struct {
 	// Default is to not close idle connections.
 	ConnMaxLifetime config.Duration
 
-	// TLS Config to use. When set, TLS will be negotiated.
+	// TLS Config to use. When set, TLS will be negotiated. Not settable from a
+	// config file; use UseTLS for config-driven TLS.
 	TLSConfig *tls.Config
+
+	// UseTLS negotiates TLS using the system certificate pool. Prefer this over
+	// TLSConfig when configuring from YAML/JSON, where TLSConfig cannot be set.
+	// Ignored when TLSConfig is already provided.
+	UseTLS bool
+
+	// TLSInsecureSkipVerify disables server certificate verification. Only set
+	// this for testing against self-signed certificates.
+	TLSInsecureSkipVerify bool
 
 	// // Disable set-lib on connect. Default is false.
 	DisableIndentity bool
@@ -177,6 +187,16 @@ func (r *RedisOptions) GetOptions(ctx context.Context, secretManager SecretManag
 		}
 
 		r.Password = password
+	}
+
+	// Allow config-driven TLS: when UseTLS is set (and no explicit TLSConfig was
+	// provided) negotiate TLS using the system certificate pool.
+	tlsConfig := r.TLSConfig
+	if tlsConfig == nil && r.UseTLS {
+		tlsConfig = &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: r.TLSInsecureSkipVerify, //nolint:gosec // gated behind explicit UseTLS/TLSInsecureSkipVerify config
+		}
 	}
 
 	return &redis.Options{
@@ -200,7 +220,7 @@ func (r *RedisOptions) GetOptions(ctx context.Context, secretManager SecretManag
 		MaxActiveConns:        r.MaxActiveConns,
 		ConnMaxIdleTime:       r.ConnMaxIdleTime.Duration,
 		ConnMaxLifetime:       r.ConnMaxLifetime.Duration,
-		TLSConfig:             r.TLSConfig,
+		TLSConfig:             tlsConfig,
 		DisableIndentity:      r.DisableIndentity,
 		Username:              r.Username,
 	}, nil

--- a/flytestdlib/cache/config.go
+++ b/flytestdlib/cache/config.go
@@ -189,8 +189,6 @@ func (r *RedisOptions) GetOptions(ctx context.Context, secretManager SecretManag
 		r.Password = password
 	}
 
-	// Allow config-driven TLS: when UseTLS is set (and no explicit TLSConfig was
-	// provided) negotiate TLS using the system certificate pool.
 	tlsConfig := r.TLSConfig
 	if tlsConfig == nil && r.UseTLS {
 		tlsConfig = &tls.Config{

--- a/flytestdlib/cache/config_tls_test.go
+++ b/flytestdlib/cache/config_tls_test.go
@@ -1,0 +1,42 @@
+package cache
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedisOptions_GetOptions_TLS(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("UseTLS negotiates TLS with the system pool", func(t *testing.T) {
+		opts, err := (&RedisOptions{Addr: "host:6379", UseTLS: true}).GetOptions(ctx, nil)
+		require.NoError(t, err)
+		require.NotNil(t, opts.TLSConfig)
+		assert.False(t, opts.TLSConfig.InsecureSkipVerify)
+		assert.Equal(t, uint16(tls.VersionTLS12), opts.TLSConfig.MinVersion)
+	})
+
+	t.Run("TLSInsecureSkipVerify is honored", func(t *testing.T) {
+		opts, err := (&RedisOptions{Addr: "host:6379", UseTLS: true, TLSInsecureSkipVerify: true}).GetOptions(ctx, nil)
+		require.NoError(t, err)
+		require.NotNil(t, opts.TLSConfig)
+		assert.True(t, opts.TLSConfig.InsecureSkipVerify)
+	})
+
+	t.Run("no TLS by default", func(t *testing.T) {
+		opts, err := (&RedisOptions{Addr: "host:6379"}).GetOptions(ctx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, opts.TLSConfig)
+	})
+
+	t.Run("explicit TLSConfig takes precedence over UseTLS", func(t *testing.T) {
+		explicit := &tls.Config{MinVersion: tls.VersionTLS13}
+		opts, err := (&RedisOptions{Addr: "host:6379", UseTLS: true, TLSConfig: explicit}).GetOptions(ctx, nil)
+		require.NoError(t, err)
+		assert.Same(t, explicit, opts.TLSConfig)
+	})
+}


### PR DESCRIPTION
## Overview

`RedisOptions.TLSConfig` is a `*tls.Config`, which cannot be set from a YAML/JSON config file. As a result a config-driven deployment cannot enable TLS for the Redis-backed cache — e.g. pointing the cache at a TLS-only managed Redis (AWS ElastiCache / GCP Memorystore) is impossible without code changes.

This adds config-settable TLS to `RedisOptions`:
- `UseTLS bool` — negotiate TLS using the system certificate pool (TLS 1.2 minimum). Use this instead of `TLSConfig` when configuring from YAML/JSON.
- `TLSInsecureSkipVerify bool` — disable server certificate verification (testing only; defaults to false).

`GetOptions` builds the `tls.Config` when `UseTLS` is set and no explicit `TLSConfig` was provided; an explicit `TLSConfig` still takes precedence.

## Test plan
`TestRedisOptions_GetOptions_TLS` covers: `UseTLS` builds a verifying `tls.Config` (TLS 1.2 floor, `InsecureSkipVerify` false), `TLSInsecureSkipVerify` honored, no TLS by default, and explicit `TLSConfig` precedence over `UseTLS`.