### PR TITLE
fix(ray): apply GPU accelerator tolerations when GPU is requested via group k8s_pod

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -95,11 +95,37 @@ func AddRequiredNodeSelectorRequirements(base *v1.Affinity, new ...v1.NodeSelect
 		nodeSelectorTerms := base.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 		for i := range nodeSelectorTerms {
 			nst := &nodeSelectorTerms[i]
-			nst.MatchExpressions = append(nst.MatchExpressions, new...)
+			for _, req := range new {
+				if !containsNodeSelectorRequirement(nst.MatchExpressions, req) {
+					nst.MatchExpressions = append(nst.MatchExpressions, req)
+				}
+			}
 		}
 	} else {
 		base.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []v1.NodeSelectorTerm{{MatchExpressions: new}}
 	}
+}
+
+// containsNodeSelectorRequirement reports whether reqs already holds an identical
+// requirement, so callers (e.g. ApplyGPUNodeSelectors, which may run more than once
+// on the same pod spec) stay idempotent instead of duplicating match expressions.
+func containsNodeSelectorRequirement(reqs []v1.NodeSelectorRequirement, req v1.NodeSelectorRequirement) bool {
+	for i := range reqs {
+		if reqs[i].Key != req.Key || reqs[i].Operator != req.Operator || len(reqs[i].Values) != len(req.Values) {
+			continue
+		}
+		match := true
+		for j := range req.Values {
+			if reqs[i].Values[j] != req.Values[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
 }
 
 // AddPreferredNodeSelectorRequirements appends the provided v1.NodeSelectorRequirement
@@ -319,7 +345,7 @@ func ApplyGPUNodeSelectors(podSpec *v1.PodSpec, gpuAccelerator *core.GPUAccelera
 			Operator: v1.TolerationOpEqual,
 			Effect:   v1.TaintEffectNoSchedule,
 		}
-		podSpec.Tolerations = append(podSpec.Tolerations, deviceTol)
+		addTolerationInPodSpec(podSpec, &deviceTol)
 	}
 
 	// Short circuit if a partition size preference is not specified
@@ -364,7 +390,7 @@ func ApplyGPUNodeSelectors(podSpec *v1.PodSpec, gpuAccelerator *core.GPUAccelera
 		AddRequiredNodeSelectorRequirements(podSpec.Affinity, *partitionSizeNsr)
 	}
 	if partitionSizeTol != nil {
-		podSpec.Tolerations = append(podSpec.Tolerations, *partitionSizeTol)
+		addTolerationInPodSpec(podSpec, partitionSizeTol)
 	}
 }
 

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -124,6 +124,9 @@ func TestAddRequiredNodeSelectorRequirements(t *testing.T) {
 			Operator: v1.NodeSelectorOpIn,
 			Values:   []string{"new"},
 		}
+		// Applying the same requirement twice must not duplicate it (callers like
+		// ApplyGPUNodeSelectors may run more than once on the same pod spec).
+		AddRequiredNodeSelectorRequirements(&affinity, nst)
 		AddRequiredNodeSelectorRequirements(&affinity, nst)
 		assert.EqualValues(
 			t,
@@ -537,6 +540,24 @@ func TestApplyGPUNodeSelectors(t *testing.T) {
 			},
 			podSpec.Tolerations,
 		)
+	})
+
+	// The ray plugin re-applies GPU node selectors after merging a group's custom pod
+	// spec, so a second application on the same pod spec must not duplicate the node
+	// selector requirements or tolerations.
+	t.Run("is idempotent", func(t *testing.T) {
+		podSpec := basePodSpec.DeepCopy()
+		accelerator := &core.GPUAccelerator{
+			Device: "nvidia-tesla-a100",
+			PartitionSizeValue: &core.GPUAccelerator_PartitionSize{
+				PartitionSize: "1g.5gb",
+			},
+		}
+		ApplyGPUNodeSelectors(podSpec, accelerator)
+		applied := podSpec.DeepCopy()
+		ApplyGPUNodeSelectors(podSpec, accelerator)
+		assert.EqualValues(t, applied.Affinity, podSpec.Affinity)
+		assert.EqualValues(t, applied.Tolerations, podSpec.Tolerations)
 	})
 
 	t.Run("with gpu device and partition size spec", func(t *testing.T) {

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -158,8 +158,9 @@ func buildGroupPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCon
 	taskTemplate, err := taskCtx.TaskReader().Read(ctx)
 	if err != nil {
 		return nil, nil, 0, nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "Unable to read task template: [%v]", err.Error())
+	} else if taskTemplate == nil {
+		return nil, nil, 0, nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "nil task specification")
 	}
