### PR TITLE
Fix flytestdlib test build broken by go 1.26 typed workqueue migration

### DIFF
--- a/flytestdlib/autorefreshcache/auto_refresh_test.go
+++ b/flytestdlib/autorefreshcache/auto_refresh_test.go
@@ -286,7 +286,7 @@ func TestInProcessing(t *testing.T) {
 // head b[0]. With the default SingleItemBatches every batch holds one item, so
 // nothing was ever marked and each resync re-enqueued items already in flight.
 func TestEnqueueBatches_MarksSingleItemBatchHead(t *testing.T) {
-	rateLimiter := workqueue.DefaultControllerRateLimiter()
+	rateLimiter := workqueue.DefaultTypedControllerRateLimiter[*Batch]()
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	c, err := newAutoRefreshCacheWithClock("head", syncFakeItem, rateLimiter, 5*time.Second, 10, 10,
 		promutils.NewTestScope(), fakeClock)

--- a/flytestdlib/cache/in_memory_auto_refresh_test.go
+++ b/flytestdlib/cache/in_memory_auto_refresh_test.go
@@ -347,7 +347,7 @@ func TestInProcessing(t *testing.T) {
 // head b[0]. With the default SingleItemBatches every batch holds one item, so
 // nothing was ever marked and each resync re-enqueued items already in flight.
 func TestEnqueueBatches_MarksSingleItemBatchHead(t *testing.T) {
-	rateLimiter := workqueue.DefaultControllerRateLimiter()
+	rateLimiter := workqueue.DefaultTypedControllerRateLimiter[*Batch]()
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	cache, err := NewInMemoryAutoRefresh("head", syncFakeItem, rateLimiter, 5*time.Second, 10, 10,
 		promutils.NewTestScope(), WithClock(fakeClock), WithSyncOnCreate(false))


### PR DESCRIPTION
## Tracking issue

Related to #7402

## Why are the changes needed?

`main` is red: the `test (flytestdlib)` job fails to build ([run](https://github.com/flyteorg/flyte/actions/runs/27363717538/job/80857591457)).

#7402 migrated the autorefresh caches from the deprecated `workqueue.RateLimiter` to `workqueue.TypedRateLimiter[*Batch]`, but `TestEnqueueBatches_MarksSingleItemBatchHead` (added concurrently in another PR) still constructs the untyped `workqueue.DefaultControllerRateLimiter()`. Both PRs passed CI individually; the combination broke the build of `flytestdlib/autorefreshcache` and `flytestdlib/cache`:

```
flytestdlib/autorefreshcache/auto_refresh_test.go:291:63: cannot use rateLimiter (variable of interface type workqueue.RateLimiter) as workqueue.TypedRateLimiter[*Batch] value in argument to newAutoRefreshCacheWithClock
flytestdlib/cache/in_memory_auto_refresh_test.go:352:61: cannot use rateLimiter (variable of interface type workqueue.RateLimiter) as workqueue.TypedRateLimiter[*Batch] value in argument to NewInMemoryAutoRefresh
```

## What changes were proposed in this pull request?

Use `workqueue.DefaultTypedControllerRateLimiter[*Batch]()` in the two missed test call sites, matching the migration #7402 applied to every other call site in these files. No production code changes.

## How was this patch tested?

```
go test ./flytestdlib/autorefreshcache/... ./flytestdlib/cache/...
ok  github.com/flyteorg/flyte/v2/flytestdlib/autorefreshcache  0.406s
ok  github.com/flyteorg/flyte/v2/flytestdlib/cache              0.672s
```

`TestEnqueueBatches_MarksSingleItemBatchHead` passes in both packages, and a repo-wide grep confirms no remaining deprecated `DefaultControllerRateLimiter`/`RateLimiter` usages.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
