### PR TITLE
fix: respect plugin GeneratedNameMaxLength in k8s PluginManager

### DIFF
--- a/executor/pkg/plugin/k8s/plugin_manager.go
+++ b/executor/pkg/plugin/k8s/plugin_manager.go
@@ -80,7 +80,13 @@ func (pm *PluginManager) addObjectMetadata(taskCtx pluginsCore.TaskExecutionMeta
 	o.SetNamespace(taskCtx.GetNamespace())
 	o.SetAnnotations(pluginsUtils.UnionMaps(cfg.DefaultAnnotations, o.GetAnnotations(), pluginsUtils.CopyMap(taskCtx.GetAnnotations())))
 	o.SetLabels(pluginsUtils.UnionMaps(cfg.DefaultLabels, o.GetLabels(), pluginsUtils.CopyMap(taskCtx.GetLabels())))
-	o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
+	name := taskCtx.GetTaskExecutionID().GetGeneratedName()
+	if pm.plugin.GetProperties().GeneratedNameMaxLength != nil {
+		if truncatedName, err := taskCtx.GetTaskExecutionID().GetGeneratedNameWith(0, *pm.plugin.GetProperties().GeneratedNameMaxLength); err == nil {
+			name = truncatedName
+		}
+	}
+	o.SetName(name)
 
 	if !pm.plugin.GetProperties().DisableInjectOwnerReferences && !cfg.DisableInjectOwnerReferences {
 		o.SetOwnerReferences([]metav1.OwnerReference{taskCtx.GetOwnerReference()})

--- a/executor/pkg/plugin/k8s/plugin_manager_test.go
+++ b/executor/pkg/plugin/k8s/plugin_manager_test.go
@@ -1,0 +1,104 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	pluginsCoreMock "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core/mocks"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/encoding"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
+	k8sMocks "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s/mocks"
+)
+
+func TestAddObjectMetadata_GeneratedNameMaxLength(t *testing.T) {
+	longName := "a-very-long-task-execution-generated-name-that-exceeds-the-limit-12345"
+
+	t.Run("nil GeneratedNameMaxLength preserves generated name", func(t *testing.T) {
+		mockPlugin := k8sMocks.NewPlugin(t)
+		mockPlugin.EXPECT().GetProperties().Return(k8s.PluginProperties{
+			GeneratedNameMaxLength: nil,
+		})
+
+		pm := NewPluginManager("test-plugin", mockPlugin, nil)
+
+		taskMetadata := &pluginsCoreMock.TaskExecutionMetadata{}
+		taskMetadata.EXPECT().GetNamespace().Return("test-ns")
+		taskMetadata.EXPECT().GetAnnotations().Return(nil)
+		taskMetadata.EXPECT().GetLabels().Return(nil)
+		taskMetadata.EXPECT().GetOwnerReference().Return(metav1.OwnerReference{})
+
+		tID := &pluginsCoreMock.TaskExecutionID{}
+		tID.EXPECT().GetGeneratedName().Return(longName)
+		taskMetadata.EXPECT().GetTaskExecutionID().Return(tID)
+
+		pod := &v1.Pod{}
+		pm.addObjectMetadata(taskMetadata, pod, &config.K8sPluginConfig{})
+
+		assert.Equal(t, longName, pod.GetName())
+		assert.Equal(t, "test-ns", pod.GetNamespace())
+	})
+
+	t.Run("GeneratedNameMaxLength set truncates long generated name", func(t *testing.T) {
+		maxLength := 20
+		mockPlugin := k8sMocks.NewPlugin(t)
+		mockPlugin.EXPECT().GetProperties().Return(k8s.PluginProperties{
+			GeneratedNameMaxLength: ptr.To(maxLength),
+		})
+
+		pm := NewPluginManager("test-plugin", mockPlugin, nil)
+
+		taskMetadata := &pluginsCoreMock.TaskExecutionMetadata{}
+		taskMetadata.EXPECT().GetNamespace().Return("test-ns")
+		taskMetadata.EXPECT().GetAnnotations().Return(nil)
+		taskMetadata.EXPECT().GetLabels().Return(nil)
+		taskMetadata.EXPECT().GetOwnerReference().Return(metav1.OwnerReference{})
+
+		tID := &pluginsCoreMock.TaskExecutionID{}
+		tID.EXPECT().GetGeneratedName().Return(longName)
+		tID.EXPECT().GetGeneratedNameWith(0, maxLength).Return(encoding.FixedLengthUniqueID(longName, maxLength))
+		taskMetadata.EXPECT().GetTaskExecutionID().Return(tID)
+
+		pod := &v1.Pod{}
+		pm.addObjectMetadata(taskMetadata, pod, &config.K8sPluginConfig{})
+
+		expectedName, err := encoding.FixedLengthUniqueID(longName, maxLength)
+		require.NoError(t, err)
+
+		assert.Equal(t, expectedName, pod.GetName())
+		assert.LessOrEqual(t, len(pod.GetName()), maxLength)
+		assert.Equal(t, "test-ns", pod.GetNamespace())
+	})
+
+	t.Run("GeneratedNameMaxLength set with short name preserves name", func(t *testing.T) {
+		maxLength := 50
+		shortName := "short-name"
+		mockPlugin := k8sMocks.NewPlugin(t)
+		mockPlugin.EXPECT().GetProperties().Return(k8s.PluginProperties{
+			GeneratedNameMaxLength: ptr.To(maxLength),
+		})
+
+		pm := NewPluginManager("test-plugin", mockPlugin, nil)
+
+		taskMetadata := &pluginsCoreMock.TaskExecutionMetadata{}
+		taskMetadata.EXPECT().GetNamespace().Return("test-ns")
+		taskMetadata.EXPECT().GetAnnotations().Return(nil)
+		taskMetadata.EXPECT().GetLabels().Return(nil)
+		taskMetadata.EXPECT().GetOwnerReference().Return(metav1.OwnerReference{})
+
+		tID := &pluginsCoreMock.TaskExecutionID{}
+		tID.EXPECT().GetGeneratedName().Return(shortName)
+		tID.EXPECT().GetGeneratedNameWith(0, maxLength).Return(shortName, nil)
+		taskMetadata.EXPECT().GetTaskExecutionID().Return(tID)
+
+		pod := &v1.Pod{}
+		pm.addObjectMetadata(taskMetadata, pod, &config.K8sPluginConfig{})
+
+		assert.Equal(t, shortName, pod.GetName())
+	})
+}

--- a/executor/pkg/plugin/task_exec_metadata.go
+++ b/executor/pkg/plugin/task_exec_metadata.go
@@ -12,6 +12,7 @@ import (
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
 	executorconfig "github.com/flyteorg/flyte/v2/executor/pkg/config"
 	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/encoding"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	flytesecret "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret"
 	pluginsUtils "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/utils"
@@ -32,11 +33,7 @@ func (t *taskExecutionID) GetGeneratedName() string {
 }
 
 func (t *taskExecutionID) GetGeneratedNameWith(minLength, maxLength int) (string, error) {
-	name := t.generatedName
-	if len(name) > maxLength {
-		name = name[:maxLength]
-	}
-	return name, nil
+	return encoding.FixedLengthUniqueID(t.generatedName, maxLength)
 }
 
 func (t *taskExecutionID) GetID() *core.TaskExecutionIdentifier {

--- a/executor/pkg/plugin/task_exec_metadata_test.go
+++ b/executor/pkg/plugin/task_exec_metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/encoding"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 )
 
@@ -103,3 +104,37 @@ func TestNewTaskExecutionMetadata_UsesTaskTemplateID(t *testing.T) {
 	require.Equal(t, taskID.GetName(), got.GetName())
 	require.Equal(t, taskID.GetVersion(), got.GetVersion())
 }
+
+func TestTaskExecutionID_GetGeneratedNameWith(t *testing.T) {
+	t.Run("within max length", func(t *testing.T) {
+		execID := &taskExecutionID{
+			generatedName: "short-name",
+		}
+		name, err := execID.GetGeneratedNameWith(0, 50)
+		require.NoError(t, err)
+		require.Equal(t, "short-name", name)
+	})
+
+	t.Run("exceeds max length uses FixedLengthUniqueID", func(t *testing.T) {
+		execID := &taskExecutionID{
+			generatedName: "a-very-long-generated-name-that-exceeds-the-max-length-limit-12345",
+		}
+		maxLength := 20
+		name, err := execID.GetGeneratedNameWith(0, maxLength)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(name), maxLength)
+
+		expected, err := encoding.FixedLengthUniqueID(execID.generatedName, maxLength)
+		require.NoError(t, err)
+		require.Equal(t, expected, name)
+	})
+
+	t.Run("max length too small returns error", func(t *testing.T) {
+		execID := &taskExecutionID{
+			generatedName: "long-name",
+		}
+		_, err := execID.GetGeneratedNameWith(0, 2)
+		require.Error(t, err)
+	})
+}
+

--- a/flytestdlib/flytestdlib/storage/mocks/mocks.go
+++ b/flytestdlib/flytestdlib/storage/mocks/mocks.go
@@ -9,8 +9,8 @@ import (
 	"io"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
-	mock "github.com/stretchr/testify/mock"
 	"github.com/golang/protobuf/proto" //nolint: staticcheck
+	mock "github.com/stretchr/testify/mock"
 )
 
 // NewMetadata creates a new instance of Metadata. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.


### PR DESCRIPTION
Fixes #7607

## Tracking issue
Fixes #7607

When a Ray task runs as a sub-action (i.e. it is launched from a parent workflow or driver task rather than being the root action), the generated resource name follows the format  {run}-{action}-{attempt}  (e.g.,  rqfn7vfrdp9j84q86stm-a0d7xyznuli5is847rvhzlkly-0 ), which is typically 48 characters.

However, `KubeRay` has a strict metadata validation constraint restricting  `RayJob` names to a maximum of 47 characters. When this limit is exceeded, ` KubeRay` rejects the metadata creation request, causing the workflow task to hang indefinitely.

To prevent this, the Ray task plugin declares a ` GeneratedNameMaxLength`  of  47  in its properties. But the unified Kubernetes plugin manager ( `PluginManager` ) in the `Flyte v2` executor was assigning the object name using  `taskCtx.GetTaskExecutionID().GetGeneratedName()`  directly without checking or applying  `GeneratedNameMaxLength`.

This PR modifies the plugin manager to check  `GeneratedNameMaxLength`  and call `GetGeneratedNameWith`  instead, ensuring that generated resource names are properly bounded and truncated within the limits of the target plugin.

## What changes were proposed in this pull request?

This PR updates the Kubernetes plugin metadata builder to respect the name length limits specified by plugins:

- Respect  `GeneratedNameMaxLength` : In `plugin_manager.go`, updated the  `addObjectMetadata`  function to inspect  `pm.plugin.GetProperties().GeneratedNameMaxLength`.
- Bounded Name Generation: If a maximum length limit is specified by the plugin properties, the manager now invokes  `GetGeneratedNameWith(0, maxLength)`
  instead of  GetGeneratedName()  to securely bound and truncate the resource name.
- Compatibility Safety: Bounding the name prior to running `validation.IsDNS1123Subdomain`  ensures that trailing hyphens or dot separators resulting from truncation are automatically cleaned up.

## How was this patch tested?
1. Unit Tests:
Ran the test suites for the executor plugin package and the Ray task plugin package to ensure that there are no regressions:
    **Run executor plugin tests**
    `go test -v ./pkg/plugin/...`

    **Run Ray plugin tests**
    `go test -v ./go/tasks/plugins/k8s/ray/...`

2. Compilation:
Verified that both the manager and executor entry points compile successfully:
    `go build ./executor/cmd/main.go`
    `go build ./manager/cmd/main.go`

### Labels
- **fixed**

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
