### PR TITLE
feat(flyte-binary): auto-grant Knative RBAC when apps are enabled

### DIFF
--- a/charts/flyte-binary/templates/clusterrole.yaml
+++ b/charts/flyte-binary/templates/clusterrole.yaml
@@ -90,6 +90,27 @@ rules:
       - patch
       - update
       - watch
+  {{- if dig "inline" "internalApps" "enabled" false (.Values.configuration | default dict) }}
+  # Knative Serving access for the data-plane app controller, added automatically
+  # when apps are enabled (configuration.inline.internalApps.enabled) so operators
+  # don't have to hand-maintain rbac.extraRules. The controller creates and watches
+  # KServices and deletes their Revisions when an app is stopped.
+  - apiGroups:
+      - serving.knative.dev
+    resources:
+      - services
+      - revisions
+      - configurations
+      - routes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  {{- end }}
   {{- if .Values.rbac.extraRules }}
   {{- toYaml .Values.rbac.extraRules | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
## Why are the changes needed?

The data-plane app controller (`configuration.inline.internalApps.enabled`) manages Knative `KService` objects — it creates and watches them, and deletes their `Revision`s when an app is stopped. That requires `serving.knative.dev` permissions on the flyte ClusterRole.

Until now operators had to discover this the hard way: enabling apps would mount the control-plane `AppService`, but `AppService.List` proxies to the `InternalAppService`, which would fail (or the controller would error at startup) because the ServiceAccount lacked Knative RBAC. The only fix was to hand-maintain `rbac.extraRules` — easy to miss, and not obviously connected to the apps flag.

## What changes were proposed in this pull request?

- **`templates/clusterrole.yaml`** — render the `serving.knative.dev` rules (`services`, `revisions`, `configurations`, `routes` — verbs `create`/`delete`/`get`/`list`/`patch`/`update`/`watch`) automatically whenever apps are enabled. The condition reads the same flag that turns the feature on:
  ```
  {{- if dig "inline" "internalApps" "enabled" false (.Values.configuration | default dict) }}
  ```
  Using `dig` keeps it nil-safe if `configuration`/`inline`/`internalApps` are unset. The block renders *before* `rbac.extraRules`, so any operator-supplied rules still apply on top.

Net effect: enabling apps is now a single flag (`configuration.inline.internalApps.enabled: true`) — the controller and its RBAC come together, no manual `extraRules` required.

## How was this patch tested?

No Helm unit-test harness exists for this chart, so verified by render + live apply on the `flyte-development` ALB cluster:

- `helm template` with `configuration.inline.internalApps.enabled=true` → the `serving.knative.dev` rule renders.
- `helm template` with the default (apps disabled) → zero `serving.knative.dev` occurrences.
- Deployed to the live `flyte` release (with `rbac.extraRules` removed from values): the resulting ClusterRole still carries the Knative rules sourced from the chart, and `kubectl auth can-i create services.serving.knative.dev --as=system:serviceaccount:flyte:flyte2` returns `yes`. The previously-404'ing `AppService/List` returns `200`.

### Labels

- **added**

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
