### PR TITLE
dataproxy: fall back to RunService.GetActionData for inline literals

### DIFF
--- a/dataproxy/service/dataproxy_service.go
+++ b/dataproxy/service/dataproxy_service.go
@@ -483,6 +483,28 @@ func (s *Service) GetActionData(
 		return nil, err
 	}
 
+	// Condition actions carry their inputs/outputs inline (the ConditionAction
+	// spec on RunInfo and the signal Literal on RunInfo.Output) rather than
+	// materialising inputs.pb / outputs.pb to object storage. RunService
+	// signals this by returning both URIs empty; fall back to RunService's
+	// GetActionData, which returns the inline literals directly.
+	if urisResp.Msg.GetInputsUri() == "" && urisResp.Msg.GetOutputsUri() == "" {
+		logger.Debugf(ctx, "GetActionData: both URIs empty for action %s, falling back to RunService.GetActionData for inline literals", actionId.String())
+		//nolint:staticcheck // RunService.GetActionData is deprecated in favour of
+		// DataProxyService.GetActionData (this method) — but calling ourselves would
+		// loop, so we must reach into the run service for the inline literal.
+		dataResp, err := s.runClient.GetActionData(ctx, connect.NewRequest(&workflow.GetActionDataRequest{
+			ActionId: actionId,
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(&dataproxy.GetActionDataResponse{
+			Inputs:  dataResp.Msg.GetInputs(),
+			Outputs: dataResp.Msg.GetOutputs(),
+		}), nil
+	}
+
 	resp := &dataproxy.GetActionDataResponse{
 		Inputs:  &task.Inputs{},
 		Outputs: &task.Outputs{},

--- a/dataproxy/service/dataproxy_service_test.go
+++ b/dataproxy/service/dataproxy_service_test.go
@@ -531,16 +531,28 @@ func TestGetActionData(t *testing.T) {
 		},
 	}
 
+	// Inline literals returned by the RunService.GetActionData fallback path
+	// (used when both URIs are empty — i.e. condition actions).
+	inlineOutputs := &task.Outputs{
+		Literals: []*task.NamedLiteral{
+			{Name: "review", Value: &core.Literal{Value: &core.Literal_Scalar{Scalar: &core.Scalar{Value: &core.Scalar_Primitive{Primitive: &core.Primitive{Value: &core.Primitive_Boolean{Boolean: true}}}}}}},
+		},
+	}
+
 	tests := []struct {
-		name             string
-		inputsURI        string
-		outputsURI       string
-		runClientErr     error
-		readInputsErr    error
-		readOutputsErr   error
-		wantErr          bool
-		expectInputsLen  int
-		expectOutputsLen int
+		name              string
+		inputsURI         string
+		outputsURI        string
+		runClientErr      error
+		readInputsErr     error
+		readOutputsErr    error
+		// Fallback path (both URIs empty) — what RunService.GetActionData returns.
+		fallbackOutputs   *task.Outputs
+		fallbackClientErr error
+		wantErr           bool
+		expectInputsLen   int
+		expectOutputsLen  int
+		expectOutputName  string
 	}{
 		{
 			name:             "success with both inputs and outputs",
@@ -548,11 +560,13 @@ func TestGetActionData(t *testing.T) {
 			outputsURI:       "s3://test-bucket/outputs/outputs.pb",
 			expectInputsLen:  1,
 			expectOutputsLen: 1,
+			expectOutputName: "o",
 		},
 		{
 			name:             "success with only inputs",
 			inputsURI:        "s3://test-bucket/inputs-dir/inputs.pb",
 			outputsURI:       "",
+			fallbackOutputs:  &task.Outputs{},
 			expectInputsLen:  1,
 			expectOutputsLen: 0,
 		},
@@ -562,13 +576,35 @@ func TestGetActionData(t *testing.T) {
 			outputsURI:       "s3://test-bucket/outputs/outputs.pb",
 			expectInputsLen:  0,
 			expectOutputsLen: 1,
+			expectOutputName: "o",
 		},
 		{
-			name:             "success with neither inputs nor outputs",
+			// Condition action: both URIs empty → fall back to
+			// RunService.GetActionData and surface the inline literal.
+			name:             "both URIs empty falls back to inline literal",
 			inputsURI:        "",
 			outputsURI:       "",
+			fallbackOutputs:  inlineOutputs,
+			expectInputsLen:  0,
+			expectOutputsLen: 1,
+			expectOutputName: "review",
+		},
+		{
+			// Condition action signaled with no payload (or before signal): the
+			// fallback succeeds but returns empty literals.
+			name:             "both URIs empty with empty fallback returns empty",
+			inputsURI:        "",
+			outputsURI:       "",
+			fallbackOutputs:  &task.Outputs{},
 			expectInputsLen:  0,
 			expectOutputsLen: 0,
+		},
+		{
+			name:              "fallback error propagates",
+			inputsURI:         "",
+			outputsURI:        "",
+			fallbackClientErr: connect.NewError(connect.CodeNotFound, assertErr("not found")),
+			wantErr:           true,
 		},
 		{
 			name:         "RunService error propagates",
@@ -600,6 +636,20 @@ func TestGetActionData(t *testing.T) {
 						InputsUri:  tt.inputsURI,
 						OutputsUri: tt.outputsURI,
 					}), nil)
+			}
+
+			// Wire up the inline-literal fallback when both URIs are empty:
+			// the handler calls RunService.GetActionData once to fetch
+			// RunInfo.Output for condition actions (see dataproxy_service.go).
+			if tt.runClientErr == nil && tt.inputsURI == "" && tt.outputsURI == "" {
+				if tt.fallbackClientErr != nil {
+					runClient.EXPECT().GetActionData(mock.Anything, mock.Anything).Return(nil, tt.fallbackClientErr)
+				} else {
+					runClient.EXPECT().GetActionData(mock.Anything, mock.Anything).Return(
+						connect.NewResponse(&workflow.GetActionDataResponse{
+							Outputs: tt.fallbackOutputs,
+						}), nil)
+				}
 			}
 
 			mockComposedStore := storageMocks.NewComposedProtobufStore(t)
@@ -655,7 +705,11 @@ func TestGetActionData(t *testing.T) {
 				assert.Equal(t, "x", resp.Msg.GetInputs().GetLiterals()[0].GetName())
 			}
 			if tt.expectOutputsLen > 0 {
-				assert.Equal(t, "o", resp.Msg.GetOutputs().GetLiterals()[0].GetName())
+				wantName := tt.expectOutputName
+				if wantName == "" {
+					wantName = "o"
+				}
+				assert.Equal(t, wantName, resp.Msg.GetOutputs().GetLiterals()[0].GetName())
 			}
 		})
 	}


