### PR TITLE
build: use ci:latest image for gen so go.mod Go version matches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 CLUSTER_NAME ?= flytev2
 
 # Docker CI image configuration
-DOCKER_CI_IMAGE := ghcr.io/flyteorg/flyte/ci:v2
+DOCKER_CI_IMAGE := ghcr.io/flyteorg/flyte/ci:latest
 
 # Environment variable flags for Docker
 DOCKER_ENV_FLAGS :=


### PR DESCRIPTION
`make gen` was leaving the connect mock files deleted (`gen/go/flyteidl2/{actions/actionsconnect,connector,plugins,project/projectconnect,workflow/workflowconnect}/mocks/mocks.go`) and not regenerating them.

Root cause: `make gen` runs `gen-local` inside the `DOCKER_CI_IMAGE`, which was pinned to `ghcr.io/flyteorg/flyte/ci:v2`. That tag is only built/pushed from the `v2` branch (see `build-ci-image.yml`), so it stayed frozen at **Go 1.24.6**. `go.mod` and `gen.Dockerfile` now require **Go 1.26.3** (#7402). Inside the stale image, `buf --clean` deletes the mock dirs (they live under `gen/go`), then mockery fails to load the module — `package requires newer Go version go1.26 (application built with go1.25/1.24)` — and aborts, so the mocks are never recreated. It works locally only because the local Go toolchain and a warm build cache resolve the packages.

Fix: point `DOCKER_CI_IMAGE` at `ci:latest`, which is built from `main` and already ships Go 1.26.3.

### Labels
- fixed

## How was this patch tested?
Reproduced inside both images with the mocks deleted: `ci:v2` aborts mockery with the Go-version load error and leaves all five mocks deleted; `ci:latest` regenerates all five and leaves a clean tree.