### PR TITLE
[Feat] Make namespace configurable

### DIFF
--- a/actions/k8s/client.go
+++ b/actions/k8s/client.go
@@ -52,16 +52,16 @@ type ActionUpdate struct {
 
 const (
 	labelTerminalStatusRecorded = "flyte.org/terminal-status-recorded"
-	// flyteNamespace is the single Kubernetes namespace used for all Flyte resources.
-	flyteNamespace = "flyte"
 )
 
 // ActionsClient handles all etcd/K8s TaskAction CR operations for the Actions service.
 type ActionsClient struct {
 	k8sClient   client.WithWatch
 	sharedCache ctrlcache.Cache
-	bufferSize  int
-	runClient   workflowconnect.InternalRunServiceClient
+	// namespace is the single Kubernetes namespace used for all Flyte resources.
+	namespace  string
+	bufferSize int
+	runClient  workflowconnect.InternalRunServiceClient
 	// recordedFilter deduplicates RecordAction calls across watch reconnects.
 	recordedFilter fastcheck.Filter
 
@@ -81,13 +81,14 @@ type ActionsClient struct {
 }
 
 // NewActionsClient creates a new Kubernetes-based actions client.
-func NewActionsClient(k8sClient client.WithWatch, sharedCache ctrlcache.Cache, bufferSize int, numWorkers int, runClient workflowconnect.InternalRunServiceClient, recordFilterSize int, scope promutils.Scope) *ActionsClient {
+func NewActionsClient(k8sClient client.WithWatch, sharedCache ctrlcache.Cache, namespace string, bufferSize int, numWorkers int, runClient workflowconnect.InternalRunServiceClient, recordFilterSize int, scope promutils.Scope) *ActionsClient {
 	if numWorkers <= 0 {
 		numWorkers = 1
 	}
 	c := &ActionsClient{
 		k8sClient:   k8sClient,
 		sharedCache: sharedCache,
+		namespace:   namespace,
 		bufferSize:  bufferSize,
 		numWorkers:  numWorkers,
 		runClient:   runClient,
@@ -117,10 +118,10 @@ func (c *ActionsClient) Enqueue(ctx context.Context, action *actions.Action, run
 
 	switch action.GetSpec().(type) {
 	case *actions.Action_Task:
-		if err := k8sutil.EnsureNamespaceExists(ctx, c.k8sClient, flyteNamespace); err != nil {
-			return fmt.Errorf("failed to ensure namespace %s: %w", flyteNamespace, err)
+		if err := k8sutil.EnsureNamespaceExists(ctx, c.k8sClient, c.namespace); err != nil {
+			return fmt.Errorf("failed to ensure namespace %s: %w", c.namespace, err)
 		}
-		taskAction := newTaskActionCR(actionID, executorv1.ActionTypeTask, isRoot)
+		taskAction := c.newTaskActionCR(actionID, executorv1.ActionTypeTask, isRoot)
 		// Set OwnerReference to parent so K8s cascades deletion to children.
 		if !isRoot {
 			parentTaskAction, err := c.setParentOwnership(ctx, taskAction, actionID.Run, *action.ParentActionName)
@@ -158,10 +159,10 @@ func (c *ActionsClient) Enqueue(ctx context.Context, action *actions.Action, run
 		if err := validateConditionDeclaredType(cond); err != nil {
 			return connect.NewError(connect.CodeInvalidArgument, err)
 		}
-		if err := k8sutil.EnsureNamespaceExists(ctx, c.k8sClient, flyteNamespace); err != nil {
-			return fmt.Errorf("failed to ensure namespace %s: %w", flyteNamespace, err)
+		if err := k8sutil.EnsureNamespaceExists(ctx, c.k8sClient, c.namespace); err != nil {
+			return fmt.Errorf("failed to ensure namespace %s: %w", c.namespace, err)
 		}
-		taskAction := newTaskActionCR(actionID, executorv1.ActionTypeCondition, isRoot)
+		taskAction := c.newTaskActionCR(actionID, executorv1.ActionTypeCondition, isRoot)
 		if !isRoot {
 			if _, err := c.setParentOwnership(ctx, taskAction, actionID.Run, *action.ParentActionName); err != nil {
 				return err
@@ -228,7 +229,7 @@ func (c *ActionsClient) AbortAction(ctx context.Context, actionID *common.Action
 	logger.Infof(ctx, "Aborting action %s (reason: %v)", taskActionName, reason)
 
 	taskAction := &executorv1.TaskAction{}
-	if err := c.k8sClient.Get(ctx, client.ObjectKey{Name: taskActionName, Namespace: flyteNamespace}, taskAction); err != nil {
+	if err := c.k8sClient.Get(ctx, client.ObjectKey{Name: taskActionName, Namespace: c.namespace}, taskAction); err != nil {
 		return fmt.Errorf("failed to get TaskAction %s: %w", taskActionName, err)
 	}
 
@@ -248,7 +249,7 @@ func (c *ActionsClient) PutStatus(ctx context.Context, actionID *common.ActionId
 	taskAction := &executorv1.TaskAction{}
 	if err := c.k8sClient.Get(ctx, client.ObjectKey{
 		Name:      taskActionName,
-		Namespace: flyteNamespace,
+		Namespace: c.namespace,
 	}, taskAction); err != nil {
 		return fmt.Errorf("failed to get TaskAction %s: %w", taskActionName, err)
 	}
@@ -293,7 +294,7 @@ func (c *ActionsClient) Signal(ctx context.Context, actionID *common.ActionIdent
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		taskAction := &executorv1.TaskAction{}
-		if err := c.k8sClient.Get(ctx, client.ObjectKey{Name: taskActionName, Namespace: flyteNamespace}, taskAction); err != nil {
+		if err := c.k8sClient.Get(ctx, client.ObjectKey{Name: taskActionName, Namespace: c.namespace}, taskAction); err != nil {
 			if apierrors.IsNotFound(err) {
 				return connect.NewError(connect.CodeNotFound, fmt.Errorf("condition action %s not found", taskActionName))
 			}
@@ -357,7 +358,7 @@ func literalPrimitiveKind(value *core.Literal) (core.SimpleType, bool) {
 func (c *ActionsClient) ListRunActions(ctx context.Context, runID *common.RunIdentifier) ([]*executorv1.TaskAction, error) {
 	taskActionList := &executorv1.TaskActionList{}
 	listOpts := []client.ListOption{
-		client.InNamespace(flyteNamespace),
+		client.InNamespace(c.namespace),
 		client.MatchingLabels{
 			"flyte.org/project": runID.Project,
 			"flyte.org/domain":  runID.Domain,
@@ -381,7 +382,7 @@ func (c *ActionsClient) ListChildActions(ctx context.Context, parentActionID *co
 	// List all TaskActions in the same run
 	taskActionList := &executorv1.TaskActionList{}
 	listOpts := []client.ListOption{
-		client.InNamespace(flyteNamespace),
+		client.InNamespace(c.namespace),
 		client.MatchingLabels{
 			"flyte.org/project": parentActionID.Run.Project,
 			"flyte.org/domain":  parentActionID.Run.Domain,
@@ -418,7 +419,7 @@ func (c *ActionsClient) GetTaskAction(ctx context.Context, actionID *common.Acti
 	taskAction := &executorv1.TaskAction{}
 	if err := c.k8sClient.Get(ctx, client.ObjectKey{
 		Name:      taskActionName,
-		Namespace: flyteNamespace,
+		Namespace: c.namespace,
 	}, taskAction); err != nil {
 		return nil, fmt.Errorf("failed to get TaskAction %s: %w", taskActionName, err)
 	}
@@ -482,7 +483,7 @@ func (c *ActionsClient) StartWatching(ctx context.Context) error {
 	}
 	c.mu.Unlock()
 
-	logger.Infof(ctx, "Starting TaskAction watcher for namespace: %s (workers: %d)", flyteNamespace, c.numWorkers)
+	logger.Infof(ctx, "Starting TaskAction watcher for namespace: %s (workers: %d)", c.namespace, c.numWorkers)
 
 	if c.sharedCache == nil {
 		return fmt.Errorf("shared cache is required for TaskAction informer")
@@ -847,11 +848,11 @@ func (c *ActionsClient) markTerminalStatusRecorded(ctx context.Context, taskActi
 
 // newTaskActionCR builds the CR skeleton (name, namespace, labels) shared by
 // all action types.
-func newTaskActionCR(actionID *common.ActionIdentifier, actionType string, isRoot bool) *executorv1.TaskAction {
+func (c *ActionsClient) newTaskActionCR(actionID *common.ActionIdentifier, actionType string, isRoot bool) *executorv1.TaskAction {
 	return &executorv1.TaskAction{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildTaskActionName(actionID),
-			Namespace: flyteNamespace,
+			Namespace: c.namespace,
 			Labels: map[string]string{
 				"flyte.org/project":     actionID.Run.Project,
 				"flyte.org/domain":      actionID.Run.Domain,
@@ -875,7 +876,7 @@ func (c *ActionsClient) setParentOwnership(ctx context.Context, child *executorv
 	parentName := buildTaskActionName(parentID)
 
 	parent := &executorv1.TaskAction{}
-	if err := c.k8sClient.Get(ctx, client.ObjectKey{Name: parentName, Namespace: flyteNamespace}, parent); err != nil {
+	if err := c.k8sClient.Get(ctx, client.ObjectKey{Name: parentName, Namespace: c.namespace}, parent); err != nil {
 		return nil, fmt.Errorf("failed to get parent TaskAction %s: %w", parentName, err)
 	}
 

--- a/actions/k8s/client_condition_test.go
+++ b/actions/k8s/client_condition_test.go
@@ -32,9 +32,10 @@ func newConditionClient(t *testing.T) *ActionsClient {
 	require.NoError(t, corev1.AddToScheme(scheme)) // EnsureNamespaceExists needs v1.Namespace
 	require.NoError(t, executorv1.AddToScheme(scheme))
 	parent := &executorv1.TaskAction{
-		ObjectMeta: metav1.ObjectMeta{Name: "run1-a0", Namespace: flyteNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: "run1-a0", Namespace: "flyte"},
 	}
 	return &ActionsClient{
+		namespace: "flyte",
 		k8sClient: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithObjects(parent).

--- a/actions/k8s/client_test.go
+++ b/actions/k8s/client_test.go
@@ -188,10 +188,6 @@ func TestBuildTaskActionName(t *testing.T) {
 	})
 }
 
-func TestFlyteNamespace(t *testing.T) {
-	assert.Equal(t, "flyte", flyteNamespace)
-}
-
 func TestExtractTaskCacheKey(t *testing.T) {
 	t.Run("returns cache key for task action", func(t *testing.T) {
 		action := &actions.Action{

--- a/actions/setup.go
+++ b/actions/setup.go
@@ -50,6 +50,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	actionsClient := actionsk8s.NewActionsClient(
 		sc.K8sClient,
 		sc.K8sCache,
+		sc.Namespace,
 		cfg.WatchBufferSize,
 		cfg.WatchWorkers,
 		runClient,

--- a/app/internal/k8s/app_client.go
+++ b/app/internal/k8s/app_client.go
@@ -116,6 +116,8 @@ type AppK8sClient struct {
 	k8sClient client.WithWatch
 	cache     ctrlcache.Cache
 	cfg       *config.InternalAppConfig
+	// Kubernetes namespace where all KService objects are deployed.
+	namespace string
 
 	// Watch management
 	mu          sync.RWMutex
@@ -125,17 +127,15 @@ type AppK8sClient struct {
 }
 
 // NewAppK8sClient creates a new AppK8sClient.
-func NewAppK8sClient(k8sClient client.WithWatch, cache ctrlcache.Cache, cfg *config.InternalAppConfig) *AppK8sClient {
+func NewAppK8sClient(k8sClient client.WithWatch, cache ctrlcache.Cache, namespace string, cfg *config.InternalAppConfig) *AppK8sClient {
 	return &AppK8sClient{
 		k8sClient:   k8sClient,
 		cache:       cache,
 		cfg:         cfg,
+		namespace:   namespace,
 		subscribers: make(map[string]map[chan *flyteapp.WatchResponse]struct{}),
 	}
 }
-
-// AppNamespace is the fixed Kubernetes namespace where all KService objects are deployed.
-const AppNamespace = "flyte"
 
 // defaultOrg is the org returned for apps that have no org persisted on the KService.
 // we always surface a non-empty value for callers (e.g. the UI) that expect one.
@@ -144,7 +144,7 @@ const defaultOrg = "flyte"
 // Deploy creates or updates the KService for the given app.
 func (c *AppK8sClient) Deploy(ctx context.Context, app *flyteapp.App) error {
 	appID := app.GetMetadata().GetId()
-	ns := AppNamespace
+	ns := c.namespace
 	name := KServiceName(appID)
 
 	if err := k8s.EnsureNamespaceExists(ctx, c.k8sClient, ns); err != nil {
@@ -208,7 +208,7 @@ func (c *AppK8sClient) Deploy(ctx context.Context, app *flyteapp.App) error {
 
 // Stop makes the app unreachable from the public gateway and scales it to zero without deleting the KService.
 func (c *AppK8sClient) Stop(ctx context.Context, appID *flyteapp.Identifier) error {
-	ns := AppNamespace
+	ns := c.namespace
 	name := KServiceName(appID)
 	// Make the Service cluster-local so it is not published to the external gateway,
 	// and set initial/min scale to zero so it converges to 0 pods.
@@ -252,7 +252,7 @@ func (c *AppK8sClient) Stop(ctx context.Context, appID *flyteapp.Identifier) err
 
 // Delete removes the KService CRD for the given app entirely.
 func (c *AppK8sClient) Delete(ctx context.Context, appID *flyteapp.Identifier) error {
-	ns := AppNamespace
+	ns := c.namespace
 	name := KServiceName(appID)
 	ksvc := &servingv1.Service{}
 	ksvc.Name = name
@@ -423,7 +423,7 @@ func (c *AppK8sClient) StopWatching() {
 
 // GetApp reads the KService and returns the full App including reconstructed Spec and live Status.
 func (c *AppK8sClient) GetApp(ctx context.Context, appID *flyteapp.Identifier) (*flyteapp.App, error) {
-	ns := AppNamespace
+	ns := c.namespace
 	name := KServiceName(appID)
 	ksvc := &servingv1.Service{}
 	if err := c.k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: ns}, ksvc); err != nil {
@@ -455,7 +455,7 @@ func specFromAnnotation(ksvc *servingv1.Service) *flyteapp.Spec {
 
 // List returns apps for the given project/domain scope with optional pagination.
 func (c *AppK8sClient) List(ctx context.Context, project, domain string, limit uint32, token string) ([]*flyteapp.App, string, error) {
-	ns := AppNamespace
+	ns := c.namespace
 
 	matchLabels := map[string]string{labelAppManaged: "true"}
 	if project != "" {
@@ -561,7 +561,7 @@ func (c *AppK8sClient) buildKService(app *flyteapp.App) (*servingv1.Service, err
 	appID := app.GetMetadata().GetId()
 	spec := app.GetSpec()
 	name := KServiceName(appID)
-	ns := AppNamespace
+	ns := c.namespace
 
 	specBytes, err := marshalSpec(spec)
 	if err != nil {
@@ -876,7 +876,7 @@ func (c *AppK8sClient) kserviceToStatus(ctx context.Context, ksvc *servingv1.Ser
 // has no ready revision yet (initial rollout), all pods for the service are
 // returned.
 func (c *AppK8sClient) GetReplicas(ctx context.Context, appID *flyteapp.Identifier) ([]*flyteapp.Replica, error) {
-	ns := AppNamespace
+	ns := c.namespace
 	name := KServiceName(appID)
 
 	labels := client.MatchingLabels{labelKnativeService: name}
@@ -908,7 +908,7 @@ func (c *AppK8sClient) GetReplicas(ctx context.Context, appID *flyteapp.Identifi
 
 // DeleteReplica force-deletes a specific pod. Knative will schedule a replacement automatically.
 func (c *AppK8sClient) DeleteReplica(ctx context.Context, replicaID *flyteapp.ReplicaIdentifier) error {
-	ns := AppNamespace
+	ns := c.namespace
 	pod := &corev1.Pod{}
 	pod.Name = replicaID.GetName()
 	pod.Namespace = ns

--- a/app/internal/k8s/app_client_test.go
+++ b/app/internal/k8s/app_client_test.go
@@ -33,6 +33,9 @@ func testScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
+// AppNamespace is the namespace all test clients are configured with.
+const AppNamespace = "flyte"
+
 // testRevision builds a Knative Revision object with a given ActualReplicas count.
 func testRevision(name, namespace string, actualReplicas int32) *servingv1.Revision {
 	return &servingv1.Revision{
@@ -59,7 +62,7 @@ func testClient(t *testing.T, objs ...client.Object) *AppK8sClient {
 		MaxRequestTimeout:     time.Hour,
 		WatchBufferSize:       100,
 	}
-	return NewAppK8sClient(fc, nil, cfg)
+	return NewAppK8sClient(fc, nil, AppNamespace, cfg)
 }
 
 // testApp builds a minimal flyteapp.App for use in tests.
@@ -281,6 +284,7 @@ func TestStop_DeletesLatestReadyRevision(t *testing.T) {
 		Build()
 	c := &AppK8sClient{
 		k8sClient: fc,
+		namespace: AppNamespace,
 		cfg:       &config.InternalAppConfig{},
 	}
 
@@ -376,6 +380,7 @@ func TestGetApp_CurrentReplicas(t *testing.T) {
 		Build()
 	c := &AppK8sClient{
 		k8sClient: fc,
+		namespace: AppNamespace,
 		cfg:       &config.InternalAppConfig{},
 	}
 
@@ -448,6 +453,7 @@ func TestList(t *testing.T) {
 		Build()
 	c := &AppK8sClient{
 		k8sClient: fc,
+		namespace: AppNamespace,
 		cfg: &config.InternalAppConfig{
 			DefaultRequestTimeout: 5 * time.Minute,
 			MaxRequestTimeout:     time.Hour,
@@ -482,6 +488,7 @@ func TestGetReplicas(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(pod).Build()
 	c := &AppK8sClient{
 		k8sClient: fc,
+		namespace: AppNamespace,
 		cfg:       &config.InternalAppConfig{},
 	}
 
@@ -526,7 +533,7 @@ func TestGetReplicas_FiltersToLatestRevision(t *testing.T) {
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
 	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ksvc, newPod, oldPod).Build()
-	c := &AppK8sClient{k8sClient: fc, cfg: &config.InternalAppConfig{}}
+	c := &AppK8sClient{k8sClient: fc, namespace: AppNamespace, cfg: &config.InternalAppConfig{}}
 
 	id := &flyteapp.Identifier{Project: "proj", Domain: "dev", Name: "myapp"}
 	replicas, err := c.GetReplicas(context.Background(), id)
@@ -546,6 +553,7 @@ func TestDeleteReplica(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(pod).Build()
 	c := &AppK8sClient{
 		k8sClient: fc,
+		namespace: AppNamespace,
 		cfg:       &config.InternalAppConfig{},
 	}
 

--- a/app/internal/service/app_logs_streamer.go
+++ b/app/internal/service/app_logs_streamer.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	appk8s "github.com/flyteorg/flyte/v2/app/internal/k8s"
 	"github.com/flyteorg/flyte/v2/flytestdlib/k8s/podlogs"
 	flyteapp "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/app"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/logs/dataplane"
@@ -26,23 +25,25 @@ const defaultInitialLines = int64(1000)
 // K8sAppLogStreamer streams logs from the pod backing an app replica.
 type K8sAppLogStreamer struct {
 	clientset kubernetes.Interface
+	// namespace is the Kubernetes namespace where app replica pods run.
+	namespace string
 }
 
 // NewK8sAppLogStreamer creates a K8sAppLogStreamer from a Kubernetes REST config.
 // It clears the timeout so that long-lived log streams are not interrupted.
-func NewK8sAppLogStreamer(k8sConfig *rest.Config) (*K8sAppLogStreamer, error) {
+func NewK8sAppLogStreamer(k8sConfig *rest.Config, namespace string) (*K8sAppLogStreamer, error) {
 	cfg := rest.CopyConfig(k8sConfig)
 	cfg.Timeout = 0
 	clientset, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
 	}
-	return &K8sAppLogStreamer{clientset: clientset}, nil
+	return &K8sAppLogStreamer{clientset: clientset, namespace: namespace}, nil
 }
 
 // TailLogs streams log lines for a replica's pod.
 func (s *K8sAppLogStreamer) TailLogs(ctx context.Context, replicaID *flyteapp.ReplicaIdentifier, send func(*flyteapp.LogLines) error) error {
-	ns := appk8s.AppNamespace
+	ns := s.namespace
 	podName := replicaID.GetName()
 
 	pod, err := s.clientset.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})

--- a/app/internal/setup.go
+++ b/app/internal/setup.go
@@ -32,7 +32,7 @@ func Setup(ctx context.Context, sc *stdlibapp.SetupContext, cfg *appconfig.Inter
 		return fmt.Errorf("internalapp: failed to register Knative scheme: %w", err)
 	}
 
-	appK8sClient := appk8s.NewAppK8sClient(sc.K8sClient, sc.K8sCache, cfg)
+	appK8sClient := appk8s.NewAppK8sClient(sc.K8sClient, sc.K8sCache, sc.Namespace, cfg)
 	internalAppSvc := service.NewInternalAppService(appK8sClient)
 
 	if err := appK8sClient.StartWatching(ctx); err != nil {
@@ -62,7 +62,7 @@ func Setup(ctx context.Context, sc *stdlibapp.SetupContext, cfg *appconfig.Inter
 	logger.Infof(ctx, "Mounted InternalAppService at /internal%s", path)
 
 	if sc.K8sConfig != nil {
-		streamer, err := service.NewK8sAppLogStreamer(sc.K8sConfig)
+		streamer, err := service.NewK8sAppLogStreamer(sc.K8sConfig, sc.Namespace)
 		if err != nil {
 			return fmt.Errorf("internalapp: failed to create log streamer: %w", err)
 		}

--- a/executor/pkg/webhook/entrypoint.go
+++ b/executor/pkg/webhook/entrypoint.go
@@ -26,7 +26,7 @@ const (
 func Setup(ctx context.Context, kubeClient kubernetes.Interface, cfg *webhookConfig.Config,
 	defaultNamespace string, scope promutils.Scope, mgr manager.Manager) error {
 
-	if err := InitCerts(ctx, kubeClient, cfg); err != nil {
+	if err := InitCerts(ctx, kubeClient, cfg, defaultNamespace); err != nil {
 		return fmt.Errorf("webhook: failed to initialize certs: %w", err)
 	}
 

--- a/executor/pkg/webhook/init_cert.go
+++ b/executor/pkg/webhook/init_cert.go
@@ -34,18 +34,14 @@ const (
 	CaCertKey            = "ca.crt"
 	ServerCertKey        = "tls.crt"
 	ServerCertPrivateKey = "tls.key"
-	podDefaultNamespace  = "flyte"
 	permission           = 0644
 	folderPerm           = 0755
 )
 
 // InitCerts generates a self-signed TLS certificate for the webhook and stores it in a k8s Secret.
-func InitCerts(ctx context.Context, kubeClient kubernetes.Interface, cfg *webhookConfig.Config) error {
-	podNamespace, found := os.LookupEnv(PodNamespaceEnvVar)
-	if !found {
-		podNamespace = podDefaultNamespace
-	}
-
+// podNamespace must be the namespace the webhook service runs in — the cert's DNS
+// names are derived from it.
+func InitCerts(ctx context.Context, kubeClient kubernetes.Interface, cfg *webhookConfig.Config, podNamespace string) error {
 	logger.Infof(ctx, "Issuing certs")
 	certs, err := createCerts(cfg.ServiceName, podNamespace)
 	if err != nil {

--- a/runs/cmd/main.go
+++ b/runs/cmd/main.go
@@ -23,21 +23,12 @@ func main() {
 			cfg := runsconfig.GetConfig()
 			sc.Host = cfg.Server.Host
 			sc.Port = cfg.Server.Port
-			sc.Namespace = "flyte" // TODO: make configurable
 
 			db, err := database.GetDB(ctx, database.GetConfig())
 			if err != nil {
 				return fmt.Errorf("failed to initialize database: %w", err)
 			}
 			sc.DB = db
-
-			k8sClient, _, err := app.InitKubernetesClient(ctx, app.K8sConfig{
-				Namespace: sc.Namespace,
-			}, nil)
-			if err != nil {
-				return fmt.Errorf("failed to initialize Kubernetes client: %w", err)
-			}
-			sc.K8sClient = k8sClient
 
 			labeled.SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey)
 			dataStore, err := storage.NewDataStore(storage.GetConfig(), promutils.NewTestScope())

--- a/runs/config/config_flags_test.go
+++ b/runs/config/config_flags_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-viper/mapstructure/v2"
+	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

Currently, actions / apps will only run on `flyte` namespace, which is hard-coded. We should make it configurable.

## What changes were proposed in this pull request?

1. Passing namespace from config to action service
2. App service read namespace from config
3. Run service do not need k8s client. Remove it.
4. Executor webhook remove duplicate pod namespace env var lookup

## How was this patch tested?

1. Update `charts/flyte-binary/values.yaml` and set namespace to `flyte-test`:

```yaml
  actions:
    kubernetes:
      namespace: "flyte-test"
```

2. Re-build and run devbox: `make devbox-build devbox-run`
3. Run an action and serve an app, check if the action / app pods are created in `flyte-test` namespace

<img width="1290" height="128" alt="image" src="https://github.com/user-attachments/assets/0af7ccac-954c-4701-95a4-b96269f99eff" />

<img width="1768" height="134" alt="image" src="https://github.com/user-attachments/assets/a365fc7a-52b6-42f9-9ad9-91a6553aa3b9" />


### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