### PR DESCRIPTION
## Overview

`DataProxyService.GetActionData` materialises action inputs/outputs by fetching `inputs.pb`/`outputs.pb` via the URIs returned by `RunService.GetActionDataURIs`. For **condition** actions (`ACTION_TYPE_CONDITION`) the literals don't live in object storage at all — the signal payload lives inline on the action row (`RunInfo.Output`). The run service signals this case by returning **both URIs empty**.

Today the dataproxy hits that empty-URIs case, skips both S3 fetches, and returns its zero-value skeleton `{Inputs: {}, Outputs: {}}` — losing the literal even though the run service has it ready to hand back inline.

This PR adds a small fallback: when both URIs come back empty, call `RunService.GetActionData` once and pass its inline `Inputs`/`Outputs` straight through. Tasks/traces are unaffected — they always have a non-empty inputs URI from RecordAction time.

## Why not unconditionally?

We don't want to lose the dataplane-fetch optimisation for tasks/traces (they hold large literals in S3 and the dataproxy is co-located with the bucket). The fallback only triggers when `urisResp.inputs_uri == "" && urisResp.outputs_uri == ""` — which today only happens for condition actions.

## Changes

- `flyteidl2/dataproxy/service/dataproxy_service.go` — new condition fallback branch in `Service.GetActionData`, gated on both URIs empty. Logs at debug level so the call site is easy to spot in traces.
- The `RunService.GetActionData` call is marked deprecated (in favour of `DataProxyService.GetActionData`), but calling ourselves would loop, so a `//nolint:staticcheck` directive explains the intentional reach-into.

## Test plan

- `make test` (flyte2 unit tests).
- Manually verified on dogfood-cloud-staging: a signaled BOOLEAN condition that previously returned `{"inputs":{}, "outputs":{}}` now returns `{"outputs":{"literals":[{"name":"<condition_name>","value":{"scalar":{"primitive":{"boolean":true}}}}]}}`.

## Upstream context

This is part of a larger end-to-end fix in `unionai/cloud` ([PR #16408](https://github.com/unionai/cloud/pull/16408)) that plumbs condition signal payloads inline through:

1. actions-service `Update.output` proto field (closed-source)
2. RedisStream replicator + workflow consumer carrying the literal
3. workflow service merging the literal into `RunInfo.Output`
4. **dataproxy fallback (this PR)** to surface the inline literal to the UI