### PR TITLE
fix(app): inject secret labels/annotations and execution env vars int…

### DIFF
--- a/app/internal/k8s/app_client.go
+++ b/app/internal/k8s/app_client.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/flyteorg/flyte/v2/app/internal/config"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret"
+	secretUtils "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/utils/secrets"
 	"github.com/flyteorg/flyte/v2/flytestdlib/k8s"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	flyteapp "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/app"
@@ -598,9 +600,33 @@ func (c *AppK8sClient) buildKService(app *flyteapp.App) (*servingv1.Service, err
 			Name:  "INTERNAL_APP_ENDPOINT_PATTERN",
 			Value: fmt.Sprintf("http://{app_fqdn}-%s.%s.svc.cluster.local", suffix, ns),
 		})
+		// Inject execution context env vars required by flyte.init_in_cluster()
+		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env,
+			corev1.EnvVar{Name: "FLYTE_INTERNAL_EXECUTION_PROJECT", Value: appID.GetProject()},
+			corev1.EnvVar{Name: "FLYTE_INTERNAL_EXECUTION_DOMAIN", Value: appID.GetDomain()},
+		)
 	}
 
 	templateAnnotations := buildAutoscalingAnnotations(spec, c.cfg)
+	// Inject secret labels and annotations into the revision template so the
+	// flyte-binary-webhook mounts the requested secrets and the secret fetcher
+	// can resolve scoped secret lookups (project/domain).
+	var templateLabels map[string]string
+	if securityContext := spec.GetSecurityContext(); securityContext != nil && len(securityContext.GetSecrets()) > 0 {
+		templateLabels = map[string]string{
+			secret.OrganizationLabel: "flyte",
+			secret.ProjectLabel:      appID.GetProject(),
+			secret.DomainLabel:       appID.GetDomain(),
+			secretUtils.PodLabel:     secretUtils.PodLabelValue,
+		}
+		secretsMap, err := secretUtils.MarshalSecretsToMapStrings(securityContext.GetSecrets())
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal secrets: %w", err)
+		}
+		for k, v := range secretsMap {
+			templateAnnotations[k] = v
+		}
+	}
 
 	timeoutSecs := c.cfg.DefaultRequestTimeout.Seconds()
 	if t := spec.GetTimeouts().GetRequestTimeout(); t != nil {
@@ -630,10 +656,11 @@ func (c *AppK8sClient) buildKService(app *flyteapp.App) (*servingv1.Service, err
 		},
 		Spec: servingv1.ServiceSpec{
 			ConfigurationSpec: servingv1.ConfigurationSpec{
-				Template: servingv1.RevisionTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: templateAnnotations,
-					},
+			Template: servingv1.RevisionTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      templateLabels,
+					Annotations: templateAnnotations,
+				},
 					Spec: servingv1.RevisionSpec{
 						PodSpec:        podSpec,
 						TimeoutSeconds: &timeoutSecsInt,

--- a/app/internal/k8s/app_client_test.go
+++ b/app/internal/k8s/app_client_test.go
@@ -121,6 +121,67 @@ func TestDeploy_InjectsInternalAppEndpointPattern(t *testing.T) {
 	assert.Equal(t, "http://{app_fqdn}-proj-dev.flyte.svc.cluster.local", pattern)
 }
 
+func TestDeploy_InjectsExecutionEnvVars(t *testing.T) {
+	c := testClient(t)
+	app := testApp("proj", "dev", "myapp", "nginx:latest")
+	require.NoError(t, c.Deploy(context.Background(), app))
+
+	ksvc := &servingv1.Service{}
+	require.NoError(t, c.k8sClient.Get(context.Background(),
+		client.ObjectKey{Name: "myapp-proj-dev", Namespace: AppNamespace}, ksvc))
+
+	envVars := ksvc.Spec.Template.Spec.Containers[0].Env
+	var gotProject, gotDomain string
+	for _, e := range envVars {
+		if e.Name == "FLYTE_INTERNAL_EXECUTION_PROJECT" {
+			gotProject = e.Value
+		}
+		if e.Name == "FLYTE_INTERNAL_EXECUTION_DOMAIN" {
+			gotDomain = e.Value
+		}
+	}
+	assert.Equal(t, "proj", gotProject)
+	assert.Equal(t, "dev", gotDomain)
+}
+
+func TestDeploy_InjectsSecretLabelsAndAnnotations(t *testing.T) {
+	c := testClient(t)
+	app := testApp("proj", "dev", "myapp", "nginx:latest")
+	app.Spec.SecurityContext = &flyteapp.SecurityContext{
+		Secrets: []*flytecoreapp.Secret{
+			{Group: "my_group", Key: "my_key", MountRequirement: flytecoreapp.Secret_ENV_VAR},
+		},
+	}
+	require.NoError(t, c.Deploy(context.Background(), app))
+
+	ksvc := &servingv1.Service{}
+	require.NoError(t, c.k8sClient.Get(context.Background(),
+		client.ObjectKey{Name: "myapp-proj-dev", Namespace: AppNamespace}, ksvc))
+
+	tpl := ksvc.Spec.Template
+	assert.Equal(t, "flyte", tpl.Labels["organization"])
+	assert.Equal(t, "proj", tpl.Labels["project"])
+	assert.Equal(t, "dev", tpl.Labels["domain"])
+	assert.Equal(t, "true", tpl.Labels["inject-flyte-secrets"])
+	assert.Contains(t, tpl.Annotations, "flyte.secrets/s0")
+}
+
+func TestDeploy_NoSecretLabelsOrAnnotationsWhenNoSecrets(t *testing.T) {
+	c := testClient(t)
+	app := testApp("proj", "dev", "myapp", "nginx:latest")
+	require.NoError(t, c.Deploy(context.Background(), app))
+
+	ksvc := &servingv1.Service{}
+	require.NoError(t, c.k8sClient.Get(context.Background(),
+		client.ObjectKey{Name: "myapp-proj-dev", Namespace: AppNamespace}, ksvc))
+
+	tpl := ksvc.Spec.Template
+	_, hasLabel := tpl.Labels["inject-flyte-secrets"]
+	assert.False(t, hasLabel, "no inject-flyte-secrets label when no secrets configured")
+	_, hasAnnotation := tpl.Annotations["flyte.secrets/s0"]
+	assert.False(t, hasAnnotation, "no secret annotations when no secrets configured")
+}
+
 func TestDeploy_DefaultServiceAccount(t *testing.T) {
 	c := testClient(t)
 	c.cfg.DefaultServiceAccount = "flyte2"


### PR DESCRIPTION
## Tracking issue
Closes #7600 

## Why are the changes needed?

The AppEnvironment path (flyte deploy) produces a Knative Service whose pod template was missing two critical pieces that the TaskAction path already provides:
1. Secret labels/annotations: The flyte-binary-webhook uses objectSelector.matchLabels{inject-flyte-secrets: "true"} to decide which pods to mutate. Without this label on the revision template, the webhook never processes the pod, so SecurityContext.secrets configured on the app are serialized into the proto but never mounted as env vars or files. The scope labels (organization/project/domain) are also required by the embedded secret manager to resolve which secret to fetch.
2. Execution env vars: The Flyte SDK's flyte.init_in_cluster() reads FLYTE_INTERNAL_EXECUTION_PROJECT and FLYTE_INTERNAL_EXECUTION_DOMAIN to construct admin API URLs. Without these, Run.get(...) builds malformed URLs like //RUN_ID (404), and with_runcontext(...) calls fail with "require_project_and_domain" errors.
## What changes were proposed in this pull request?

In app/internal/k8s/app_client.go:
1. Secret injection: Added code in buildKService that, when app.Spec.SecurityContext.Secrets is non-empty, injects the following into the Knative revision template's ObjectMeta:
- Labels: organization: "flyte", project: <app project>, domain: <app domain>, inject-flyte-secrets: "true"
- Annotations: flyte.secrets/s<index> from secrets.MarshalSecretsToMapStrings()
This mirrors what executor/pkg/plugin/task_exec_metadata.go:81-95 does for TaskAction pods.
2. Execution env vars: Added FLYTE_INTERNAL_EXECUTION_PROJECT and FLYTE_INTERNAL_EXECUTION_DOMAIN to the container's env vars, derived from appID.Project and appID.Domain. This mirrors what flyteplugins/.../flytek8s/k8s_resource_adds.go:57-63 (via GetExecutionEnvVars) provides for task pods.

## How was this patch tested?

Tests were added in app/internal/k8s/app_client_test.go:
1. TestDeploy_InjectsExecutionEnvVars — deploys an app and asserts the revision template's container env contains FLYTE_INTERNAL_EXECUTION_PROJECT=proj and FLYTE_INTERNAL_EXECUTION_DOMAIN=dev.
2. TestDeploy_InjectsSecretLabelsAndAnnotations — deploys an app with SecurityContext.Secrets: [{group: "my_group", key: "my_key", mount_requirement: ENV_VAR}] and asserts the revision template has labels organization: "flyte", project: "proj", domain: "dev", inject-flyte-secrets: "true", and that flyte.secrets/s0 annotation is present.
3. TestDeploy_NoSecretLabelsOrAnnotationsWhenNoSecrets — deploys an app without a SecurityContext and verifies neither inject-flyte-secrets label nor flyte.secrets/s* annotations appear on the template (negative case).
All 45 tests in ./app/... pass with -count=1, go build ./app/... compiles clean.
### Labels

Please add one or more of the following labels to categorize your PR:
- **fixed**

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
