### PR TITLE
fix(webhook): allow disabling or scoping the self-registered MutatingWebhookConfiguration

### DIFF
--- a/flytepropeller/pkg/webhook/config/config.go
+++ b/flytepropeller/pkg/webhook/config/config.go
@@ -5,6 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/flyteorg/flyte/flytestdlib/config"
 )
@@ -105,7 +106,8 @@ type Config struct {
 	GCPSecretManagerConfig   GCPSecretManagerConfig   `json:"gcpSecretManager" pflag:",GCP Secret Manager config."`
 	VaultSecretManagerConfig VaultSecretManagerConfig `json:"vaultSecretManager" pflag:",Vault Secret Manager config."`
 
-	DisableCreateMutatingWebhookConfig bool `json:"disableCreateMutatingWebhookConfig" pflag:",Disable registration of the MutatingWebhookConfiguration, leaving it to be managed out of band."`
+	DisableCreateMutatingWebhookConfig bool                  `json:"disableCreateMutatingWebhookConfig" pflag:",Disable registration of the MutatingWebhookConfiguration, leaving it to be managed out of band."`
+	NamespaceSelector                  *metav1.LabelSelector `json:"namespaceSelector" pflag:"-,NamespaceSelector to scope the created MutatingWebhookConfiguration. Nil matches all namespaces."`
 }
 
 func (c Config) ExpandCertDir() string {

--- a/flytepropeller/pkg/webhook/config/config.go
+++ b/flytepropeller/pkg/webhook/config/config.go
@@ -53,6 +53,7 @@ var (
 			Role:      "flyte",
 			KVVersion: KVVersion2,
 		},
+		DisableCreateMutatingWebhookConfig: false,
 	}
 
 	configSection = config.MustRegisterSection("webhook", DefaultConfig)
@@ -103,6 +104,8 @@ type Config struct {
 	AWSSecretManagerConfig   AWSSecretManagerConfig   `json:"awsSecretManager" pflag:",AWS Secret Manager config."`
 	GCPSecretManagerConfig   GCPSecretManagerConfig   `json:"gcpSecretManager" pflag:",GCP Secret Manager config."`
 	VaultSecretManagerConfig VaultSecretManagerConfig `json:"vaultSecretManager" pflag:",Vault Secret Manager config."`
+
+	DisableCreateMutatingWebhookConfig bool `json:"disableCreateMutatingWebhookConfig" pflag:",Disable registration of the MutatingWebhookConfiguration, leaving it to be managed out of band."`
 }
 
 func (c Config) ExpandCertDir() string {

--- a/flytepropeller/pkg/webhook/config/config_flags.go
+++ b/flytepropeller/pkg/webhook/config/config_flags.go
@@ -60,5 +60,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "awsSecretManager.sidecarImage"), DefaultConfig.AWSSecretManagerConfig.SidecarImage, "Specifies the sidecar docker image to use")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gcpSecretManager.sidecarImage"), DefaultConfig.GCPSecretManagerConfig.SidecarImage, "Specifies the sidecar docker image to use")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "vaultSecretManager.role"), DefaultConfig.VaultSecretManagerConfig.Role, "Specifies the vault role to use")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "disableCreateMutatingWebhookConfig"), DefaultConfig.DisableCreateMutatingWebhookConfig, "Disable registration of the MutatingWebhookConfiguration,  leaving it to be managed out of band.")
 	return cmdFlags
 }

--- a/flytepropeller/pkg/webhook/config/config_flags_test.go
+++ b/flytepropeller/pkg/webhook/config/config_flags_test.go
@@ -239,4 +239,18 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_disableCreateMutatingWebhookConfig", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("disableCreateMutatingWebhookConfig", testValue)
+			if vBool, err := cmdFlags.GetBool("disableCreateMutatingWebhookConfig"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vBool), &actual.DisableCreateMutatingWebhookConfig)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/flytepropeller/pkg/webhook/entrypoint.go
+++ b/flytepropeller/pkg/webhook/entrypoint.go
@@ -43,8 +43,9 @@ func Run(ctx context.Context, propellerCfg *config.Config, cfg *config2.Config,
 	secretsWebhook := NewPodMutator(cfg, mgr.GetScheme(), webhookScope)
 
 	// Creates a MutationConfig to instruct ApiServer to call this service whenever a Pod is being created.
-	err = createMutationConfig(ctx, kubeClient, secretsWebhook, defaultNamespace)
-	if err != nil {
+	if cfg.DisableCreateMutatingWebhookConfig {
+		logger.Infof(ctx, "Skipping MutatingWebhookConfiguration creation, disabled by config")
+	} else if err = createMutationConfig(ctx, kubeClient, secretsWebhook, defaultNamespace); err != nil {
 		return err
 	}
 

--- a/flytepropeller/pkg/webhook/pod.go
+++ b/flytepropeller/pkg/webhook/pod.go
@@ -199,6 +199,7 @@ func (pm PodMutator) CreateMutationWebhookConfiguration(namespace string) (*admi
 					"v1",
 					"v1beta1",
 				},
+				NamespaceSelector: pm.cfg.NamespaceSelector,
 				ObjectSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						secrets.PodLabel: secrets.PodLabelValue,

--- a/flytepropeller/pkg/webhook/pod_test.go
+++ b/flytepropeller/pkg/webhook/pod_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd/api/latest"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -97,6 +98,22 @@ func Test_CreateMutationWebhookConfiguration(t *testing.T) {
 		c, err := pm.CreateMutationWebhookConfiguration("my-namespace")
 		assert.NoError(t, err)
 		assert.NotNil(t, c)
+		assert.Nil(t, c.Webhooks[0].NamespaceSelector)
+	})
+
+	t.Run("With namespace selector", func(t *testing.T) {
+		selector := &metav1.LabelSelector{
+			MatchLabels: map[string]string{"kubernetes.io/metadata.name": "my-namespace"},
+		}
+		pm := NewPodMutator(&config.Config{
+			CertDir:           "testdata",
+			ServiceName:       "my-service",
+			NamespaceSelector: selector,
+		}, latest.Scheme, promutils.NewTestScope())
+
+		c, err := pm.CreateMutationWebhookConfiguration("my-namespace")
+		assert.NoError(t, err)
+		assert.Equal(t, selector, c.Webhooks[0].NamespaceSelector)
 	})
 }
 


### PR DESCRIPTION
## Tracking issue
Closes #7618

Related to #7614, v1 counterpart of #7616.

## Why are the changes needed?
Running Flyte 1 and Flyte 2 in the same cluster is the recommended migration setup, but the propeller webhook always registers a MutatingWebhookConfiguration matching the `inject-flyte-secrets` label in all namespaces with `failurePolicy: Fail`, so it intercepts and rejects the other control plane's secret-requesting task pods. #7616 fixed the v2 side; this is the v1 side.

## What changes were proposed in this pull request?
Two independent commits, mirroring #7616:
1. Add `webhook.disableCreateMutatingWebhookConfig` (same key as v2), skipping self-registration so operators can manage a scoped MutatingWebhookConfiguration out of band. Includes the regenerated pflags files.
2. Add optional `webhook.namespaceSelector` applied to the generated MutatingWebhookConfiguration. Nil keeps the current behavior of matching all namespaces.

## How was this patch tested?
Extended `Test_CreateMutationWebhookConfiguration` with selector propagation and nil-default cases; `go test ./pkg/webhook/...` in `flytepropeller`.

### Labels
- **added**: `webhook.disableCreateMutatingWebhookConfig` and `webhook.namespaceSelector` options to scope or disable the self-registered MutatingWebhookConfiguration