-
 	// Group-level extended resources override the execution-level overrides, which in
 	// turn override the task-level defaults. ToK8sPodSpec performs the same merge
 	// internally; this computes the result so the effective accelerator can be returned.

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -149,22 +149,39 @@ func (rayJobResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsC
 // volumes), the group's extended resources are layered into the task overrides and the
 // pod spec is rebuilt once via ToK8sPodSpec, which performs the effective merge. When a
 // group does not set extended_resources, the already-built base pod spec is reused.
-func buildGroupPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, basePodSpec *v1.PodSpec, baseObjectMeta *metav1.ObjectMeta, basePrimaryContainerIdx int, groupExtendedResources *core.ExtendedResources) (*v1.PodSpec, *metav1.ObjectMeta, int, error) {
-	if groupExtendedResources == nil {
-		return basePodSpec.DeepCopy(), baseObjectMeta, basePrimaryContainerIdx, nil
+//
+// The group's effective GPU accelerator is also returned so the pod template builders
+// can re-apply the accelerator node selectors and tolerations after merging the group's
+// custom k8s_pod: ToK8sPodSpec runs before that merge, and skips them when the GPU
+// resource only arrives with the custom pod spec.
+func buildGroupPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, basePodSpec *v1.PodSpec, baseObjectMeta *metav1.ObjectMeta, basePrimaryContainerIdx int, groupExtendedResources *core.ExtendedResources) (*v1.PodSpec, *metav1.ObjectMeta, int, *core.GPUAccelerator, error) {
+	taskTemplate, err := taskCtx.TaskReader().Read(ctx)
+	if err != nil {
+		return nil, nil, 0, nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "Unable to read task template: [%v]", err.Error())
 	}
 
 	// Group-level extended resources override the execution-level overrides, which in
-	// turn override the task-level defaults (handled inside ToK8sPodSpec).
+	// turn override the task-level defaults. ToK8sPodSpec performs the same merge
+	// internally; this computes the result so the effective accelerator can be returned.
 	effectiveOverrides := flytek8s.ApplyExtendedResourcesOverrides(
 		taskCtx.TaskExecutionMetadata().GetOverrides().GetExtendedResources(),
 		groupExtendedResources,
 	)
+	effectiveExtendedResources := flytek8s.ApplyExtendedResourcesOverrides(
+		taskTemplate.GetExtendedResources(),
+		effectiveOverrides,
+	)
+	gpuAccelerator := effectiveExtendedResources.GetGpuAccelerator()
+
+	if groupExtendedResources == nil {
+		return basePodSpec.DeepCopy(), baseObjectMeta, basePrimaryContainerIdx, gpuAccelerator, nil
+	}
+
 	groupTaskCtx := flytek8s.NewPluginTaskExecutionContext(taskCtx, flytek8s.WithExtendedResources(effectiveOverrides))
 
 	podSpec, objectMeta, primaryContainerName, err := flytek8s.ToK8sPodSpec(ctx, groupTaskCtx)
 	if err != nil {
-		return nil, nil, 0, flyteerr.Errorf(flyteerr.BadTaskSpecification, "Unable to create pod spec: [%v]", err.Error())
+		return nil, nil, 0, nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "Unable to create pod spec: [%v]", err.Error())
 	}
 
 	primaryContainerIdx := -1
@@ -175,18 +192,18 @@ func buildGroupPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCon
 		}
 	}
 	if primaryContainerIdx < 0 {
-		return nil, nil, 0, flyteerr.Errorf(flyteerr.BadTaskSpecification, "Unable to get primary container from the pod")
+		return nil, nil, 0, nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "Unable to get primary container from the pod")
 	}
 
 	podSpec.ServiceAccountName = GetConfig().ServiceAccount
