### PR TITLE
Rename ActionMetadata.funtion_name to function_name

### DIFF
--- a/flyteidl2/workflow/run_definition.proto
+++ b/flyteidl2/workflow/run_definition.proto
@@ -185,7 +185,7 @@ message ActionMetadata {
   string environment_name = 12;
 
   // Function name
-  string funtion_name = 13;
+  string function_name = 13;
 
   // Trigger name
   string trigger_name = 14;

--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -1530,8 +1530,8 @@ func setActionDetailsSpecFromActionSpec(details *workflow.ActionDetails, actionS
 // actionMetadataFromModel builds an ActionMetadata proto from DB model columns.
 func actionMetadataFromModel(action *models.Action) *workflow.ActionMetadata {
 	metadata := &workflow.ActionMetadata{
-		ActionType:  workflow.ActionType(action.ActionType),
-		FuntionName: action.FunctionName,
+		ActionType:   workflow.ActionType(action.ActionType),
+		FunctionName: action.FunctionName,
 	}
 	if action.ParentActionName.Valid {
 		metadata.Parent = action.ParentActionName.String
@@ -1829,7 +1829,7 @@ func (s *RunService) convertNodeUpdateToEnrichedProto(
 		// No-op, this should never happen.
 	}
 
-	metadata.FuntionName = action.FunctionName
+	metadata.FunctionName = action.FunctionName
 	metadata.Source = workflow.RunSource(workflow.RunSource_value[action.RunSource])
 
 	if action.TriggerName.Valid {


### PR DESCRIPTION
## Tracking issue

Closes #7558

## Why are the changes needed?

The protobuf field `ActionMetadata.funtion_name` is misspelled (missing the `c` in "function"). The typo is exposed through the generated stubs in every language and the published `flyteidl2` package that the Python SDK depends on, so the misspelled name leaks into public API surfaces.

## What changes were proposed in this pull request?

- `flyteidl2/workflow/run_definition.proto`: rename field `funtion_name` to `function_name`, keeping wire number `13` so the change is backward-compatible on the wire.
- `runs/service/run_service.go`: update the two hand-written references (`actionMetadataFromModel` and the metadata assignment around line 1832) from `FuntionName` to `FunctionName`.

The `gen/` stubs are generated and need `make buf`, which I do not have the toolchain for locally. Per the issue's note, I'll comment `/regen` on this PR so CI regenerates and commits the Go/Python/TypeScript/Rust stubs.

## How was this patch tested?

`gofmt -l runs/service/run_service.go` reports no formatting issues, and `grep -rn "funtion" .` returns nothing outside the still-to-be-regenerated `gen/` stubs. The Go backend will build once the stubs are regenerated via `/regen`, since `runs/...` is the only hand-written consumer of the renamed proto symbol.

### Labels

- **changed**

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
