### PR TITLE
fix: make devbox build work with Helm v4

### DIFF
--- a/docker/devbox-bundled/Makefile
+++ b/docker/devbox-bundled/Makefile
@@ -97,16 +97,26 @@ dep_update: SANDBOX_CHART_DIR := ../../charts/flyte-devbox
 dep_update: dep_build
 	cd $(SANDBOX_CHART_DIR)/charts && rm -rf docker-registry flyte-binary knative-serving && for f in *.tgz; do tar xzf "$$f"; done
 
+# Use the executor's pinned, Helm-v4-compatible kustomize instead of whatever
+# kustomize the developer happens to have on PATH. Older kustomize probes with
+# `helm version -c --short`, and Helm v4 dropped the `-c` flag, so a bare
+# `kustomize build --enable-helm` fails on machines with Helm v4 installed.
+KUSTOMIZE := ../../executor/bin/kustomize
+
+.PHONY: kustomize
+kustomize:
+	$(MAKE) -C ../../executor kustomize
+
 .PHONY: manifests
-manifests: dep_update
+manifests: dep_update kustomize
 	mkdir -p manifests
-	kustomize build \
+	$(KUSTOMIZE) build \
 		--enable-helm \
 		--load-restrictor=LoadRestrictionsNone \
 		kustomize/complete > manifests/complete.yaml
 	@printf "\n---\n" >> manifests/complete.yaml
 	@cat kustomize/net-kourier.yaml >> manifests/complete.yaml
-	kustomize build \
+	$(KUSTOMIZE) build \
 		--enable-helm \
 		--load-restrictor=LoadRestrictionsNone \
 		kustomize/dev > manifests/dev.yaml

--- a/docker/devbox-bundled/Makefile
+++ b/docker/devbox-bundled/Makefile
@@ -98,9 +98,7 @@ dep_update: dep_build
 	cd $(SANDBOX_CHART_DIR)/charts && rm -rf docker-registry flyte-binary knative-serving && for f in *.tgz; do tar xzf "$$f"; done
 
 # Use the executor's pinned, Helm-v4-compatible kustomize instead of whatever
-# kustomize the developer happens to have on PATH. Older kustomize probes with
-# `helm version -c --short`, and Helm v4 dropped the `-c` flag, so a bare
-# `kustomize build --enable-helm` fails on machines with Helm v4 installed.
+# kustomize the developer happens to have on PATH.
 KUSTOMIZE := ../../executor/bin/kustomize
 
 .PHONY: kustomize

--- a/executor/Makefile
+++ b/executor/Makefile
@@ -192,7 +192,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v5.7.1
+KUSTOMIZE_VERSION ?= v5.8.1
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')


### PR DESCRIPTION
## Why are the changes needed?

`make devbox-build` runs `kustomize build --enable-helm`, and kustomize < v5.8.0 probes Helm with `helm version -c --short`. Helm v4 removed the `-c`/`--client` shorthand, so the build fails for any developer who has Helm v4 installed:

```
Error: unknown shorthand flag: 'c' in -c
: unable to run: 'helm version -c --short' ... (is 'helm' installed?): exit status 1
make[1]: *** [manifests] Error 1
make: *** [devbox-build] Error 2
```

The devbox `manifests` target also called bare `kustomize` from `PATH`, so the build depended on whatever kustomize/helm version a developer happened to have installed.

## What changes were proposed in this pull request?

- `executor/Makefile`: bump pinned kustomize `v5.7.1` → `v5.8.1`. v5.8.0 added Helm v4 support ([kustomize#6016](https://github.com/kubernetes-sigs/kustomize/pull/6016)); v5.8.1 fixes the v5.8.0 namespace-propagation regression ([kustomize#6044](https://github.com/kubernetes-sigs/kustomize/issues/6013)).
- `docker/devbox-bundled/Makefile`: the `manifests` target now uses the executor's pinned kustomize binary (`../../executor/bin/kustomize`) instead of system `kustomize`, so the devbox build is reproducible regardless of local helm/kustomize versions.

No chart changes are needed: both charts are already `apiVersion: v2` (Helm 3 + 4 compatible), and CI installs its own Helm 3.

## How was this patch tested?

Reproduced with a stub "Helm v4" that rejects the `-c` flag like the real release:

- kustomize **v5.7.1** → reproduces the exact `unknown shorthand flag: 'c' in -c` / `helm version -c --short` error.
- kustomize **v5.8.1** → clears the version probe (no `-c`).

### Labels

- **fixed**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.