### PR TITLE
fix(clustered): correctly reconcile JobSet phase during restarts

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
@@ -227,6 +227,8 @@ func TestInjectTorchRunEnv_Static(t *testing.T) {
 	assert.Equal(t, "8", envMap["NPROC_PER_NODE"])
 	assert.Equal(t, "29500", envMap["MASTER_PORT"])
 	assert.Equal(t, "static", envMap["RDZV_BACKEND"])
+	// No failure policy set → budget defaults to 0 (every failure is terminal).
+	assert.Equal(t, "0", envMap["JOBSET_MAX_RESTARTS"])
 
 	// Downward API env vars should be present.
 	names := make(map[string]bool)
@@ -235,7 +237,26 @@ func TestInjectTorchRunEnv_Static(t *testing.T) {
 	}
 	assert.True(t, names["JOBSET_NAME"])
 	assert.True(t, names["JOBSET_RESTART_ATTEMPT"])
+	assert.True(t, names["JOBSET_MAX_RESTARTS"])
 	assert.True(t, names["POD_NAMESPACE"])
+}
+
+func TestInjectTorchRunEnv_MaxRestarts(t *testing.T) {
+	spec := &clusteredpb.ClusteredTaskSpec{
+		Replicas:      2,
+		NprocPerNode:  4,
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 3},
+	}
+	container := &corev1.Container{}
+	injectTorchRunEnv(container, spec)
+
+	for _, e := range container.Env {
+		if e.Name == "JOBSET_MAX_RESTARTS" {
+			assert.Equal(t, "3", e.Value)
+			return
+		}
+	}
+	t.Fatal("JOBSET_MAX_RESTARTS not found")
 }
 
 func TestInjectTorchRunEnv_C10D(t *testing.T) {

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
@@ -711,6 +711,40 @@ func TestGetTaskPhase_FastFail_PendingImagePullRegardlessBudget(t *testing.T) {
 	assert.Equal(t, pluginsCore.PhaseRetryableFailure, phase.Phase())
 }
 
+func TestGetTaskPhase_NoCondition_ZeroBudgetFailureFastFails(t *testing.T) {
+	// maxRestarts == 0 and a worker has failed, but the JobSet controller has not yet
+	// written any condition. hasJobSetStarted must still treat this as started so the
+	// failure is surfaced via maybeFastFailWorker0 instead of falling back to Initializing.
+	js := makeJobSet("", "", false)
+	js.Spec.FailurePolicy = &jobsetv1alpha2.FailurePolicy{MaxRestarts: 0}
+	js.Status.ReplicatedJobsStatus = []jobsetv1alpha2.ReplicatedJobStatus{
+		{Name: workersReplicatedJobName, Failed: 1},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: rank0PodName(testJobName) + "-abc12", Namespace: testNS},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "primary", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1}}},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(k8sscheme.Scheme).WithObjects(pod).Build()
+
+	spec := &clusteredpb.ClusteredTaskSpec{
+		Replicas:      2,
+		NprocPerNode:  1,
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 0},
+	}
+	pCtx := dummyPluginCtx(buildTaskTemplate(spec), fakeClient)
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRetryableFailure, phase.Phase())
+}
+
 func TestGetTaskPhase_RestartingCondition_ReportsRunningWithAttempt(t *testing.T) {
 	js := makeJobSet("", "", false)
 	js.Spec.FailurePolicy = &jobsetv1alpha2.FailurePolicy{MaxRestarts: 1}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
@@ -2,6 +2,7 @@ package clustered
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
 	coreMocks "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core/mocks"
 	pluginIOMocks "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/io/mocks"
+	plugink8s "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
 	k8smocks "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s/mocks"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
@@ -336,6 +338,15 @@ func emptyK8sReader() client.Reader {
 }
 
 func dummyPluginCtx(taskTemplate *core.TaskTemplate, k8sReader client.Reader) *k8smocks.PluginContext {
+	return dummyPluginCtxWithState(taskTemplate, k8sReader, plugink8s.PluginState{}, nil)
+}
+
+func dummyPluginCtxWithState(
+	taskTemplate *core.TaskTemplate,
+	k8sReader client.Reader,
+	pluginState plugink8s.PluginState,
+	pluginStateErr error,
+) *k8smocks.PluginContext {
 	pCtx := &k8smocks.PluginContext{}
 
 	taskReader := &coreMocks.TaskReader{}
@@ -358,7 +369,15 @@ func dummyPluginCtx(taskTemplate *core.TaskTemplate, k8sReader client.Reader) *k
 	pCtx.EXPECT().TaskExecutionMetadata().Return(meta)
 
 	pluginStateReader := &coreMocks.PluginStateReader{}
-	pluginStateReader.EXPECT().Get(mock.Anything).Return(uint8(0), nil)
+	pluginStateReader.EXPECT().Get(mock.Anything).RunAndReturn(func(t interface{}) (uint8, error) {
+		if pluginStateErr != nil {
+			return 0, pluginStateErr
+		}
+		if s, ok := t.(*plugink8s.PluginState); ok {
+			*s = pluginState
+		}
+		return 0, nil
+	})
 	pCtx.EXPECT().PluginStateReader().Return(pluginStateReader)
 
 	return pCtx
@@ -482,7 +501,7 @@ func TestGetTaskPhase_FastFail_Worker0Failed(t *testing.T) {
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      rank0PodName(testJobName),
+			Name:      rank0PodName(testJobName) + "-abc12",
 			Namespace: testNS,
 		},
 		Status: corev1.PodStatus{
@@ -518,7 +537,7 @@ func TestGetTaskPhase_MaintenanceRetry_SystemFailure(t *testing.T) {
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      rank0PodName(testJobName),
+			Name:      rank0PodName(testJobName) + "-abc12",
 			Namespace: testNS,
 		},
 		Status: corev1.PodStatus{
@@ -540,6 +559,238 @@ func TestGetTaskPhase_MaintenanceRetry_SystemFailure(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, pluginsCore.PhaseRetryableFailure, phase.Phase())
 	assert.Equal(t, core.ExecutionError_SYSTEM, phase.Err().GetKind())
+}
+
+func TestFindRank0Pod_SuffixedAndDeterministic(t *testing.T) {
+	oldFailed := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              rank0PodName(testJobName) + "-aaaa1",
+			Namespace:         testNS,
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Minute)),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodFailed},
+	}
+	newRunning := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              rank0PodName(testJobName) + "-bbbb2",
+			Namespace:         testNS,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	otherPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testJobName + "-workers-0-1-ccccc",
+			Namespace: testNS,
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(k8sscheme.Scheme).WithObjects(oldFailed, newRunning, otherPod).Build()
+
+	pCtx := &k8smocks.PluginContext{}
+	pCtx.EXPECT().K8sReader().Return(fakeClient)
+
+	js := makeJobSet("", "", false)
+	pod := findRank0Pod(context.Background(), pCtx, js)
+	assert.NotNil(t, pod)
+	assert.Equal(t, newRunning.Name, pod.Name)
+}
+
+func TestGetTaskPhase_FastFail_FailedWithBudgetRemainingReturnsRunning(t *testing.T) {
+	js := makeJobSet("", "", false)
+	js.Spec.FailurePolicy = &jobsetv1alpha2.FailurePolicy{MaxRestarts: 2}
+	js.Status.Restarts = 1
+	js.Status.ReplicatedJobsStatus = []jobsetv1alpha2.ReplicatedJobStatus{
+		{Name: workersReplicatedJobName, Failed: 1, Active: 1},
+	}
+	js.Status.Conditions = []metav1.Condition{
+		{Type: "SomeActiveCondition", Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now())},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: rank0PodName(testJobName) + "-abc12", Namespace: testNS},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "primary", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1}}},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(k8sscheme.Scheme).WithObjects(pod).Build()
+
+	spec := &clusteredpb.ClusteredTaskSpec{
+		Replicas:      2,
+		NprocPerNode:  1,
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 2},
+	}
+	pCtx := dummyPluginCtx(buildTaskTemplate(spec), fakeClient)
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRunning, phase.Phase())
+}
+
+func TestGetTaskPhase_FastFail_FailedWithBudgetExhaustedReturnsRetryableFailure(t *testing.T) {
+	js := makeJobSet("", "", false)
+	js.Spec.FailurePolicy = &jobsetv1alpha2.FailurePolicy{MaxRestarts: 1}
+	js.Status.Restarts = 1
+	js.Status.ReplicatedJobsStatus = []jobsetv1alpha2.ReplicatedJobStatus{
+		{Name: workersReplicatedJobName, Failed: 1, Active: 1},
+	}
+	js.Status.Conditions = []metav1.Condition{
+		{Type: "SomeActiveCondition", Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now())},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: rank0PodName(testJobName) + "-abc12", Namespace: testNS},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "primary", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1}}},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(k8sscheme.Scheme).WithObjects(pod).Build()
+
+	spec := &clusteredpb.ClusteredTaskSpec{
+		Replicas:      2,
+		NprocPerNode:  1,
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 1},
+	}
+	pCtx := dummyPluginCtx(buildTaskTemplate(spec), fakeClient)
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRetryableFailure, phase.Phase())
+}
+
+func TestGetTaskPhase_FastFail_PendingImagePullRegardlessBudget(t *testing.T) {
+	js := makeJobSet("", "", false)
+	js.Spec.FailurePolicy = &jobsetv1alpha2.FailurePolicy{MaxRestarts: 3}
+	js.Status.Restarts = 1
+	js.Status.Conditions = []metav1.Condition{
+		{Type: "SomeActiveCondition", Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now())},
+	}
+
+	oldTransition := metav1.NewTime(time.Now().Add(-24 * time.Hour))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: rank0PodName(testJobName) + "-abc12", Namespace: testNS},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady", LastTransitionTime: oldTransition},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "primary",
+					Ready: false,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "ImagePullBackOff",
+							Message: "Back-off pulling image",
+						},
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(k8sscheme.Scheme).WithObjects(pod).Build()
+
+	spec := &clusteredpb.ClusteredTaskSpec{
+		Replicas:      2,
+		NprocPerNode:  1,
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 3},
+	}
+	pCtx := dummyPluginCtx(buildTaskTemplate(spec), fakeClient)
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRetryableFailure, phase.Phase())
+}
+
+func TestGetTaskPhase_RestartingCondition_ReportsRunningWithAttempt(t *testing.T) {
+	js := makeJobSet("", "", false)
+	js.Spec.FailurePolicy = &jobsetv1alpha2.FailurePolicy{MaxRestarts: 1}
+	js.Status.Restarts = 1
+	js.Status.ReplicatedJobsStatus = []jobsetv1alpha2.ReplicatedJobStatus{
+		{Name: workersReplicatedJobName, Failed: 1},
+	}
+	js.Status.Conditions = []metav1.Condition{
+		{Type: jobSetRestartingConditionType, Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now())},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: rank0PodName(testJobName) + "-abc12", Namespace: testNS},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "primary", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1}}},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(k8sscheme.Scheme).WithObjects(pod).Build()
+	pCtx := dummyPluginCtx(buildTaskTemplate(&clusteredpb.ClusteredTaskSpec{Replicas: 2, NprocPerNode: 1}), fakeClient)
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRunning, phase.Phase())
+	assert.Contains(t, phase.Reason(), "restart in progress (attempt 1)")
+}
+
+func TestGetTaskPhase_NoTrueConditionWithRestarts_ReportsRunning(t *testing.T) {
+	js := makeJobSet("", "", false)
+	js.Status.Restarts = 1
+	js.Status.Conditions = []metav1.Condition{
+		{Type: string(jobsetv1alpha2.JobSetSuspended), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now())},
+		{Type: string(jobsetv1alpha2.JobSetCompleted), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now())},
+	}
+
+	pCtx := dummyPluginCtx(buildTaskTemplate(&clusteredpb.ClusteredTaskSpec{Replicas: 2, NprocPerNode: 1}), emptyK8sReader())
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRunning, phase.Phase())
+	assert.Contains(t, phase.Reason(), "restart attempt 1")
+}
+
+func TestGetTaskPhase_NoConditionWithPriorRunningState_ReportsRunning(t *testing.T) {
+	js := makeJobSet("", "", false)
+	pCtx := dummyPluginCtxWithState(
+		buildTaskTemplate(&clusteredpb.ClusteredTaskSpec{Replicas: 2, NprocPerNode: 1}),
+		emptyK8sReader(),
+		plugink8s.PluginState{Phase: pluginsCore.PhaseRunning, PhaseVersion: 1},
+		nil,
+	)
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRunning, phase.Phase())
+}
+
+func TestGetTaskPhase_NoTrueCondition_StateReadErrorFallsBackToStatus(t *testing.T) {
+	js := makeJobSet("", "", false)
+	js.Status.Restarts = 1
+	js.Status.Conditions = []metav1.Condition{
+		{Type: string(jobsetv1alpha2.JobSetCompleted), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now())},
+	}
+
+	pCtx := dummyPluginCtxWithState(
+		buildTaskTemplate(&clusteredpb.ClusteredTaskSpec{Replicas: 2, NprocPerNode: 1}),
+		emptyK8sReader(),
+		plugink8s.PluginState{},
+		errors.New("state read failed"),
+	)
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRunning, phase.Phase())
 }
 
 func TestGetTaskPhase_LogContext(t *testing.T) {

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/logs.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/logs.go
@@ -3,7 +3,6 @@ package clustered
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -99,9 +98,6 @@ func getLogContext(ctx context.Context, pluginContext k8s.PluginContext, jobSet 
 		return nil
 	}
 
-	// rank0PodName returns "<jobset>-workers-0-0"; the real pod carries an additional
-	// random suffix, so match on prefix to identify the primary (rank-0) pod.
-	primaryPrefix := rank0PodName(jobSet.Name)
 	// The authoritative primary container name is stored on the JobSet at build time
 	// (see build.go). Child pods don't carry the annotations BuildPodLogContext infers
 	// from, so set it explicitly to avoid resolving to the wrong container (e.g. a sidecar).
@@ -113,7 +109,7 @@ func getLogContext(ctx context.Context, pluginContext k8s.PluginContext, jobSet 
 		if pod.Status.Phase == v1.PodPending {
 			continue
 		}
-		if strings.HasPrefix(pod.Name, primaryPrefix) {
+		if isRank0PodName(jobSet.Name, pod.Name) {
 			logCtx.PrimaryPodName = pod.Name
 		}
 		podLogCtx := flytek8s.BuildPodLogContext(pod)

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/phase.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/phase.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
@@ -17,6 +18,12 @@ import (
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 	clusteredpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/plugins"
+)
+
+const (
+	// jobSetRestartingConditionType is emitted by newer JobSet controllers, but the pinned v0.5.2 API package
+	// predates this constant. Keep this string check until we can bump the dependency.
+	jobSetRestartingConditionType = "RestartingJobSet"
 )
 
 func (clusteredResourceHandler) GetTaskPhase(ctx context.Context, pluginContext k8s.PluginContext, resource client.Object) (pluginsCore.PhaseInfo, error) {
@@ -49,10 +56,17 @@ func (clusteredResourceHandler) GetTaskPhase(ctx context.Context, pluginContext 
 		OccurredAt: &occurredAt,
 		CustomInfo: statusDetails,
 	}
+	maxRestarts := getMaxRestarts(jobSet, &spec)
 
 	condition := extractCurrentCondition(jobSet.Status.Conditions)
 	if condition == nil {
-		// JobSet exists, no terminal condition yet.
+		if hasJobSetStarted(ctx, pluginContext, jobSet, maxRestarts) {
+			if phase, ok := maybeFastFailWorker0(ctx, pluginContext, jobSet, &taskInfo, maxRestarts, true); ok {
+				return phase, nil
+			}
+			return runningPhaseInfo(ctx, pluginContext, &taskInfo, runningReason(jobSet.Status.Restarts)), nil
+		}
+
 		return pluginsCore.PhaseInfoInitializing(occurredAt, pluginsCore.DefaultPhaseVersion, "pods scheduling / DNS resolving", &taskInfo), nil
 	}
 
@@ -67,38 +81,142 @@ func (clusteredResourceHandler) GetTaskPhase(ctx context.Context, pluginContext 
 			}
 		}
 		return pluginsCore.PhaseInfoRetryableFailure(condition.Reason, condition.Message, &taskInfo), nil
+
+	case jobsetv1alpha2.JobSetConditionType(jobSetRestartingConditionType):
+		if phase, ok := maybeFastFailWorker0(ctx, pluginContext, jobSet, &taskInfo, maxRestarts, false); ok {
+			return phase, nil
+		}
+		return runningPhaseInfo(
+			ctx,
+			pluginContext,
+			&taskInfo,
+			fmt.Sprintf("restart in progress (attempt %d)", jobSet.Status.Restarts),
+		), nil
 	}
 
-	// Running: check for fast-fail before reporting PhaseRunning.
-	if phase, ok := maybeFastFailWorker0(ctx, pluginContext, jobSet, &taskInfo); ok {
+	if phase, ok := maybeFastFailWorker0(ctx, pluginContext, jobSet, &taskInfo, maxRestarts, true); ok {
 		return phase, nil
 	}
-
-	phaseInfo := pluginsCore.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion, &taskInfo)
-
-	if err := k8s.MaybeUpdatePhaseVersionFromPluginContext(&phaseInfo, &pluginContext); err != nil {
-		return phaseInfo, err
-	}
-	return phaseInfo, nil
+	return runningPhaseInfo(ctx, pluginContext, &taskInfo, runningReason(jobSet.Status.Restarts)), nil
 }
 
-// maybeFastFailWorker0 inspects the rank-0 pod when at least one Job under the "workers"
-// ReplicatedJob has failed. Returns (phaseInfo, true) if the pod is in a terminal failed state.
-// This surfaces the failure before the JobSet controller sets JobSetFailed, reducing tail latency.
-func maybeFastFailWorker0(ctx context.Context, pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet, taskInfo *pluginsCore.TaskInfo) (pluginsCore.PhaseInfo, bool) {
-	for _, s := range jobSet.Status.ReplicatedJobsStatus {
-		if s.Name == workersReplicatedJobName && s.Failed > 0 {
-			podName := rank0PodName(jobSet.Name)
-			containerName := jobSet.Annotations[primaryContainerAnnotation]
-			phase, err := flytek8s.DemystifyFailedOrPendingPod(ctx, pluginContext, *taskInfo, jobSet.Namespace, podName, containerName)
-			if err != nil {
-				logger.Warnf(ctx, "failed to inspect rank-0 pod for fast-fail: %v", err)
-				return pluginsCore.PhaseInfoUndefined, false
-			}
-			if phase.Phase().IsFailure() {
-				return phase, true
-			}
+func runningReason(restarts int32) string {
+	return fmt.Sprintf("running (restart attempt %d)", restarts)
+}
+
+func runningPhaseInfo(
+	ctx context.Context,
+	pluginContext k8s.PluginContext,
+	taskInfo *pluginsCore.TaskInfo,
+	reason string,
+) pluginsCore.PhaseInfo {
+	phaseInfo := pluginsCore.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion, taskInfo)
+	if reason != "" {
+		phaseInfo.WithReason(reason)
+	}
+	if err := k8s.MaybeUpdatePhaseVersionFromPluginContext(&phaseInfo, &pluginContext); err != nil {
+		logger.Warnf(ctx, "failed to update running phase version from plugin state: %v", err)
+	}
+	return phaseInfo
+}
+
+func getMaxRestarts(jobSet *jobsetv1alpha2.JobSet, spec *clusteredpb.ClusteredTaskSpec) int32 {
+	if jobSet.Spec.FailurePolicy != nil {
+		return jobSet.Spec.FailurePolicy.MaxRestarts
+	}
+	return spec.GetFailurePolicy().GetMaxRestarts()
+}
+
+func getWorkersStatus(jobSet *jobsetv1alpha2.JobSet) *jobsetv1alpha2.ReplicatedJobStatus {
+	for i := range jobSet.Status.ReplicatedJobsStatus {
+		if jobSet.Status.ReplicatedJobsStatus[i].Name == workersReplicatedJobName {
+			return &jobSet.Status.ReplicatedJobsStatus[i]
 		}
+	}
+	return nil
+}
+
+func workersHaveFailures(jobSet *jobsetv1alpha2.JobSet) bool {
+	workersStatus := getWorkersStatus(jobSet)
+	return workersStatus != nil && workersStatus.Failed > 0
+}
+
+func isRestartBudgetExhausted(jobSet *jobsetv1alpha2.JobSet, maxRestarts int32) bool {
+	return jobSet.Status.Restarts >= maxRestarts
+}
+
+func hasRestartBudgetRemaining(jobSet *jobsetv1alpha2.JobSet, maxRestarts int32) bool {
+	return !isRestartBudgetExhausted(jobSet, maxRestarts)
+}
+
+func readPluginState(ctx context.Context, pluginContext k8s.PluginContext) (k8s.PluginState, bool) {
+	pluginState := k8s.PluginState{}
+	if _, err := pluginContext.PluginStateReader().Get(&pluginState); err != nil {
+		logger.Warnf(ctx, "failed to read plugin state: %v", err)
+		return pluginState, false
+	}
+	return pluginState, true
+}
+
+func hasJobSetStarted(ctx context.Context, pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet, maxRestarts int32) bool {
+	if jobSet.Status.Restarts > 0 {
+		return true
+	}
+
+	if workersStatus := getWorkersStatus(jobSet); workersStatus != nil {
+		if workersStatus.Ready > 0 || workersStatus.Active > 0 || workersStatus.Succeeded > 0 {
+			return true
+		}
+		if workersStatus.Failed > 0 && hasRestartBudgetRemaining(jobSet, maxRestarts) {
+			return true
+		}
+	}
+
+	if pluginState, ok := readPluginState(ctx, pluginContext); ok && pluginState.Phase >= pluginsCore.PhaseRunning {
+		return true
+	}
+	return false
+}
+
+// maybeFastFailWorker0 inspects the real rank-0 pod (suffix-tolerant lookup) for pending/failed diagnostics.
+// Pending demystification is always evaluated; failed demystification is gated on exhausted restart budget.
+func maybeFastFailWorker0(
+	ctx context.Context,
+	pluginContext k8s.PluginContext,
+	jobSet *jobsetv1alpha2.JobSet,
+	taskInfo *pluginsCore.TaskInfo,
+	maxRestarts int32,
+	allowFailedPath bool,
+) (pluginsCore.PhaseInfo, bool) {
+	pod := findRank0Pod(ctx, pluginContext, jobSet)
+	if pod == nil {
+		return pluginsCore.PhaseInfoUndefined, false
+	}
+
+	if pod.Status.Phase == v1.PodPending {
+		phase, err := flytek8s.DemystifyPending(pod.Status, *taskInfo)
+		if err != nil {
+			logger.Warnf(ctx, "failed to inspect pending rank-0 pod for fast-fail: %v", err)
+			return pluginsCore.PhaseInfoUndefined, false
+		}
+		if phase.Phase().IsFailure() {
+			return phase, true
+		}
+		return pluginsCore.PhaseInfoUndefined, false
+	}
+
+	if pod.Status.Phase != v1.PodFailed || !allowFailedPath || !workersHaveFailures(jobSet) || !isRestartBudgetExhausted(jobSet, maxRestarts) {
+		return pluginsCore.PhaseInfoUndefined, false
+	}
+
+	containerName := jobSet.Annotations[primaryContainerAnnotation]
+	phase, err := flytek8s.DemystifyFailure(ctx, pod.Status, *taskInfo, containerName)
+	if err != nil {
+		logger.Warnf(ctx, "failed to inspect failed rank-0 pod for fast-fail: %v", err)
+		return pluginsCore.PhaseInfoUndefined, false
+	}
+	if phase.Phase().IsFailure() {
+		return phase, true
 	}
 	return pluginsCore.PhaseInfoUndefined, false
 }
@@ -108,9 +226,26 @@ func maybeFastFailWorker0(ctx context.Context, pluginContext k8s.PluginContext, 
 // PhaseInfoSystemRetryableFailureWithCleanup so Flyte retries without charging user's max_restarts.
 // Best-effort: if the pod is already cleaned up, returns (_, false) and the caller falls through.
 func maybeSystemRetryOnMaintenance(ctx context.Context, pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet, taskInfo *pluginsCore.TaskInfo) (pluginsCore.PhaseInfo, bool) {
-	podName := rank0PodName(jobSet.Name)
+	pod := findRank0Pod(ctx, pluginContext, jobSet)
+	if pod == nil {
+		return pluginsCore.PhaseInfoUndefined, false
+	}
+
 	containerName := jobSet.Annotations[primaryContainerAnnotation]
-	phase, err := flytek8s.DemystifyFailedOrPendingPod(ctx, pluginContext, *taskInfo, jobSet.Namespace, podName, containerName)
+	var (
+		phase pluginsCore.PhaseInfo
+		err   error
+	)
+
+	switch pod.Status.Phase {
+	case v1.PodFailed:
+		phase, err = flytek8s.DemystifyFailure(ctx, pod.Status, *taskInfo, containerName)
+	case v1.PodPending:
+		phase, err = flytek8s.DemystifyPending(pod.Status, *taskInfo)
+	default:
+		return pluginsCore.PhaseInfoUndefined, false
+	}
+
 	if err != nil {
 		logger.Warnf(ctx, "failed to inspect rank-0 pod for maintenance retry: %v", err)
 		return pluginsCore.PhaseInfoUndefined, false

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/phase.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/phase.go
@@ -60,7 +60,7 @@ func (clusteredResourceHandler) GetTaskPhase(ctx context.Context, pluginContext 
 
 	condition := extractCurrentCondition(jobSet.Status.Conditions)
 	if condition == nil {
-		if hasJobSetStarted(ctx, pluginContext, jobSet, maxRestarts) {
+		if hasJobSetStarted(ctx, pluginContext, jobSet) {
 			if phase, ok := maybeFastFailWorker0(ctx, pluginContext, jobSet, &taskInfo, maxRestarts, true); ok {
 				return phase, nil
 			}
@@ -145,10 +145,6 @@ func isRestartBudgetExhausted(jobSet *jobsetv1alpha2.JobSet, maxRestarts int32) 
 	return jobSet.Status.Restarts >= maxRestarts
 }
 
-func hasRestartBudgetRemaining(jobSet *jobsetv1alpha2.JobSet, maxRestarts int32) bool {
-	return !isRestartBudgetExhausted(jobSet, maxRestarts)
-}
-
 func readPluginState(ctx context.Context, pluginContext k8s.PluginContext) (k8s.PluginState, bool) {
 	pluginState := k8s.PluginState{}
 	if _, err := pluginContext.PluginStateReader().Get(&pluginState); err != nil {
@@ -158,7 +154,7 @@ func readPluginState(ctx context.Context, pluginContext k8s.PluginContext) (k8s.
 	return pluginState, true
 }
 
-func hasJobSetStarted(ctx context.Context, pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet, maxRestarts int32) bool {
+func hasJobSetStarted(ctx context.Context, pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet) bool {
 	if jobSet.Status.Restarts > 0 {
 		return true
 	}
@@ -167,7 +163,10 @@ func hasJobSetStarted(ctx context.Context, pluginContext k8s.PluginContext, jobS
 		if workersStatus.Ready > 0 || workersStatus.Active > 0 || workersStatus.Succeeded > 0 {
 			return true
 		}
-		if workersStatus.Failed > 0 && hasRestartBudgetRemaining(jobSet, maxRestarts) {
+		// A non-zero Failed count means rank-0 pods have run, so the JobSet has started
+		// regardless of remaining restart budget. Budget gating for surfacing the failure
+		// is enforced downstream in maybeFastFailWorker0.
+		if workersStatus.Failed > 0 {
 			return true
 		}
 	}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/runtime_torch.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/runtime_torch.go
@@ -29,6 +29,10 @@ func injectTorchRunEnv(container *corev1.Container, spec *clusteredpb.ClusteredT
 		{Name: "NPROC_PER_NODE", Value: strconv.Itoa(int(spec.GetNprocPerNode()))},
 		{Name: "MASTER_PORT", Value: "29500"},
 		{Name: "RDZV_BACKEND", Value: rdzvBackend},
+		// Restart budget so the SDK runtime can detect the terminal attempt and only write
+		// error.pb once the JobSet has exhausted its restarts. Same source as failure.go's
+		// buildFailurePolicy, so it always matches the JobSet FailurePolicy.MaxRestarts.
+		{Name: "JOBSET_MAX_RESTARTS", Value: strconv.Itoa(int(spec.GetFailurePolicy().GetMaxRestarts()))},
 		{
 			Name: "JOBSET_NAME",
 			ValueFrom: &corev1.EnvVarSource{

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/util.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/util.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
@@ -61,7 +62,7 @@ func shouldPreferRank0Pod(candidate, current *v1.Pod) bool {
 // Returns nil when not found or when listing pods fails.
 func findRank0Pod(ctx context.Context, pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet) *v1.Pod {
 	podList := &v1.PodList{}
-	if err := pluginContext.K8sReader().List(ctx, podList); err != nil {
+	if err := pluginContext.K8sReader().List(ctx, podList, client.InNamespace(jobSet.Namespace)); err != nil {
 		logger.Warnf(ctx, "failed to list pods for JobSet %s/%s rank-0 lookup: %v", jobSet.Namespace, jobSet.Name, err)
 		return nil
 	}

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/util.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/util.go
@@ -1,6 +1,16 @@
 package clustered
 
-import "regexp"
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
+	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
+)
 
 // Name of the sole ReplicatedJob in the JobSet. Pod names follow the pattern
 // <jobsetName>-<replicatedJob>-<jobIdx>-<podIdx>; we run a single ReplicatedJob
@@ -19,14 +29,59 @@ var (
 	labelTrailingRE = regexp.MustCompile(`[^a-zA-Z0-9]$`)
 )
 
-// sanitizeLabelValue coerces an arbitrary string into a valid Kubernetes label
-// value (≤63 chars, alphanumeric start/end, [a-zA-Z0-9._-] in between).
-// Used for human-supplied identifiers like execution names.
-// rank0PodName returns the pod name for rank 0 (jobIdx=0, podIdx=0) in the workers ReplicatedJob.
+// rank0PodName returns the unsuffixed pod name for rank 0 (jobIdx=0, podIdx=0) in the workers ReplicatedJob.
+// Real Job pods carry an additional random suffix assigned by the Job controller.
 func rank0PodName(jobSetName string) string {
 	return jobSetName + "-" + workersReplicatedJobName + "-0-0"
 }
 
+func isRank0PodName(jobSetName, podName string) bool {
+	return strings.HasPrefix(podName, rank0PodName(jobSetName))
+}
+
+func isActivePodPhase(phase v1.PodPhase) bool {
+	return phase == v1.PodRunning || phase == v1.PodPending
+}
+
+// shouldPreferRank0Pod reports whether candidate should replace current as the selected rank-0 pod.
+// Prefer active pods (Running/Pending) to avoid selecting stale failed pods from previous attempts.
+func shouldPreferRank0Pod(candidate, current *v1.Pod) bool {
+	candidateActive := isActivePodPhase(candidate.Status.Phase)
+	currentActive := isActivePodPhase(current.Status.Phase)
+	if candidateActive != currentActive {
+		return candidateActive
+	}
+	if candidate.CreationTimestamp.Time.Equal(current.CreationTimestamp.Time) {
+		return candidate.Name > current.Name
+	}
+	return candidate.CreationTimestamp.After(current.CreationTimestamp.Time)
+}
+
+// findRank0Pod locates the rank-0 pod by prefix-matching the real pod name, which includes a random suffix.
+// Returns nil when not found or when listing pods fails.
+func findRank0Pod(ctx context.Context, pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet) *v1.Pod {
+	podList := &v1.PodList{}
+	if err := pluginContext.K8sReader().List(ctx, podList); err != nil {
+		logger.Warnf(ctx, "failed to list pods for JobSet %s/%s rank-0 lookup: %v", jobSet.Namespace, jobSet.Name, err)
+		return nil
+	}
+
+	var selected *v1.Pod
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if !isRank0PodName(jobSet.Name, pod.Name) {
+			continue
+		}
+		if selected == nil || shouldPreferRank0Pod(pod, selected) {
+			selected = pod
+		}
+	}
+	return selected
+}
+
+// sanitizeLabelValue coerces an arbitrary string into a valid Kubernetes label
+// value (≤63 chars, alphanumeric start/end, [a-zA-Z0-9._-] in between).
+// Used for human-supplied identifiers like execution names.
 func sanitizeLabelValue(value string) string {
 	if value == "" {
 		return "none"

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/util.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/util.go
@@ -58,7 +58,12 @@ func shouldPreferRank0Pod(candidate, current *v1.Pod) bool {
 	return candidate.CreationTimestamp.After(current.CreationTimestamp.Time)
 }
 
-// findRank0Pod locates the rank-0 pod by prefix-matching the real pod name, which includes a random suffix.
+// findRank0Pod locates the rank-0 pod among this execution's child pods.
+//
+// The plugin's K8sReader already scopes List calls to this node execution's namespace and
+// execution-id/node-id labels (propagated onto the pod template in build.go), so the returned
+// pods belong to this JobSet. We keep an explicit namespace filter as defense-in-depth and then
+// prefix-match the real pod name, which carries a random suffix assigned by the Job controller.
 // Returns nil when not found or when listing pods fails.
 func findRank0Pod(ctx context.Context, pluginContext k8s.PluginContext, jobSet *jobsetv1alpha2.JobSet) *v1.Pod {
 	podList := &v1.PodList{}


### PR DESCRIPTION
## Why are the changes needed?
  
The clustered (JobSet) plugin was prematurely surfacing task failures during JobSet restarts: a single worker failure
within the restart budget could fast-fail the task, and rank-0 pod lookups used an unsuffixed name that never matched the real, randomly-suffixed pod. This caused spurious failures and missed diagnostics while a JobSet was legitimately restarting.


## What changes were proposed in this pull request?
- Gate maybeFastFailWorker0 on restart budget: worker failures only surface as RetryableFailure once Status.Restarts >= MaxRestarts; otherwise the task stays Running. Pending-pod diagnostics (e.g. ImagePullBackOff) still fast-fail regardless of budget.
- Handle the RestartingJobSet condition and the no-condition-yet case via a new hasJobSetStarted check (restarts, worker readiness/activity, or prior plugin state), reporting Running with a restart-attempt reason instead of falling back to Initializing/failure.
- Replace unsuffixed rank0PodName matching with findRank0Pod, a suffix-tolerant lookup that deterministically prefer

## How was this patch tested?
- go test ./flyteplugins/go/tasks/plugins/k8s/clustered/...
 - New unit tests cover: suffixed/deterministic rank-0 selection, failure-with-budget-remaining → Running, budget-exhausted → RetryableFailure, pending ImagePullBackOff → fast-fail regardless of budget, RestartingJobSet condition → Running (attempt N), restarts with no true condition → Running, and plugin-state read error → fallback to status.
 - Tested a failing example from the sdk on dogfood-1

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
