### PR TITLE
fix(devbox): trust ALB X-Forwarded-Proto in bundled Traefik

### DIFF
--- a/charts/flyte-devbox/templates/proxy/traefik-config.yaml
+++ b/charts/flyte-devbox/templates/proxy/traefik-config.yaml
@@ -11,6 +11,10 @@ spec:
     ports:
       web:
         nodePort: 30080
+        # ALB terminates TLS and forwards plaintext to this entrypoint. Trust its
+        # X-Forwarded-Proto: https instead of letting Traefik rewrite it to http.
+        forwardedHeaders:
+          insecure: true
         transport:
           respondingTimeouts:
             readTimeout: 0


### PR DESCRIPTION
## Why are the changes needed?

In devbox the request chain is **ALB (terminates TLS, https) → bundled k3s Traefik `web` entrypoint (plaintext)**. The ALB sets `X-Forwarded-Proto: https`, but Traefik does not trust upstream `X-Forwarded-*` headers by default, so it rewrites `X-Forwarded-Proto` to `http` (the scheme of the plaintext entrypoint it actually received the request on).

Combined with flyteorg/flyte#7583 (dataproxy `SelectCluster` now returns a scheme-qualified `ClusterEndpoint` derived from `X-Forwarded-Proto`), this makes dataproxy return an `http://...` endpoint. The console, served over https, then breaks (mixed-content / wrong scheme).

## What changes were proposed in this pull request?

Set `forwardedHeaders.insecure` on Traefik's `web` entrypoint so it preserves the ALB's `X-Forwarded-Proto: https` instead of overwriting it.

The ALB is the only ingress to the devbox NodePort, so trusting forwarded headers there is acceptable. A tighter alternative is `trustedIPs: [<ALB CIDR>]`, but that requires plumbing the ALB subnet CIDR through chart values; `insecure` keeps the devbox chart self-contained.

## How was this patch tested?

Rendered the chart and confirmed the `forwardedHeaders.insecure: true` block lands on the `web` entrypoint of the Traefik `HelmChartConfig`.

### Labels

- **fixed**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

- Related to #7583
