### PR TITLE
fix(executor): make TaskAction GC actually collect (initial sweep + APIReader pagination)

### DIFF
--- a/executor/pkg/controller/garbage_collector.go
+++ b/executor/pkg/controller/garbage_collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -44,9 +45,7 @@ func (gc *GarbageCollector) Start(ctx context.Context) error {
 
 	// Sweep once immediately on startup. time.Ticker only fires its first tick
 	// after a full interval, so without this a restart defers the first
-	// collection by the whole interval -- and restarts that arrive faster than
-	// the interval keep resetting the ticker before it ever fires, so terminal
-	// TaskActions accumulate without bound.
+	// collection by the whole interval.
 	if err := gc.collect(ctx); err != nil {
 		logger.Error(err, "initial garbage collection cycle failed")
 	}
@@ -104,6 +103,13 @@ func (gc *GarbageCollector) collect(ctx context.Context) error {
 			// The minute-precision format is lexicographically ordered, so string comparison works.
 			if completedTime < cutoff {
 				if err := gc.client.Delete(ctx, ta); err != nil {
+					// Already gone is the desired state: a child TaskAction is
+					// often cascade-deleted (via OwnerReferences) when its parent
+					// is deleted earlier in this same pass, so the explicit delete
+					// races with the cascade and returns NotFound. Not an error.
+					if apierrors.IsNotFound(err) {
+						continue
+					}
 					logger.Error(err, "failed to delete expired TaskAction",
 						"name", ta.Name, "namespace", ta.Namespace, "completedTime", completedTime)
 					continue

--- a/executor/pkg/controller/garbage_collector.go
+++ b/executor/pkg/controller/garbage_collector.go
@@ -36,6 +36,15 @@ func (gc *GarbageCollector) Start(ctx context.Context) error {
 	ticker := time.NewTicker(gc.interval)
 	defer ticker.Stop()
 
+	// Sweep once immediately on startup. time.Ticker only fires its first tick
+	// after a full interval, so without this a restart defers the first
+	// collection by the whole interval -- and restarts that arrive faster than
+	// the interval keep resetting the ticker before it ever fires, so terminal
+	// TaskActions accumulate without bound.
+	if err := gc.collect(ctx); err != nil {
+		logger.Error(err, "initial garbage collection cycle failed")
+	}
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/executor/pkg/controller/garbage_collector.go
+++ b/executor/pkg/controller/garbage_collector.go
@@ -14,14 +14,20 @@ import (
 // It implements the controller-runtime manager.Runnable interface.
 type GarbageCollector struct {
 	client   client.Client
+	reader   client.Reader
 	interval time.Duration
 	maxTTL   time.Duration
 }
 
-// NewGarbageCollector creates a new GarbageCollector.
-func NewGarbageCollector(c client.Client, interval, maxTTL time.Duration) *GarbageCollector {
+// NewGarbageCollector creates a new GarbageCollector. reader must be an
+// uncached reader (e.g. mgr.GetAPIReader()): collect() lists with Continue
+// pagination, which the controller-runtime cache does not support
+// ("continue list option is not supported by the cache"). client is used for
+// the deletes.
+func NewGarbageCollector(c client.Client, reader client.Reader, interval, maxTTL time.Duration) *GarbageCollector {
 	return &GarbageCollector{
 		client:   c,
+		reader:   reader,
 		interval: interval,
 		maxTTL:   maxTTL,
 	}
@@ -58,7 +64,9 @@ func (gc *GarbageCollector) Start(ctx context.Context) error {
 	}
 }
 
-const gcPageSize = 500
+// gcPageSize bounds each List page. It's a var (not const) so tests can lower
+// it to exercise the Continue pagination path without creating 500 objects.
+var gcPageSize = 500
 
 // collect lists all terminated TaskActions (paginated) and deletes those whose completed-time has expired.
 func (gc *GarbageCollector) collect(ctx context.Context) error {
@@ -80,7 +88,7 @@ func (gc *GarbageCollector) collect(ctx context.Context) error {
 			listOpts = append(listOpts, client.Continue(continueToken))
 		}
 
-		if err := gc.client.List(ctx, &taskActions, listOpts...); err != nil {
+		if err := gc.reader.List(ctx, &taskActions, listOpts...); err != nil {
 			return err
 		}
 

--- a/executor/pkg/controller/garbage_collector_test.go
+++ b/executor/pkg/controller/garbage_collector_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -100,6 +101,28 @@ var _ = Describe("GarbageCollector", func() {
 	It("should handle empty list gracefully", func() {
 		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour)
 		Expect(gc.collect(ctx)).To(Succeed())
+	})
+
+	It("should sweep immediately on Start without waiting a full interval", func() {
+		expiredTime := time.Now().UTC().Add(-2 * time.Hour).Format(labelTimeFormat)
+		createTaskAction(ctx, "gc-startup", map[string]string{
+			LabelTerminationStatus: LabelValueTerminated,
+			LabelCompletedTime:     expiredTime,
+		})
+
+		// A long interval means the ticker will not fire during the test, so the
+		// expired TaskAction can only be deleted by the immediate startup sweep.
+		// Before the fix, Start waited a full interval before its first collect.
+		gc := NewGarbageCollector(k8sClient, 30*time.Minute, 1*time.Hour)
+		startCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		go func() { _ = gc.Start(startCtx) }()
+
+		Eventually(func() bool {
+			ta := &flyteorgv1.TaskAction{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: "gc-startup", Namespace: "default"}, ta)
+			return apierrors.IsNotFound(err)
+		}, 10*time.Second, 200*time.Millisecond).Should(BeTrue(), "Start should delete the expired TaskAction via its initial sweep")
 	})
 })
 

--- a/executor/pkg/controller/garbage_collector_test.go
+++ b/executor/pkg/controller/garbage_collector_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -63,7 +64,7 @@ var _ = Describe("GarbageCollector", func() {
 			LabelCompletedTime:     expiredTime,
 		})
 
-		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour)
 		Expect(gc.collect(ctx)).To(Succeed())
 
 		ta := &flyteorgv1.TaskAction{}
@@ -79,7 +80,7 @@ var _ = Describe("GarbageCollector", func() {
 			LabelCompletedTime:     recentTime,
 		})
 
-		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour)
 		Expect(gc.collect(ctx)).To(Succeed())
 
 		ta := &flyteorgv1.TaskAction{}
@@ -90,7 +91,7 @@ var _ = Describe("GarbageCollector", func() {
 	It("should retain non-terminated TaskActions", func() {
 		createTaskAction(ctx, "gc-active", nil)
 
-		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour)
 		Expect(gc.collect(ctx)).To(Succeed())
 
 		ta := &flyteorgv1.TaskAction{}
@@ -99,8 +100,33 @@ var _ = Describe("GarbageCollector", func() {
 	})
 
 	It("should handle empty list gracefully", func() {
-		gc := NewGarbageCollector(k8sClient, 1*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour)
 		Expect(gc.collect(ctx)).To(Succeed())
+	})
+
+	It("should paginate across multiple pages of expired TaskActions", func() {
+		// collect() lists with Continue pagination; this exercises that path
+		// (regression: it ran against the cache client, which rejects Continue
+		// with "continue list option is not supported by the cache" once a run
+		// has more than one page of terminal actions). Reader must be uncached.
+		orig := gcPageSize
+		gcPageSize = 2
+		defer func() { gcPageSize = orig }()
+
+		expiredTime := time.Now().UTC().Add(-2 * time.Hour).Format(labelTimeFormat)
+		for i := 0; i < 5; i++ {
+			createTaskAction(ctx, fmt.Sprintf("gc-page-%d", i), map[string]string{
+				LabelTerminationStatus: LabelValueTerminated,
+				LabelCompletedTime:     expiredTime,
+			})
+		}
+
+		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour)
+		Expect(gc.collect(ctx)).To(Succeed())
+
+		var list flyteorgv1.TaskActionList
+		Expect(k8sClient.List(ctx, &list, client.InNamespace("default"))).To(Succeed())
+		Expect(list.Items).To(BeEmpty(), "every expired TaskAction across all pages should be deleted")
 	})
 
 	It("should sweep immediately on Start without waiting a full interval", func() {
@@ -113,7 +139,7 @@ var _ = Describe("GarbageCollector", func() {
 		// A long interval means the ticker will not fire during the test, so the
 		// expired TaskAction can only be deleted by the immediate startup sweep.
 		// Before the fix, Start waited a full interval before its first collect.
-		gc := NewGarbageCollector(k8sClient, 30*time.Minute, 1*time.Hour)
+		gc := NewGarbageCollector(k8sClient, k8sClient, 30*time.Minute, 1*time.Hour)
 		startCtx, cancel := context.WithCancel(ctx)
 		doneCh := make(chan struct{})
 		go func() {

--- a/executor/pkg/controller/garbage_collector_test.go
+++ b/executor/pkg/controller/garbage_collector_test.go
@@ -115,9 +115,15 @@ var _ = Describe("GarbageCollector", func() {
 		// Before the fix, Start waited a full interval before its first collect.
 		gc := NewGarbageCollector(k8sClient, 30*time.Minute, 1*time.Hour)
 		startCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		go func() { _ = gc.Start(startCtx) }()
-
+		doneCh := make(chan struct{})
+		go func() {
+			defer close(doneCh)
+			_ = gc.Start(startCtx)
+		}()
+		defer func() {
+			cancel()
+			Eventually(doneCh, 2*time.Second, 50*time.Millisecond).Should(BeClosed())
+		}()
 		Eventually(func() bool {
 			ta := &flyteorgv1.TaskAction{}
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: "gc-startup", Namespace: "default"}, ta)

--- a/executor/pkg/controller/garbage_collector_test.go
+++ b/executor/pkg/controller/garbage_collector_test.go
@@ -124,9 +124,14 @@ var _ = Describe("GarbageCollector", func() {
 		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 1*time.Hour)
 		Expect(gc.collect(ctx)).To(Succeed())
 
-		var list flyteorgv1.TaskActionList
-		Expect(k8sClient.List(ctx, &list, client.InNamespace("default"))).To(Succeed())
-		Expect(list.Items).To(BeEmpty(), "every expired TaskAction across all pages should be deleted")
+		// Assert only the actions this spec created are gone -- checking the whole
+		// namespace is flaky because other specs can leave TaskActions lingering
+		// with a finalizer (DeletionTimestamp set but not yet removed).
+		for i := 0; i < 5; i++ {
+			ta := &flyteorgv1.TaskAction{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("gc-page-%d", i), Namespace: "default"}, ta)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "gc-page-%d should be deleted across pages", i)
+		}
 	})
 
 	It("should sweep immediately on Start without waiting a full interval", func() {

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -189,7 +189,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		if cfg.GC.MaxTTL.Duration <= 0 {
 			return fmt.Errorf("executor: gc.maxTTL must be positive when gc is enabled, got %v", cfg.GC.MaxTTL.Duration)
 		}
-		gc := controller.NewGarbageCollector(mgr.GetClient(), cfg.GC.Interval.Duration, cfg.GC.MaxTTL.Duration)
+		gc := controller.NewGarbageCollector(mgr.GetClient(), mgr.GetAPIReader(), cfg.GC.Interval.Duration, cfg.GC.MaxTTL.Duration)
 		if err := mgr.Add(gc); err != nil {
 			return fmt.Errorf("executor: failed to add garbage collector: %w", err)
 		}


### PR DESCRIPTION
## Why are the changes needed?

Terminal `TaskAction` CRDs were never garbage-collected on a busy dev cluster (~19k `Completed` piled up, oldest well past the 1h TTL). Two independent GC bugs:

1. **First sweep deferred a full interval.** `GarbageCollector.Start` used `time.NewTicker`, whose first tick fires only after a full interval (default 30m). So the first collection was always delayed by the whole interval, and any restart sooner than the interval reset the ticker before it fired — under active redeploys, GC never ran.

2. **GC list failed against the cache.** `collect()` lists with `Limit`/`Continue` pagination, but GC was given the manager's **cache-backed** client. The controller-runtime cache doesn't support the `Continue` list option, so once a run had more than one page (>500) of terminal actions, every cycle failed:
   ```
   garbage collection cycle failed: continue list option is not supported by the cache
   ```
   (This surfaced as soon as fix #1 let GC actually run.)

Together these meant GC effectively never collected on any cluster with sustained churn.

## What changes were proposed in this pull request?

- **Initial sweep:** run `gc.collect(ctx)` once immediately on `Start`, before entering the ticker loop.
- **Paginated list via APIReader:** add an uncached `client.Reader` (`mgr.GetAPIReader()`) and list through it (the API server supports `Continue`); deletes stay on the cached client.

## How was this patch tested?

`garbage_collector_test.go` (envtest):
- *sweep immediately on Start* — with a long interval (ticker won't fire), `Start` must still delete an expired TaskAction via the initial sweep. Fails without fix #1 (10s timeout), passes with it.
- *paginate across multiple pages* — lowers `gcPageSize` and creates several pages of expired actions to exercise the `Continue` loop end-to-end.
- Existing delete/retain/empty cases still pass.

Full `GarbageCollector` suite green.

### Labels
- **fixed**

## Check all the applicable boxes
- [x] All new and existing tests passed.
- [x] All commits are signed-off.