### PR TITLE
fix(plugins/ray): disable ANSI color codes and Ray Data progress bars in pod logs

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -429,6 +429,16 @@ func buildHeadPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodSpe
 				},
 			},
 		},
+		// Disable Ray's terminal-oriented log decorations (ANSI-colored log prefixes and
+		// Ray Data progress bars) so logs collected from non-interactive pods stay readable.
+		{
+			Name:  "RAY_COLOR_PREFIX",
+			Value: "0",
+		},
+		{
+			Name:  "RAY_DATA_DISABLE_PROGRESS_BARS",
+			Value: "1",
+		},
 	}
 
 	// Removed 'a0 ..' / 'pyflyte-execute ..' args from the pod spec.
@@ -526,6 +536,16 @@ func buildWorkerPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodS
 	envs := []v1.EnvVar{
 		{
 			Name:  "RAY_DISABLE_DOCKER_CPU_WARNING",
+			Value: "1",
+		},
+		// Disable Ray's terminal-oriented log decorations (ANSI-colored log prefixes and
+		// Ray Data progress bars) so logs collected from non-interactive pods stay readable.
+		{
+			Name:  "RAY_COLOR_PREFIX",
+			Value: "0",
+		},
+		{
+			Name:  "RAY_DATA_DISABLE_PROGRESS_BARS",
 			Value: "1",
 		},
 		{

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -415,6 +415,16 @@ func injectLogsSidecar(primaryContainer *v1.Container, podSpec *v1.PodSpec) {
 	podSpec.Containers = append(podSpec.Containers, *sidecar)
 }
 
+// logNoiseDisablingEnvVars disables Ray's terminal-oriented log decorations (ANSI-colored log
+// prefixes and Ray Data progress bars) so logs collected from non-interactive head and worker
+// pods stay readable. Shared by the head and worker builders to keep the two in sync.
+func logNoiseDisablingEnvVars() []v1.EnvVar {
+	return []v1.EnvVar{
+		{Name: "RAY_COLOR_PREFIX", Value: "0"},
+		{Name: "RAY_DATA_DISABLE_PROGRESS_BARS", Value: "1"},
+	}
+}
+
 func buildHeadPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodSpec, objectMeta *metav1.ObjectMeta, taskCtx pluginsCore.TaskExecutionContext, spec *plugins.HeadGroupSpec, gpuAccelerator *core.GPUAccelerator) (v1.PodTemplateSpec, error) {
 	// Some configs are copy from  https://github.com/ray-project/kuberay/blob/b72e6bdcd9b8c77a9dc6b5da8560910f3a0c3ffd/apiserver/pkg/util/cluster.go#L97
 	// They should always be the same, so we could hard code here.
@@ -429,17 +439,8 @@ func buildHeadPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodSpe
 				},
 			},
 		},
-		// Disable Ray's terminal-oriented log decorations (ANSI-colored log prefixes and
-		// Ray Data progress bars) so logs collected from non-interactive pods stay readable.
-		{
-			Name:  "RAY_COLOR_PREFIX",
-			Value: "0",
-		},
-		{
-			Name:  "RAY_DATA_DISABLE_PROGRESS_BARS",
-			Value: "1",
-		},
 	}
+	envs = append(envs, logNoiseDisablingEnvVars()...)
 
 	// Removed 'a0 ..' / 'pyflyte-execute ..' args from the pod spec.
 	primaryContainer.Args = []string{}
@@ -538,16 +539,6 @@ func buildWorkerPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodS
 			Name:  "RAY_DISABLE_DOCKER_CPU_WARNING",
 			Value: "1",
 		},
-		// Disable Ray's terminal-oriented log decorations (ANSI-colored log prefixes and
-		// Ray Data progress bars) so logs collected from non-interactive pods stay readable.
-		{
-			Name:  "RAY_COLOR_PREFIX",
-			Value: "0",
-		},
-		{
-			Name:  "RAY_DATA_DISABLE_PROGRESS_BARS",
-			Value: "1",
-		},
 		{
 			Name:  "TYPE",
 			Value: "worker",
@@ -605,6 +596,7 @@ func buildWorkerPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodS
 			},
 		},
 	}
+	envs = append(envs, logNoiseDisablingEnvVars()...)
 
 	primaryContainer.Env = append(primaryContainer.Env, envs...)
 

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -482,6 +482,38 @@ func TestBuildResourceRayDefaultAffinityDilution(t *testing.T) {
 	assertEveryTermHasRequirement(t, workerSpec, defaultAffinityReq)
 }
 
