### PR TITLE
feat(executor): add OTel metrics for the TaskAction garbage collector

### DIFF
--- a/executor/pkg/controller/garbage_collector.go
+++ b/executor/pkg/controller/garbage_collector.go
@@ -4,11 +4,31 @@ import (
 	"context"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 )
+
+// gcMetrics holds the Prometheus instruments for the garbage collector. They are
+// created once (in newGCMetrics) and only updated thereafter, never re-registered.
+type gcMetrics struct {
+	deleted   prometheus.Counter
+	errors    prometheus.Counter
+	sweepTime promutils.StopWatch
+}
+
+// newGCMetrics builds the garbage collector instruments under the given scope.
+// Call exactly once per scope to avoid duplicate registration panics.
+func newGCMetrics(scope promutils.Scope) gcMetrics {
+	return gcMetrics{
+		deleted:   scope.MustNewCounter("objects_deleted", "Total TaskActions deleted by the garbage collector"),
+		errors:    scope.MustNewCounter("deletion_errors", "Total errors encountered while deleting expired TaskActions"),
+		sweepTime: scope.MustNewStopWatch("sweep_duration", "Duration of a full garbage collection sweep", time.Millisecond),
+	}
+}
 
 // GarbageCollector periodically deletes terminal TaskActions that have exceeded their TTL.
 // It implements the controller-runtime manager.Runnable interface.
@@ -16,14 +36,16 @@ type GarbageCollector struct {
 	client   client.Client
 	interval time.Duration
 	maxTTL   time.Duration
+	metrics  gcMetrics
 }
 
 // NewGarbageCollector creates a new GarbageCollector.