-	return podSpec, objectMeta, primaryContainerIdx, nil
+	return podSpec, objectMeta, primaryContainerIdx, gpuAccelerator, nil
 }
 
 func constructRayJob(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, rayJob *plugins.RayJob, objectMeta *metav1.ObjectMeta, taskPodSpec v1.PodSpec, headNodeRayStartParams map[string]string, primaryContainerIdx int, primaryContainer v1.Container) (*rayv1.RayJob, error) {
 	enableIngress := true
 	cfg := GetConfig()
 
-	headPodSpec, headObjectMeta, headPrimaryContainerIdx, err := buildGroupPodSpec(
+	headPodSpec, headObjectMeta, headPrimaryContainerIdx, headGPUAccelerator, err := buildGroupPodSpec(
 		ctx, taskCtx, &taskPodSpec, objectMeta, primaryContainerIdx, rayJob.RayCluster.HeadGroupSpec.GetExtendedResources())
 	if err != nil {
 		return nil, err
@@ -197,6 +214,7 @@ func constructRayJob(ctx context.Context, taskCtx pluginsCore.TaskExecutionConte
 		headObjectMeta,
 		taskCtx,
 		rayJob.RayCluster.HeadGroupSpec,
+		headGPUAccelerator,
 	)
 	if err != nil {
 		return nil, err
@@ -214,7 +232,7 @@ func constructRayJob(ctx context.Context, taskCtx pluginsCore.TaskExecutionConte
 	}
 
 	for _, spec := range rayJob.RayCluster.WorkerGroupSpec {
-		workerPodSpec, workerObjectMeta, workerPrimaryContainerIdx, err := buildGroupPodSpec(
+		workerPodSpec, workerObjectMeta, workerPrimaryContainerIdx, workerGPUAccelerator, err := buildGroupPodSpec(
 			ctx, taskCtx, &taskPodSpec, objectMeta, primaryContainerIdx, spec.GetExtendedResources())
 		if err != nil {
 			return nil, err
@@ -225,6 +243,7 @@ func constructRayJob(ctx context.Context, taskCtx pluginsCore.TaskExecutionConte
 			workerObjectMeta,
 			taskCtx,
 			spec,
+			workerGPUAccelerator,
 		)
 		if err != nil {
 			return nil, err
@@ -395,7 +414,7 @@ func injectLogsSidecar(primaryContainer *v1.Container, podSpec *v1.PodSpec) {
 	podSpec.Containers = append(podSpec.Containers, *sidecar)
 }
 
-func buildHeadPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodSpec, objectMeta *metav1.ObjectMeta, taskCtx pluginsCore.TaskExecutionContext, spec *plugins.HeadGroupSpec) (v1.PodTemplateSpec, error) {
+func buildHeadPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodSpec, objectMeta *metav1.ObjectMeta, taskCtx pluginsCore.TaskExecutionContext, spec *plugins.HeadGroupSpec, gpuAccelerator *core.GPUAccelerator) (v1.PodTemplateSpec, error) {
 	// Some configs are copy from  https://github.com/ray-project/kuberay/blob/b72e6bdcd9b8c77a9dc6b5da8560910f3a0c3ffd/apiserver/pkg/util/cluster.go#L97
 	// They should always be the same, so we could hard code here.
 	primaryContainer.Name = RayHeadContainerName
@@ -440,6 +459,13 @@ func buildHeadPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodSpe
 		return v1.PodTemplateSpec{}, err
 	}
 
+	// Re-apply the accelerator node selectors and tolerations now that the group's
+	// custom pod spec is merged: when the GPU resource is requested only via the
+	// group's k8s_pod (not the task container), ToK8sPodSpec ran before the merge
+	// and skipped them. ApplyGPUNodeSelectors is idempotent, so this is a no-op
+	// when they were already applied.
+	flytek8s.ApplyGPUNodeSelectors(basePodSpec, gpuAccelerator)
+
 	basePodSpec = flytek8s.AddTolerationsForExtendedResources(basePodSpec)
 
 	podTemplateSpec := v1.PodTemplateSpec{
@@ -482,7 +508,7 @@ func buildSubmitterPodTemplate(rayClusterSpec *rayv1.RayClusterSpec) v1.PodTempl
 	}
 }
 
-func buildWorkerPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodSpec, objectMetadata *metav1.ObjectMeta, taskCtx pluginsCore.TaskExecutionContext, spec *plugins.WorkerGroupSpec) (v1.PodTemplateSpec, error) {
+func buildWorkerPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodSpec, objectMetadata *metav1.ObjectMeta, taskCtx pluginsCore.TaskExecutionContext, spec *plugins.WorkerGroupSpec, gpuAccelerator *core.GPUAccelerator) (v1.PodTemplateSpec, error) {
 	// Some configs are copy from  https://github.com/ray-project/kuberay/blob/b72e6bdcd9b8c77a9dc6b5da8560910f3a0c3ffd/apiserver/pkg/util/cluster.go#L185
 	// They should always be the same, so we could hard code here.
 
@@ -585,6 +611,13 @@ func buildWorkerPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodS
 	if err != nil {
 		return v1.PodTemplateSpec{}, err
 	}
+
+	// Re-apply the accelerator node selectors and tolerations now that the group's
+	// custom pod spec is merged: when the GPU resource is requested only via the
+	// group's k8s_pod (not the task container), ToK8sPodSpec ran before the merge
+	// and skipped them. ApplyGPUNodeSelectors is idempotent, so this is a no-op
+	// when they were already applied.
+	flytek8s.ApplyGPUNodeSelectors(basePodSpec, gpuAccelerator)
 
 	basePodSpec = flytek8s.AddTolerationsForExtendedResources(basePodSpec)
 

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -616,6 +616,127 @@ func TestBuildResourceRayGroupExtendedResourcesOverride(t *testing.T) {
 		workerNodeSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms)
 }
 
+// TestBuildResourceRayGroupK8SPodGPU is a regression test for the case where the GPU
+// resource is requested only through a group's custom k8s_pod (not the task container).
+// ToK8sPodSpec applies GPU node selectors before the custom pod spec is merged, so the
+// builders must re-apply them post-merge or the device toleration and node affinity are
+// silently dropped (while the generic nvidia.com/gpu toleration, which is computed
+// post-merge, still appears).
+func TestBuildResourceRayGroupK8SPodGPU(t *testing.T) {
+	assert.NoError(t, config.SetK8sPluginConfig(&config.K8sPluginConfig{
+		GpuDeviceNodeLabel:                 "gpu-node-label",
+		GpuResourceName:                    flytek8s.ResourceNvidiaGPU,
+		AddTolerationsForExtendedResources: []string{"nvidia.com/gpu"},
+	}))
+
+	// Task-level resources do not include any GPU.
+	cpuOnlyResources := &corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1000m"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	gpuResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			flytek8s.ResourceNvidiaGPU: resource.MustParse("1"),
+		},
+		Requests: corev1.ResourceList{
+			flytek8s.ResourceNvidiaGPU: resource.MustParse("1"),
+		},
+	}
+	workerGPUPod := &core.K8SPod{
+		PodSpec: transformStructToStructPB(t, &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:      "ray-worker",
+					Resources: gpuResources,
+				},
+			},
+		}),
+	}
+
+	expectedNodeSelectorTerms := []corev1.NodeSelectorTerm{
+		{
+			MatchExpressions: []corev1.NodeSelectorRequirement{
+				{
+					Key:      "gpu-node-label",
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"nvidia-tesla-t4"},
+				},
+			},
+		},
+	}
+	expectedTolerations := []corev1.Toleration{
+		{
+			Key:      "gpu-node-label",
+			Value:    "nvidia-tesla-t4",
+			Operator: corev1.TolerationOpEqual,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "nvidia.com/gpu",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+
+	params := []struct {
+		name                   string
+		taskExtendedResources  *core.ExtendedResources
+		groupExtendedResources *core.ExtendedResources
+	}{
+		{
+			name: "accelerator from group extended resources",
+			groupExtendedResources: &core.ExtendedResources{
+				GpuAccelerator: &core.GPUAccelerator{Device: "nvidia-tesla-t4"},
+			},
+		},
+		{
+			name: "accelerator from task extended resources",
+			taskExtendedResources: &core.ExtendedResources{
+				GpuAccelerator: &core.GPUAccelerator{Device: "nvidia-tesla-t4"},
+			},
+		},
+	}
+
+	for _, p := range params {
+		t.Run(p.name, func(t *testing.T) {
+			rayJobObj := dummyRayCustomObj()
+			rayJobObj.RayCluster.WorkerGroupSpec[0].K8SPod = workerGPUPod
+			rayJobObj.RayCluster.WorkerGroupSpec[0].ExtendedResources = p.groupExtendedResources
+
+			taskTemplate := dummyRayTaskTemplate("ray-id", rayJobObj)
+			taskTemplate.ExtendedResources = p.taskExtendedResources
+			taskContext := dummyRayTaskContext(taskTemplate, cpuOnlyResources, nil, "", serviceAccount)
+			r, err := rayJobResourceHandler{}.BuildResource(context.TODO(), taskContext)
+			assert.NoError(t, err)
+			rayJob, ok := r.(*rayv1.RayJob)
+			assert.True(t, ok)
+
+			// The worker pod's GPU comes only from the group's k8s_pod, so the device
+			// node affinity and toleration must be applied after that merge.
+			workerNodeSpec := rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec
+			assert.NotNil(t, workerNodeSpec.Affinity)
+			assert.NotNil(t, workerNodeSpec.Affinity.NodeAffinity)
+			assert.EqualValues(t, expectedNodeSelectorTerms,
+				workerNodeSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms)
+			assert.EqualValues(t, expectedTolerations, workerNodeSpec.Tolerations)
+
+			// The head pod requests no GPU, so it must not pick up GPU scheduling
+			// constraints. (ToK8sPodSpec always initializes an empty Affinity via
+			// ApplyInterruptibleNodeAffinity, so only NodeAffinity is asserted.)
+			headNodeSpec := rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec
+			assert.Nil(t, headNodeSpec.Affinity.NodeAffinity)
+			assert.Empty(t, headNodeSpec.Tolerations)
+		})
+	}
+}
+
 func TestBuildResourceRayCustomK8SPod(t *testing.T) {
 	assert.NoError(t, config.SetK8sPluginConfig(&config.K8sPluginConfig{}))
 


### PR DESCRIPTION
## Why are the changes needed?

When a Ray head/worker group requests its GPU only through the group's custom `k8s_pod` (rather than the task container resources), the pod ends up with the generic `nvidia.com/gpu:NoSchedule op=Exists` toleration but **without** the accelerator-specific node affinity and toleration (e.g. `k8s.amazonaws.com/accelerator=nvidia-t4:NoSchedule`), even though the group's `extended_resources` declare the accelerator. The pod then can't schedule onto the tainted accelerator nodes it targets.

Root cause is an ordering problem in the ray plugin:

1. `buildGroupPodSpec` → `ToK8sPodSpec` runs `ApplyGPUNodeSelectors`, whose `podRequiresAccelerator` guard checks container GPU **limits** — which aren't there yet, so it silently short-circuits.
2. `buildHeadPodTemplate`/`buildWorkerPodTemplate` later merge the group's `k8s_pod` (which carries the GPU limits) via `mergeCustomPodSpec`, but the accelerator logic never runs again.
3. `AddTolerationsForExtendedResources` *does* run post-merge — which is why the generic `Exists` toleration appears while the device toleration doesn't.

## What changes were proposed in this pull request?

- `buildGroupPodSpec` now also returns the group's effective GPU accelerator (task-level ⊕ execution overrides ⊕ group `extended_resources`).
- `buildHeadPodTemplate`/`buildWorkerPodTemplate` re-apply `ApplyGPUNodeSelectors` right after `mergeCustomPodSpec`, mirroring how `AddTolerationsForExtendedResources` already runs post-merge. Merging earlier instead is not viable: `ToK8sPodSpec` rebuilds the spec from the task context, and the overlay merges containers by the `ray-head`/`ray-worker` names that only exist after the builders rename the primary container.
- `ApplyGPUNodeSelectors` is made idempotent so the re-application is a no-op when the selectors were already applied inside `ToK8sPodSpec`: tolerations go through the existing `addTolerationInPodSpec` dedupe helper, and `AddRequiredNodeSelectorRequirements` now skips requirements already present in a term (previously it appended blindly).

## How was this patch tested?

```python
import asyncio
import typing

import ray
from flyteplugins.ray.task import HeadNodeConfig, RayJobConfig, WorkerNodeConfig
from kubernetes.client import V1Container, V1EnvVar, V1PodSpec, V1ResourceRequirements

import flyte.remote
import flyte.storage


@ray.remote
def f(x):
    return x * x


# A custom pod template for the worker group: it sets a custom env var and cpu/memory on the
# ``ray-worker`` container. Combined with ``requests=Resources(gpu=...)`` below, this exercises the
# fix that *merges* requests/limits into the pod_template instead of dropping the template.
worker_pod_template = flyte.PodTemplate(
    pod_spec=V1PodSpec(
        containers=[
            V1Container(
                name="ray-worker",
                env=[V1EnvVar(name="RAY_WORKER_CUSTOM", value="merged-pod-template")],
                resources=V1ResourceRequirements(
                    requests={"cpu": "1", "memory": "2Gi"},
                    limits={"cpu": "1", "memory": "2Gi"},
                ),
            )
        ]
    )
)

ray_config = RayJobConfig(
    head_node_config=HeadNodeConfig(ray_start_params={"log-color": "True"}),
    worker_node_config=[
        WorkerNodeConfig(
            group_name="ray-group",
            replicas=1,
            # GPU type/count for the worker group. Change "T4:1" to whatever your cluster offers.
            requests=flyte.Resources(gpu="L4:1"),
            pod_template=worker_pod_template,
        )
    ],
    runtime_env={"pip": ["numpy", "pandas"]},
    enable_autoscaling=False,
    shutdown_after_job_finishes=True,
    ttl_seconds_after_finished=300,
)

image = (
    flyte.Image.from_debian_base(name="ray")
    .with_apt_packages("wget", "git")
    .with_pip_packages(
        "ray[default]==2.46.0",
        # Install the plugin from the PR branch so the cluster runtime matches the patched SDK.
        # The merge itself happens during local serialization, so also install this branch locally:
        #   pip install --no-deps --force-reinstall \
        #     "git+https://github.com/flyteorg/flyte-sdk.git@fix/ray-pod-template-resources-merge#subdirectory=plugins/ray"
        "flyteplugins-ray @ git+https://github.com/flyteorg/flyte-sdk.git"
        "@fix/ray-pod-template-resources-merge#subdirectory=plugins/ray",
        "pip",
        "mypy",
    )
)

task_env = flyte.TaskEnvironment(
    name="hello_ray", resources=flyte.Resources(cpu=(1, 2), memory=("400Mi", "1000Mi")), image=image
)
ray_env = flyte.TaskEnvironment(
    name="ray_env",
    plugin_config=ray_config,
    image=image,
    resources=flyte.Resources(cpu=(3, 4), memory=("3000Mi", "5000Mi")),
    depends_on=[task_env],
)


@task_env.task()
async def hello_ray():
    await asyncio.sleep(20)
    print("Hello from the Ray task!")


@ray_env.task
async def hello_ray_nested(n: int = 3) -> typing.List[int]:
    print("running ray task")
    t = asyncio.create_task(hello_ray())
    futures = [f.remote(i) for i in range(n)]
    res = ray.get(futures)
    await t
    return res


if __name__ == "__main__":
    flyte.init_from_config()
    run = flyte.run(hello_ray_nested)
    print("run name:", run.name)
    print("run url:", run.url)
    run.wait()

    action_details = flyte.remote.ActionDetails.get(run_name=run.name, name="a0")
    for log in action_details.pb2.attempts[-1].log_info:
        print(f"{log.name}: {log.uri}")

```

- New regression test `TestBuildResourceRayGroupK8SPodGPU`: GPU requested only via the worker group's `k8s_pod`, accelerator declared via group-level and task-level `extended_resources` (both variants). Verified it **fails without the ray.go change** and passes with it. Also asserts the GPU-less head pod picks up no GPU scheduling constraints.
- New idempotence tests for `ApplyGPUNodeSelectors` and `AddRequiredNodeSelectorRequirements`.
- Full `go test ./flyteplugins/...` passes.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
