### PR TITLE
fix(apps): run app pods under a configurable service account

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -72,6 +72,12 @@ type InternalAppConfig struct {
 	// WatchBufferSize is the buffer size for each subscriber's event channel.
 	// A larger value reduces the chance of dropped events under burst load.
 	WatchBufferSize int `json:"watchBufferSize" pflag:",Buffer size for watch subscriber channels"`
+
+	// DefaultServiceAccount is assigned to app pods that don't request one via their
+	// security context. Empty means the namespace's `default` ServiceAccount is used.
+	// Set this to the flyte service account (which carries the IRSA role) so app pods
+	// get cloud credentials/region for object storage.
+	DefaultServiceAccount string `json:"defaultServiceAccount" pflag:",Default k8s service account for app pods when the app does not set one"`
 }
 
 var defaultInternalAppConfig = &InternalAppConfig{

--- a/app/internal/k8s/app_client.go
+++ b/app/internal/k8s/app_client.go
@@ -573,10 +573,6 @@ func (c *AppK8sClient) buildKService(app *flyteapp.App) (*servingv1.Service, err
 	if err != nil {
 		return nil, err
 	}
-	// Run the app pod under the app's requested service account, falling back to the
-	// configured default. Without this the Knative pod uses the namespace's `default`
-	// SA, which (unlike the flyte SA) has no IRSA role — so the pod gets no cloud
-	// credentials/region and fails to read its code bundle from object storage.
 	if sa := spec.GetSecurityContext().GetRunAs().GetK8SServiceAccount(); sa != "" {
 		podSpec.ServiceAccountName = sa
 	} else if c.cfg.DefaultServiceAccount != "" {

--- a/app/internal/k8s/app_client.go
+++ b/app/internal/k8s/app_client.go
@@ -573,6 +573,15 @@ func (c *AppK8sClient) buildKService(app *flyteapp.App) (*servingv1.Service, err
 	if err != nil {
 		return nil, err
 	}
+	// Run the app pod under the app's requested service account, falling back to the
+	// configured default. Without this the Knative pod uses the namespace's `default`
+	// SA, which (unlike the flyte SA) has no IRSA role — so the pod gets no cloud
+	// credentials/region and fails to read its code bundle from object storage.
+	if sa := spec.GetSecurityContext().GetRunAs().GetK8SServiceAccount(); sa != "" {
+		podSpec.ServiceAccountName = sa
+	} else if c.cfg.DefaultServiceAccount != "" {
+		podSpec.ServiceAccountName = c.cfg.DefaultServiceAccount
+	}
 	// Inject cluster-level default env vars (e.g. _U_EP_OVERRIDE) before user vars
 	// so they can be overridden by app-specific env vars if needed.
 	if len(c.cfg.DefaultEnvVars) > 0 && len(podSpec.Containers) > 0 {

--- a/app/internal/k8s/app_client_test.go
+++ b/app/internal/k8s/app_client_test.go
@@ -121,6 +121,42 @@ func TestDeploy_InjectsInternalAppEndpointPattern(t *testing.T) {
 	assert.Equal(t, "http://{app_fqdn}-proj-dev.flyte.svc.cluster.local", pattern)
 }
 
+func TestDeploy_DefaultServiceAccount(t *testing.T) {
+	c := testClient(t)
+	c.cfg.DefaultServiceAccount = "flyte2"
+	require.NoError(t, c.Deploy(context.Background(), testApp("proj", "dev", "myapp", "nginx:latest")))
+
+	ksvc := &servingv1.Service{}
+	require.NoError(t, c.k8sClient.Get(context.Background(),
+		client.ObjectKey{Name: "myapp-proj-dev", Namespace: AppNamespace}, ksvc))
+	assert.Equal(t, "flyte2", ksvc.Spec.Template.Spec.ServiceAccountName)
+}
+
+func TestDeploy_AppServiceAccountOverridesDefault(t *testing.T) {
+	c := testClient(t)
+	c.cfg.DefaultServiceAccount = "flyte2"
+	app := testApp("proj", "dev", "myapp", "nginx:latest")
+	app.Spec.SecurityContext = &flyteapp.SecurityContext{
+		RunAs: &flytecoreapp.Identity{K8SServiceAccount: "app-requested-sa"},
+	}
+	require.NoError(t, c.Deploy(context.Background(), app))
+
+	ksvc := &servingv1.Service{}
+	require.NoError(t, c.k8sClient.Get(context.Background(),
+		client.ObjectKey{Name: "myapp-proj-dev", Namespace: AppNamespace}, ksvc))
+	assert.Equal(t, "app-requested-sa", ksvc.Spec.Template.Spec.ServiceAccountName)
+}
+
+func TestDeploy_NoServiceAccountWhenUnset(t *testing.T) {
+	c := testClient(t) // cfg.DefaultServiceAccount is empty
+	require.NoError(t, c.Deploy(context.Background(), testApp("proj", "dev", "myapp", "nginx:latest")))
+
+	ksvc := &servingv1.Service{}
+	require.NoError(t, c.k8sClient.Get(context.Background(),
+		client.ObjectKey{Name: "myapp-proj-dev", Namespace: AppNamespace}, ksvc))
+	assert.Empty(t, ksvc.Spec.Template.Spec.ServiceAccountName)
+}
+
 func TestDeploy_UpdateOnSpecChange(t *testing.T) {
 	c := testClient(t)
 	app := testApp("proj", "dev", "myapp", "nginx:1.0")


### PR DESCRIPTION
## Why are the changes needed?

The app deployment controller (`app/internal/k8s/app_client.go`) builds the Knative pod spec **without setting `serviceAccountName`**, so every app pod runs under its namespace's `default` ServiceAccount.

On clusters that use **IRSA** (EKS), the `default` SA has no `eks.amazonaws.com/role-arn` annotation, so the pod-identity webhook injects **no `AWS_REGION` and no credentials**. The object-store client (obstore) then defaults to `us-east-1`, and an app whose bucket lives in another region fails to download its own code bundle:

```
Generic S3 error: Error performing HEAD https://s3.us-east-1.amazonaws.com/<bucket>/... -
Received redirect without LOCATION, this normally indicates an incorrectly configured region
```

Task pods already avoid this via `executor.defaultK8sServiceAccount`; apps had no equivalent.

## What changes were proposed in this pull request?

- **`app/internal/k8s/app_client.go`** — `buildKService` now sets `PodSpec.ServiceAccountName`, preferring the app's own security context (`spec.security_context.run_as.k8s_service_account`) and falling back to the new config default.
- **`app/config/config.go`** — add `InternalAppConfig.DefaultServiceAccount` (`internalApps.defaultServiceAccount`). Empty preserves the old behavior (namespace `default` SA).

Deployments set `internalApps.defaultServiceAccount` to the flyte service account (which carries the IRSA role) so app pods get cloud credentials/region.

## How was this patch tested?

- `go build ./app/...` and `app/internal/k8s` tests pass.
- Live on the `flyte-development` EKS/ALB cluster: before, the streamlit app pod ran under SA `default` (no IRSA) and CrashLoopBackOff'd with the S3 region error. After deploying this change with `internalApps.defaultServiceAccount: flyte2`, a new revision's pod runs under SA `flyte2` with `AWS_REGION=us-east-2` and `AWS_ROLE_ARN=...flyte-binary` injected, and starts cleanly (2/2 Running).

### Labels

- **fixed**

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.