+func TestBuildResourceRay_DisablesLogNoiseEnv(t *testing.T) {
+	rayJobResourceHandler := rayJobResourceHandler{}
+	taskTemplate := dummyRayTaskTemplate("ray-id", dummyRayCustomObj())
+	rayCtx := dummyRayTaskContext(taskTemplate, resourceRequirements, nil, "", serviceAccount)
+
+	RayResource, err := rayJobResourceHandler.BuildResource(context.TODO(), rayCtx)
+	assert.Nil(t, err)
+	ray, ok := RayResource.(*rayv1.RayJob)
+	assert.True(t, ok)
+
+	hasEnv := func(containers []corev1.Container, name, value string) bool {
+		for _, c := range containers {
+			for _, e := range c.Env {
+				if e.Name == name && e.Value == value {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	headContainers := ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers
+	workerContainers := ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers
+	for _, env := range []struct{ name, value string }{
+		{"RAY_COLOR_PREFIX", "0"},
+		{"RAY_DATA_DISABLE_PROGRESS_BARS", "1"},
+	} {
+		assert.True(t, hasEnv(headContainers, env.name, env.value), "head container must set %s=%s", env.name, env.value)
+		assert.True(t, hasEnv(workerContainers, env.name, env.value), "worker container must set %s=%s", env.name, env.value)
+	}
+}
+
 func TestBuildResourceRayContainerImage(t *testing.T) {
 	assert.NoError(t, config.SetK8sPluginConfig(&config.K8sPluginConfig{}))
 

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -487,30 +487,39 @@ func TestBuildResourceRay_DisablesLogNoiseEnv(t *testing.T) {
 	taskTemplate := dummyRayTaskTemplate("ray-id", dummyRayCustomObj())
 	rayCtx := dummyRayTaskContext(taskTemplate, resourceRequirements, nil, "", serviceAccount)
 
-	RayResource, err := rayJobResourceHandler.BuildResource(context.TODO(), rayCtx)
-	assert.Nil(t, err)
-	ray, ok := RayResource.(*rayv1.RayJob)
-	assert.True(t, ok)
+	rayResource, err := rayJobResourceHandler.BuildResource(context.TODO(), rayCtx)
+	require.NoError(t, err)
+	ray, ok := rayResource.(*rayv1.RayJob)
+	require.True(t, ok)
 
-	hasEnv := func(containers []corev1.Container, name, value string) bool {
+	// envOf returns the named container's env vars as name->value. The log-noise vars must land
+	// on the Ray container itself, not an injected sidecar, so select by container name rather
+	// than scanning every container in the pod.
+	envOf := func(containers []corev1.Container, containerName string) map[string]string {
 		for _, c := range containers {
-			for _, e := range c.Env {
-				if e.Name == name && e.Value == value {
-					return true
+			if c.Name == containerName {
+				env := make(map[string]string, len(c.Env))
+				for _, e := range c.Env {
+					env[e.Name] = e.Value
 				}
+				return env
 			}
 		}
-		return false
+		return nil
 	}
 
-	headContainers := ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers
-	workerContainers := ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers
+	require.NotEmpty(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs, "expected at least one worker group")
+	headEnv := envOf(ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers, RayHeadContainerName)
+	workerEnv := envOf(ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers, "ray-worker")
+	require.NotNil(t, headEnv, "head pod is missing the %s container", RayHeadContainerName)
+	require.NotNil(t, workerEnv, "worker pod is missing the ray-worker container")
+
 	for _, env := range []struct{ name, value string }{
 		{"RAY_COLOR_PREFIX", "0"},
 		{"RAY_DATA_DISABLE_PROGRESS_BARS", "1"},
 	} {
-		assert.True(t, hasEnv(headContainers, env.name, env.value), "head container must set %s=%s", env.name, env.value)
-		assert.True(t, hasEnv(workerContainers, env.name, env.value), "worker container must set %s=%s", env.name, env.value)
+		assert.Equal(t, env.value, headEnv[env.name], "head container must set %s", env.name)
+		assert.Equal(t, env.value, workerEnv[env.name], "worker container must set %s", env.name)
 	}
 }
 


### PR DESCRIPTION
## Why are the changes needed?

Ray decorates its output for an interactive terminal — ANSI-colored log prefixes and tqdm-style Ray Data progress bars. Flyte collects Ray pod stdout to a non-interactive log sink, where these turn into escape-sequence noise (`\x1b[2m\x1b[36m(pid=...)\x1b[0m`) and repeated progress-bar frames that hurt log readability and search.

## What changes were proposed in this pull request?

Set two env vars on the Ray head and worker containers to turn the decorations off: `RAY_COLOR_PREFIX=0` (no ANSI in prefixes) and `RAY_DATA_DISABLE_PROGRESS_BARS=1` (no Ray Data progress bars). They sit alongside the existing `RAY_DISABLE_DOCKER_CPU_WARNING` and are no-ops on Ray builds that don't read them.

## How was this patch tested?

`TestBuildResourceRay_DisablesLogNoiseEnv` asserts both land on the head and worker containers. Against a real Ray 2.55.1 runtime, `RAY_COLOR_PREFIX=0` strips the colored `(pid=…)` prefix that otherwise reaches the log sink; on a live KubeRay cluster the vars carry through to the running head pod's container.

### Labels
fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
