### PR TITLE
fix(dataproxy): return scheme-qualified ClusterEndpoint from SelectCluster

### DIFF
--- a/dataproxy/service/cluster_service.go
+++ b/dataproxy/service/cluster_service.go
@@ -38,11 +38,14 @@ func (s *ClusterService) SelectCluster(
 	if requestHost != "" {
 		scheme := "http"
 		if proto := req.Header().Get("X-Forwarded-Proto"); proto != "" {
-			// X-Forwarded-Proto may be a comma-separated list (proxy chain); the first
-			// value is the scheme the client used.
-			scheme = strings.TrimSpace(strings.Split(proto, ",")[0])
+			// X-Forwarded-Proto may be a comma-separated list (proxy chain); the first value
+			// is the scheme the client used.
+			candidate := strings.ToLower(strings.TrimSpace(strings.Split(proto, ",")[0]))
+			if candidate == "http" || candidate == "https" {
+				scheme = candidate
+			}
 		}
-		endpoint = scheme + "://" + requestHost
+		endpoint = scheme + "://" + strings.TrimSpace(requestHost)
 	}
 
 	return connect.NewResponse(&cluster.SelectClusterResponse{

--- a/dataproxy/service/cluster_service.go
+++ b/dataproxy/service/cluster_service.go
@@ -11,6 +11,14 @@ import (
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/cluster/clusterconnect"
 )
 
+const (
+	// headerXForwardedProto is the header a TLS-terminating proxy/LB sets to the scheme
+	// the client used.
+	headerXForwardedProto = "X-Forwarded-Proto"
+	schemeHTTP            = "http"
+	schemeHTTPS           = "https"
+)
+
 type ClusterService struct {
 	clusterconnect.UnimplementedClusterServiceHandler
 }
@@ -37,12 +45,12 @@ func (s *ClusterService) SelectCluster(
 	var endpoint string
 	host := strings.TrimSpace(requestHost)
 	if host != "" {
-		scheme := "http"
-		if proto := req.Header().Get("X-Forwarded-Proto"); proto != "" {
+		scheme := schemeHTTP
+		if proto := req.Header().Get(headerXForwardedProto); proto != "" {
 			// X-Forwarded-Proto may be a comma-separated list (proxy chain); the first value
 			// is the scheme the client used.
 			candidate := strings.ToLower(strings.TrimSpace(strings.Split(proto, ",")[0]))
-			if candidate == "http" || candidate == "https" {
+			if candidate == schemeHTTP || candidate == schemeHTTPS {
 				scheme = candidate
 			}
 		}

--- a/dataproxy/service/cluster_service.go
+++ b/dataproxy/service/cluster_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"strings"
 
 	"connectrpc.com/connect"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
@@ -26,7 +27,25 @@ func (s *ClusterService) SelectCluster(
 ) (*connect.Response[cluster.SelectClusterResponse], error) {
 	requestHost := req.Header().Get("Host")
 	logger.Debugf(ctx, "Request Host: %s", requestHost)
+
+	// Return a scheme-qualified base URL, not a bare host. Clients (the console) use
+	// ClusterEndpoint directly as a Connect transport base URL; a value without a scheme
+	// is treated by the browser as a relative path and resolved against the current page,
+	// producing a 404. Prefer X-Forwarded-Proto, which any TLS-terminating proxy/LB sets
+	// (e.g. the ALB on the dev cluster → https). When it's absent the request reached us
+	// directly with no proxy (e.g. a local devbox over http), so default to http.
+	var endpoint string
+	if requestHost != "" {
+		scheme := "http"
+		if proto := req.Header().Get("X-Forwarded-Proto"); proto != "" {
+			// X-Forwarded-Proto may be a comma-separated list (proxy chain); the first
+			// value is the scheme the client used.
+			scheme = strings.TrimSpace(strings.Split(proto, ",")[0])
+		}
+		endpoint = scheme + "://" + requestHost
+	}
+
 	return connect.NewResponse(&cluster.SelectClusterResponse{
-		ClusterEndpoint: requestHost,
+		ClusterEndpoint: endpoint,
 	}), nil
 }

--- a/dataproxy/service/cluster_service.go
+++ b/dataproxy/service/cluster_service.go
@@ -35,7 +35,8 @@ func (s *ClusterService) SelectCluster(
 	// (e.g. the ALB on the dev cluster → https). When it's absent the request reached us
 	// directly with no proxy (e.g. a local devbox over http), so default to http.
 	var endpoint string
-	if requestHost != "" {
+	host := strings.TrimSpace(requestHost)
+	if host != "" {
 		scheme := "http"
 		if proto := req.Header().Get("X-Forwarded-Proto"); proto != "" {
 			// X-Forwarded-Proto may be a comma-separated list (proxy chain); the first value
@@ -45,7 +46,7 @@ func (s *ClusterService) SelectCluster(
 				scheme = candidate
 			}
 		}
-		endpoint = scheme + "://" + strings.TrimSpace(requestHost)
+		endpoint = scheme + "://" + host
 	}
 
 	return connect.NewResponse(&cluster.SelectClusterResponse{

--- a/dataproxy/service/cluster_service_test.go
+++ b/dataproxy/service/cluster_service_test.go
@@ -24,6 +24,8 @@ func TestSelectCluster_ReturnsSchemeQualifiedEndpoint(t *testing.T) {
 		{name: "devbox direct http (no forwarded proto)", host: "localhost:8090", want: "http://localhost:8090"},
 		{name: "explicit http forwarded proto", host: "localhost:8090", fwdProto: "http", want: "http://localhost:8090"},
 		{name: "takes first of proxy-chain list", host: "development.uniondemo.run", fwdProto: "https, http", want: "https://development.uniondemo.run"},
+		{name: "normalizes uppercase forwarded proto", host: "development.uniondemo.run", fwdProto: "HTTPS", want: "https://development.uniondemo.run"},
+		{name: "blank forwarded proto defaults to http", host: "localhost:8090", fwdProto: "  ", want: "http://localhost:8090"},
 		{name: "empty host yields empty endpoint", host: "", want: ""},
 	}
 	for _, tt := range tests {

--- a/dataproxy/service/cluster_service_test.go
+++ b/dataproxy/service/cluster_service_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/cluster"
+)
+
+func TestSelectCluster_ReturnsSchemeQualifiedEndpoint(t *testing.T) {
+	svc := NewClusterService()
+
+	tests := []struct {
+		name     string
+		host     string
+		fwdProto string
+		want     string
+	}{
+		{name: "ALB sets X-Forwarded-Proto https", host: "development.uniondemo.run", fwdProto: "https", want: "https://development.uniondemo.run"},
+		{name: "devbox direct http (no forwarded proto)", host: "localhost:8090", want: "http://localhost:8090"},
+		{name: "explicit http forwarded proto", host: "localhost:8090", fwdProto: "http", want: "http://localhost:8090"},
+		{name: "takes first of proxy-chain list", host: "development.uniondemo.run", fwdProto: "https, http", want: "https://development.uniondemo.run"},
+		{name: "empty host yields empty endpoint", host: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := connect.NewRequest(&cluster.SelectClusterRequest{})
+			if tt.host != "" {
+				req.Header().Set("Host", tt.host)
+			}
+			if tt.fwdProto != "" {
+				req.Header().Set("X-Forwarded-Proto", tt.fwdProto)
+			}
+			resp, err := svc.SelectCluster(context.Background(), req)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, resp.Msg.GetClusterEndpoint())
+		})
+	}
+}


### PR DESCRIPTION
## Why are the changes needed?

`ClusterService.SelectCluster` returned the bare `Host` header (e.g. `development.uniondemo.run`) as `clusterEndpoint`. The console (flyte2-ui) uses `clusterEndpoint` directly as a Connect transport base URL. A value **without a scheme** is treated by the browser as a *relative* path and resolved against the current page, so `GetActionData` requests went to:

```
https://development.uniondemo.run/v2/.../runs/development.uniondemo.run/flyteidl2.dataproxy.DataProxyService/GetActionData  → 404
```

## What changes were proposed in this pull request?

Return a **scheme-qualified** base URL. Prefer `X-Forwarded-Proto` (set by any TLS-terminating proxy/LB — the dev cluster's ALB sets `https`); default to `http` when absent so a **direct local devbox** (no proxy, http) keeps working. `X-Forwarded-Proto` proxy-chain lists take the first value.

## How was this patch tested?

Added `dataproxy/service/cluster_service_test.go` covering: ALB `X-Forwarded-Proto: https` → `https://…`, devbox (no header) → `http://…`, explicit `http`, proxy-chain list, and empty host → empty. `go test ./dataproxy/service/` passes.

### Labels

- **fixed**

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