-func NewGarbageCollector(c client.Client, interval, maxTTL time.Duration) *GarbageCollector {
+func NewGarbageCollector(c client.Client, interval, maxTTL time.Duration, scope promutils.Scope) *GarbageCollector {
 	return &GarbageCollector{
 		client:   c,
 		interval: interval,
 		maxTTL:   maxTTL,
+		metrics:  newGCMetrics(scope),
 	}
 }
 
@@ -54,6 +76,10 @@ const gcPageSize = 500
 // collect lists all terminated TaskActions (paginated) and deletes those whose completed-time has expired.
 func (gc *GarbageCollector) collect(ctx context.Context) error {
 	logger := log.FromContext(ctx).WithName("gc")
+
+	// Time the full sweep, defer guarantees it records on every return path.
+	timer := gc.metrics.sweepTime.Start()
+	defer timer.Stop()
 
 	cutoff := time.Now().UTC().Add(-gc.maxTTL).Format(labelTimeFormat)
 	deleted := 0
@@ -87,11 +113,13 @@ func (gc *GarbageCollector) collect(ctx context.Context) error {
 			// The minute-precision format is lexicographically ordered, so string comparison works.
 			if completedTime < cutoff {
 				if err := gc.client.Delete(ctx, ta); err != nil {
+					gc.metrics.errors.Inc()
 					logger.Error(err, "failed to delete expired TaskAction",
 						"name", ta.Name, "namespace", ta.Namespace, "completedTime", completedTime)
 					continue
 				}
 				deleted++
+				gc.metrics.deleted.Inc()
 			}
 		}
 

--- a/executor/pkg/controller/garbage_collector.go
+++ b/executor/pkg/controller/garbage_collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"go.opentelemetry.io/otel/metric"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -18,19 +19,27 @@ type GarbageCollector struct {
 	reader   client.Reader
 	interval time.Duration
 	maxTTL   time.Duration
+	metrics  *gcMetrics
 }
 
 // NewGarbageCollector creates a new GarbageCollector. reader must be an
 // uncached reader (e.g. mgr.GetAPIReader()): collect() lists with Continue
 // pagination, which the controller-runtime cache does not support
 // ("continue list option is not supported by the cache"). client is used for
-// the deletes.
-func NewGarbageCollector(c client.Client, reader client.Reader, interval, maxTTL time.Duration) *GarbageCollector {
+// the deletes. provider is the executor's OTel meter provider
+// (otelutils.GetMeterProvider(otelServiceName) in executor/setup.go).
+func NewGarbageCollector(c client.Client, reader client.Reader, interval, maxTTL time.Duration, provider metric.MeterProvider) *GarbageCollector {
+	metrics, err := newGCMetrics(provider)
+	if err != nil {
+		// Non-fatal: run unmetered rather than fail startup.
+		log.Log.Error(err, "failed to register garbage collector metrics")
+	}
 	return &GarbageCollector{
 		client:   c,
 		reader:   reader,
 		interval: interval,
 		maxTTL:   maxTTL,
+		metrics:  metrics,
 	}
 }
 
@@ -68,7 +77,9 @@ func (gc *GarbageCollector) Start(ctx context.Context) error {
 var gcPageSize = 500
 
 // collect lists all terminated TaskActions (paginated) and deletes those whose completed-time has expired.
-func (gc *GarbageCollector) collect(ctx context.Context) error {
+func (gc *GarbageCollector) collect(ctx context.Context) (err error) {
+	start := time.Now()
+	defer func() { gc.metrics.recordSweep(ctx, start, err) }()
 	logger := log.FromContext(ctx).WithName("gc")
 
 	cutoff := time.Now().UTC().Add(-gc.maxTTL).Format(labelTimeFormat)
@@ -112,9 +123,11 @@ func (gc *GarbageCollector) collect(ctx context.Context) error {
 					}
 					logger.Error(err, "failed to delete expired TaskAction",
 						"name", ta.Name, "namespace", ta.Namespace, "completedTime", completedTime)
+					gc.metrics.recordDeletion(ctx, err)
 					continue
 				}
 				deleted++
+				gc.metrics.recordDeletion(ctx, nil)
 			}
 		}
 

--- a/executor/pkg/controller/garbage_collector.go
+++ b/executor/pkg/controller/garbage_collector.go
@@ -119,15 +119,16 @@ func (gc *GarbageCollector) collect(ctx context.Context) (err error) {
 					// is deleted earlier in this same pass, so the explicit delete
 					// races with the cascade and returns NotFound. Not an error.
 					if apierrors.IsNotFound(err) {
+						gc.metrics.recordDeletion(ctx, gcOutcomeAlreadyGone)
 						continue
 					}
 					logger.Error(err, "failed to delete expired TaskAction",
 						"name", ta.Name, "namespace", ta.Namespace, "completedTime", completedTime)
-					gc.metrics.recordDeletion(ctx, err)
+					gc.metrics.recordDeletion(ctx, gcOutcomeFailed)
 					continue
 				}
 				deleted++
-				gc.metrics.recordDeletion(ctx, nil)
+				gc.metrics.recordDeletion(ctx, gcOutcomeDeleted)
 			}
 		}
 

--- a/executor/pkg/controller/garbage_collector_metrics.go
+++ b/executor/pkg/controller/garbage_collector_metrics.go
@@ -1,0 +1,70 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+)
+
+const gcMeterName = "taskaction-gc"
+
+// gcMetrics holds OTel instruments for the garbage collector.
+type gcMetrics struct {
+	deletions     metric.Int64Counter
+	sweepDuration metric.Float64Histogram
+}
+
+// newGCMetrics builds the garbage collector instruments on the given provider.
+// Returns nil when metrics are disabled (noop provider).
+func newGCMetrics(provider metric.MeterProvider) (*gcMetrics, error) {
+	if _, ok := provider.(metricnoop.MeterProvider); ok {
+		return nil, nil
+	}
+
+	meter := provider.Meter(gcMeterName)
+
+	deletions, err := meter.Int64Counter(
+		"taskaction.gc.deletions",
+		metric.WithDescription("TaskAction deletions issued by the garbage collector, labeled by error"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	sweepDuration, err := meter.Float64Histogram(
+		"taskaction.gc.sweep.duration",
+		metric.WithDescription("Duration of one garbage collection sweep, labeled by error"),
+		metric.WithUnit("ms"),
+		// The SDK's default buckets top out at 10s, but a sweep over a large
+		// backlog runs for minutes, these keep the slow tail measurable.
+		metric.WithExplicitBucketBoundaries(100, 500, 1000, 5000, 10000, 30000, 60000, 300000),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gcMetrics{deletions: deletions, sweepDuration: sweepDuration}, nil
+}
+
+// recordDeletion counts one delete issued by the garbage collector. Callers skip
+// already-deleted (NotFound) objects, which are therefore counted under neither
+// error value. No-op when metrics are disabled.
+func (m *gcMetrics) recordDeletion(ctx context.Context, err error) {
+	if m == nil || m.deletions == nil {
+		return
+	}
+	m.deletions.Add(ctx, 1, metric.WithAttributes(attribute.Bool("error", err != nil)))
+}
+
+// recordSweep records the duration of one sweep, labeled by whether the sweep
+// failed. No-op when metrics are disabled.
+func (m *gcMetrics) recordSweep(ctx context.Context, start time.Time, err error) {
+	if m == nil || m.sweepDuration == nil {
+		return
+	}
+	m.sweepDuration.Record(ctx, float64(time.Since(start).Microseconds())/1000.0,
+		metric.WithAttributes(attribute.Bool("error", err != nil)))
+}

--- a/executor/pkg/controller/garbage_collector_metrics.go
+++ b/executor/pkg/controller/garbage_collector_metrics.go
@@ -11,6 +11,13 @@ import (
 
 const gcMeterName = "taskaction-gc"
 
+// Values for the "outcome" attribute on taskaction.gc.deletions.
+const (
+	gcOutcomeDeleted     = "deleted"
+	gcOutcomeAlreadyGone = "already_gone"
+	gcOutcomeFailed      = "failed"
+)
+
 // gcMetrics holds OTel instruments for the garbage collector.
 type gcMetrics struct {
 	deletions     metric.Int64Counter
@@ -28,7 +35,7 @@ func newGCMetrics(provider metric.MeterProvider) (*gcMetrics, error) {
 
 	deletions, err := meter.Int64Counter(
 		"taskaction.gc.deletions",
-		metric.WithDescription("TaskAction deletions issued by the garbage collector, labeled by error"),
+		metric.WithDescription("TaskAction delete attempts by the garbage collector, labeled by outcome"),
 	)
 	if err != nil {
 		return nil, err
@@ -49,14 +56,14 @@ func newGCMetrics(provider metric.MeterProvider) (*gcMetrics, error) {
 	return &gcMetrics{deletions: deletions, sweepDuration: sweepDuration}, nil
 }
 
-// recordDeletion counts one delete issued by the garbage collector. Callers skip
-// already-deleted (NotFound) objects, which are therefore counted under neither
-// error value. No-op when metrics are disabled.
-func (m *gcMetrics) recordDeletion(ctx context.Context, err error) {
+// recordDeletion counts one delete attempt by outcome: deleted, already_gone
+// (removed by cascade before the GC got to it), or failed. No-op when metrics
+// are disabled.
+func (m *gcMetrics) recordDeletion(ctx context.Context, outcome string) {
 	if m == nil || m.deletions == nil {
 		return
 	}
-	m.deletions.Add(ctx, 1, metric.WithAttributes(attribute.Bool("error", err != nil)))
+	m.deletions.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", outcome)))
 }
 
 // recordSweep records the duration of one sweep, labeled by whether the sweep

--- a/executor/pkg/controller/garbage_collector_metrics_test.go
+++ b/executor/pkg/controller/garbage_collector_metrics_test.go
@@ -1,0 +1,97 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
+)
+
+// newExpiredTaskAction builds a terminated TaskAction whose completed time is well past
+// any sane maxTTL, so the GC will treat it as expired and delete it.
+func newExpiredTaskAction() *flyteorgv1.TaskAction {
+	expired := time.Now().UTC().Add(-2 * time.Hour).Format(labelTimeFormat)
+	return &flyteorgv1.TaskAction{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gc-expired",
+			Namespace: "default",
+			Labels: map[string]string{
+				LabelTerminationStatus: LabelValueTerminated,
+				LabelCompletedTime:     expired,
+			},
+		},
+	}
+}
+
+// newGCTestClient returns an in-memory fake client seeded with one expired TaskAction.
+// If deleteErr is non-nil, every Delete fails with it, so we can exercise the error path.
+func newGCTestClient(t *testing.T, deleteErr error) client.Client {
+	scheme := runtime.NewScheme()
+	require.NoError(t, flyteorgv1.AddToScheme(scheme))
+	builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newExpiredTaskAction())
+	if deleteErr != nil {
+		builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error {
+				return deleteErr
+			},
+		})
+	}
+	return builder.Build()
+}
+
+// sweepObservations reports how many times the sweep_duration stopwatch has recorded.
+// sweep_duration is a Summary, so testutil.ToFloat64 can not read it.
+// Instead, we collect the metric and read its sample count directly.
+func sweepObservations(t *testing.T, gc *GarbageCollector) uint64 {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 1)
+	gc.metrics.sweepTime.Observer.(prometheus.Collector).Collect(ch)
+	close(ch)
+	var m dto.Metric
+	require.NoError(t, (<-ch).Write(&m))
+	return m.GetSummary().GetSampleCount()
+}
+
+// TestGarbageCollectorDeletedMetric: a successful delete moves objects_deleted
+// from 0 to 1, records one sweep, and leaves deletion_errors at 0.
+func TestGarbageCollectorDeletedMetric(t *testing.T) {
+	gc := NewGarbageCollector(newGCTestClient(t, nil), time.Minute, time.Hour, promutils.NewTestScope())
+
+	require.Equal(t, 0.0, testutil.ToFloat64(gc.metrics.deleted))
+	require.Equal(t, 0.0, testutil.ToFloat64(gc.metrics.errors))
+
+	require.NoError(t, gc.collect(context.Background()))
+
+	require.Equal(t, 1.0, testutil.ToFloat64(gc.metrics.deleted))
+	require.Equal(t, 0.0, testutil.ToFloat64(gc.metrics.errors))
+	require.GreaterOrEqual(t, sweepObservations(t, gc), uint64(1))
+}
+
+// TestGarbageCollectorDeletionErrorMetric: when a delete fails, deletion_errors moves
+// 0 to 1 and objects_deleted stays at 0.
+func TestGarbageCollectorDeletionErrorMetric(t *testing.T) {
+	gc := NewGarbageCollector(
+		newGCTestClient(t, errors.New("simulated delete failure")),
+		time.Minute, time.Hour, promutils.NewTestScope(),
+	)
+
+	require.Equal(t, 0.0, testutil.ToFloat64(gc.metrics.errors))
+
+	require.NoError(t, gc.collect(context.Background()))
+
+	require.Equal(t, 1.0, testutil.ToFloat64(gc.metrics.errors))
+	require.Equal(t, 0.0, testutil.ToFloat64(gc.metrics.deleted))
+}

--- a/executor/pkg/controller/garbage_collector_metrics_test.go
+++ b/executor/pkg/controller/garbage_collector_metrics_test.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestNewGCMetricsNoop(t *testing.T) {
+	m, err := newGCMetrics(metricnoop.NewMeterProvider())
+	require.NoError(t, err)
+	assert.Nil(t, m)
+}
+
+func TestRecordDeletion(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	m, err := newGCMetrics(provider)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+
+	ctx := context.Background()
+	m.recordDeletion(ctx, nil)
+	m.recordDeletion(ctx, nil)
+	m.recordDeletion(ctx, errors.New("boom"))
+
+	sum, ok := collectMetric(t, reader, "taskaction.gc.deletions").Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+
+	counts := map[bool]int64{}
+	for _, dp := range sum.DataPoints {
+		v, ok := dp.Attributes.Value(attribute.Key("error"))
+		require.True(t, ok)
+		counts[v.AsBool()] = dp.Value
+	}
+	assert.Equal(t, int64(2), counts[false])
+	assert.Equal(t, int64(1), counts[true])
+
+	var nilMetrics *gcMetrics
+	assert.NotPanics(t, func() { nilMetrics.recordDeletion(ctx, nil) })
+}
+
+func TestRecordSweep(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	m, err := newGCMetrics(provider)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+
+	ctx := context.Background()
+	// Backdated start so the recorded duration is reliably non-zero.
+	m.recordSweep(ctx, time.Now().Add(-50*time.Millisecond), nil)
+	m.recordSweep(ctx, time.Now(), errors.New("boom"))
+
+	hist, ok := collectMetric(t, reader, "taskaction.gc.sweep.duration").Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+
+	points := map[bool]metricdata.HistogramDataPoint[float64]{}
+	for _, dp := range hist.DataPoints {
+		v, ok := dp.Attributes.Value(attribute.Key("error"))
+		require.True(t, ok)
+		points[v.AsBool()] = dp
+	}
+	require.Len(t, points, 2)
+	assert.Equal(t, uint64(1), points[false].Count)
+	assert.GreaterOrEqual(t, points[false].Sum, 50.0)
+	assert.Equal(t, uint64(1), points[true].Count)
+
+	var nilMetrics *gcMetrics
+	assert.NotPanics(t, func() { nilMetrics.recordSweep(ctx, time.Now(), nil) })
+}

--- a/executor/pkg/controller/garbage_collector_metrics_test.go
+++ b/executor/pkg/controller/garbage_collector_metrics_test.go
@@ -29,24 +29,26 @@ func TestRecordDeletion(t *testing.T) {
 	require.NotNil(t, m)
 
 	ctx := context.Background()
-	m.recordDeletion(ctx, nil)
-	m.recordDeletion(ctx, nil)
-	m.recordDeletion(ctx, errors.New("boom"))
+	m.recordDeletion(ctx, gcOutcomeDeleted)
+	m.recordDeletion(ctx, gcOutcomeDeleted)
+	m.recordDeletion(ctx, gcOutcomeAlreadyGone)
+	m.recordDeletion(ctx, gcOutcomeFailed)
 
 	sum, ok := collectMetric(t, reader, "taskaction.gc.deletions").Data.(metricdata.Sum[int64])
 	require.True(t, ok)
 
-	counts := map[bool]int64{}
+	counts := map[string]int64{}
 	for _, dp := range sum.DataPoints {
-		v, ok := dp.Attributes.Value(attribute.Key("error"))
+		v, ok := dp.Attributes.Value(attribute.Key("outcome"))
 		require.True(t, ok)
-		counts[v.AsBool()] = dp.Value
+		counts[v.AsString()] = dp.Value
 	}
-	assert.Equal(t, int64(2), counts[false])
-	assert.Equal(t, int64(1), counts[true])
+	assert.Equal(t, int64(2), counts[gcOutcomeDeleted])
+	assert.Equal(t, int64(1), counts[gcOutcomeAlreadyGone])
+	assert.Equal(t, int64(1), counts[gcOutcomeFailed])
 
 	var nilMetrics *gcMetrics
-	assert.NotPanics(t, func() { nilMetrics.recordDeletion(ctx, nil) })
+	assert.NotPanics(t, func() { nilMetrics.recordDeletion(ctx, gcOutcomeDeleted) })
 }
 
 func TestRecordSweep(t *testing.T) {

--- a/executor/pkg/controller/garbage_collector_test.go
+++ b/executor/pkg/controller/garbage_collector_test.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 )
 
 func createTaskAction(ctx context.Context, name string, labels map[string]string) *flyteorgv1.TaskAction {
@@ -62,7 +63,7 @@ var _ = Describe("GarbageCollector", func() {
 			LabelCompletedTime:     expiredTime,
 		})
 
-		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour, promutils.NewTestScope())
 		Expect(gc.collect(ctx)).To(Succeed())
 
 		ta := &flyteorgv1.TaskAction{}
@@ -78,7 +79,7 @@ var _ = Describe("GarbageCollector", func() {
 			LabelCompletedTime:     recentTime,
 		})
 
-		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour, promutils.NewTestScope())
 		Expect(gc.collect(ctx)).To(Succeed())
 
 		ta := &flyteorgv1.TaskAction{}
@@ -89,7 +90,7 @@ var _ = Describe("GarbageCollector", func() {
 	It("should retain non-terminated TaskActions", func() {
 		createTaskAction(ctx, "gc-active", nil)
 
-		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour, promutils.NewTestScope())
 		Expect(gc.collect(ctx)).To(Succeed())
 
 		ta := &flyteorgv1.TaskAction{}
@@ -98,7 +99,7 @@ var _ = Describe("GarbageCollector", func() {
 	})
 
 	It("should handle empty list gracefully", func() {
-		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour, promutils.NewTestScope())
 		Expect(gc.collect(ctx)).To(Succeed())
 	})
 })

--- a/executor/pkg/controller/garbage_collector_test.go
+++ b/executor/pkg/controller/garbage_collector_test.go
@@ -193,17 +193,17 @@ var _ = Describe("GarbageCollector", func() {
 
 		sum, ok := data["taskaction.gc.deletions"].(metricdata.Sum[int64])
 		Expect(ok).To(BeTrue())
-		var succeeded int64
+		var deleted int64
 		for _, dp := range sum.DataPoints {
-			v, found := dp.Attributes.Value(attribute.Key("error"))
+			v, found := dp.Attributes.Value(attribute.Key("outcome"))
 			Expect(found).To(BeTrue())
-			if !v.AsBool() {
-				succeeded += dp.Value
+			if v.AsString() == gcOutcomeDeleted {
+				deleted += dp.Value
 			}
 		}
 		// At least one: the AfterEach cleanup is asynchronous, so a TaskAction
-		// from a previous spec can still be present and get swept here too.d
-		Expect(succeeded).To(BeNumerically(">=", 1))
+		// from a previous spec can still be present and get swept here too.
+		Expect(deleted).To(BeNumerically(">=", 1))
 
 		hist, ok := data["taskaction.gc.sweep.duration"].(metricdata.Histogram[float64])
 		Expect(ok).To(BeTrue())

--- a/executor/pkg/controller/garbage_collector_test.go
+++ b/executor/pkg/controller/garbage_collector_test.go
@@ -7,6 +7,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.opentelemetry.io/otel/attribute"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -64,7 +68,7 @@ var _ = Describe("GarbageCollector", func() {
 			LabelCompletedTime:     expiredTime,
 		})
 
-		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour, metricnoop.NewMeterProvider())
 		Expect(gc.collect(ctx)).To(Succeed())
 
 		ta := &flyteorgv1.TaskAction{}
@@ -80,7 +84,7 @@ var _ = Describe("GarbageCollector", func() {
 			LabelCompletedTime:     recentTime,
 		})
 
-		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour, metricnoop.NewMeterProvider())
 		Expect(gc.collect(ctx)).To(Succeed())
 
 		ta := &flyteorgv1.TaskAction{}
