### PR TITLE
fix(k8s): stop custom pod-spec merge from diluting required node-affinity (Ray + Spark)

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -175,17 +175,35 @@ func ApplyInterruptibleNodeAffinity(interruptible bool, podSpec *v1.PodSpec) {
 	ApplyInterruptibleNodeSelectorRequirement(interruptible, podSpec.Affinity)
 }
 
-// ApplyInterruptibleScheduling re-applies the interruptible scheduling constraints
-// (node-affinity requirement, node selector and tolerations) that correspond to the
-// task's interruptibility onto podSpec. All three operations are idempotent, so it
-// is safe to call after a custom pod-spec merge that may have appended its own node
-// selector terms — those appended terms are OR'd by Kubernetes, so without this the
-// (Non)InterruptibleNodeSelectorRequirement would only sit on the base term and a
-// pod could schedule on a node that satisfies the custom term alone.
-func ApplyInterruptibleScheduling(interruptible bool, podSpec *v1.PodSpec) {
-	// AddRequiredNodeSelectorRequirements adds the requirement to every term,
-	// skipping any term that already carries it, so this stays duplicate-free.
-	ApplyInterruptibleNodeAffinity(interruptible, podSpec)
+// ApplyPlatformSchedulingConstraints re-applies the platform-injected scheduling
+// constraints that a custom pod-spec merge can dilute or drop, and MUST be called
+// after MergeOverlayPodSpecOntoBase. mergo appends a custom pod's node selector terms
+// as new OR'd alternatives, so any REQUIRED node-affinity requirement the base carried
+// — the configured DefaultAffinity requirements and the (non)interruptible requirement
+// — ends up only on the base term; a pod could then satisfy an appended custom term
+// alone and escape the constraint. This re-adds those requirements to every term and
+// re-applies the interruptible node selector and tolerations. All operations are
+// idempotent (AddRequiredNodeSelectorRequirements / addTolerationInPodSpec skip
+// entries already present), so re-applying to an unmerged base pod is a no-op.
+//
+// Note: DefaultAffinity requirements are AND'd onto every term, which is the intended
+// semantics for the common single-term DefaultAffinity. A DefaultAffinity expressed as
+// multiple OR'd terms would be tightened to AND across those requirements.
+func ApplyPlatformSchedulingConstraints(interruptible bool, podSpec *v1.PodSpec) {
+	if podSpec.Affinity == nil {
+		podSpec.Affinity = &v1.Affinity{}
+	}
+
+	// Re-add the configured DefaultAffinity required requirements to every term.
+	if da := config.GetK8sPluginConfig().DefaultAffinity; da != nil && da.NodeAffinity != nil &&
+		da.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		for _, term := range da.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+			AddRequiredNodeSelectorRequirements(podSpec.Affinity, term.MatchExpressions...)
+		}
+	}
+
+	// Re-add the (non)interruptible requirement to every term.
+	ApplyInterruptibleNodeSelectorRequirement(interruptible, podSpec.Affinity)
 
 	if !interruptible {
 		return

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -175,6 +175,33 @@ func ApplyInterruptibleNodeAffinity(interruptible bool, podSpec *v1.PodSpec) {
 	ApplyInterruptibleNodeSelectorRequirement(interruptible, podSpec.Affinity)
 }
 
+// ApplyInterruptibleScheduling re-applies the interruptible scheduling constraints
+// (node-affinity requirement, node selector and tolerations) that correspond to the
+// task's interruptibility onto podSpec. All three operations are idempotent, so it
+// is safe to call after a custom pod-spec merge that may have appended its own node
+// selector terms — those appended terms are OR'd by Kubernetes, so without this the
+// (Non)InterruptibleNodeSelectorRequirement would only sit on the base term and a
+// pod could schedule on a node that satisfies the custom term alone.
+func ApplyInterruptibleScheduling(interruptible bool, podSpec *v1.PodSpec) {
+	// AddRequiredNodeSelectorRequirements adds the requirement to every term,
+	// skipping any term that already carries it, so this stays duplicate-free.
+	ApplyInterruptibleNodeAffinity(interruptible, podSpec)
+
+	if !interruptible {
+		return
+	}
+
+	cfg := config.GetK8sPluginConfig()
+	if len(cfg.InterruptibleNodeSelector) > 0 {
+		podSpec.NodeSelector = utils.UnionMaps(podSpec.NodeSelector, cfg.InterruptibleNodeSelector)
+	}
+	// addTolerationInPodSpec is a no-op when the toleration is already present, so
+	// re-applying does not duplicate tolerations seeded earlier by UpdatePod.
+	for i := range cfg.InterruptibleTolerations {
+		addTolerationInPodSpec(podSpec, &cfg.InterruptibleTolerations[i])
+	}
+}
+
 // Specialized merging of overrides into a base *core.ExtendedResources object. Note
 // that doing a nested merge may not be the intended behavior all the time, so we
 // handle each field separately here.

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -473,7 +473,7 @@ func buildHeadPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodSpe
 	// merged: a custom k8s_pod may have appended its own node selector terms (OR'd
 	// by Kubernetes), so the (Non)InterruptibleNodeSelectorRequirement must be added
 	// to every term to keep a non-interruptible pod off spot nodes. Idempotent.
-	flytek8s.ApplyInterruptibleScheduling(taskCtx.TaskExecutionMetadata().IsInterruptible(), basePodSpec)
+	flytek8s.ApplyPlatformSchedulingConstraints(taskCtx.TaskExecutionMetadata().IsInterruptible(), basePodSpec)
 
 	podTemplateSpec := v1.PodTemplateSpec{
 		Spec:       *basePodSpec,
@@ -632,7 +632,7 @@ func buildWorkerPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodS
 	// merged: a custom k8s_pod may have appended its own node selector terms (OR'd
 	// by Kubernetes), so the (Non)InterruptibleNodeSelectorRequirement must be added
 	// to every term to keep a non-interruptible pod off spot nodes. Idempotent.
-	flytek8s.ApplyInterruptibleScheduling(taskCtx.TaskExecutionMetadata().IsInterruptible(), basePodSpec)
+	flytek8s.ApplyPlatformSchedulingConstraints(taskCtx.TaskExecutionMetadata().IsInterruptible(), basePodSpec)
 
 	podTemplateSpec := v1.PodTemplateSpec{
 		Spec:       *basePodSpec,

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -469,6 +469,12 @@ func buildHeadPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodSpe
 
 	basePodSpec = flytek8s.AddTolerationsForExtendedResources(basePodSpec)
 
+	// Re-apply interruptible scheduling now that the group's custom pod spec is
+	// merged: a custom k8s_pod may have appended its own node selector terms (OR'd
+	// by Kubernetes), so the (Non)InterruptibleNodeSelectorRequirement must be added
+	// to every term to keep a non-interruptible pod off spot nodes. Idempotent.
+	flytek8s.ApplyInterruptibleScheduling(taskCtx.TaskExecutionMetadata().IsInterruptible(), basePodSpec)
+
 	podTemplateSpec := v1.PodTemplateSpec{
 		Spec:       *basePodSpec,
 		ObjectMeta: *objectMeta,
@@ -621,6 +627,12 @@ func buildWorkerPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodS
 	flytek8s.ApplyGPUNodeSelectors(basePodSpec, gpuAccelerator)
 
 	basePodSpec = flytek8s.AddTolerationsForExtendedResources(basePodSpec)
+
+	// Re-apply interruptible scheduling now that the group's custom pod spec is
+	// merged: a custom k8s_pod may have appended its own node selector terms (OR'd
+	// by Kubernetes), so the (Non)InterruptibleNodeSelectorRequirement must be added
+	// to every term to keep a non-interruptible pod off spot nodes. Idempotent.
+	flytek8s.ApplyInterruptibleScheduling(taskCtx.TaskExecutionMetadata().IsInterruptible(), basePodSpec)
 
 	podTemplateSpec := v1.PodTemplateSpec{
 		Spec:       *basePodSpec,

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -111,6 +111,10 @@ func dummyRayTaskTemplate(id string, rayJob *plugins.RayJob) *core.TaskTemplate 
 }
 
 func dummyRayTaskContext(taskTemplate *core.TaskTemplate, resources *corev1.ResourceRequirements, extendedResources *core.ExtendedResources, containerImage, serviceAccount string) pluginsCore.TaskExecutionContext {
+	return dummyRayTaskContextInterruptible(taskTemplate, resources, extendedResources, containerImage, serviceAccount, true)
+}
+
+func dummyRayTaskContextInterruptible(taskTemplate *core.TaskTemplate, resources *corev1.ResourceRequirements, extendedResources *core.ExtendedResources, containerImage, serviceAccount string, interruptible bool) pluginsCore.TaskExecutionContext {
 	taskCtx := &mocks.TaskExecutionContext{}
 	inputReader := &pluginIOMocks.InputReader{}
 	inputReader.EXPECT().GetInputPrefixPath().Return("/input/prefix")
@@ -157,7 +161,7 @@ func dummyRayTaskContext(taskTemplate *core.TaskTemplate, resources *corev1.Reso
 		Kind: "node",
 		Name: "blah",
 	})
-	taskExecutionMetadata.EXPECT().IsInterruptible().Return(true)
+	taskExecutionMetadata.EXPECT().IsInterruptible().Return(interruptible)
 	taskExecutionMetadata.EXPECT().GetOverrides().Return(overrides)
 	taskExecutionMetadata.EXPECT().GetK8sServiceAccount().Return(serviceAccount)
 	taskExecutionMetadata.EXPECT().GetPlatformResources().Return(&corev1.ResourceRequirements{})
@@ -223,6 +227,195 @@ func TestBuildResourceRay(t *testing.T) {
 	ray, ok = RayResource.(*rayv1.RayJob)
 	assert.True(t, ok)
 	assert.Equal(t, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.ServiceAccountName, GetConfig().ServiceAccount)
+}
+
+var (
+	interruptibleNSR = &corev1.NodeSelectorRequirement{
+		Key:      "interruptible",
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{"true"},
+	}
+	nonInterruptibleNSR = &corev1.NodeSelectorRequirement{
+		Key:      "interruptible",
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{"false"},
+	}
+	interruptibleNodeSelector  = map[string]string{"interruptible-node": "true"}
+	interruptibleTolerationVal = corev1.Toleration{
+		Key:      "interruptible",
+		Value:    "true",
+		Operator: corev1.TolerationOpEqual,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+)
+
+func interruptibleK8sPluginConfig() *config.K8sPluginConfig {
+	return &config.K8sPluginConfig{
+		InterruptibleNodeSelectorRequirement:    interruptibleNSR,
+		NonInterruptibleNodeSelectorRequirement: nonInterruptibleNSR,
+		InterruptibleNodeSelector:               interruptibleNodeSelector,
+		InterruptibleTolerations:                []corev1.Toleration{interruptibleTolerationVal},
+	}
+}
+
+// countRequirement returns how many times req appears across all node selector terms.
+func countRequirement(terms []corev1.NodeSelectorTerm, req corev1.NodeSelectorRequirement) int {
+	count := 0
+	for _, term := range terms {
+		for _, e := range term.MatchExpressions {
+			if reflect.DeepEqual(e, req) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+// assertEveryTermHasRequirement asserts that every node selector term contains req
+// exactly once. This is what guarantees a non-interruptible pod cannot land on a
+// spot node via an OR'd alternative term contributed by a custom k8s_pod overlay.
+func assertEveryTermHasRequirement(t *testing.T, spec corev1.PodSpec, req corev1.NodeSelectorRequirement) {
+	t.Helper()
+	require.NotNil(t, spec.Affinity)
+	require.NotNil(t, spec.Affinity.NodeAffinity)
+	require.NotNil(t, spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+	terms := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.NotEmpty(t, terms)
+	for i, term := range terms {
+		assert.Truef(t, containsRequirement(term.MatchExpressions, req),
+			"node selector term %d is missing the expected scheduling requirement %v", i, req)
+	}
+}
+
+func containsRequirement(reqs []corev1.NodeSelectorRequirement, req corev1.NodeSelectorRequirement) bool {
+	for _, r := range reqs {
+		if reflect.DeepEqual(r, req) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasToleration(tolerations []corev1.Toleration, tol corev1.Toleration) bool {
+	for _, t := range tolerations {
+		if reflect.DeepEqual(t, tol) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBuildResourceRayInterruptible verifies that the task's interruptible flag is
+// reflected on both the head and worker pod templates: interruptible tasks get the
+// interruptible node selector requirement / node selector / tolerations, and
+// non-interruptible tasks get the non-interruptible requirement and none of the
+// interruptible scheduling hints.
+func TestBuildResourceRayInterruptible(t *testing.T) {
+	for _, interruptible := range []bool{true, false} {
+		name := "non-interruptible"
+		if interruptible {
+			name = "interruptible"
+		}
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, config.SetK8sPluginConfig(interruptibleK8sPluginConfig()))
+
+			taskTemplate := dummyRayTaskTemplate("ray-id", dummyRayCustomObj())
+			taskContext := dummyRayTaskContextInterruptible(taskTemplate, resourceRequirements, nil, "", serviceAccount, interruptible)
+			r, err := rayJobResourceHandler{}.BuildResource(context.TODO(), taskContext)
+			require.NoError(t, err)
+			rayJob, ok := r.(*rayv1.RayJob)
+			require.True(t, ok)
+
+			expectedReq := *nonInterruptibleNSR
+			if interruptible {
+				expectedReq = *interruptibleNSR
+			}
+
+			specs := map[string]corev1.PodSpec{
+				"head":   rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec,
+				"worker": rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec,
+			}
+			for group, spec := range specs {
+				t.Run(group, func(t *testing.T) {
+					assertEveryTermHasRequirement(t, spec, expectedReq)
+					// Idempotency: the requirement must appear exactly once per pod.
+					assert.Equal(t, 1, countRequirement(
+						spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+						expectedReq), "requirement should be applied exactly once")
+
+					if interruptible {
+						assert.Equal(t, "true", spec.NodeSelector["interruptible-node"])
+						assert.True(t, hasToleration(spec.Tolerations, interruptibleTolerationVal))
+						assert.Equal(t, 1, tolerationCount(spec.Tolerations, interruptibleTolerationVal),
+							"interruptible toleration should be applied exactly once")
+					} else {
+						assert.NotContains(t, spec.NodeSelector, "interruptible-node")
+						assert.False(t, hasToleration(spec.Tolerations, interruptibleTolerationVal))
+					}
+				})
+			}
+		})
+	}
+}
+
+func tolerationCount(tolerations []corev1.Toleration, tol corev1.Toleration) int {
+	count := 0
+	for _, t := range tolerations {
+		if reflect.DeepEqual(t, tol) {
+			count++
+		}
+	}
+	return count
+}
+
+// TestBuildResourceRayInterruptibleCustomAffinity is the regression test for the
+// OR-hole: when a worker's custom k8s_pod carries its own node selector term, the
+// custom-pod merge (mergo WithAppendSlice) appends it as a new OR'd term. Without
+// re-applying interruptible scheduling after the merge, that appended term lacks
+// the non-interruptible requirement, letting the pod schedule on a spot node.
+func TestBuildResourceRayInterruptibleCustomAffinity(t *testing.T) {
+	require.NoError(t, config.SetK8sPluginConfig(interruptibleK8sPluginConfig()))
+
+	customAffinityPod := &core.K8SPod{
+		PodSpec: transformStructToStructPB(t, &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "ray-worker"}},
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "zone",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"us-east-1a"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}),
+	}
+
+	rayJobObj := dummyRayCustomObj()
+	rayJobObj.RayCluster.WorkerGroupSpec[0].K8SPod = customAffinityPod
+	taskTemplate := dummyRayTaskTemplate("ray-id", rayJobObj)
+	// interruptible=false: every resulting node selector term (the base term and the
+	// appended custom term) must carry the non-interruptible requirement.
+	taskContext := dummyRayTaskContextInterruptible(taskTemplate, resourceRequirements, nil, "", serviceAccount, false)
+
+	r, err := rayJobResourceHandler{}.BuildResource(context.TODO(), taskContext)
+	require.NoError(t, err)
+	rayJob, ok := r.(*rayv1.RayJob)
+	require.True(t, ok)
+
+	workerSpec := rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec
+	terms := workerSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	// Sanity: the custom term was actually appended as a separate OR'd term.
+	require.GreaterOrEqual(t, len(terms), 2, "expected the custom affinity term to be appended as a separate term")
+	assertEveryTermHasRequirement(t, workerSpec, *nonInterruptibleNSR)
 }
 
 func TestBuildResourceRayContainerImage(t *testing.T) {

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -418,6 +418,70 @@ func TestBuildResourceRayInterruptibleCustomAffinity(t *testing.T) {
 	assertEveryTermHasRequirement(t, workerSpec, *nonInterruptibleNSR)
 }
 
+// TestBuildResourceRayDefaultAffinityDilution probes whether a platform-injected
+// DefaultAffinity required node-selector term survives a worker's custom k8s_pod
+// that carries its own affinity term. Same OR-append mechanism as the interruptible
+// bug: if it reproduces, the appended custom term lacks the default-affinity
+// requirement, letting the pod escape the cluster's default node constraint.
+func TestBuildResourceRayDefaultAffinityDilution(t *testing.T) {
+	defaultAffinityReq := corev1.NodeSelectorRequirement{
+		Key:      "node-pool",
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{"flyte-dedicated"},
+	}
+	require.NoError(t, config.SetK8sPluginConfig(&config.K8sPluginConfig{
+		DefaultAffinity: &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{MatchExpressions: []corev1.NodeSelectorRequirement{defaultAffinityReq}},
+					},
+				},
+			},
+		},
+	}))
+
+	// CPU-only so GPU handling does not pre-seed Affinity (which would skip
+	// DefaultAffinity application in UpdatePod).
+	cpuOnly := &corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1000m"), corev1.ResourceMemory: resource.MustParse("1Gi")},
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("512Mi")},
+	}
+
+	customAffinityPod := &core.K8SPod{
+		PodSpec: transformStructToStructPB(t, &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "ray-worker"}},
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{MatchExpressions: []corev1.NodeSelectorRequirement{
+								{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1a"}},
+							}},
+						},
+					},
+				},
+			},
+		}),
+	}
+
+	rayJobObj := dummyRayCustomObj()
+	rayJobObj.RayCluster.WorkerGroupSpec[0].K8SPod = customAffinityPod
+	taskTemplate := dummyRayTaskTemplate("ray-id", rayJobObj)
+	taskContext := dummyRayTaskContext(taskTemplate, cpuOnly, nil, "", serviceAccount)
+
+	r, err := rayJobResourceHandler{}.BuildResource(context.TODO(), taskContext)
+	require.NoError(t, err)
+	rayJob, ok := r.(*rayv1.RayJob)
+	require.True(t, ok)
+
+	workerSpec := rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec
+	terms := workerSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.GreaterOrEqual(t, len(terms), 2, "expected the custom affinity term to be appended as a separate term")
+	// If this fails, DefaultAffinity is diluted (bug). If it passes, no bug.
+	assertEveryTermHasRequirement(t, workerSpec, defaultAffinityReq)
+}
+
 func TestBuildResourceRayContainerImage(t *testing.T) {
 	assert.NoError(t, config.SetK8sPluginConfig(&config.K8sPluginConfig{}))
 

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -203,6 +203,11 @@ func createDriverSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCont
 		}
 	}
 
