### PR TITLE
ci(flyte-binary-v2): tag :latest on workflow_dispatch

### DIFF
--- a/.github/workflows/flyte-binary-v2.yml
+++ b/.github/workflows/flyte-binary-v2.yml
@@ -88,6 +88,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/flyte-binary-v2
           tags: |
             type=raw,value=nightly,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=sha,format=long
       - name: Set up Depot
         uses: depot/setup-action@v1


### PR DESCRIPTION
## Why are the changes needed?

A manual `workflow_dispatch` run of the flyte-binary-v2 workflow already pushes the `flyte-binary-v2` image, but only tags it with `sha-<long-sha>`. There was no convenient floating `:latest` tag to pull the manually-built image — unlike the devbox-bundled images, which already tag `:latest` on `workflow_dispatch`.

## What changes were proposed in this pull request?

Add a `latest` tag to the `flyte-binary-v2` image when the workflow is triggered via `workflow_dispatch`, mirroring the existing behavior for the devbox-bundled images:

```yaml
type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
```

Push behavior is unchanged (`PUSH_IMAGES` is already true for `workflow_dispatch`); only an extra tag is added.

## How was this patch tested?

CI-config change only — verified the `enable` gating matches the existing devbox-bundled `:latest` tag pattern in the same workflow. No unit tests applicable.

### Labels
- **added**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
