### PR TITLE
[Plugins] remove EnabledPlugins & add sleep plugin

### DIFF
--- a/executor/pkg/config/task_plugin_config.go
+++ b/executor/pkg/config/task_plugin_config.go
@@ -19,13 +19,9 @@ var (
 // TasksConfig is the top-level tasks configuration container.
 type TasksConfig struct{}
 
-// TaskPluginConfig holds the task plugin enablement and routing configuration,
+// TaskPluginConfig holds the task plugin routing configuration,
 // read from the tasks.task-plugins config section.
 type TaskPluginConfig struct {
-	// EnabledPlugins is an allowlist of plugin executor IDs to load at startup.
-	// An empty slice loads all compiled-in plugins (default behaviour).
-	EnabledPlugins []string `json:"enabled-plugins"`
-
 	// DefaultForTaskTypes overrides which plugin handles a given task type.
 	// Key: task type string, Value: plugin ID string.
 	DefaultForTaskTypes map[string]string `json:"default-for-task-types"`

--- a/executor/pkg/plugin/registry.go
+++ b/executor/pkg/plugin/registry.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sync"
 
 	executorConfig "github.com/flyteorg/flyte/v2/executor/pkg/config"
@@ -43,23 +42,6 @@ func NewRegistry(setupCtx pluginsCore.SetupContext, pluginRegistry PluginRegistr
 	}
 }
 
-type PluginsConfigMeta struct {
-	EnabledPlugins []string
-}
-
-func GetEnabledPlugins() *PluginsConfigMeta {
-	return &PluginsConfigMeta{
-		EnabledPlugins: executorConfig.GetTaskPluginConfig().EnabledPlugins,
-	}
-}
-
-func (pcm *PluginsConfigMeta) isAllowed(id string) bool {
-	if len(pcm.EnabledPlugins) == 0 {
-		return true
-	}
-	return slices.Contains(pcm.EnabledPlugins, id)
-}
-
 // Initialize loads all registered plugins. Must be called once during startup.
 func (r *Registry) Initialize(ctx context.Context) error {
 	r.mu.Lock()
@@ -69,14 +51,8 @@ func (r *Registry) Initialize(ctx context.Context) error {
 		return nil
 	}
 
-	pluginMeta := GetEnabledPlugins()
 	// Load k8s plugins
 	for _, entry := range r.pluginRegistry.GetK8sPlugins() {
-		if !pluginMeta.isAllowed(entry.ID) {
-			logger.Infof(ctx, "Skipping k8s plugin [%s]: not in enabled-plugins allowlist", entry.ID)
-			continue
-		}
-
 		pm := executorK8s.NewPluginManager(
 			entry.ID,
 			entry.Plugin,
@@ -107,11 +83,6 @@ func (r *Registry) Initialize(ctx context.Context) error {
 
 	// Load core plugins
 	for _, entry := range r.pluginRegistry.GetCorePlugins() {
-		if !pluginMeta.isAllowed(entry.ID) {
-			logger.Infof(ctx, "Skipping core plugin [%s]: not in enabled-plugins allowlist", entry.ID)
-			continue
-		}
-
 		plugin, err := pluginsCore.LoadPlugin(ctx, r.setupCtx, entry)
 		if err != nil {
 			return fmt.Errorf("failed to load core plugin %s: %w", entry.ID, err)

--- a/executor/pkg/plugin/registry_test.go
+++ b/executor/pkg/plugin/registry_test.go
@@ -56,87 +56,8 @@ func newTestRegistry(reg PluginRegistryIface) *Registry {
 	return NewRegistry(setupCtx, reg)
 }
 
-func resetConfig(t *testing.T, enabled []string) {
-	t.Helper()
-	require.NoError(t, executorConfig.SetTaskPluginConfig(&executorConfig.TaskPluginConfig{
-		EnabledPlugins: enabled,
-	}))
-	t.Cleanup(func() {
-		_ = executorConfig.SetTaskPluginConfig(&executorConfig.TaskPluginConfig{})
-	})
-}
-
-func TestPluginsConfigMeta(t *testing.T) {
-	tests := []struct {
-		name           string
-		configPlugins  []string
-		checkAllowed   string
-		wantAllowed    bool
-		checkGetConfig bool
-		wantGetPlugins []string
-	}{
-		{
-			name:           "GetEnabledPlugins reflects config",
-			configPlugins:  []string{"container", "spark"},
-			checkGetConfig: true,
-			wantGetPlugins: []string{"container", "spark"},
-		},
-		{
-			name:           "GetEnabledPlugins empty config",
-			configPlugins:  nil,
-			checkGetConfig: true,
-			wantGetPlugins: nil,
-		},
-		{
-			name:          "empty EnabledPlugins allows any id",
-			configPlugins: nil,
-			checkAllowed:  "anything",
-			wantAllowed:   true,
-		},
-		{
-			name:          "empty EnabledPlugins allows empty string",
-			configPlugins: nil,
-			checkAllowed:  "",
-			wantAllowed:   true,
-		},
-		{
-			name:          "listed id is allowed",
-			configPlugins: []string{"container", "spark"},
-			checkAllowed:  "container",
-			wantAllowed:   true,
-		},
-		{
-			name:          "unlisted id is blocked",
-			configPlugins: []string{"container"},
-			checkAllowed:  "ray",
-			wantAllowed:   false,
-		},
-		{
-			name:          "empty string blocked when list non-empty",
-			configPlugins: []string{"container"},
-			checkAllowed:  "",
-			wantAllowed:   false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			resetConfig(t, tc.configPlugins)
-			if tc.checkGetConfig {
-				meta := GetEnabledPlugins()
-				assert.Equal(t, tc.wantGetPlugins, meta.EnabledPlugins)
-				return
-			}
-			pcm := &PluginsConfigMeta{EnabledPlugins: tc.configPlugins}
-			assert.Equal(t, tc.wantAllowed, pcm.isAllowed(tc.checkAllowed))
-		})
-	}
-}
-
-// 3.1 Empty allowlist loads all plugins.
-func TestRegistry_EmptyAllowlist_LoadsAll(t *testing.T) {
-	resetConfig(t, nil)
-
+// All compiled-in plugins are loaded.
+func TestRegistry_LoadsAllPlugins(t *testing.T) {
 	reg := &mockPluginRegistry{
 		corePlugins: []pluginsCore.PluginEntry{
 			coreEntry("container", "container"),
@@ -153,63 +74,6 @@ func TestRegistry_EmptyAllowlist_LoadsAll(t *testing.T) {
 	p, err = r.ResolvePlugin("sidecar")
 	require.NoError(t, err)
 	assert.Equal(t, "sidecar", p.GetID())
-}
-
-// 3.2 Non-empty allowlist filters out plugins not in the list.
-func TestRegistry_Allowlist_FiltersPlugins(t *testing.T) {
-	resetConfig(t, []string{"container"})
-
-	reg := &mockPluginRegistry{
-		corePlugins: []pluginsCore.PluginEntry{
-			coreEntry("container", "container"),
-			coreEntry("ray", "ray"),
-		},
-	}
-	r := newTestRegistry(reg)
-	require.NoError(t, r.Initialize(context.Background()))
-
-	p, err := r.ResolvePlugin("container")
-	require.NoError(t, err)
-	assert.Equal(t, "container", p.GetID())
-
-	// "ray" was filtered out — no default plugin, so ResolvePlugin should error
-	_, err = r.ResolvePlugin("ray")
-	assert.Error(t, err)
-}
-
-// 3.3 ResolvePlugin returns error for task types belonging to filtered plugins.
-func TestRegistry_ResolvePlugin_ErrorForFilteredTaskType(t *testing.T) {
-	resetConfig(t, []string{"container"})
-
-	reg := &mockPluginRegistry{
-		corePlugins: []pluginsCore.PluginEntry{
-			coreEntry("container", "container"),
-			coreEntry("spark", "spark"),
-		},
-	}
-	r := newTestRegistry(reg)
-	require.NoError(t, r.Initialize(context.Background()))
-
-	_, err := r.ResolvePlugin("spark")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "spark")
-}
-
-// 3.4 Allowlist with unknown ID does not affect loading of other plugins.
-func TestRegistry_Allowlist_UnknownIDIgnored(t *testing.T) {
-	resetConfig(t, []string{"container", "nonexistent-plugin"})
-
-	reg := &mockPluginRegistry{
-		corePlugins: []pluginsCore.PluginEntry{
-			coreEntry("container", "container"),
-		},
-	}
-	r := newTestRegistry(reg)
-	require.NoError(t, r.Initialize(context.Background()))
-
-	p, err := r.ResolvePlugin("container")
-	require.NoError(t, err)
-	assert.Equal(t, "container", p.GetID())
 }
 
 // 3.5 DefaultForTaskTypes routes a task type to a different loaded plugin.

--- a/executor/plugins/loader.go
+++ b/executor/plugins/loader.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/core/sleep"
 	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/dask"
 	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/kfoperators/mpi"
 	_ "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch"

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -62,15 +62,8 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 
 	cfg := config.GetConfig()
 
-	taskPluginCfg := config.GetTaskPluginConfig()
-	enabledPlugins := make(map[string]bool, len(taskPluginCfg.EnabledPlugins))
-	for _, id := range taskPluginCfg.EnabledPlugins {
-		enabledPlugins[id] = true
-	}
 	for _, reg := range pluginmachinery.PluginRegistry().GetSchemeRegisters() {
-		if len(enabledPlugins) == 0 || enabledPlugins[reg.ID] {
-			utilruntime.Must(reg.AddToScheme(scheme))
-		}
+		utilruntime.Must(reg.AddToScheme(scheme))
 	}
 
 	var tlsOpts []func(*tls.Config)


### PR DESCRIPTION
## Tracking issue


## Why are the changes needed?

1. Register "sleep" plugin
2. Register all available plugins at once. User do not need to manually configure `enabled-plugins` in the config. 

A runtime error will be raised if running a plugin which its CRD is not install



## What changes were proposed in this pull request?

- Remove `EnabledPlugins` field in plugin config

## How was this patch tested?

1. Run `python examples/plugins/sleep_example.py`, ensure it run successfully

<img width="2758" height="760" alt="image" src="https://github.com/user-attachments/assets/417c8961-2f08-4362-ab68-221c2f147cb3" />

2. Run ray task without install ray CRD, will get runtime error


<img width="3276" height="1116" alt="image" src="https://github.com/user-attachments/assets/b0fd0d92-3efd-4957-9016-f49341cf8a84" />


### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