+	// Re-apply platform scheduling after the custom driver pod merge: the merge can
+	// append OR'd node selector terms that would otherwise escape the default-affinity
+	// and (forced) non-interruptible requirements. Idempotent.
+	flytek8s.ApplyPlatformSchedulingConstraints(nonInterruptibleTaskCtx.TaskExecutionMetadata().IsInterruptible(), podSpec)
+
 	primaryContainer, err := flytek8s.GetContainer(podSpec, primaryContainerName)
 	if err != nil {
 		return nil, err
@@ -254,6 +259,11 @@ func createExecutorSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 			primaryContainerName = executorPod.GetPrimaryContainerName()
 		}
 	}
+
+	// Re-apply platform scheduling after the custom executor pod merge: the merge can
+	// append OR'd node selector terms that would otherwise escape the default-affinity
+	// and (non)interruptible requirements. Idempotent.
+	flytek8s.ApplyPlatformSchedulingConstraints(taskCtx.TaskExecutionMetadata().IsInterruptible(), podSpec)
 
 	primaryContainer, err := flytek8s.GetContainer(podSpec, primaryContainerName)
 	if err != nil {

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
@@ -13,6 +13,7 @@ import (
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1283,4 +1284,66 @@ func TestGetCompletionTime_WrongResourceType(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, result.IsZero())
 	assert.Contains(t, err.Error(), "unexpected resource type")
+}
+
+// TestBuildResourceSparkExecutorAffinityDilution probes whether the non-interruptible
+// node-selector requirement (interruptible=false) survives on a Spark executor whose
+// custom executorPod carries its own node-affinity term. Spark merges the executor
+// overlay (spark.go createExecutorSpec) but re-applies no scheduling afterwards, so
+// this is the Spark analogue of the Ray OR-append dilution. If it fails, the appended
+// custom term lacks the non-interruptible requirement (bug); if it passes, no bug.
+func TestBuildResourceSparkExecutorAffinityDilution(t *testing.T) {
+	sparkResourceHandler := sparkResourceHandler{}
+	defaultConfig := defaultPluginConfig()
+	require.NoError(t, config.SetK8sPluginConfig(defaultConfig))
+
+	executorPodSpec := &corev1.PodSpec{
+		Affinity: &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1a"}},
+						}},
+					},
+				},
+			},
+		},
+	}
+	podSpecPb, err := utils.MarshalObjToStruct(executorPodSpec)
+	require.NoError(t, err)
+
+	sparkJob := dummySparkCustomObj(dummySparkConf)
+	sparkJob.ExecutorPod = &core.K8SPod{PodSpec: podSpecPb}
+
+	sparkJobJSON, err := utils.MarshalToString(sparkJob)
+	require.NoError(t, err)
+	structObj := structpb.Struct{}
+	require.NoError(t, stdlibUtils.UnmarshalStringToPb(sparkJobJSON, &structObj))
+	taskTemplate := &core.TaskTemplate{
+		Id:     &core.Identifier{Name: "spark-exec-affinity"},
+		Type:   "container",
+		Target: &core.TaskTemplate_Container{Container: &core.Container{Image: testImage, Args: testArgs, Env: dummyEnvVars}},
+		Custom: &structObj,
+	}
+
+	resource, err := sparkResourceHandler.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, false))
+	require.NoError(t, err)
+	sparkApp, ok := resource.(*sj.SparkApplication)
+	require.True(t, ok)
+
+	require.NotNil(t, sparkApp.Spec.Executor.Affinity)
+	require.NotNil(t, sparkApp.Spec.Executor.Affinity.NodeAffinity)
+	terms := sparkApp.Spec.Executor.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.GreaterOrEqual(t, len(terms), 2, "expected the custom executor affinity term to be appended as a separate term")
+	for i, term := range terms {
+		found := false
+		for _, e := range term.MatchExpressions {
+			if reflect.DeepEqual(e, *defaultConfig.NonInterruptibleNodeSelectorRequirement) {
+				found = true
+				break
+			}
+		}
+		assert.Truef(t, found, "executor node selector term %d is missing the non-interruptible requirement", i)
+	}
 }


