### PR TITLE
ci: only cancel in-progress workflow runs for PRs, not pushes to main

### DIFF
--- a/.github/workflows/flyte-binary-v2.yml
+++ b/.github/workflows/flyte-binary-v2.yml
@@ -1,8 +1,9 @@
 name: Build & Push Flyte Single Binary Images v2
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Only cancel superseded runs on PRs; runs on main queue up instead.
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
 
 on:
   push:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -8,7 +8,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Only cancel superseded runs on PRs; runs on main queue up instead.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   go-tests:


### PR DESCRIPTION
## Why are the changes needed?

`cancel-in-progress: true` applies to every event, so back-to-back merges to `main` cancel each other's in-flight runs. A cancelled main run leaves the merge commit with no test/build results — e.g. a build break like the one fixed in #7503 can go unnoticed until a later run finally completes.

## What changes were proposed in this pull request?

Make `cancel-in-progress` conditional on the PR event, so PR runs are still cancelled when superseded by a newer push, while runs on `main` queue up instead of being cancelled:

- `go-tests.yml`: `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`
- `flyte-binary-v2.yml`: same, but matching its `pull_request_target` trigger; also added the `|| github.ref` fallback to its concurrency group — previously `github.event.pull_request.number` was empty for `push`/`workflow_dispatch` runs, collapsing them all into a single empty-suffix group.

## How was this patch tested?

YAML validated locally. Behavior is exercised by this PR's own runs (PR event → superseded runs cancelled); the queue-instead-of-cancel path for `main` takes effect after merge.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
