### PR TITLE
fix(actions): bump TaskAction watch workers and buffer size

### DIFF
--- a/actions/config/config.go
+++ b/actions/config/config.go
@@ -23,7 +23,7 @@ var defaultConfig = &Config{
 	// NOTE: total buffering is WatchWorkers * WatchBufferSize watch.Event entries.
 	// Each entry includes a DeepCopy() of the TaskAction; tune carefully to avoid large memory spikes under backlog.
 	WatchBufferSize: 1000,
-	WatchWorkers:    100
+	WatchWorkers:    100,
 	RunServiceURL:   "http://localhost:8090",
 	// 8M slots × 8 bytes/pointer = 64 MB; can track ~8M unique actions.
 	RecordFilterSize: 1 << 23,

--- a/actions/config/config.go
+++ b/actions/config/config.go
@@ -20,8 +20,10 @@ var defaultConfig = &Config{
 		Burst:     2000,
 		Timeout:   "30s",
 	},
+	// NOTE: total buffering is WatchWorkers * WatchBufferSize watch.Event entries.
+	// Each entry includes a DeepCopy() of the TaskAction; tune carefully to avoid large memory spikes under backlog.
 	WatchBufferSize: 1000,
-	WatchWorkers:    100,
+	WatchWorkers:    100
 	RunServiceURL:   "http://localhost:8090",
 	// 8M slots × 8 bytes/pointer = 64 MB; can track ~8M unique actions.
 	RecordFilterSize: 1 << 23,

--- a/actions/config/config.go
+++ b/actions/config/config.go
@@ -20,8 +20,8 @@ var defaultConfig = &Config{
 		Burst:     2000,
 		Timeout:   "30s",
 	},
-	WatchBufferSize: 100,
-	WatchWorkers:    10,
+	WatchBufferSize: 1000,
+	WatchWorkers:    100,
 	RunServiceURL:   "http://localhost:8090",
 	// 8M slots × 8 bytes/pointer = 64 MB; can track ~8M unique actions.
 	RecordFilterSize: 1 << 23,


### PR DESCRIPTION
## Tracking issue

Related to #7640 (this PR is 1 of 3 splitting that PR into independently reviewable changes).

## Why are the changes needed?

Under high held-action concurrency (tens of thousands of live `TaskActions`), the TaskAction watch pipeline in the actions client backs up. `dispatchEvent` does a **blocking** send to a sharded worker pool (`actions/k8s/client.go`), so with only `WatchWorkers: 10` and `WatchBufferSize: 100` the informer's event handler stalls waiting for a free worker/buffer slot, adding latency to event processing during the completion burst. This is **backpressure/latency**, not event loss on this path — the dispatcher blocks rather than dropping. (The only drop-on-full path is the separate subscriber-notification channel in `notifySubscribers`, which a larger buffer also helps.)

## What changes were proposed in this pull request?

Raise the defaults in `actions/config/config.go`:

- `WatchBufferSize`: `100 -> 1000`
- `WatchWorkers`: `10 -> 100`

Config-default change only; no logic changes. A wider worker pool and deeper buffer keep the blocking dispatch send from stalling the informer handler under high concurrency, so events are processed with lower latency. Prerequisite for the coalescing/batching changes split out into the sibling PRs.

## How was this patch tested?

Validated as part of the 40k-held-action scale benchmark on a dev cluster: with the larger worker pool and buffer the watch dispatch no longer applies backpressure to the informer during the completion burst. No unit test added (config-default constants only).

### Labels
changed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
