### PR TITLE
fix multipart blob dimensionality for directory uploads

### DIFF
--- a/flytecopilot/data/upload.go
+++ b/flytecopilot/data/upload.go
@@ -61,61 +61,65 @@ func (u Uploader) handleBlobType(ctx context.Context, localPath string, toPath s
 	if err != nil {
 		return nil, err
 	}
-	if info.IsDir() {
-		var files []dirFile
-		err := filepath.Walk(localPath, func(path string, info os.FileInfo, err error) error {
+	if !info.IsDir() {
+		size := info.Size()
+		// Should we make this a go routine as well, so that we can introduce timeouts
+		return coreutils.MakeLiteralForBlob(toPath, false, ""), UploadFileToStorage(ctx, fpath, toPath, size, u.store)
+	}
+	return u.handleBlobTypeMultipart(ctx, localPath, toPath)
+}
+
+func (u Uploader) handleBlobTypeMultipart(ctx context.Context, localPath string, toPath storage.DataReference) (*core.Literal, error) {
+	var files []dirFile
+	err := filepath.Walk(localPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			logger.Errorf(ctx, "encountered error when uploading multipart blob, %s", err)
+			return err
+		}
+		if info.IsDir() {
+			logger.Warnf(ctx, "Currently nested directories are not supported in multipart blob uploads, for directory @ %s", path)
+		} else {
+			ref, err := u.store.ConstructReference(ctx, toPath, info.Name())
 			if err != nil {
-				logger.Errorf(ctx, "encountered error when uploading multipart blob, %s", err)
 				return err
 			}
-			if info.IsDir() {
-				logger.Warnf(ctx, "Currently nested directories are not supported in multipart blob uploads, for directory @ %s", path)
-			} else {
-				ref, err := u.store.ConstructReference(ctx, toPath, info.Name())
-				if err != nil {
-					return err
-				}
-				files = append(files, dirFile{
-					path: path,
-					info: info,
-					ref:  ref,
-				})
-			}
-			return nil
-		})
+			files = append(files, dirFile{
+				path: path,
+				info: info,
+				ref:  ref,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Infof(ctx, "Found [%d] files for multipart blob upload from [%s]", len(files), localPath)
+
+	childCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	fileUploader := make([]futures.Future, 0, len(files))
+	for _, f := range files {
+		pth := f.path
+		ref := f.ref
+		size := f.info.Size()
+		fileUploader = append(fileUploader, futures.NewAsyncFuture(childCtx, func(i2 context.Context) (i interface{}, e error) {
+			return nil, UploadFileToStorage(i2, pth, ref, size, u.store)
+		}))
+	}
+
+	for _, f := range fileUploader {
+		// TODO maybe we should have timeouts, or we can have a global timeout at the top level
+		_, err := f.Get(ctx)
 		if err != nil {
 			return nil, err
 		}
-
-		logger.Infof(ctx, "Found [%d] files for multipart blob upload from [%s]", len(files), localPath)
-
-		childCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		fileUploader := make([]futures.Future, 0, len(files))
-		for _, f := range files {
-			pth := f.path
-			ref := f.ref
-			size := f.info.Size()
-			fileUploader = append(fileUploader, futures.NewAsyncFuture(childCtx, func(i2 context.Context) (i interface{}, e error) {
-				return nil, UploadFileToStorage(i2, pth, ref, size, u.store)
-			}))
-		}
-
-		for _, f := range fileUploader {
-			// TODO maybe we should have timeouts, or we can have a global timeout at the top level
-			_, err := f.Get(ctx)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		logger.Infof(ctx, "Successfully uploaded multipart blob from [%s] to [%s]", localPath, toPath)
-
-		return coreutils.MakeLiteralForBlob(toPath, true, ""), nil
 	}
-	size := info.Size()
-	// Should we make this a go routine as well, so that we can introduce timeouts
-	return coreutils.MakeLiteralForBlob(toPath, false, ""), UploadFileToStorage(ctx, fpath, toPath, size, u.store)
+
+	logger.Infof(ctx, "Successfully uploaded multipart blob from [%s] to [%s]", localPath, toPath)
+
+	return coreutils.MakeLiteralForBlob(toPath, true, ""), nil
 }
 
 func (u Uploader) RecursiveUpload(ctx context.Context, vars *core.VariableMap, fromPath string, metaOutputPath, dataRawPath storage.DataReference) error {

--- a/flytecopilot/data/upload.go
+++ b/flytecopilot/data/upload.go
@@ -87,6 +87,8 @@ func (u Uploader) handleBlobType(ctx context.Context, localPath string, toPath s
 			return nil, err
 		}
 
+		logger.Infof(ctx, "Found [%d] files for multipart blob upload from [%s]", len(files), localPath)
+
 		childCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		fileUploader := make([]futures.Future, 0, len(files))
@@ -107,7 +109,9 @@ func (u Uploader) handleBlobType(ctx context.Context, localPath string, toPath s
 			}
 		}
 
-		return coreutils.MakeLiteralForBlob(toPath, false, ""), nil
+		logger.Infof(ctx, "Successfully uploaded multipart blob from [%s] to [%s]", localPath, toPath)
+
+		return coreutils.MakeLiteralForBlob(toPath, true, ""), nil
 	}
 	size := info.Size()
 	// Should we make this a go routine as well, so that we can introduce timeouts

--- a/flytecopilot/data/upload_test.go
+++ b/flytecopilot/data/upload_test.go
@@ -53,6 +53,7 @@ func TestUploader_RecursiveUpload(t *testing.T) {
 		assert.NotNil(t, outputs.GetLiterals()["x"])
 		assert.NotNil(t, outputs.GetLiterals()["x"].GetScalar())
 		assert.NotNil(t, outputs.GetLiterals()["x"].GetScalar().GetBlob())
+		assert.Equal(t, core.BlobType_SINGLE, outputs.GetLiterals()["x"].GetScalar().GetBlob().GetMetadata().GetType().GetDimensionality())
 		ref := storage.DataReference(outputs.GetLiterals()["x"].GetScalar().GetBlob().GetUri())
 		r, err := store.ReadRaw(context.TODO(), ref)
 		assert.NoError(t, err, "%s does not exist", ref)
@@ -60,5 +61,55 @@ func TestUploader_RecursiveUpload(t *testing.T) {
 		b, err := io.ReadAll(r)
 		assert.NoError(t, err)
 		assert.Equal(t, string(data), string(b), "content dont match")
+	})
+
+	t.Run("upload-multipart-blob", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp(tmpFolderLocation, tmpPrefix)
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, os.RemoveAll(tmpDir))
+		}()
+
+		vmap := &core.VariableMap{
+			Variables: map[string]*core.Variable{
+				"x": {
+					Type: &core.LiteralType{
+						Type: &core.LiteralType_Blob{
+							Blob: &core.BlobType{
+								// The input dimensionality is not used by handleBlobType; the local
+								// directory below is what should produce a MULTIPART literal.
+								Dimensionality: core.BlobType_MULTIPART,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert.NoError(t, os.Mkdir(path.Join(tmpDir, "x"), os.ModePerm)) // #nosec G301
+		assert.NoError(t, os.WriteFile(path.Join(tmpDir, "x", "part-1"), []byte("part1"), os.ModePerm))
+		assert.NoError(t, os.WriteFile(path.Join(tmpDir, "x", "part-2"), []byte("part2"), os.ModePerm))
+
+		store, err := storage.NewDataStore(&storage.Config{Type: storage.TypeMemory}, promutils.NewTestScope())
+		assert.NoError(t, err)
+
+		outputRef := storage.DataReference("output")
+		rawRef := storage.DataReference("raw")
+		u := NewUploader(context.TODO(), store, core.DataLoadingConfig_JSON, core.IOStrategy_UPLOAD_ON_EXIT, "error")
+		assert.NoError(t, u.RecursiveUpload(context.TODO(), vmap, tmpDir, outputRef, rawRef))
+
+		outputs := &core.LiteralMap{}
+		assert.NoError(t, store.ReadProtobuf(context.TODO(), outputRef, outputs))
+
+		// literals:
+		//   x:
+		//     scalar.blob:
+		//       uri: "/raw/x"
+		//       dimensionality: MULTIPART
+		assert.Len(t, outputs.GetLiterals(), 1)
+		assert.NotNil(t, outputs.GetLiterals()["x"])
+		assert.NotNil(t, outputs.GetLiterals()["x"].GetScalar())
+		assert.NotNil(t, outputs.GetLiterals()["x"].GetScalar().GetBlob())
+		assert.Equal(t, core.BlobType_MULTIPART, outputs.GetLiterals()["x"].GetScalar().GetBlob().GetMetadata().GetType().GetDimensionality())
 	})
 }

--- a/flytecopilot/data/upload_test.go
+++ b/flytecopilot/data/upload_test.go
@@ -87,8 +87,8 @@ func TestUploader_RecursiveUpload(t *testing.T) {
 		}
 
 		assert.NoError(t, os.Mkdir(path.Join(tmpDir, "x"), os.ModePerm)) // #nosec G301
-		assert.NoError(t, os.WriteFile(path.Join(tmpDir, "x", "part-1"), []byte("part1"), os.ModePerm))
-		assert.NoError(t, os.WriteFile(path.Join(tmpDir, "x", "part-2"), []byte("part2"), os.ModePerm))
+		assert.NoError(t, os.WriteFile(path.Join(tmpDir, "x", "part-1"), []byte("part1"), 0o600))
+		assert.NoError(t, os.WriteFile(path.Join(tmpDir, "x", "part-2"), []byte("part2"), 0o600))
 
 		store, err := storage.NewDataStore(&storage.Config{Type: storage.TypeMemory}, promutils.NewTestScope())
 		assert.NoError(t, err)


### PR DESCRIPTION
## Why are the changes needed?

Directory blob uploads currently return a blob literal with SINGLE dimensionality, even though uploading a directory represents a multipart blob.

## What changes were proposed in this pull request?

This PR updates the directory upload path in handleBlobType to return a blob literal with MULTIPART dimensionality.

It also adds a regression test that verifies a directory-based blob upload produces output metadata with:

dimensionality: MULTIPART

## How was this patch tested?

Added a unit test for multipart blob uploads.

Tested with:

go test ./flytecopilot/data

Result:

PASS
ok      github.com/flyteorg/flyte/flytecopilot/data

In addition, we built a Flyte container image with this patch applied to our current Flyte version and tested it in our environment. The patched version correctly returns multipart blob outputs with MULTIPART dimensionality for directory uploads.

### Labels

fixed

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] All new and existing tests passed.
- [x] All commits are signed-off.