### PR TITLE
fix(runs): honor Offset in ListActions so WatchActions returns all actions

### DIFF
--- a/runs/repository/impl/action.go
+++ b/runs/repository/impl/action.go
@@ -346,6 +346,15 @@ func (r *actionRepo) ListActions(ctx context.Context, input interfaces.ListResou
 	queryBuilder.WriteString(" LIMIT ?")
 	args = append(args, input.Limit+1)
 
+	// Offset-based pagination (mutually exclusive with CursorToken, per
+	// ListResourceInput). Without emitting OFFSET, callers that page by Offset
+	// (e.g. WatchActions' initial full listing) silently re-read the first page
+	// on every iteration, capping the result at a single page (~Limit rows).
+	if input.Offset > 0 {
+		queryBuilder.WriteString(" OFFSET ?")
+		args = append(args, input.Offset)
+	}
+
 	query := sqlx.Rebind(sqlx.DOLLAR, queryBuilder.String())
 
 	var actions []*models.Action

--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -392,6 +392,49 @@ func TestListRuns(t *testing.T) {
 	}
 }
 
+func TestListActions_OffsetPagination(t *testing.T) {
+	db := setupActionDB(t)
+	defer func() { db.Exec("DELETE FROM actions") }()
+	actionRepo, err := NewActionRepo(db, testDbConfig)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Five root actions in one project.
+	for _, name := range []string{"run-1", "run-2", "run-3", "run-4", "run-5"} {
+		_, err := actionRepo.CreateAction(ctx, &models.Run{
+			Project: "proj1",
+			Domain:  "domain1",
+			RunName: name,
+			Name:    rootActionName,
+			Phase:   int32(common.ActionPhase_ACTION_PHASE_QUEUED),
+		}, false)
+		require.NoError(t, err)
+	}
+
+	filter := NewIsRootActionFilter().And(NewEqualFilter("project", "proj1"))
+	count := func(limit, offset int) int {
+		got, err := actionRepo.ListActions(ctx, interfaces.ListResourceInput{
+			Filter: filter,
+			Limit:  limit,
+			Offset: offset,
+		})
+		require.NoError(t, err)
+		return len(got)
+	}
+
+	require.Equal(t, 5, count(50, 0), "all five root actions")
+
+	// Offset must skip rows: offset N of 5 returns 5-N. Before OFFSET was honored,
+	// the offset was ignored and every one of these returned all 5 rows.
+	assert.Equal(t, 3, count(50, 2), "offset=2 skips the first two")
+	assert.Equal(t, 1, count(50, 4), "offset=4 leaves only the last")
+	assert.Equal(t, 0, count(50, 5), "offset past the end returns nothing")
+
+	// Offset composes with the Limit+1 keyset probe: page size 2 at offset 2 still
+	// returns from the third row onward (up to Limit+1).
+	assert.Equal(t, 3, count(2, 2), "Limit=2 at offset=2 returns rows 3..5 (limit+1 probe)")
+}
+
 func setupActionEventDB(t *testing.T) (*sqlx.DB, *actionRepo) {
 	db := setupActionDB(t)
 	r, err := NewActionRepo(db, testDbConfig)


### PR DESCRIPTION
## Problem

`WatchActions` only ever returns ~100 actions for a run, even when the run has many more (e.g. 1,000). Observed on a run with 1,000 actions — the client/console only sees the first ~100.

## Root cause

`ListResourceInput` supports two mutually-exclusive pagination modes: keyset (`CursorToken`) and `Offset`. `actionRepo.ListActions` implements **only** the cursor path — it builds `... LIMIT ?` and never emits an `OFFSET`, so the `Offset` field is silently ignored.

`WatchActions`' initial full listing (`listAndSendAllActions`) paginates by **`Offset`** (`offset += pageSize`). Because `ListActions` ignored it, every page re-read the same first `~Limit` rows, so only the first page was ever delivered.

## Fix

Emit `OFFSET ?` when `input.Offset > 0`. Cursor-based callers (the `ListActions` RPC handlers) pass `Offset == 0` and are unchanged; only the offset-based `WatchActions` initial listing is affected.

```go
queryBuilder.WriteString(" LIMIT ?")
args = append(args, input.Limit+1)

if input.Offset > 0 {
    queryBuilder.WriteString(" OFFSET ?")
    args = append(args, input.Offset)
}
```

## Test

`TestListActions_OffsetPagination` — creates 5 root actions and asserts `offset=N` returns `total-N` rows (order-independent counts). These assertions fail on the old behavior (offset ignored → every page returned all 5). Existing `TestListRuns` (cursor pagination) still passes, confirming the change is additive.

```
ok  github.com/flyteorg/flyte/v2/runs/repository/impl  12.176s
```

https://claude.ai/code/session_01AjhEAjx4yGQY9MhpY5DEXd