### PR TITLE
Remove deprecated finalizers

### DIFF
--- a/flyteplugins/go/tasks/plugins/array/k8s/subtask.go
+++ b/flyteplugins/go/tasks/plugins/array/k8s/subtask.go
@@ -32,10 +32,7 @@ const (
 	ErrReplaceCmdTemplate     stdErrors.ErrorCode = "CMD_TEMPLATE_FAILED"
 	FlyteK8sArrayIndexVarName string              = "FLYTE_K8S_ARRAY_INDEX"
 	finalizer                 string              = "flyte.org/finalizer-array"
-	// Old non-domain-qualified finalizer for backwards compatibility
-	// This should eventually be removed
-	oldFinalizer    string = "flyte/array"
-	JobIndexVarName string = "BATCH_JOB_ARRAY_INDEX_VAR_NAME"
+	JobIndexVarName           string              = "BATCH_JOB_ARRAY_INDEX_VAR_NAME"
 )
 
 var (
@@ -150,8 +147,7 @@ func clearFinalizer(ctx context.Context, o client.Object, kubeClient pluginsCore
 	// Checking for the old finalizer too for backwards compatibility. This should eventually be removed
 	// Go does short-circuiting so we have to make sure both are removed
 	finalizerRemoved := controllerutil.RemoveFinalizer(o, finalizer)
-	oldFinalizerRemoved := controllerutil.RemoveFinalizer(o, oldFinalizer)
-	if finalizerRemoved || oldFinalizerRemoved {
+	if finalizerRemoved {
 		err := kubeClient.GetClient().Update(ctx, o)
 		if err != nil && !isK8sObjectNotExists(err) {
 			logger.Warningf(ctx, "Failed to clear finalizer for Resource with name: %v/%v. Error: %v", o.GetNamespace(), o.GetName(), err)

--- a/flytepropeller/pkg/controller/controller.go
+++ b/flytepropeller/pkg/controller/controller.go
@@ -62,10 +62,7 @@ import (
 
 const (
 	// Finalizer is the global and domain-qualified Flyte finalizer
-	Finalizer = "flyte.org/finalizer"
-	// OldFinalizer is the old non-domain-qualified finalizer, kept for backwards compatibility
-	// This should eventually be removed
-	OldFinalizer                      = "flyte-finalizer"
+	Finalizer                         = "flyte.org/finalizer"
 	resourceLevelMonitorCycleDuration = 5 * time.Second
 	missing                           = "missing"
 	podDefaultNamespace               = "flyte"

--- a/flytepropeller/pkg/controller/handler.go
+++ b/flytepropeller/pkg/controller/handler.go
@@ -213,7 +213,7 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 	if w.GetExecutionStatus().IsTerminated() {
 		// Checking for the old finalizer for backwards compatibility
 		// This should be eventually removed
-		if HasCompletedLabel(w) && !controllerutil.ContainsFinalizer(w, Finalizer) && !controllerutil.ContainsFinalizer(w, OldFinalizer) {
+		if HasCompletedLabel(w) && !controllerutil.ContainsFinalizer(w, Finalizer) {
 			logger.Debugf(ctx, "Workflow is terminated.")
 			// This workflow had previously completed, let us ignore it
 			return nil
@@ -329,8 +329,6 @@ func (p *Propeller) streak(ctx context.Context, w *v1alpha1.FlyteWorkflow, wfClo
 			// We add a completed label so that we can avoid polling for this workflow
 			SetCompletedLabel(mutatedWf, time.Now())
 			_ = controllerutil.RemoveFinalizer(mutatedWf, Finalizer)
-			// Backwards compatibility. This should eventually be removed
-			_ = controllerutil.RemoveFinalizer(mutatedWf, OldFinalizer)
 		}
 	}
 
@@ -389,8 +387,6 @@ func (p *Propeller) streak(ctx context.Context, w *v1alpha1.FlyteWorkflow, wfClo
 			// catch potential indefinite update loop
 			if mutatedWf.GetExecutionStatus().IsTerminated() {
 				_ = controllerutil.RemoveFinalizer(mutableW, Finalizer)
-				// Backwards compatibility. This should eventually be removed
-				_ = controllerutil.RemoveFinalizer(mutableW, OldFinalizer)
 				SetDefinitionVersionIfEmpty(mutableW, v1alpha1.LatestWorkflowDefinitionVersion)
 				SetCompletedLabel(mutableW, time.Now())
 				msg := fmt.Sprintf("Workflow size has breached threshold. Finalized with status: %v", mutatedWf.GetExecutionStatus().GetPhase())

--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -46,9 +46,6 @@ import (
 
 const (
 	finalizer = "flyte.org/finalizer-k8s"
-	// Old non-domain-qualified finalizer for backwards compatibility
-	// This should eventually be removed
-	oldFinalizer = "flyte/flytek8s"
 )
 
 const pluginStateVersion = 1
@@ -493,8 +490,7 @@ func (e *PluginManager) clearFinalizer(ctx context.Context, o client.Object) err
 	// Checking for the old finalizer too for backwards compatibility. This should eventually be removed
 	// Go does short-circuiting and we have to make sure both are removed
 	finalizerRemoved := controllerutil.RemoveFinalizer(o, finalizer)
-	oldFinalizerRemoved := controllerutil.RemoveFinalizer(o, oldFinalizer)
-	if finalizerRemoved || oldFinalizerRemoved {
+	if finalizerRemoved {
 		// Patch finalizers to reduce conflicts caused by a stale informer cache vs full Update().
 		err := e.kubeClient.GetClient().Patch(ctx, o, client.MergeFrom(original))
 		if err != nil && !isK8sObjectNotExists(err) {


### PR DESCRIPTION
## Why are the changes needed?
Removes support for deprecated finalizer to simplify the code.

## What changes were proposed in this pull request?
Remove code branches for deprecated finalizers that should no longer be used.

## How was this patch tested?
Tested in our production environment but the finalizer should not be set for many years now.

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