### PR DESCRIPTION
## Summary

A custom `k8s_pod`/pod-spec override merged onto a plugin's base pod could **escape platform-injected required node-affinity** (interruptible and `DefaultAffinity`), because `MergeOverlayPodSpecOntoBase` uses `mergo.WithAppendSlice`: the custom pod's `NodeSelectorTerms` are **appended as new OR'd terms**, and Kubernetes ORs terms. So a required requirement that the base carried only sits on the base term, and a pod satisfying just the appended custom term bypasses it.

Originally reported for Ray (`interruptible=False` worker landing on spot). Investigation found the same class affects `DefaultAffinity` and the Spark driver/executor path.

## Fix

Add `flytek8s.ApplyPlatformSchedulingConstraints(interruptible, podSpec)` (`pod_helper.go`): re-applies, idempotently, the configured `DefaultAffinity` requirements and the `(Non)InterruptibleNodeSelectorRequirement` to **every** node selector term (including appended ones), plus the interruptible node selector/tolerations. Call it **after** each custom pod-spec merge:

- **Ray** `buildHeadPodTemplate` / `buildWorkerPodTemplate` (head + worker follow the task flag).
- **Spark** `createDriverSpec` (forced non-interruptible) / `createExecutorSpec` (follows the task flag).

`AddRequiredNodeSelectorRequirements` and `addTolerationInPodSpec` skip entries already present, so re-applying to an unmerged base pod is a no-op — the no-custom-pod paths are unchanged.

**Dask** is unaffected: it merges no custom pod overlay (`createWorkerSpec` deep-copies the base) and its proto exposes no per-worker pod-spec field, so there is no dilution vector. Existing `TestBuildResourceDaskInterruptible` already covers it.

## Tests (each reproduces the bug, then passes with the fix)

- `TestBuildResourceRayInterruptible` + `TestBuildResourceRayInterruptibleCustomAffinity` (interruptible, incl. OR-hole).
- `TestBuildResourceRayDefaultAffinityDilution` (DefaultAffinity OR-hole).
- `TestBuildResourceSparkExecutorAffinityDilution` (Spark executor OR-hole).

`go test ./go/tasks/plugins/k8s/ray/... ./go/tasks/plugins/k8s/spark/... ./go/tasks/plugins/k8s/dask/... ./go/tasks/pluginmachinery/flytek8s/...` passes; `go vet` clean.

## Out of scope (intentional, not bugs)
Scalar overrides (`SchedulerName` / `PriorityClassName` / `RuntimeClassName`) and `NodeSelector` map-key collisions only change when the user's own pod template sets them — a deliberate override, not silent loss of a platform constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)