@@ -91,7 +95,7 @@ var _ = Describe("GarbageCollector", func() {
 	It("should retain non-terminated TaskActions", func() {
 		createTaskAction(ctx, "gc-active", nil)
 
-		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour, metricnoop.NewMeterProvider())
 		Expect(gc.collect(ctx)).To(Succeed())
 
 		ta := &flyteorgv1.TaskAction{}
@@ -100,7 +104,7 @@ var _ = Describe("GarbageCollector", func() {
 	})
 
 	It("should handle empty list gracefully", func() {
-		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour, metricnoop.NewMeterProvider())
 		Expect(gc.collect(ctx)).To(Succeed())
 	})
 
@@ -121,7 +125,7 @@ var _ = Describe("GarbageCollector", func() {
 			})
 		}
 
-		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour, metricnoop.NewMeterProvider())
 		Expect(gc.collect(ctx)).To(Succeed())
 
 		// Assert only the actions this spec created are gone -- checking the whole
@@ -144,7 +148,7 @@ var _ = Describe("GarbageCollector", func() {
 		// A long interval means the ticker will not fire during the test, so the
 		// expired TaskAction can only be deleted by the immediate startup sweep.
 		// Before the fix, Start waited a full interval before its first collect.
-		gc := NewGarbageCollector(k8sClient, k8sClient, 30*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, k8sClient, 30*time.Minute, 1*time.Hour, metricnoop.NewMeterProvider())
 		startCtx, cancel := context.WithCancel(ctx)
 		doneCh := make(chan struct{})
 		go func() {
@@ -160,6 +164,51 @@ var _ = Describe("GarbageCollector", func() {
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: "gc-startup", Namespace: "default"}, ta)
 			return apierrors.IsNotFound(err)
 		}, 10*time.Second, 200*time.Millisecond).Should(BeTrue(), "Start should delete the expired TaskAction via its initial sweep")
+	})
+
+	It("should record deletion and sweep metrics", func() {
+		expiredTime := time.Now().UTC().Add(-2 * time.Hour).Format(labelTimeFormat)
+		createTaskAction(ctx, "gc-metrics", map[string]string{
+			LabelTerminationStatus: LabelValueTerminated,
+			LabelCompletedTime:     expiredTime,
+		})
+
+		// Unlike the other specs, this one uses a real meter provider so the
+		// recording calls inside collect() are observable.
+		reader := sdkmetric.NewManualReader()
+		provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour, provider)
+
+		Expect(gc.collect(ctx)).To(Succeed())
+
+		var rm metricdata.ResourceMetrics
+		Expect(reader.Collect(ctx, &rm)).To(Succeed())
+
+		data := map[string]metricdata.Aggregation{}
+		for _, sm := range rm.ScopeMetrics {
+			for _, m := range sm.Metrics {
+				data[m.Name] = m.Data
+			}
+		}
+
+		sum, ok := data["taskaction.gc.deletions"].(metricdata.Sum[int64])
+		Expect(ok).To(BeTrue())
+		var succeeded int64
+		for _, dp := range sum.DataPoints {
+			v, found := dp.Attributes.Value(attribute.Key("error"))
+			Expect(found).To(BeTrue())
+			if !v.AsBool() {
+				succeeded += dp.Value
+			}
+		}
+		// At least one: the AfterEach cleanup is asynchronous, so a TaskAction
+		// from a previous spec can still be present and get swept here too.d
+		Expect(succeeded).To(BeNumerically(">=", 1))
+
+		hist, ok := data["taskaction.gc.sweep.duration"].(metricdata.Histogram[float64])
+		Expect(ok).To(BeTrue())
+		Expect(hist.DataPoints).To(HaveLen(1))
+		Expect(hist.DataPoints[0].Count).To(Equal(uint64(1)))
 	})
 })
 

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -189,7 +189,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		if cfg.GC.MaxTTL.Duration <= 0 {
 			return fmt.Errorf("executor: gc.maxTTL must be positive when gc is enabled, got %v", cfg.GC.MaxTTL.Duration)
 		}
