### PR TITLE
fix(flyte-binary): make task/app log streaming work (pods/log RBAC + AppLogsService route)

### DIFF
--- a/charts/flyte-binary/templates/_helpers.tpl
+++ b/charts/flyte-binary/templates/_helpers.tpl
@@ -191,6 +191,8 @@ Get the Flyte API paths for ingress.
 - /flyteidl2.project.ProjectService/*
 - /flyteidl2.app.AppService
 - /flyteidl2.app.AppService/*
+- /flyteidl2.app.AppLogsService
+- /flyteidl2.app.AppLogsService/*
 - /flyteidl2.trigger.TriggerService
 - /flyteidl2.trigger.TriggerService/*
 - /flyteidl2.auth.IdentityService

--- a/charts/flyte-binary/templates/clusterrole.yaml
+++ b/charts/flyte-binary/templates/clusterrole.yaml
@@ -42,6 +42,12 @@ rules:
       - watch
   - apiGroups:
       - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - ""
       - events.k8s.io
     resources:
       - events


### PR DESCRIPTION
## Why are the changes needed?

Two chart bugs broke task/app **log streaming**, even though the service handlers are mounted in the binary:

1. **`RunLogsService/TailLogs` → 403.** Streaming a pod's logs reads the Kubernetes `pods/log` subresource, which is a *distinct* RBAC resource from `pods`. The ClusterRole only granted `pods`, so streaming failed with `cannot get resource "pods/log"`.
2. **`AppLogsService/TailLogs` → 404.** The ingress `apiPaths` helper enumerates Connect service paths explicitly and listed `AppService` but not `AppLogsService`, so those requests fell through to a 404 instead of reaching the binary.

## What changes were proposed in this pull request?

- `templates/clusterrole.yaml`: add a minimal `pods/log` `get` rule (only `get` — log streaming with `follow=true` is still a `GET` on the subresource).
- `templates/_helpers.tpl`: add `/flyteidl2.app.AppLogsService` and `/flyteidl2.app.AppLogsService/*` to `flyte-binary.ingress.apiPaths`, alongside the existing `AppService` paths (consumed by both the http and api-jwt ingress templates).

## How was this patch tested?

- `helm template` renders both the `pods/log` rule and the `AppLogsService` ingress paths (http + api-jwt).
- On the `flyte-development` cluster:
  - reading a task pod's logs as the service account succeeds where it was previously forbidden (`kubectl logs <pod> --as=system:serviceaccount:flyte:flyte2`);
  - after adding the ingress paths, `POST /flyteidl2.app.AppLogsService/TailLogs` returns the auth challenge (302) — identical to `AppService` — instead of 404.

### Labels

- **fixed**

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
