### PR TITLE
fix(webhook): honor disableCreateMutatingWebhookConfig, add namespaceSelector

### DIFF
--- a/executor/pkg/webhook/entrypoint.go
+++ b/executor/pkg/webhook/entrypoint.go
@@ -35,7 +35,9 @@ func Setup(ctx context.Context, kubeClient kubernetes.Interface, cfg *webhookCon
 		return fmt.Errorf("webhook: failed to create pod mutator: %w", err)
 	}
 
-	if err := createMutationConfig(ctx, kubeClient, podMutator, defaultNamespace); err != nil {
+	if cfg.DisableCreateMutatingWebhookConfig {
+		logger.Infof(ctx, "Skipping MutatingWebhookConfiguration creation, disabled by config")
+	} else if err := createMutationConfig(ctx, kubeClient, podMutator, defaultNamespace); err != nil {
 		return fmt.Errorf("webhook: failed to create MutatingWebhookConfiguration: %w", err)
 	}
 

--- a/executor/pkg/webhook/pod.go
+++ b/executor/pkg/webhook/pod.go
@@ -127,6 +127,7 @@ func (pm PodMutator) CreateMutationWebhookConfiguration(namespace string) (*admi
 				FailurePolicy:           &fail,
 				SideEffects:             &sideEffects,
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				NamespaceSelector:       pm.cfg.NamespaceSelector,
 				ObjectSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						secretUtils.PodLabel: secretUtils.PodLabelValue,

--- a/executor/pkg/webhook/pod_test.go
+++ b/executor/pkg/webhook/pod_test.go
@@ -1,0 +1,33 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	webhookConfig "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret/config"
+)
+
+func TestCreateMutationWebhookConfigurationNamespaceSelector(t *testing.T) {
+	t.Run("nil selector matches all namespaces", func(t *testing.T) {
+		pm := PodMutator{cfg: &webhookConfig.Config{ServiceName: "flyte-pod-webhook", ServicePort: 443, CertDir: t.TempDir()}}
+
+		mutateConfig, err := pm.CreateMutationWebhookConfiguration("flyte")
+
+		assert.NoError(t, err)
+		assert.Nil(t, mutateConfig.Webhooks[0].NamespaceSelector)
+	})
+
+	t.Run("selector is propagated", func(t *testing.T) {
+		selector := &metav1.LabelSelector{
+			MatchLabels: map[string]string{"kubernetes.io/metadata.name": "flyte"},
+		}
+		pm := PodMutator{cfg: &webhookConfig.Config{ServiceName: "flyte-pod-webhook", ServicePort: 443, CertDir: t.TempDir(), NamespaceSelector: selector}}
+
+		mutateConfig, err := pm.CreateMutationWebhookConfiguration("flyte")
+
+		assert.NoError(t, err)
+		assert.Equal(t, selector, mutateConfig.Webhooks[0].NamespaceSelector)
+	})
+}

--- a/flyteplugins/go/tasks/pluginmachinery/secret/config/config.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/config/config.go
@@ -169,11 +169,12 @@ type Config struct {
 	AzureSecretManagerConfig    AzureSecretManagerConfig    `json:"azureSecretManager" pflag:",Azure Secret Manager config."`
 
 	// Ignore PFlag for Image Builder
-	ImageBuilderConfig                 ImageBuilderConfig `json:"imageBuilderConfig,omitempty" pflag:"-,"`
-	WebhookTimeout                     int32              `json:"webhookTimeout" pflag:",Timeout for webhook calls in seconds. Defaults to 30 seconds."`
-	DisableCreateMutatingWebhookConfig bool               `json:"disableCreateMutatingWebhookConfig"`
-	KubeClientConfig                   KubeClientConfig   `json:"kubeClientConfig" pflag:",Configuration to control the Kubernetes client used by the webhook"`
-	SecretEnvVarPrefix                 string             `json:"secretEnvVarPrefix" pflag:",The prefix for secret environment variables. Used by K8s, Global, and Embedded secret managers. Defaults to _UNION_"`
+	ImageBuilderConfig                 ImageBuilderConfig    `json:"imageBuilderConfig,omitempty" pflag:"-,"`
+	WebhookTimeout                     int32                 `json:"webhookTimeout" pflag:",Timeout for webhook calls in seconds. Defaults to 30 seconds."`
+	DisableCreateMutatingWebhookConfig bool                  `json:"disableCreateMutatingWebhookConfig"`
+	NamespaceSelector                  *metav1.LabelSelector `json:"namespaceSelector" pflag:"-,NamespaceSelector to scope the created MutatingWebhookConfiguration. Nil matches all namespaces."`
+	KubeClientConfig                   KubeClientConfig      `json:"kubeClientConfig" pflag:",Configuration to control the Kubernetes client used by the webhook"`
+	SecretEnvVarPrefix                 string                `json:"secretEnvVarPrefix" pflag:",The prefix for secret environment variables. Used by K8s, Global, and Embedded secret managers. Defaults to _UNION_"`
 }
 
 //go:generate enumer --type=EmbeddedSecretManagerType -json -yaml -trimprefix=EmbeddedSecretManagerType


### PR DESCRIPTION
## Tracking issue
Closes #7614

## Why are the changes needed?
Running Flyte v2 alongside a Flyte v1 deployment in the same cluster breaks v1: the executor always registers a MutatingWebhookConfiguration that matches the `inject-flyte-secrets` label in all namespaces with `failurePolicy: Fail`, so it intercepts and can reject v1 task pods. `webhook.disableCreateMutatingWebhookConfig` exists in the config but was never read.

## What changes were proposed in this pull request?
Two independent commits:
1. Honor `disableCreateMutatingWebhookConfig` in webhook `Setup`, so operators can manage a scoped MutatingWebhookConfiguration themselves.
2. Add optional `webhook.namespaceSelector` applied to the generated MutatingWebhookConfiguration. Nil keeps the current behavior of matching all namespaces.

## How was this patch tested?
Added `executor/pkg/webhook/pod_test.go` covering selector propagation and the nil default; `go test ./executor/pkg/webhook/ ./flyteplugins/go/tasks/pluginmachinery/secret/config/`.

### Labels
- **fixed**: `webhook.disableCreateMutatingWebhookConfig` is now honored
- **added**: `webhook.namespaceSelector` to scope the generated MutatingWebhookConfiguration
