### PR TITLE
chore: sync generated package-lock after make gen

### DIFF
--- a/gen/ts/package-lock.json
+++ b/gen/ts/package-lock.json
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/typescript": {


### PR DESCRIPTION
Running `make gen` on main produces a diff in `gen/ts/package-lock.json` because the TypeScript generation step runs `npm install`, which resolves `@bufbuild/protobuf` to a newer upstream patch (2.12.0 -> 2.12.1). This left main out of sync with its generated output. This commits the regenerated lockfile so the tree is clean again.

Note: `make gen` also appears to delete the connect mock files (`gen/go/.../mocks/mocks.go`), but that is a generation-ordering artifact — `buf generate --clean` removes them and mockery recreates them byte-identical afterward, so they are intentionally not part of this PR.

### Labels
- changed

## How was this patch tested?
`cd gen/ts && npx tsc --noEmit` passes and `go build ./...` passes.