### PR TITLE
fix(actions): scope WatchForUpdates pub/sub by run to stop cross-run contamination

### DIFF
--- a/actions/k8s/client.go
+++ b/actions/k8s/client.go
@@ -338,28 +338,39 @@ func (c *ActionsClient) GetTaskAction(ctx context.Context, actionID *common.Acti
 }
 
 // Subscribe creates a new subscription channel for action updates for specified parent action name
-func (c *ActionsClient) Subscribe(parentActionName string) chan *ActionUpdate {
+// subscriberKey scopes a subscription to a single (run, parent action) pair.
+// The parent action name alone is NOT unique across runs -- every run's root
+// action is named "a0" -- so keying on it alone broadcasts each run's child
+// updates to every other run's watch stream. Same-named children then collide
+// in the SDK informer cache and clobber each other's phase, wedging the parent.
+func subscriberKey(runName, parentActionName string) string {
+	return runName + "/" + parentActionName
+}
+
+func (c *ActionsClient) Subscribe(runName, parentActionName string) chan *ActionUpdate {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	key := subscriberKey(runName, parentActionName)
 	ch := make(chan *ActionUpdate, c.bufferSize)
-	if c.subscribers[parentActionName] == nil {
-		c.subscribers[parentActionName] = make(map[chan *ActionUpdate]struct{})
+	if c.subscribers[key] == nil {
+		c.subscribers[key] = make(map[chan *ActionUpdate]struct{})
 	}
-	c.subscribers[parentActionName][ch] = struct{}{}
+	c.subscribers[key][ch] = struct{}{}
 	return ch
 }
 
-// Unsubscribe removes the given channel from the subscription list for the parent action name
-func (c *ActionsClient) Unsubscribe(parentActionName string, ch chan *ActionUpdate) {
+// Unsubscribe removes the given channel from the subscription list for the (run, parent action)
+func (c *ActionsClient) Unsubscribe(runName, parentActionName string, ch chan *ActionUpdate) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if channels, ok := c.subscribers[parentActionName]; ok {
+	key := subscriberKey(runName, parentActionName)
+	if channels, ok := c.subscribers[key]; ok {
 		delete(channels, ch)
 		close(ch)
 		if len(channels) == 0 {
-			delete(c.subscribers, parentActionName)
+			delete(c.subscribers, key)
 		}
 	}
 }
@@ -536,7 +547,8 @@ func (c *ActionsClient) notifySubscribers(ctx context.Context, update *ActionUpd
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	for ch := range c.subscribers[update.ParentActionName] {
+	key := subscriberKey(update.ActionID.GetRun().GetName(), update.ParentActionName)
+	for ch := range c.subscribers[key] {
 		select {
 		case ch <- update:
 		default:

--- a/actions/k8s/client.go
+++ b/actions/k8s/client.go
@@ -337,7 +337,7 @@ func (c *ActionsClient) GetTaskAction(ctx context.Context, actionID *common.Acti
 	return taskAction, nil
 }
 
-// Subscribe creates a new subscription channel for action updates for specified parent action name
+// Subscribe creates a new subscription channel for action updates scoped to the given (run, parent action).
 // subscriberKey scopes a subscription to a single (run, parent action) pair.
 // The parent action name alone is NOT unique across runs -- every run's root
 // action is named "a0" -- so keying on it alone broadcasts each run's child

--- a/actions/k8s/client_subscribe_test.go
+++ b/actions/k8s/client_subscribe_test.go
@@ -63,7 +63,7 @@ func TestUnsubscribeScopedByRun(t *testing.T) {
 	c.Unsubscribe("runA", "a0", ch)
 
 	// Unsubscribing the only subscriber should drop the key entirely.
-	if _, ok := c.subscribers["runA/a0"]; ok {
+	if _, ok := c.subscribers[subscriberKey("runA", "a0")]; ok {
 		t.Fatal("subscriber key not cleaned up after Unsubscribe")
 	}
 

--- a/actions/k8s/client_subscribe_test.go
+++ b/actions/k8s/client_subscribe_test.go
@@ -1,0 +1,72 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
+)
+
+// newSubscribeTestClient builds a minimal ActionsClient exercising only the
+// pub/sub machinery (Subscribe/Unsubscribe/notifySubscribers).
+func newSubscribeTestClient() *ActionsClient {
+	return &ActionsClient{
+		bufferSize:  10,
+		subscribers: make(map[string]map[chan *ActionUpdate]struct{}),
+	}
+}
+
+func childUpdate(runName, childName, parentName string) *ActionUpdate {
+	return &ActionUpdate{
+		ActionID: &common.ActionIdentifier{
+			Run:  &common.RunIdentifier{Name: runName},
+			Name: childName,
+		},
+		ParentActionName: parentName,
+		Phase:            common.ActionPhase_ACTION_PHASE_SUCCEEDED,
+	}
+}
+
+// Every run's root action is named "a0", so keying subscriptions on the parent
+// action name alone leaks one run's child updates into every other run's watch.
+// Subscriptions must be scoped by (run, parent action).
+func TestSubscribeIsScopedByRun(t *testing.T) {
+	c := newSubscribeTestClient()
+
+	chA := c.Subscribe("runA", "a0")
+	chB := c.Subscribe("runB", "a0")
+
+	// An update for runA's child must reach only runA's subscriber.
+	c.notifySubscribers(context.Background(), childUpdate("runA", "child1", "a0"))
+
+	select {
+	case got := <-chA:
+		assert.Equal(t, "runA", got.ActionID.GetRun().GetName())
+	default:
+		t.Fatal("runA subscriber did not receive its own update")
+	}
+
+	select {
+	case leaked := <-chB:
+		t.Fatalf("runB subscriber leaked a runA update: %+v", leaked)
+	default:
+		// expected: no cross-run delivery
+	}
+}
+
+func TestUnsubscribeScopedByRun(t *testing.T) {
+	c := newSubscribeTestClient()
+
+	ch := c.Subscribe("runA", "a0")
+	c.Unsubscribe("runA", "a0", ch)
+
+	// Unsubscribing the only subscriber should drop the key entirely.
+	if _, ok := c.subscribers["runA/a0"]; ok {
+		t.Fatal("subscriber key not cleaned up after Unsubscribe")
+	}
+
+	// Notifying after unsubscribe must not panic or deliver.
+	c.notifySubscribers(context.Background(), childUpdate("runA", "child1", "a0"))
+}

--- a/actions/service/actions_service.go
+++ b/actions/service/actions_service.go
@@ -74,8 +74,8 @@ func (s *ActionsService) WatchForUpdates(
 	}
 
 	// Subscribe before listing to avoid missing events between snapshot and watch.
-	updateCh := s.client.Subscribe(parentActionID.Name)
-	defer s.client.Unsubscribe(parentActionID.Name, updateCh)
+	updateCh := s.client.Subscribe(parentActionID.GetRun().GetName(), parentActionID.Name)
+	defer s.client.Unsubscribe(parentActionID.GetRun().GetName(), parentActionID.Name, updateCh)
 
 	// Send initial state snapshot.
 	childActions, err := s.client.ListChildActions(ctx, parentActionID)

--- a/actions/service/interfaces.go
+++ b/actions/service/interfaces.go
@@ -26,11 +26,11 @@ type ActionsClientInterface interface {
 	// ListChildActions lists all TaskActions that are children of the given parent action.
 	ListChildActions(ctx context.Context, parentActionID *common.ActionIdentifier) ([]*executorv1.TaskAction, error)
 
-	// Subscribe creates a new subscription channel for action updates for the given parent action name.
-	Subscribe(parentActionName string) chan *k8s.ActionUpdate
+	// Subscribe creates a new subscription channel for action updates scoped to the given (run, parent action).
+	Subscribe(runName, parentActionName string) chan *k8s.ActionUpdate
 
-	// Unsubscribe removes the given channel from the subscription list for the parent action name.
-	Unsubscribe(parentActionName string, ch chan *k8s.ActionUpdate)
+	// Unsubscribe removes the given channel from the subscription list for the (run, parent action).
+	Unsubscribe(runName, parentActionName string, ch chan *k8s.ActionUpdate)
 
 	// StartWatching starts watching TaskAction resources.
 	StartWatching(ctx context.Context) error

--- a/actions/service/mocks/mocks.go
+++ b/actions/service/mocks/mocks.go
@@ -391,16 +391,16 @@ func (_c *ActionsClientInterface_StopWatching_Call) RunAndReturn(run func()) *Ac
 }
 
 // Subscribe provides a mock function for the type ActionsClientInterface
-func (_mock *ActionsClientInterface) Subscribe(parentActionName string) chan *k8s.ActionUpdate {
-	ret := _mock.Called(parentActionName)
+func (_mock *ActionsClientInterface) Subscribe(runName string, parentActionName string) chan *k8s.ActionUpdate {
+	ret := _mock.Called(runName, parentActionName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Subscribe")
 	}
 
 	var r0 chan *k8s.ActionUpdate
-	if returnFunc, ok := ret.Get(0).(func(string) chan *k8s.ActionUpdate); ok {
-		r0 = returnFunc(parentActionName)
+	if returnFunc, ok := ret.Get(0).(func(string, string) chan *k8s.ActionUpdate); ok {
+		r0 = returnFunc(runName, parentActionName)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(chan *k8s.ActionUpdate)
@@ -415,19 +415,25 @@ type ActionsClientInterface_Subscribe_Call struct {
 }
 
 // Subscribe is a helper method to define mock.On call
+//   - runName string
 //   - parentActionName string
-func (_e *ActionsClientInterface_Expecter) Subscribe(parentActionName interface{}) *ActionsClientInterface_Subscribe_Call {
-	return &ActionsClientInterface_Subscribe_Call{Call: _e.mock.On("Subscribe", parentActionName)}
+func (_e *ActionsClientInterface_Expecter) Subscribe(runName interface{}, parentActionName interface{}) *ActionsClientInterface_Subscribe_Call {
+	return &ActionsClientInterface_Subscribe_Call{Call: _e.mock.On("Subscribe", runName, parentActionName)}
 }
 
-func (_c *ActionsClientInterface_Subscribe_Call) Run(run func(parentActionName string)) *ActionsClientInterface_Subscribe_Call {
+func (_c *ActionsClientInterface_Subscribe_Call) Run(run func(runName string, parentActionName string)) *ActionsClientInterface_Subscribe_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
 			arg0 = args[0].(string)
 		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -438,14 +444,14 @@ func (_c *ActionsClientInterface_Subscribe_Call) Return(actionUpdateCh chan *k8s
 	return _c
 }
 
-func (_c *ActionsClientInterface_Subscribe_Call) RunAndReturn(run func(parentActionName string) chan *k8s.ActionUpdate) *ActionsClientInterface_Subscribe_Call {
+func (_c *ActionsClientInterface_Subscribe_Call) RunAndReturn(run func(runName string, parentActionName string) chan *k8s.ActionUpdate) *ActionsClientInterface_Subscribe_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Unsubscribe provides a mock function for the type ActionsClientInterface
-func (_mock *ActionsClientInterface) Unsubscribe(parentActionName string, ch chan *k8s.ActionUpdate) {
-	_mock.Called(parentActionName, ch)
+func (_mock *ActionsClientInterface) Unsubscribe(runName string, parentActionName string, ch chan *k8s.ActionUpdate) {
+	_mock.Called(runName, parentActionName, ch)
 	return
 }
 
@@ -455,25 +461,31 @@ type ActionsClientInterface_Unsubscribe_Call struct {
 }
 
 // Unsubscribe is a helper method to define mock.On call
+//   - runName string
 //   - parentActionName string
 //   - ch chan *k8s.ActionUpdate
-func (_e *ActionsClientInterface_Expecter) Unsubscribe(parentActionName interface{}, ch interface{}) *ActionsClientInterface_Unsubscribe_Call {
-	return &ActionsClientInterface_Unsubscribe_Call{Call: _e.mock.On("Unsubscribe", parentActionName, ch)}
+func (_e *ActionsClientInterface_Expecter) Unsubscribe(runName interface{}, parentActionName interface{}, ch interface{}) *ActionsClientInterface_Unsubscribe_Call {
+	return &ActionsClientInterface_Unsubscribe_Call{Call: _e.mock.On("Unsubscribe", runName, parentActionName, ch)}
 }
 
-func (_c *ActionsClientInterface_Unsubscribe_Call) Run(run func(parentActionName string, ch chan *k8s.ActionUpdate)) *ActionsClientInterface_Unsubscribe_Call {
+func (_c *ActionsClientInterface_Unsubscribe_Call) Run(run func(runName string, parentActionName string, ch chan *k8s.ActionUpdate)) *ActionsClientInterface_Unsubscribe_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
 			arg0 = args[0].(string)
 		}
-		var arg1 chan *k8s.ActionUpdate
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(chan *k8s.ActionUpdate)
+			arg1 = args[1].(string)
+		}
+		var arg2 chan *k8s.ActionUpdate
+		if args[2] != nil {
+			arg2 = args[2].(chan *k8s.ActionUpdate)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -484,7 +496,7 @@ func (_c *ActionsClientInterface_Unsubscribe_Call) Return() *ActionsClientInterf
 	return _c
 }
 
-func (_c *ActionsClientInterface_Unsubscribe_Call) RunAndReturn(run func(parentActionName string, ch chan *k8s.ActionUpdate)) *ActionsClientInterface_Unsubscribe_Call {
+func (_c *ActionsClientInterface_Unsubscribe_Call) RunAndReturn(run func(runName string, parentActionName string, ch chan *k8s.ActionUpdate)) *ActionsClientInterface_Unsubscribe_Call {
 	_c.Run(run)
 	return _c
 }


### PR DESCRIPTION
## Why are the changes needed?

Parent actions were getting stuck in `Executing` forever on the development cluster under concurrent load (e.g. the `sleep_fanout` stress test), even though all of their children had completed.

Root cause: watch subscriptions were keyed **solely on the parent action name**. Every run's root action is named `a0`, so `subscribers["a0"]` collected the watch channels of *every concurrent run*, and `notifySubscribers` fanned each child update out to all of them with **no run filter**:

```go
// actions/k8s/client.go
updateCh := s.client.Subscribe(parentActionID.Name)          // Subscribe("a0")
...
for ch := range c.subscribers[update.ParentActionName] {     // "a0" -> all runs' parents
    ch <- update
}
```

So a parent received child updates from every other run watching `a0`. Combined with the SDK informer caching children by **bare action name** (no run), and the fanout example naming its children deterministically (so the same 10 names recur every run), a child that `SUCCEEDED` in run A had its cached phase repeatedly clobbered back to `RUNNING` by run B's same-named child. The parent never saw all of its own children simultaneously terminal and hung indefinitely.

Evidence from a stuck parent pod on flyte-development: its controller log referenced **dozens of foreign runs** (more lines for a foreign run than for itself), child output URIs pointing at other runs, and one child's phase oscillating `RUNNING`/`SUCCEEDED` (97/48).

## What changes were proposed in this pull request?

Scope the watch pub/sub by **(run, parent action)** instead of parent action name alone:

- `actions/k8s/client.go` — add `subscriberKey(runName, parentActionName)` (`runName + "/" + parentActionName`); `Subscribe`/`Unsubscribe` take a `runName` and key on the composite; `notifySubscribers` routes on the child update's own run (`update.ActionID.GetRun().GetName()`, nil-safe).
- `actions/service/actions_service.go` — `WatchForUpdates` passes `parentActionID.GetRun().GetName()`.
- `actions/service/interfaces.go` — interface signatures updated.
- `actions/service/mocks/mocks.go` — regenerated via `mockery`.

This isolates each run's watch stream at the source. (The SDK-side defensive guard — dropping foreign-run updates / keying the informer cache by full action id — is a separate flyte-sdk change.)

## How was this patch tested?

Added `actions/k8s/client_subscribe_test.go`:
- `TestSubscribeIsScopedByRun` — two subscribers on parent `a0` under different runs; a `runA` update reaches `runA` only and does **not** leak to `runB` (the exact failure before this fix).
- `TestUnsubscribeScopedByRun` — the run-scoped key is cleaned up; notify after unsubscribe is a safe no-op.

`go test ./actions/...` passes; `go build ./actions/... ./app/...` and `go vet ./actions/...` are clean. The apps service uses a separate `AppK8sClientInterface` and is unaffected.

### Labels
- **fixed**

## Check all the applicable boxes
- [x] All new and existing tests passed.
- [x] All commits are signed-off.