### PR TITLE
pointing to internally-reachable rust endpoint

### DIFF
--- a/charts/flyte-devbox/values.yaml
+++ b/charts/flyte-devbox/values.yaml
@@ -59,7 +59,12 @@ flyte-binary:
       storage:
         signedURL:
           stowConfigOverride:
-            endpoint: http://localhost:30002
+            # Presigned URLs must be reachable from BOTH the host client and pods. `localhost`
+            # is host-only (inside a pod it's the pod's own localhost -> ConnectError, which
+            # breaks in-pod uploads like flyteplugins-hitl's spec.pb). `rustfs.localhost`
+            # resolves to 127.0.0.1 on the host and, via the coredns-custom rewrite, to the
+            # rustfs ClusterIP in pods. Port 9000 = the rustfs service port.
+            endpoint: http://rustfs.localhost:9000
       plugins:
         k8s:
           default-env-vars:

--- a/docker/devbox-bundled/Makefile
+++ b/docker/devbox-bundled/Makefile
@@ -157,6 +157,7 @@ start:
 			--publish "30000:30000" \
 			--publish "30001:5432" \
 			--publish "30002:30002" \
+			--publish "9000:30002" \
 			--publish "30080:30080" \
 			--publish "30081:30081" \
 			$(FLYTE_DEVBOX_IMAGE); \

--- a/docker/devbox-bundled/kustomize/complete/kustomization.yaml
+++ b/docker/devbox-bundled/kustomize/complete/kustomization.yaml
@@ -27,6 +27,7 @@ helmCharts:
 resources:
 - ../namespace.yaml
 - ../embedded-postgres-service.yaml
+- ../coredns-custom.yaml
 - ../../../../charts/flyte-devbox/charts/knative-serving/crds/serving-crds.yaml
 
 patches:

--- a/docker/devbox-bundled/kustomize/coredns-custom.yaml
+++ b/docker/devbox-bundled/kustomize/coredns-custom.yaml
@@ -1,0 +1,16 @@
+# Split-horizon resolution for the rustfs presigned-URL host.
+#
+# The control plane mints presigned object-store URLs with host `rustfs.localhost:9000`
+# (see charts/flyte-devbox/values.yaml storage.signedURL.stowConfigOverride.endpoint).
+# On the host, `*.localhost` resolves natively to 127.0.0.1 (-> published rustfs port).
+# Inside pods, k3s CoreDNS imports /etc/coredns/custom/*.override; this rewrite points
+# `rustfs.localhost` at the stable rustfs ClusterIP so in-pod uploads/downloads (e.g.
+# flyteplugins-hitl's spec.pb) reach the object store instead of the pod's own localhost.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  rustfs.override: |
+    rewrite name rustfs.localhost rustfs-svc.flyte.svc.cluster.local

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -7801,7 +7801,7 @@ data:
     storage:
       signedURL:
         stowConfigOverride:
-          endpoint: http://localhost:30002
+          endpoint: http://rustfs.localhost:9000
     task_resources:
       defaults:
         cpu: 500m
@@ -10423,3 +10423,14 @@ spec:
       app: 3scale-kourier-gateway
 
 ---
+---
+# Added for the presigned-URL split-horizon fix (mirrors kustomize/coredns-custom.yaml).
+# Regenerate with `make manifests` to reproduce.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  rustfs.override: |
+    rewrite name rustfs.localhost rustfs-svc.flyte.svc.cluster.local

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -10423,7 +10423,6 @@ spec:
       app: 3scale-kourier-gateway
 
 ---
----
 # Added for the presigned-URL split-horizon fix (mirrors kustomize/coredns-custom.yaml).
 # Regenerate with `make manifests` to reproduce.
 apiVersion: v1

--- a/gen/ts/package-lock.json
+++ b/gen/ts/package-lock.json
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/typescript": {


### PR DESCRIPTION
## Why are the changes needed?

- `flyteplugins-hitl'`s `new_event()` calls `serve()` at runtime, inside the task pod.   
- Building/registering that app means serializing its definition and uploading it as `spec.pb` to object storage so the control plane can create the knative service from it. That upload goes through the dataproxy's `create_upload_location`, which hands back a presigned URL (host `localhost:30002`) — and the pod `PUT`s to it. That PUT operation gets a connect error:

```
[flyte] WARNING Upload failed for spec.pb, backing off for 0.50s [retry 1/3]: ConnectError: All connection attempts failed
[flyte] WARNING Upload failed for spec.pb, backing off for 1.00s [retry 2/3]: ConnectError: All connection attempts failed
[flyte] WARNING Upload failed for spec.pb, backing off for 2.00s [retry 3/3]: ConnectError: All connection attempts failed
[flyte] ERROR Task failed with error: Failed to upload /tmp/<uuid>/spec.pb after 3 retries:
       ConnectError: All connection attempts failed
```
The host comes from the default configuration:

```yaml
flyte-binary:
  configuration:
    inline:
      storage:
        signedURL:
          stowConfigOverride:
            endpoint: http://localhost:30002 
```
Regular Pods are able to reach this thanks to `FLYTE_AWS_ENDPOINT=http://rustfs-svc.<ns>:9000`. 

## What changes were proposed in this pull request?

One hostname, `rustfs.localhost`, with split-horizon resolution — `127.0.0.1` on the host (native `*.localhost`), the rustfs ClusterIP in pods (via a CoreDNS rewrite) — on port 9000. So presigned URLs are reachable from both sides.

## How was this patch tested?

Applied the patch to a `2.5.7` devbox and got HITL running:

<img width="1283" height="487" alt="image" src="https://github.com/user-attachments/assets/30033c70-4d88-42fb-bc96-17fbdac6c3db" />

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
