### PR TITLE
Update install script to paginate releases

### DIFF
--- a/.github/workflows/validate-helm-charts.yaml
+++ b/.github/workflows/validate-helm-charts.yaml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.10"
           check-latest: true
 
-      - uses: unionai/flytectl-setup-action@v0.0.3
+      - uses: unionai-oss/flytectl-setup-action@v0.0.4
         name: Setup flytectl
 
       - name: Set up chart-testing

--- a/flytectl/install.sh
+++ b/flytectl/install.sh
@@ -326,21 +326,29 @@ http_download() {
 http_copy() {
   tmp=$(mktemp)
   http_download "${tmp}" "$1" "$2" || return 1
-  # $tmp is an array of dicts where each dict contains a tag_name.
-  # Assume that we can pull the tag_name out of the json using `jq`.
-  # We want to filter out the elements that do not have a tag_name prefixed
-  # with `flytectl/`.
-  body=$(cat "$tmp" |  jq 'map(select(.tag_name | startswith("flytectl/"))) | .[].tag_name')
+  body=$(cat "$tmp")
   rm -f "${tmp}"
   echo "$body"
+}
+
+github_releases() {
+  owner_repo=$1
+  page=1
+  while :; do
+    giturl="https://api.github.com/repos/${owner_repo}/releases?per_page=100&page=${page}"
+    json=$(http_copy "$giturl" "Accept:application/json") || return 1
+    release_count=$(echo "$json" | jq 'length') || return 1
+    test "$release_count" -eq 0 && break
+    echo "$json" | jq 'map(select((.tag_name // "") | startswith("flytectl/"))) | .[].tag_name'
+    page=$((page + 1))
+  done
 }
 
 github_release() {
   owner_repo=$1
   version=$2
   test -z "$version" && version="latest"
-  giturl="https://api.github.com/repos/${owner_repo}/releases"
-  json=$(http_copy "$giturl" "Accept:application/json")
+  json=$(github_releases "$owner_repo")
   test -z "$json" && return 1
   if [ "$version" = "latest" ]; then
     # Get the first element of the filtered json array

--- a/flytectl/install.sh
+++ b/flytectl/install.sh
@@ -334,14 +334,25 @@ http_copy() {
 github_releases() {
   owner_repo=$1
   page=1
+  tmp=$(mktemp)
   while :; do
     giturl="https://api.github.com/repos/${owner_repo}/releases?per_page=100&page=${page}"
-    json=$(http_copy "$giturl" "Accept:application/json") || return 1
-    release_count=$(echo "$json" | jq 'length') || return 1
+    http_download "${tmp}" "$giturl" "Accept:application/json" || {
+      rm -f "${tmp}"
+      return 1
+    }
+    release_count=$(jq 'length' "${tmp}") || {
+      rm -f "${tmp}"
+      return 1
+    }
     test "$release_count" -eq 0 && break
-    echo "$json" | jq 'map(select((.tag_name // "") | startswith("flytectl/"))) | .[].tag_name'
+    jq 'map(select((.tag_name // "") | startswith("flytectl/"))) | .[].tag_name' "${tmp}" || {
+      rm -f "${tmp}"
+      return 1
+    }
     page=$((page + 1))
   done
+  rm -f "${tmp}"
 }
 
 github_release() {


### PR DESCRIPTION
## Why are the changes needed?
This pull request fixes the flytectl install script in a similar way to how I fixed the flytectl GitHub action. It needs to paginate over releases since the last 30 releases may not contain flytectl. 

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