-		gc := controller.NewGarbageCollector(mgr.GetClient(), cfg.GC.Interval.Duration, cfg.GC.MaxTTL.Duration)
+		gc := controller.NewGarbageCollector(mgr.GetClient(), cfg.GC.Interval.Duration, cfg.GC.MaxTTL.Duration, executorScope.NewSubScope("gc"))
 		if err := mgr.Add(gc); err != nil {
 			return fmt.Errorf("executor: failed to add garbage collector: %w", err)
 		}

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -248,7 +248,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		if cfg.GC.MaxTTL.Duration <= 0 {
 			return fmt.Errorf("executor: gc.maxTTL must be positive when gc is enabled, got %v", cfg.GC.MaxTTL.Duration)
 		}
-		gc := controller.NewGarbageCollector(mgr.GetClient(), mgr.GetAPIReader(), cfg.GC.Interval.Duration, cfg.GC.MaxTTL.Duration)
+		gc := controller.NewGarbageCollector(mgr.GetClient(), mgr.GetAPIReader(), cfg.GC.Interval.Duration, cfg.GC.MaxTTL.Duration, otelutils.GetMeterProvider(otelServiceName))
 		if err := mgr.Add(gc); err != nil {
 			return fmt.Errorf("executor: failed to add garbage collector: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/alicebob/miniredis/v2 v2.38.0
+	github.com/prometheus/client_model v0.6.2
 )
 
 require (
@@ -189,7 +190,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds OpenTelemetry metrics for the executor's TaskAction garbage collector, registered on the executor's existing meter provider.

| metric | type | labels |
|---|---|---|
| `taskaction.gc.deletions` | `Int64Counter` | `outcome` = `deleted` \| `already_gone` \| `failed` |
| `taskaction.gc.sweep.duration` | `Float64Histogram` (ms) | `error` = `true` \| `false` |

This replaces the promutils implementation this PR originally carried, per review feedback that OTel is the direction for executor metrics. The pattern follows `executor/pkg/controller/metrics.go` from #7483.

A few design notes:

- **Registration failure is non-fatal.** If instrument registration fails, the GC runs unmetered rather than blocking startup, matching `registerTaskActionMetrics`.
- **Deletions are labeled by `outcome`, not a boolean.** A delete attempt has three results: it succeeded, the object was already gone (Kubernetes cascade-deleted it when the GC removed its parent earlier in the same sweep), or it failed. A boolean can't express the middle case, and skipping it undercounts what the sweep actually removed.
- **The sweep histogram keeps a boolean `error` label**, since a sweep has only two outcomes.
- **The histogram overrides the SDK's default bucket boundaries**, which top out at 10s. A sweep over a large backlog runs for minutes, so the defaults would collapse every slow sweep into the overflow bucket and make it impossible to tell a 12-second sweep from a 4-minute one.

## Why are the changes needed?

The executor gets reconcile counts and workqueue metrics for free from controller-runtime, but nothing reports garbage collection activity: how much is being deleted, whether deletes are failing, or how long a sweep takes. See #7455.

## How was this patch tested?

- Unit tests for the instruments: a noop provider returns no metrics, deletions record under each of the three outcomes, sweep duration records with its error label, and recording through a nil metrics struct is a safe no-op.
- An envtest integration spec that runs the real `collect()` against a live API server with a real meter provider and asserts the recorded values, so the call sites in `collect()` are covered rather than just the helpers.
- Verified the spec catches regressions: it fails if a recording call is removed from `collect()`.

## Labels

Related to #7455