### PR TITLE
Instrument runs service DB repository layer with Prometheus metrics

### DIFF
--- a/runs/repository/impl/action.go
+++ b/runs/repository/impl/action.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/database"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
@@ -30,6 +31,7 @@ type actionRepo struct {
 	db       *sqlx.DB
 	dsn      string // stored for pq.Listener
 	listener *pq.Listener
+	metrics  dbMetrics
 
 	// Subscriber management for LISTEN/NOTIFY
 	runSubscribers    map[chan string]bool
@@ -41,12 +43,15 @@ type actionRepo struct {
 	runNotifyCh    chan string
 }
 
-// NewActionRepo creates a new PostgreSQL repository
-func NewActionRepo(db *sqlx.DB, dbConfig database.DbConfig) (interfaces.ActionRepo, error) {
+// NewActionRepo creates a new PostgreSQL repository. The provided scope is used
+// to register per-operation DB metrics under a "db" sub-scope; pass nil to
+// disable metrics (e.g. in unit tests).
+func NewActionRepo(db *sqlx.DB, dbConfig database.DbConfig, scope promutils.Scope) (interfaces.ActionRepo, error) {
 	dsn := database.GetPostgresDsn(context.Background(), dbConfig.Postgres)
 	repo := &actionRepo{
 		db:                db,
 		dsn:               dsn,
+		metrics:           newDBMetrics(scope),
 		runSubscribers:    make(map[chan string]bool),
 		actionSubscribers: make(map[chan string]bool),
 	}
@@ -66,6 +71,17 @@ func NewActionRepo(db *sqlx.DB, dbConfig database.DbConfig) (interfaces.ActionRe
 
 // GetRun retrieves a run by identifier
 func (r *actionRepo) GetRun(ctx context.Context, runID *common.RunIdentifier) (*models.Run, error) {
+	var run *models.Run
+	if err := r.metrics.observe(ctx, "get_run", func() (err error) {
+		run, err = r.getRun(ctx, runID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return run, nil
+}
+
+func (r *actionRepo) getRun(ctx context.Context, runID *common.RunIdentifier) (*models.Run, error) {
 	var run models.Run
 	err := sqlx.GetContext(ctx, r.db, &run,
 		"SELECT * FROM actions WHERE project = $1 AND domain = $2 AND run_name = $3 AND parent_action_name IS NULL",
@@ -86,6 +102,12 @@ func (r *actionRepo) GetRun(ctx context.Context, runID *common.RunIdentifier) (*
 // K8s cascades CRD deletion to child actions via OwnerReferences; the action service
 // informer handles marking them ABORTED in DB when their CRDs are deleted.
 func (r *actionRepo) AbortRun(ctx context.Context, runID *common.RunIdentifier, reason string, abortedBy *common.EnrichedIdentity) error {
+	return r.metrics.observe(ctx, "abort_run", func() error {
+		return r.abortRun(ctx, runID, reason, abortedBy)
+	})
+}
+
+func (r *actionRepo) abortRun(ctx context.Context, runID *common.RunIdentifier, reason string, abortedBy *common.EnrichedIdentity) error {
 	now := time.Now()
 
 	var rootName string
@@ -115,6 +137,12 @@ func (r *actionRepo) AbortRun(ctx context.Context, runID *common.RunIdentifier, 
 
 // InsertEvents inserts a batch of action events, ignoring duplicates (same PK = idempotent).
 func (r *actionRepo) InsertEvents(ctx context.Context, events []*models.ActionEvent) error {
+	return r.metrics.observe(ctx, "insert_events", func() error {
+		return r.insertEvents(ctx, events)
+	})
+}
+
+func (r *actionRepo) insertEvents(ctx context.Context, events []*models.ActionEvent) error {
 	if len(events) == 0 {
 		return nil
 	}
@@ -153,6 +181,17 @@ func (r *actionRepo) InsertEvents(ctx context.Context, events []*models.ActionEv
 // ListEvents lists action events for a given action identifier.
 func (r *actionRepo) ListEvents(ctx context.Context, actionID *common.ActionIdentifier, limit int) ([]*models.ActionEvent, error) {
 	var events []*models.ActionEvent
+	if err := r.metrics.observe(ctx, "list_events", func() (err error) {
+		events, err = r.listEvents(ctx, actionID, limit)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+func (r *actionRepo) listEvents(ctx context.Context, actionID *common.ActionIdentifier, limit int) ([]*models.ActionEvent, error) {
+	var events []*models.ActionEvent
 	err := sqlx.SelectContext(ctx, r.db, &events,
 		`SELECT * FROM action_events
 		 WHERE project = $1 AND domain = $2 AND run_name = $3 AND name = $4
@@ -167,6 +206,23 @@ func (r *actionRepo) ListEvents(ctx context.Context, actionID *common.ActionIden
 
 // ListEventsSince lists action events for a given action identifier updated at or after the provided checkpoint.
 func (r *actionRepo) ListEventsSince(
+	ctx context.Context,
+	actionID *common.ActionIdentifier,
+	attempt uint32,
+	since time.Time,
+	offset, limit int,
+) ([]*models.ActionEvent, error) {
+	var events []*models.ActionEvent
+	if err := r.metrics.observe(ctx, "list_events_since", func() (err error) {
+		events, err = r.listEventsSince(ctx, actionID, attempt, since, offset, limit)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+func (r *actionRepo) listEventsSince(
 	ctx context.Context,
 	actionID *common.ActionIdentifier,
 	attempt uint32,
@@ -190,6 +246,17 @@ func (r *actionRepo) ListEventsSince(
 // GetLatestEventByAttempt returns the most recent event for a given attempt,
 // ordered by version descending, without deserializing all events.
 func (r *actionRepo) GetLatestEventByAttempt(ctx context.Context, actionID *common.ActionIdentifier, attempt uint32) (*models.ActionEvent, error) {
+	var event *models.ActionEvent
+	if err := r.metrics.observe(ctx, "get_latest_event_by_attempt", func() (err error) {
+		event, err = r.getLatestEventByAttempt(ctx, actionID, attempt)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+func (r *actionRepo) getLatestEventByAttempt(ctx context.Context, actionID *common.ActionIdentifier, attempt uint32) (*models.ActionEvent, error) {
 	var event models.ActionEvent
 	err := sqlx.GetContext(ctx, r.db, &event,
 		`SELECT * FROM action_events
@@ -210,6 +277,17 @@ func (r *actionRepo) GetLatestEventByAttempt(ctx context.Context, actionID *comm
 // When updateTriggeredAt is true and the action has a TriggerName set, triggered_at on the
 // corresponding trigger row is updated to now() in the same transaction.
 func (r *actionRepo) CreateAction(ctx context.Context, action *models.Action, updateTriggeredAt bool) (*models.Action, error) {
+	var created *models.Action
+	if err := r.metrics.observe(ctx, "create_action", func() (err error) {
+		created, err = r.createAction(ctx, action, updateTriggeredAt)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+func (r *actionRepo) createAction(ctx context.Context, action *models.Action, updateTriggeredAt bool) (*models.Action, error) {
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to begin tx: %w", err)
@@ -283,6 +361,17 @@ func (r *actionRepo) CreateAction(ctx context.Context, action *models.Action, up
 
 // GetAction retrieves an action by identifier
 func (r *actionRepo) GetAction(ctx context.Context, actionID *common.ActionIdentifier) (*models.Action, error) {
+	var action *models.Action
+	if err := r.metrics.observe(ctx, "get_action", func() (err error) {
+		action, err = r.getAction(ctx, actionID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return action, nil
+}
+
+func (r *actionRepo) getAction(ctx context.Context, actionID *common.ActionIdentifier) (*models.Action, error) {
 	var action models.Action
 	err := sqlx.GetContext(ctx, r.db, &action,
 		"SELECT * FROM actions WHERE project = $1 AND domain = $2 AND run_name = $3 AND name = $4",
@@ -300,6 +389,17 @@ func (r *actionRepo) GetAction(ctx context.Context, actionID *common.ActionIdent
 
 // ListActions lists actions matching the given input filter, sort, and pagination.
 func (r *actionRepo) ListActions(ctx context.Context, input interfaces.ListResourceInput) ([]*models.Action, error) {
+	var actions []*models.Action
+	if err := r.metrics.observe(ctx, "list_actions", func() (err error) {
+		actions, err = r.listActions(ctx, input)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return actions, nil
+}
+
+func (r *actionRepo) listActions(ctx context.Context, input interfaces.ListResourceInput) ([]*models.Action, error) {
 	var queryBuilder strings.Builder
 	var args []interface{}
 
@@ -366,6 +466,19 @@ func (r *actionRepo) UpdateActionPhase(
 	cacheStatus core.CatalogCacheStatus,
 	endTime *time.Time,
 ) error {
+	return r.metrics.observe(ctx, "update_action_phase", func() error {
+		return r.updateActionPhase(ctx, actionID, phase, attempts, cacheStatus, endTime)
+	})
+}
+
+func (r *actionRepo) updateActionPhase(
+	ctx context.Context,
+	actionID *common.ActionIdentifier,
+	phase common.ActionPhase,
+	attempts uint32,
+	cacheStatus core.CatalogCacheStatus,
+	endTime *time.Time,
+) error {
 	now := time.Now()
 	retryablePhases := []int32{
 		int32(common.ActionPhase_ACTION_PHASE_FAILED),
@@ -420,6 +533,12 @@ func (r *actionRepo) UpdateActionPhase(
 // K8s cascades CRD deletion to descendants via OwnerReferences; the action service
 // informer handles marking them ABORTED in DB when their CRDs are deleted.
 func (r *actionRepo) AbortAction(ctx context.Context, actionID *common.ActionIdentifier, reason string, abortedBy *common.EnrichedIdentity) error {
+	return r.metrics.observe(ctx, "abort_action", func() error {
+		return r.abortAction(ctx, actionID, reason, abortedBy)
+	})
+}
+
+func (r *actionRepo) abortAction(ctx context.Context, actionID *common.ActionIdentifier, reason string, abortedBy *common.EnrichedIdentity) error {
 	now := time.Now()
 
 	result, err := r.db.ExecContext(ctx,
@@ -445,6 +564,17 @@ func (r *actionRepo) AbortAction(ctx context.Context, actionID *common.ActionIde
 // ListPendingAborts returns all actions that have abort_requested_at set (i.e. awaiting pod termination).
 func (r *actionRepo) ListPendingAborts(ctx context.Context) ([]*models.Action, error) {
 	var actions []*models.Action
+	if err := r.metrics.observe(ctx, "list_pending_aborts", func() (err error) {
+		actions, err = r.listPendingAborts(ctx)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return actions, nil
+}
+
+func (r *actionRepo) listPendingAborts(ctx context.Context) ([]*models.Action, error) {
+	var actions []*models.Action
 	err := sqlx.SelectContext(ctx, r.db, &actions,
 		"SELECT * FROM actions WHERE abort_requested_at IS NOT NULL")
 	if err != nil {
@@ -456,6 +586,15 @@ func (r *actionRepo) ListPendingAborts(ctx context.Context) ([]*models.Action, e
 // MarkAbortAttempt increments abort_attempt_count and returns the new value.
 // Called by the reconciler before each actionsClient.Abort call.
 func (r *actionRepo) MarkAbortAttempt(ctx context.Context, actionID *common.ActionIdentifier) (int, error) {
+	var attemptCount int
+	err := r.metrics.observe(ctx, "mark_abort_attempt", func() (e error) {
+		attemptCount, e = r.markAbortAttempt(ctx, actionID)
+		return e
+	})
+	return attemptCount, err
+}
+
+func (r *actionRepo) markAbortAttempt(ctx context.Context, actionID *common.ActionIdentifier) (int, error) {
 	var abortAttemptCount int
 	err := r.db.QueryRowxContext(ctx,
 		`UPDATE actions SET abort_attempt_count = abort_attempt_count + 1, updated_at = $1
@@ -471,6 +610,12 @@ func (r *actionRepo) MarkAbortAttempt(ctx context.Context, actionID *common.Acti
 
 // ClearAbortRequest clears abort_requested_at (and resets counters) once the pod is confirmed terminated.
 func (r *actionRepo) ClearAbortRequest(ctx context.Context, actionID *common.ActionIdentifier) error {
+	return r.metrics.observe(ctx, "clear_abort_request", func() error {
+		return r.clearAbortRequest(ctx, actionID)
+	})
+}
+
+func (r *actionRepo) clearAbortRequest(ctx context.Context, actionID *common.ActionIdentifier) error {
 	_, err := r.db.ExecContext(ctx,
 		`UPDATE actions SET abort_requested_at = NULL, abort_attempt_count = 0, updated_at = $1
 		 WHERE project = $2 AND domain = $3 AND run_name = $4 AND name = $5`,
@@ -483,6 +628,12 @@ func (r *actionRepo) ClearAbortRequest(ctx context.Context, actionID *common.Act
 
 // UpdateActionState updates the state of an action
 func (r *actionRepo) UpdateActionState(ctx context.Context, actionID *common.ActionIdentifier, state string) error {
+	return r.metrics.observe(ctx, "update_action_state", func() error {
+		return r.updateActionState(ctx, actionID, state)
+	})
+}
+
+func (r *actionRepo) updateActionState(ctx context.Context, actionID *common.ActionIdentifier, state string) error {
 	// Parse the state JSON to extract the phase
 	var stateObj map[string]interface{}
 	if err := json.Unmarshal([]byte(state), &stateObj); err != nil {
@@ -532,6 +683,15 @@ func (r *actionRepo) UpdateActionState(ctx context.Context, actionID *common.Act
 
 // GetActionState retrieves the state of an action
 func (r *actionRepo) GetActionState(ctx context.Context, actionID *common.ActionIdentifier) (string, error) {
+	var state string
+	err := r.metrics.observe(ctx, "get_action_state", func() (e error) {
+		state, e = r.getActionState(ctx, actionID)
+		return e
+	})
+	return state, err
+}
+
+func (r *actionRepo) getActionState(ctx context.Context, actionID *common.ActionIdentifier) (string, error) {
 	var actionDetails []byte
 	err := r.db.QueryRowContext(ctx,
 		"SELECT action_details FROM actions WHERE project = $1 AND domain = $2 AND run_name = $3 AND name = $4",
@@ -546,6 +706,12 @@ func (r *actionRepo) GetActionState(ctx context.Context, actionID *common.Action
 
 // NotifyStateUpdate sends a notification about a state update
 func (r *actionRepo) NotifyStateUpdate(ctx context.Context, actionID *common.ActionIdentifier) error {
+	return r.metrics.observe(ctx, "notify_state_update", func() error {
+		return r.notifyStateUpdate(ctx, actionID)
+	})
+}
+
+func (r *actionRepo) notifyStateUpdate(ctx context.Context, actionID *common.ActionIdentifier) error {
 	// This is already handled by notifyActionUpdate
 	r.notifyActionUpdate(ctx, actionID)
 	return nil
@@ -864,6 +1030,17 @@ func (r *actionRepo) notifyRunUpdate(ctx context.Context, runID *common.RunIdent
 
 // ListRootActions lists root actions (runs) matching scope and date filters.
 func (r *actionRepo) ListRootActions(ctx context.Context, project, domain string, startDate, endDate *time.Time, limit int) ([]*models.Action, error) {
+	var actions []*models.Action
+	if err := r.metrics.observe(ctx, "list_root_actions", func() (err error) {
+		actions, err = r.listRootActions(ctx, project, domain, startDate, endDate, limit)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return actions, nil
+}
+
+func (r *actionRepo) listRootActions(ctx context.Context, project, domain string, startDate, endDate *time.Time, limit int) ([]*models.Action, error) {
 	var queryBuilder strings.Builder
 	var args []interface{}
 	argIdx := 1

--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -46,7 +46,7 @@ func setupActionDB(t *testing.T) *sqlx.DB {
 func TestCreateRun(t *testing.T) {
 	db := setupActionDB(t)
 	defer func() { db.Exec("DELETE FROM actions") }()
-	actionRepo, err := NewActionRepo(db, testDbConfig)
+	actionRepo, err := NewActionRepo(db, testDbConfig, nil)
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -85,7 +85,7 @@ func TestCreateRun(t *testing.T) {
 func TestUpdateActionPhasePersistsAttemptsAndCacheStatus(t *testing.T) {
 	db := setupActionDB(t)
 	defer func() { db.Exec("DELETE FROM actions") }()
-	actionRepo, err := NewActionRepo(db, testDbConfig)
+	actionRepo, err := NewActionRepo(db, testDbConfig, nil)
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -124,7 +124,7 @@ func TestUpdateActionPhasePersistsAttemptsAndCacheStatus(t *testing.T) {
 func TestWatchActionUpdates_OnlyStreamsTargetAction(t *testing.T) {
 	db := setupActionDB(t)
 	defer func() { db.Exec("DELETE FROM actions") }()
-	repo, err := NewActionRepo(db, testDbConfig)
+	repo, err := NewActionRepo(db, testDbConfig, nil)
 	require.NoError(t, err)
 	repoImpl := repo.(*actionRepo)
 
@@ -196,7 +196,7 @@ func TestWatchActionUpdates_OnlyStreamsTargetAction(t *testing.T) {
 func TestUpdateActionPhase_AllowsRetryTransition(t *testing.T) {
 	db := setupActionDB(t)
 	defer func() { db.Exec("DELETE FROM actions") }()
-	actionRepo, err := NewActionRepo(db, testDbConfig)
+	actionRepo, err := NewActionRepo(db, testDbConfig, nil)
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -240,7 +240,7 @@ func TestUpdateActionPhase_AllowsRetryTransition(t *testing.T) {
 func TestUpdateActionPhase_BlocksBackwardFromNonRetryable(t *testing.T) {
 	db := setupActionDB(t)
 	defer func() { db.Exec("DELETE FROM actions") }()
-	actionRepo, err := NewActionRepo(db, testDbConfig)
+	actionRepo, err := NewActionRepo(db, testDbConfig, nil)
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -278,7 +278,7 @@ func TestUpdateActionPhase_BlocksBackwardFromNonRetryable(t *testing.T) {
 func TestUpdateActionPhase_BlocksBackwardFromSucceeded(t *testing.T) {
 	db := setupActionDB(t)
 	defer func() { db.Exec("DELETE FROM actions") }()
-	actionRepo, err := NewActionRepo(db, testDbConfig)
+	actionRepo, err := NewActionRepo(db, testDbConfig, nil)
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -317,7 +317,7 @@ func TestUpdateActionPhase_BlocksBackwardFromSucceeded(t *testing.T) {
 func TestListRuns(t *testing.T) {
 	db := setupActionDB(t)
 	defer func() { db.Exec("DELETE FROM actions") }()
-	actionRepo, err := NewActionRepo(db, testDbConfig)
+	actionRepo, err := NewActionRepo(db, testDbConfig, nil)
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -394,7 +394,7 @@ func TestListRuns(t *testing.T) {
 
 func setupActionEventDB(t *testing.T) (*sqlx.DB, *actionRepo) {
 	db := setupActionDB(t)
-	r, err := NewActionRepo(db, testDbConfig)
+	r, err := NewActionRepo(db, testDbConfig, nil)
 	require.NoError(t, err)
 	repo := r.(*actionRepo)
 	return db, repo
@@ -666,7 +666,7 @@ func TestInsertEvents_WithLogContext(t *testing.T) {
 // RecordActionEvents before the TaskAction finalizer is removed.
 func TestUpdateActionPhase_AbortedDoesNotInsertEvent(t *testing.T) {
 	db := setupActionDB(t)
-	actionRepo, err := NewActionRepo(db, testDbConfig)
+	actionRepo, err := NewActionRepo(db, testDbConfig, nil)
 	require.NoError(t, err)
 	ctx := context.Background()
 

--- a/runs/repository/impl/metrics.go
+++ b/runs/repository/impl/metrics.go
@@ -1,0 +1,79 @@
+package impl
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
+)
+
+// operationLabel is the single, low-cardinality label applied to every repository
+// DB metric. It carries the logical operation name (e.g. "get_task"), never row
+// IDs, project, domain, or user values.
+const operationLabel = "operation"
+
+// dbMetrics holds the Prometheus instruments shared by the runs repository
+// implementations. All metrics are vectors labeled by operation name so that a
+// single registration serves every DB operation without high label cardinality.
+//
+// A zero-value dbMetrics (returned when no Scope is provided) is a safe no-op:
+// observe still runs the wrapped function and propagates its error, it simply
+// records nothing.
+type dbMetrics struct {
+	calls   *prometheus.CounterVec
+	errors  *prometheus.CounterVec
+	latency *promutils.StopWatchVec
+}
+
+// newDBMetrics builds a dbMetrics under the "db" sub-scope of the provided scope.
+// Metrics are registered once here, so each repository should construct its
+// metrics exactly once (in its constructor) to avoid duplicate-registration
+// panics. A nil scope yields a no-op dbMetrics, keeping constructors usable in
+// contexts (e.g. unit tests) that do not wire metrics.
+func newDBMetrics(scope promutils.Scope) dbMetrics {
+	if scope == nil {
+		return dbMetrics{}
+	}
+	dbScope := scope.NewSubScope("db")
+	return dbMetrics{
+		calls: dbScope.MustNewCounterVec(
+			"calls_total",
+			"Total number of DB calls made by the runs repository, by operation.",
+			operationLabel,
+		),
+		errors: dbScope.MustNewCounterVec(
+			"errors_total",
+			"Total number of failed DB calls made by the runs repository, by operation.",
+			operationLabel,
+		),
+		latency: dbScope.MustNewStopWatchVec(
+			"latency",
+			"Latency of DB calls made by the runs repository, by operation.",
+			time.Millisecond,
+			operationLabel,
+		),
+	}
+}
+
+// observe wraps a single DB operation with metrics: it increments the call
+// counter, times the call, and increments the error counter when the operation
+// returns a non-nil error. The wrapped error is returned unchanged so callers
+// keep their existing error handling. It is a no-op recorder when dbMetrics is
+// the zero value.
+func (m dbMetrics) observe(_ context.Context, operation string, fn func() error) error {
+	if m.calls == nil {
+		// No-op metrics (nil scope): still execute the operation.
+		return fn()
+	}
+	m.calls.WithLabelValues(operation).Inc()
+	timer := m.latency.WithLabelValues(operation).Start()
+	defer timer.Stop()
+
+	if err := fn(); err != nil {
+		m.errors.WithLabelValues(operation).Inc()
+		return err
+	}
+	return nil
+}

--- a/runs/repository/impl/metrics_test.go
+++ b/runs/repository/impl/metrics_test.go
@@ -1,0 +1,102 @@
+package impl
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/v2/runs/repository/models"
+)
+
+func TestNewDBMetrics_NilScopeIsNoOp(t *testing.T) {
+	// A nil scope must not panic and must produce a usable (no-op) metrics value
+	// so existing callers/tests that don't wire a scope keep working.
+	m := newDBMetrics(nil)
+	assert.NotPanics(t, func() {
+		err := m.observe(context.Background(), "get_task", func() error { return nil })
+		assert.NoError(t, err)
+	})
+}
+
+func TestDBMetrics_ObserveRecordsSuccess(t *testing.T) {
+	scope := promutils.NewTestScope()
+	m := newDBMetrics(scope)
+
+	err := m.observe(context.Background(), "get_task", func() error { return nil })
+	assert.NoError(t, err)
+
+	// One successful call: call counter incremented, error counter untouched, latency observed.
+	assert.Equal(t, float64(1), testutil.ToFloat64(m.calls.WithLabelValues("get_task")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(m.errors.WithLabelValues("get_task")))
+	assert.Equal(t, 1, testutil.CollectAndCount(m.latency.SummaryVec))
+}
+
+func TestDBMetrics_ObserveRecordsError(t *testing.T) {
+	scope := promutils.NewTestScope()
+	m := newDBMetrics(scope)
+
+	sentinel := errors.New("boom")
+	err := m.observe(context.Background(), "create_task", func() error { return sentinel })
+	assert.ErrorIs(t, err, sentinel)
+
+	// One failed call: both call and error counters incremented.
+	assert.Equal(t, float64(1), testutil.ToFloat64(m.calls.WithLabelValues("create_task")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(m.errors.WithLabelValues("create_task")))
+}
+
+func TestDBMetrics_LabeledByOperationOnly(t *testing.T) {
+	scope := promutils.NewTestScope()
+	m := newDBMetrics(scope)
+
+	for i := 0; i < 3; i++ {
+		assert.NoError(t, m.observe(context.Background(), "list_tasks", func() error { return nil }))
+	}
+	assert.NoError(t, m.observe(context.Background(), "get_task", func() error { return nil }))
+
+	assert.Equal(t, float64(3), testutil.ToFloat64(m.calls.WithLabelValues("list_tasks")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(m.calls.WithLabelValues("get_task")))
+}
+
+// TestProjectRepo_InstrumentsCreateProject is an end-to-end check that a real
+// repository operation increments its call counter and records latency through
+// the wired-in metrics, against the embedded test database.
+func TestProjectRepo_InstrumentsCreateProject(t *testing.T) {
+	db := setupDB(t)
+	t.Cleanup(func() { db.Exec("DELETE FROM projects") })
+
+	scope := promutils.NewTestScope()
+	repo := NewProjectRepo(db, scope)
+	ctx := context.Background()
+	state := int32(0)
+
+	require.NoError(t, repo.CreateProject(ctx, &models.Project{
+		Identifier: "metrics-proj",
+		Name:       "metrics-proj",
+		State:      &state,
+	}))
+
+	// Reach into the concrete type to read the instruments registered by the
+	// constructor from the same scope.
+	m := repo.(*projectRepo).metrics
+	assert.Equal(t, float64(1), testutil.ToFloat64(m.calls.WithLabelValues("create_project")),
+		"create_project call counter should be incremented")
+	assert.Equal(t, float64(0), testutil.ToFloat64(m.errors.WithLabelValues("create_project")),
+		"create_project error counter should be zero on success")
+	assert.Equal(t, 1, testutil.CollectAndCount(m.latency.SummaryVec),
+		"create_project latency should be recorded")
+
+	// A duplicate create returns ErrProjectAlreadyExists and must bump the error counter.
+	err := repo.CreateProject(ctx, &models.Project{
+		Identifier: "metrics-proj",
+		Name:       "metrics-proj",
+		State:      &state,
+	})
+	require.Error(t, err)
+	assert.Equal(t, float64(2), testutil.ToFloat64(m.calls.WithLabelValues("create_project")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(m.errors.WithLabelValues("create_project")))
+}

--- a/runs/repository/impl/project.go
+++ b/runs/repository/impl/project.go
@@ -12,80 +12,96 @@ import (
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/database"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
 	"github.com/flyteorg/flyte/v2/runs/repository/models"
 )
 
 type projectRepo struct {
-	db *sqlx.DB
+	db      *sqlx.DB
+	metrics dbMetrics
 }
 
-func NewProjectRepo(db *sqlx.DB) interfaces.ProjectRepo {
+// NewProjectRepo creates a project repository. The provided scope is used to
+// register per-operation DB metrics under a "db" sub-scope; pass nil to disable
+// metrics (e.g. in unit tests).
+func NewProjectRepo(db *sqlx.DB, scope promutils.Scope) interfaces.ProjectRepo {
 	return &projectRepo{
-		db: db,
+		db:      db,
+		metrics: newDBMetrics(scope),
 	}
 }
 
 func (r *projectRepo) CreateProject(ctx context.Context, project *models.Project) error {
-	now := time.Now().UTC()
-	project.CreatedAt = now
-	project.UpdatedAt = now
+	return r.metrics.observe(ctx, "create_project", func() error {
+		now := time.Now().UTC()
+		project.CreatedAt = now
+		project.UpdatedAt = now
 
-	result, err := r.db.ExecContext(ctx,
-		`INSERT INTO projects (identifier, name, description, labels, state, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7)
-		 ON CONFLICT (identifier) DO NOTHING`,
-		project.Identifier, project.Name, project.Description, project.Labels, project.State, project.CreatedAt, project.UpdatedAt)
-	if err != nil {
-		if database.IsPgErrorWithCode(err, database.PgDuplicatedKey) {
+		result, err := r.db.ExecContext(ctx,
+			`INSERT INTO projects (identifier, name, description, labels, state, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7)
+			 ON CONFLICT (identifier) DO NOTHING`,
+			project.Identifier, project.Name, project.Description, project.Labels, project.State, project.CreatedAt, project.UpdatedAt)
+		if err != nil {
+			if database.IsPgErrorWithCode(err, database.PgDuplicatedKey) {
+				return fmt.Errorf("%w: %s", interfaces.ErrProjectAlreadyExists, project.Identifier)
+			}
+			return fmt.Errorf("failed to create project %s: %w", project.Identifier, err)
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
+		if rowsAffected == 0 {
 			return fmt.Errorf("%w: %s", interfaces.ErrProjectAlreadyExists, project.Identifier)
 		}
-		return fmt.Errorf("failed to create project %s: %w", project.Identifier, err)
-	}
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	}
-	if rowsAffected == 0 {
-		return fmt.Errorf("%w: %s", interfaces.ErrProjectAlreadyExists, project.Identifier)
-	}
-	return nil
+		return nil
+	})
 }
 
 func (r *projectRepo) GetProject(ctx context.Context, identifier string) (*models.Project, error) {
 	var project models.Project
-	err := sqlx.GetContext(ctx, r.db, &project, "SELECT * FROM projects WHERE identifier = $1", identifier)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("%w: %s", interfaces.ErrProjectNotFound, identifier)
+	err := r.metrics.observe(ctx, "get_project", func() error {
+		err := sqlx.GetContext(ctx, r.db, &project, "SELECT * FROM projects WHERE identifier = $1", identifier)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("%w: %s", interfaces.ErrProjectNotFound, identifier)
+			}
+			logger.Errorf(ctx, "failed to get project %s: %v", identifier, err)
+			return fmt.Errorf("failed to get project %s: %w", identifier, err)
 		}
-		logger.Errorf(ctx, "failed to get project %s: %v", identifier, err)
-		return nil, fmt.Errorf("failed to get project %s: %w", identifier, err)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &project, nil
 }
 
 func (r *projectRepo) UpdateProject(ctx context.Context, project *models.Project) error {
-	now := time.Now().UTC()
+	return r.metrics.observe(ctx, "update_project", func() error {
+		now := time.Now().UTC()
 
-	result, err := r.db.ExecContext(ctx,
-		`UPDATE projects SET name = $1, description = $2, labels = $3, state = $4, updated_at = $5
-		 WHERE identifier = $6`,
-		project.Name, project.Description, project.Labels, project.State, now, project.Identifier)
-	if err != nil {
-		logger.Errorf(ctx, "failed to update project %s: %v", project.Identifier, err)
-		return fmt.Errorf("failed to update project %s: %w", project.Identifier, err)
-	}
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	}
-	if rowsAffected == 0 {
-		return fmt.Errorf("%w: %s", interfaces.ErrProjectNotFound, project.Identifier)
-	}
+		result, err := r.db.ExecContext(ctx,
+			`UPDATE projects SET name = $1, description = $2, labels = $3, state = $4, updated_at = $5
+			 WHERE identifier = $6`,
+			project.Name, project.Description, project.Labels, project.State, now, project.Identifier)
+		if err != nil {
+			logger.Errorf(ctx, "failed to update project %s: %v", project.Identifier, err)
+			return fmt.Errorf("failed to update project %s: %w", project.Identifier, err)
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
+		if rowsAffected == 0 {
+			return fmt.Errorf("%w: %s", interfaces.ErrProjectNotFound, project.Identifier)
+		}
 
-	return nil
+		return nil
+	})
 }
 
 func (r *projectRepo) ListProjects(ctx context.Context, input interfaces.ListResourceInput) ([]*models.Project, error) {
@@ -130,9 +146,15 @@ func (r *projectRepo) ListProjects(ctx context.Context, input interfaces.ListRes
 	}
 
 	var projects []*models.Project
-	if err := sqlx.SelectContext(ctx, r.db, &projects, queryBuilder.String(), args...); err != nil {
-		logger.Errorf(ctx, "failed to list projects: %v", err)
-		return nil, fmt.Errorf("failed to list projects: %w", err)
+	err := r.metrics.observe(ctx, "list_projects", func() error {
+		if err := sqlx.SelectContext(ctx, r.db, &projects, queryBuilder.String(), args...); err != nil {
+			logger.Errorf(ctx, "failed to list projects: %v", err)
+			return fmt.Errorf("failed to list projects: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return projects, nil

--- a/runs/repository/impl/project_test.go
+++ b/runs/repository/impl/project_test.go
@@ -15,7 +15,7 @@ func TestCreateProject_ReturnsAlreadyExists(t *testing.T) {
 	db := setupDB(t)
 	t.Cleanup(func() { db.Exec("DELETE FROM projects") })
 
-	repo := NewProjectRepo(db)
+	repo := NewProjectRepo(db, nil)
 	ctx := context.Background()
 	state := int32(0)
 

--- a/runs/repository/impl/task.go
+++ b/runs/repository/impl/task.go
@@ -11,17 +11,23 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
 	"github.com/flyteorg/flyte/v2/runs/repository/models"
 )
 
 type tasksRepo struct {
-	db *sqlx.DB
+	db      *sqlx.DB
+	metrics dbMetrics
 }
 
-func NewTaskRepo(db *sqlx.DB) interfaces.TaskRepo {
+// NewTaskRepo creates a task repository. The provided scope is used to register
+// per-operation DB metrics under a "db" sub-scope; pass nil to disable metrics
+// (e.g. in unit tests).
+func NewTaskRepo(db *sqlx.DB, scope promutils.Scope) interfaces.TaskRepo {
 	return &tasksRepo{
-		db: db,
+		db:      db,
+		metrics: newDBMetrics(scope),
 	}
 }
 
@@ -31,6 +37,12 @@ func NewTaskRepo(db *sqlx.DB) interfaces.TaskRepo {
 // set of triggers via refreshTaskTriggerMeta, so they are intentionally NOT
 // set by the task upsert itself.
 func (r *tasksRepo) CreateTask(ctx context.Context, newTask *models.Task, triggers []*models.Trigger) error {
+	return r.metrics.observe(ctx, "create_task", func() error {
+		return r.createTask(ctx, newTask, triggers)
+	})
+}
+
+func (r *tasksRepo) createTask(ctx context.Context, newTask *models.Task, triggers []*models.Trigger) error {
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin tx: %w", err)
@@ -116,45 +128,59 @@ func (r *tasksRepo) CreateTask(ctx context.Context, newTask *models.Task, trigge
 
 func (r *tasksRepo) GetTask(ctx context.Context, key models.TaskKey) (*models.Task, error) {
 	var task models.Task
-	err := sqlx.GetContext(ctx, r.db, &task,
-		"SELECT * FROM tasks WHERE project = $1 AND domain = $2 AND name = $3 AND version = $4",
-		key.Project, key.Domain, key.Name, key.Version)
+	err := r.metrics.observe(ctx, "get_task", func() error {
+		err := sqlx.GetContext(ctx, r.db, &task,
+			"SELECT * FROM tasks WHERE project = $1 AND domain = $2 AND name = $3 AND version = $4",
+			key.Project, key.Domain, key.Name, key.Version)
 
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("task not found: %v", key)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("task not found: %v", key)
+			}
+			logger.Errorf(ctx, "failed to get task %v: %v", key, err)
+			return fmt.Errorf("failed to get task %v: %w", key, err)
 		}
-		logger.Errorf(ctx, "failed to get task %v: %v", key, err)
-		return nil, fmt.Errorf("failed to get task %v: %w", key, err)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &task, nil
 }
 
 func (r *tasksRepo) CreateTaskSpec(ctx context.Context, taskSpec *models.TaskSpec) error {
-	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO task_specs (digest, spec) VALUES ($1, $2) ON CONFLICT (digest) DO NOTHING`,
-		taskSpec.Digest, taskSpec.Spec)
+	return r.metrics.observe(ctx, "create_task_spec", func() error {
+		_, err := r.db.ExecContext(ctx,
+			`INSERT INTO task_specs (digest, spec) VALUES ($1, $2) ON CONFLICT (digest) DO NOTHING`,
+			taskSpec.Digest, taskSpec.Spec)
 
-	if err != nil {
-		logger.Errorf(ctx, "failed to create task spec %v: %v", taskSpec.Digest, err)
-		return fmt.Errorf("failed to create task spec %v: %w", taskSpec.Digest, err)
-	}
+		if err != nil {
+			logger.Errorf(ctx, "failed to create task spec %v: %v", taskSpec.Digest, err)
+			return fmt.Errorf("failed to create task spec %v: %w", taskSpec.Digest, err)
+		}
 
-	return nil
+		return nil
+	})
 }
 
 func (r *tasksRepo) GetTaskSpec(ctx context.Context, digest string) (*models.TaskSpec, error) {
 	var taskSpec models.TaskSpec
-	err := sqlx.GetContext(ctx, r.db, &taskSpec,
-		"SELECT * FROM task_specs WHERE digest = $1", digest)
+	err := r.metrics.observe(ctx, "get_task_spec", func() error {
+		err := sqlx.GetContext(ctx, r.db, &taskSpec,
+			"SELECT * FROM task_specs WHERE digest = $1", digest)
 
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("task spec not found: %s", digest)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("task spec not found: %s", digest)
+			}
+			logger.Errorf(ctx, "failed to get task spec %v: %v", digest, err)
+			return fmt.Errorf("failed to get task spec %v: %w", digest, err)
 		}
-		logger.Errorf(ctx, "failed to get task spec %v: %v", digest, err)
-		return nil, fmt.Errorf("failed to get task spec %v: %w", digest, err)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &taskSpec, nil
@@ -249,9 +275,14 @@ LIMIT $%d OFFSET $%d`, filteredWhere, unfilteredWhere, orderBy, argIdx, argIdx+1
 		Total         uint32 `db:"total"`
 	}
 	var rows []taskWithCounts
-	if err := sqlx.SelectContext(ctx, r.db, &rows, cte, allArgs...); err != nil {
-		logger.Errorf(ctx, "failed to list tasks: %v", err)
-		return nil, fmt.Errorf("failed to list tasks: %w", err)
+	if err := r.metrics.observe(ctx, "list_tasks", func() error {
+		if err := sqlx.SelectContext(ctx, r.db, &rows, cte, allArgs...); err != nil {
+			logger.Errorf(ctx, "failed to list tasks: %v", err)
+			return fmt.Errorf("failed to list tasks: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	tasks := make([]*models.Task, 0, len(rows))
@@ -310,9 +341,14 @@ func (r *tasksRepo) ListVersions(ctx context.Context, input interfaces.ListResou
 	args = append(args, input.Limit, input.Offset)
 
 	var versions []*models.TaskVersion
-	if err := sqlx.SelectContext(ctx, r.db, &versions, queryBuilder.String(), args...); err != nil {
-		logger.Errorf(ctx, "failed to list versions: %v", err)
-		return nil, fmt.Errorf("failed to list versions: %w", err)
+	if err := r.metrics.observe(ctx, "list_versions", func() error {
+		if err := sqlx.SelectContext(ctx, r.db, &versions, queryBuilder.String(), args...); err != nil {
+			logger.Errorf(ctx, "failed to list versions: %v", err)
+			return fmt.Errorf("failed to list versions: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return versions, nil

--- a/runs/repository/impl/task_test.go
+++ b/runs/repository/impl/task_test.go
@@ -29,7 +29,7 @@ func setupTestDB(t *testing.T) *sqlx.DB {
 
 func TestCreateTask(t *testing.T) {
 	db := setupTestDB(t)
-	repo := NewTaskRepo(db)
+	repo := NewTaskRepo(db, nil)
 	ctx := context.Background()
 
 	task := &models.Task{
@@ -59,7 +59,7 @@ func TestCreateTask(t *testing.T) {
 
 func TestGetTask_NotFound(t *testing.T) {
 	db := setupTestDB(t)
-	repo := NewTaskRepo(db)
+	repo := NewTaskRepo(db, nil)
 	ctx := context.Background()
 
 	key := models.TaskKey{
@@ -76,7 +76,7 @@ func TestGetTask_NotFound(t *testing.T) {
 
 func TestListTasks(t *testing.T) {
 	db := setupTestDB(t)
-	repo := NewTaskRepo(db)
+	repo := NewTaskRepo(db, nil)
 	ctx := context.Background()
 
 	task1 := &models.Task{
@@ -116,7 +116,7 @@ func TestListTasks(t *testing.T) {
 
 func TestCreateTaskSpec(t *testing.T) {
 	db := setupTestDB(t)
-	repo := NewTaskRepo(db)
+	repo := NewTaskRepo(db, nil)
 	ctx := context.Background()
 
 	spec := &models.TaskSpec{
@@ -135,7 +135,7 @@ func TestCreateTaskSpec(t *testing.T) {
 
 func TestCreateTask_UpdatePreservesCreatedAt(t *testing.T) {
 	db := setupTestDB(t)
-	repo := NewTaskRepo(db)
+	repo := NewTaskRepo(db, nil)
 	ctx := context.Background()
 
 	task := &models.Task{

--- a/runs/repository/impl/trigger.go
+++ b/runs/repository/impl/trigger.go
@@ -11,39 +11,53 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 	triggerpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/trigger"
 	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
 	"github.com/flyteorg/flyte/v2/runs/repository/models"
 )
 
 type triggerRepo struct {
-	db *sqlx.DB
+	db      *sqlx.DB
+	metrics dbMetrics
 }
 
-func NewTriggerRepo(db *sqlx.DB) interfaces.TriggerRepo {
-	return &triggerRepo{db: db}
+// NewTriggerRepo creates a trigger repository. The provided scope is used to
+// register per-operation DB metrics under a "db" sub-scope; pass nil to disable
+// metrics (e.g. in unit tests).
+func NewTriggerRepo(db *sqlx.DB, scope promutils.Scope) interfaces.TriggerRepo {
+	return &triggerRepo{db: db, metrics: newDBMetrics(scope)}
 }
 
 func (r *triggerRepo) SaveTrigger(ctx context.Context, trigger *models.Trigger, expectedRevision uint64) (*models.Trigger, error) {
+	if err := r.metrics.observe(ctx, "save_trigger", func() error {
+		return r.saveTrigger(ctx, trigger, expectedRevision)
+	}); err != nil {
+		return nil, err
+	}
+	return trigger, nil
+}
+
+func (r *triggerRepo) saveTrigger(ctx context.Context, trigger *models.Trigger, expectedRevision uint64) error {
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to begin tx: %w", err)
+		return fmt.Errorf("failed to begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
 	if err := upsertTrigger(ctx, tx, trigger, expectedRevision); err != nil {
 		logger.Errorf(ctx, "SaveTrigger failed for %s/%s/%s/%s: %v",
 			trigger.Project, trigger.Domain, trigger.TaskName, trigger.Name, err)
-		return nil, err
+		return err
 	}
 	if err := refreshTaskTriggerMeta(ctx, tx, trigger); err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("failed to commit tx: %w", err)
+		return fmt.Errorf("failed to commit tx: %w", err)
 	}
-	return trigger, nil
+	return nil
 }
 
 // upsertTrigger upserts a trigger row and appends an immutable revision snapshot.
@@ -107,38 +121,48 @@ func upsertTrigger(ctx context.Context, tx *sqlx.Tx, trigger *models.Trigger, ex
 
 func (r *triggerRepo) GetTrigger(ctx context.Context, key interfaces.TriggerNameKey) (*models.Trigger, error) {
 	var t models.Trigger
-	var err error
-	if key.TaskName != "" {
-		err = sqlx.GetContext(ctx, r.db, &t,
-			`SELECT * FROM triggers WHERE deleted_at IS NULL
-			   AND project = $1 AND domain = $2 AND task_name = $3 AND name = $4`,
-			key.Project, key.Domain, key.TaskName, key.Name)
-	} else {
-		err = sqlx.GetContext(ctx, r.db, &t,
-			`SELECT * FROM triggers WHERE deleted_at IS NULL
-			   AND project = $1 AND domain = $2 AND name = $3`,
-			key.Project, key.Domain, key.Name)
-	}
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("trigger not found: %s/%s/%s/%s: %w", key.Project, key.Domain, key.TaskName, key.Name, err)
+	if err := r.metrics.observe(ctx, "get_trigger", func() error {
+		var err error
+		if key.TaskName != "" {
+			err = sqlx.GetContext(ctx, r.db, &t,
+				`SELECT * FROM triggers WHERE deleted_at IS NULL
+				   AND project = $1 AND domain = $2 AND task_name = $3 AND name = $4`,
+				key.Project, key.Domain, key.TaskName, key.Name)
+		} else {
+			err = sqlx.GetContext(ctx, r.db, &t,
+				`SELECT * FROM triggers WHERE deleted_at IS NULL
+				   AND project = $1 AND domain = $2 AND name = $3`,
+				key.Project, key.Domain, key.Name)
 		}
-		return nil, fmt.Errorf("failed to get trigger: %w", err)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("trigger not found: %s/%s/%s/%s: %w", key.Project, key.Domain, key.TaskName, key.Name, err)
+			}
+			return fmt.Errorf("failed to get trigger: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return &t, nil
 }
 
 func (r *triggerRepo) GetTriggerRevision(ctx context.Context, project, domain, taskName, name string, revision uint64) (*models.TriggerRevision, error) {
 	var rev models.TriggerRevision
-	err := sqlx.GetContext(ctx, r.db, &rev,
-		`SELECT * FROM trigger_revisions
-		 WHERE project = $1 AND domain = $2 AND task_name = $3 AND name = $4 AND revision = $5`,
-		project, domain, taskName, name, revision)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("trigger revision not found: %s/%s/%s/%s@%d: %w", project, domain, taskName, name, revision, err)
+	if err := r.metrics.observe(ctx, "get_trigger_revision", func() error {
+		err := sqlx.GetContext(ctx, r.db, &rev,
+			`SELECT * FROM trigger_revisions
+			 WHERE project = $1 AND domain = $2 AND task_name = $3 AND name = $4 AND revision = $5`,
+			project, domain, taskName, name, revision)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("trigger revision not found: %s/%s/%s/%s@%d: %w", project, domain, taskName, name, revision, err)
+			}
+			return fmt.Errorf("failed to get trigger revision: %w", err)
 		}
-		return nil, fmt.Errorf("failed to get trigger revision: %w", err)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return &rev, nil
 }
@@ -189,27 +213,43 @@ func (r *triggerRepo) ListTriggers(ctx context.Context, input interfaces.ListRes
 	args = append(args, input.Limit, input.Offset)
 
 	var triggers []*models.Trigger
-	if err := sqlx.SelectContext(ctx, r.db, &triggers, queryBuilder.String(), args...); err != nil {
-		return nil, fmt.Errorf("failed to list triggers: %w", err)
+	if err := r.metrics.observe(ctx, "list_triggers", func() error {
+		if err := sqlx.SelectContext(ctx, r.db, &triggers, queryBuilder.String(), args...); err != nil {
+			return fmt.Errorf("failed to list triggers: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return triggers, nil
 }
 
 func (r *triggerRepo) ListTriggerRevisions(ctx context.Context, project, domain, taskName, name string, input interfaces.ListResourceInput) ([]*models.TriggerRevision, error) {
 	var revisions []*models.TriggerRevision
-	err := sqlx.SelectContext(ctx, r.db, &revisions,
-		`SELECT * FROM trigger_revisions
-		 WHERE project = $1 AND domain = $2 AND task_name = $3 AND name = $4
-		 ORDER BY revision DESC
-		 LIMIT $5 OFFSET $6`,
-		project, domain, taskName, name, input.Limit, input.Offset)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list trigger revisions: %w", err)
+	if err := r.metrics.observe(ctx, "list_trigger_revisions", func() error {
+		err := sqlx.SelectContext(ctx, r.db, &revisions,
+			`SELECT * FROM trigger_revisions
+			 WHERE project = $1 AND domain = $2 AND task_name = $3 AND name = $4
+			 ORDER BY revision DESC
+			 LIMIT $5 OFFSET $6`,
+			project, domain, taskName, name, input.Limit, input.Offset)
+		if err != nil {
+			return fmt.Errorf("failed to list trigger revisions: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return revisions, nil
 }
 
 func (r *triggerRepo) UpdateTriggers(ctx context.Context, keys []interfaces.TriggerNameKey, active bool) error {
+	return r.metrics.observe(ctx, "update_triggers", func() error {
+		return r.updateTriggers(ctx, keys, active)
+	})
+}
+
+func (r *triggerRepo) updateTriggers(ctx context.Context, keys []interfaces.TriggerNameKey, active bool) error {
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin tx: %w", err)
@@ -256,6 +296,12 @@ func (r *triggerRepo) UpdateTriggers(ctx context.Context, keys []interfaces.Trig
 }
 
 func (r *triggerRepo) DeleteTriggers(ctx context.Context, keys []interfaces.TriggerNameKey) error {
+	return r.metrics.observe(ctx, "delete_triggers", func() error {
+		return r.deleteTriggers(ctx, keys)
+	})
+}
+
+func (r *triggerRepo) deleteTriggers(ctx context.Context, keys []interfaces.TriggerNameKey) error {
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin tx: %w", err)

--- a/runs/repository/repository.go
+++ b/runs/repository/repository.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/database"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/v2/runs/repository/impl"
 	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
 )
@@ -17,17 +18,29 @@ type repository struct {
 	triggerRepo interfaces.TriggerRepo
 }
 
-// NewRepository creates a new Repository instance
-func NewRepository(db *sqlx.DB, dbConfig database.DbConfig) (interfaces.Repository, error) {
-	actionRepo, err := impl.NewActionRepo(db, dbConfig)
+// NewRepository creates a new Repository instance. Each underlying repository
+// gets its own metrics sub-scope (action/task/trigger) so the per-operation DB
+// metrics they register under "db" do not collide. Pass a nil scope to disable
+// metrics.
+func NewRepository(db *sqlx.DB, dbConfig database.DbConfig, scope promutils.Scope) (interfaces.Repository, error) {
+	actionRepo, err := impl.NewActionRepo(db, dbConfig, subScope(scope, "action"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create action repo: %w", err)
 	}
 	return &repository{
 		actionRepo:  actionRepo,
-		taskRepo:    impl.NewTaskRepo(db),
-		triggerRepo: impl.NewTriggerRepo(db),
+		taskRepo:    impl.NewTaskRepo(db, subScope(scope, "task")),
+		triggerRepo: impl.NewTriggerRepo(db, subScope(scope, "trigger")),
 	}, nil
+}
+
+// subScope returns a named sub-scope, or nil if the parent scope is nil so that
+// metrics can be disabled entirely (e.g. in tests).
+func subScope(scope promutils.Scope, name string) promutils.Scope {
+	if scope == nil {
+		return nil
+	}
+	return scope.NewSubScope(name)
 }
 
 // ActionRepo returns the action repository

--- a/runs/service/project_service_test.go
+++ b/runs/service/project_service_test.go
@@ -14,7 +14,7 @@ import (
 
 func setupProjectService(t *testing.T) *ProjectService {
 	t.Cleanup(func() { testDB.Exec("DELETE FROM projects") })
-	return NewProjectService(impl.NewProjectRepo(testDB), []*project.Domain{
+	return NewProjectService(impl.NewProjectRepo(testDB, nil), []*project.Domain{
 		{Id: "development", Name: "Development"},
 		{Id: "production", Name: "Production"},
 	})

--- a/runs/setup.go
+++ b/runs/setup.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/otelutils"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 )
 
 const otelServiceName = "runs-service"
@@ -53,7 +54,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		return fmt.Errorf("creating otel interceptor: %w", err)
 	}
 
-	repo, err := repository.NewRepository(sc.DB, cfg.Database)
+	repo, err := repository.NewRepository(sc.DB, cfg.Database, sc.Scope)
 	if err != nil {
 		return fmt.Errorf("runs: failed to create repository: %w", err)
 	}
@@ -133,12 +134,21 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 			Name: d.Name,
 		})
 	}
-	projectSvc := service.NewProjectService(impl.NewProjectRepo(sc.DB), domains)
+	// Construct the project repo once: its DB metrics are registered in the
+	// constructor, so a second NewProjectRepo with the same scope would panic on
+	// duplicate registration. The same instance is shared by the service and the
+	// seed step below.
+	var projectScope promutils.Scope
+	if sc.Scope != nil {
+		projectScope = sc.Scope.NewSubScope("project")
+	}
+	projectRepo := impl.NewProjectRepo(sc.DB, projectScope)
+	projectSvc := service.NewProjectService(projectRepo, domains)
 	projectPath, projectHandler := projectconnect.NewProjectServiceHandler(projectSvc, connect.WithInterceptors(otelInterceptor))
 	sc.Mux.Handle(projectPath, projectHandler)
 	logger.Infof(ctx, "Mounted ProjectService at %s", projectPath)
 
-	if err := seedProjects(ctx, impl.NewProjectRepo(sc.DB), cfg.SeedProjects); err != nil {
+	if err := seedProjects(ctx, projectRepo, cfg.SeedProjects); err != nil {
 		return fmt.Errorf("runs: failed to seed projects: %w", err)
 	}
 

--- a/runs/test/api/setup_test.go
+++ b/runs/test/api/setup_test.go
@@ -103,7 +103,7 @@ func TestMain(m *testing.M) {
 	log.Println("Database migrations completed")
 
 	// Create repository and services
-	repo, err := repository.NewRepository(testDB, *dbConfig)
+	repo, err := repository.NewRepository(testDB, *dbConfig, nil)
 	if err != nil {
 		log.Printf("Failed to create repository: %v", err)
 		exitCode = 1


### PR DESCRIPTION
## Summary

Implements #7448 — instruments the flyte2 runs service DB repository layer with Prometheus metrics.

Adds a `dbMetrics` helper (`runs/repository/impl/metrics.go`) recording, per DB operation, a calls counter, an errors counter, and a latency stopwatch, built from a `promutils.Scope` sub-scope — mirroring flyte's existing metrics idiom (a `Metrics` struct from a `promutils.Scope` via a `newMetrics(scope)` constructor). A `promutils.Scope` is threaded into the action / task / project / trigger repo constructors (each gets its own named sub-scope), and every DB op is wrapped through a DRY `observe(ctx, operation, fn)` helper. Metrics are labeled by operation name only (low cardinality, never row/project/user values). A nil scope yields a no-op `dbMetrics`, so constructors stay usable in unit tests.

## Test plan

- New `runs/repository/impl/metrics_test.go` (TDD red→green): nil-scope no-op, success/error observation, operation-only labeling, plus an end-to-end `CreateProject` test against the embedded postgres DB asserting the call counter, latency, and error counter.
- `go build ./...` exit 0, `gofmt`/`go vet` clean on touched files, `go test ./runs/repository/impl/` ok.

Fixes #7448
