### PR TITLE
[Feat] set executor concurr to 512

### DIFF
--- a/executor/pkg/config/config.go
+++ b/executor/pkg/config/config.go
@@ -25,6 +25,7 @@ var (
 		CacheServiceURL:        "http://localhost:8094",
 		Cluster:                "",
 		MaxSystemFailures:      3,
+		MaxConcurrentReconciles: 512,
 		GC: GCConfig{
 			Interval: stdconfig.Duration{Duration: 30 * time.Minute},
 			MaxTTL:   stdconfig.Duration{Duration: 1 * time.Hour},
@@ -88,6 +89,9 @@ type Config struct {
 	// errors and plugin-reported system-retryable failures) before a TaskAction is
 	// converted to a permanent failure.
 	MaxSystemFailures int32 `json:"maxSystemFailures" pflag:",Max consecutive system-level failures before forcing permanent failure"`
+
+	// MaxConcurrentReconciles is the maximum number of concurrent reconcile loops for TaskActions.
+	MaxConcurrentReconciles int `json:"maxConcurrentReconciles" pflag:",Max concurrent reconcile loops for TaskActions"`
 
 	// GC configures the garbage collector for terminal TaskActions.
 	GC GCConfig `json:"gc" pflag:",Garbage collector configuration for terminal TaskActions"`

--- a/executor/pkg/controller/taskaction_controller.go
+++ b/executor/pkg/controller/taskaction_controller.go
@@ -919,13 +919,12 @@ func createStateJSON(actionSpec *workflow.ActionSpec, phase string) string {
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *TaskActionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *TaskActionReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&flyteorgv1.TaskAction{}).
 		Owns(&corev1.Pod{}).
 		Named("taskaction").
-		// NOTE: hardcoded for load testing; promote to executor config if it sticks
-		WithOptions(controller.Options{MaxConcurrentReconciles: 512}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/executor/pkg/controller/taskaction_controller.go
+++ b/executor/pkg/controller/taskaction_controller.go
@@ -37,6 +37,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -923,6 +924,8 @@ func (r *TaskActionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&flyteorgv1.TaskAction{}).
 		Owns(&corev1.Pod{}).
 		Named("taskaction").
+		// NOTE: hardcoded for load testing; promote to executor config if it sticks
+		WithOptions(controller.Options{MaxConcurrentReconciles: 512}).
 		Complete(r)
 }
 

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -181,7 +181,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		return fmt.Errorf("executor: maxSystemFailures must be non-negative, got %d", cfg.MaxSystemFailures)
 	}
 	reconciler.MaxSystemFailures = uint32(cfg.MaxSystemFailures)
-	if err := reconciler.SetupWithManager(mgr); err != nil {
+	if err := reconciler.SetupWithManager(mgr, cfg.MaxConcurrentReconciles); err != nil {
 		return fmt.Errorf("executor: failed to setup controller: %w", err)
 	}
 


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

Enable configuring k8s controller concurrency

## What changes were proposed in this pull request?

make controller concurrency configurable and set default to 512

## How was this patch tested?


### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
