### PR TITLE
Treat K8s Invalid/BadRequest on resource create as permanent user failure

### DIFF
--- a/executor/pkg/plugin/k8s/plugin_manager.go
+++ b/executor/pkg/plugin/k8s/plugin_manager.go
@@ -113,6 +113,12 @@ func (pm *PluginManager) launchResource(ctx context.Context, tCtx pluginsCore.Ta
 		if k8serrors.IsRequestEntityTooLargeError(err) {
 			return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("EntityTooLarge", err.Error(), nil)), nil
 		}
+		// K8s rejected the resource as invalid (e.g. HTTP 422 for a pod spec with an empty
+		// container image). The same spec will be rejected on every attempt, so retrying as a
+		// system failure only burns retries while the task appears Queued with an error attached.
+		if k8serrors.IsInvalid(err) || k8serrors.IsBadRequest(err) {
+			return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("InvalidResource", err.Error(), nil)), nil
+		}
 		reason := k8serrors.ReasonForError(err)
 		logger.Errorf(ctx, "Failed to launch job, system error. err: %v", err)
 		return pluginsCore.UnknownTransition, errors.Wrapf(stdErrors.ErrorCode(reason), err, "failed to create resource")

--- a/executor/pkg/plugin/k8s/plugin_manager_test.go
+++ b/executor/pkg/plugin/k8s/plugin_manager_test.go
@@ -1,0 +1,128 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
+
+	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
+	coreMocks "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core/mocks"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
+	k8sMocks "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s/mocks"
+)
+
+func newLaunchTestPluginManager(t *testing.T, createErr error) (*PluginManager, pluginsCore.TaskExecutionContext) {
+	tID := coreMocks.NewTaskExecutionID(t)
+	tID.EXPECT().GetGeneratedName().Return("test-pod")
+
+	meta := coreMocks.NewTaskExecutionMetadata(t)
+	meta.EXPECT().GetTaskExecutionID().Return(tID)
+	meta.EXPECT().GetNamespace().Return("test-ns")
+	meta.EXPECT().GetAnnotations().Return(nil)
+	meta.EXPECT().GetLabels().Return(nil)
+	meta.EXPECT().GetOwnerReference().Return(metav1.OwnerReference{Kind: "node", Name: "n1"})
+
+	tCtx := coreMocks.NewTaskExecutionContext(t)
+	tCtx.EXPECT().TaskExecutionMetadata().Return(meta)
+
+	plugin := k8sMocks.NewPlugin(t)
+	plugin.EXPECT().GetProperties().Return(k8s.PluginProperties{})
+	plugin.EXPECT().BuildResource(mock.Anything, tCtx).Return(&corev1.Pod{}, nil)
+
+	builder := fake.NewClientBuilder().WithScheme(k8sscheme.Scheme)
+	if createErr != nil {
+		builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+				return createErr
+			},
+		})
+	}
+
+	kubeClient := coreMocks.NewKubeClient(t)
+	kubeClient.EXPECT().GetClient().Return(builder.Build())
+
+	return NewPluginManager("test", plugin, kubeClient), tCtx
+}
+
+func TestLaunchResourceCreateErrorHandling(t *testing.T) {
+	invalidErr := k8serrors.NewInvalid(
+		schema.GroupKind{Kind: "Pod"},
+		"test-pod",
+		field.ErrorList{field.Required(field.NewPath("spec", "containers").Index(0).Child("image"), "")},
+	)
+
+	tests := []struct {
+		name      string
+		createErr error
+		wantPhase pluginsCore.Phase
+		wantCode  string
+		wantKind  core.ExecutionError_ErrorKind
+	}{
+		{
+			name:      "invalid resource is a permanent user failure",
+			createErr: invalidErr,
+			wantPhase: pluginsCore.PhasePermanentFailure,
+			wantCode:  "InvalidResource",
+			wantKind:  core.ExecutionError_USER,
+		},
+		{
+			name:      "bad request is a permanent user failure",
+			createErr: k8serrors.NewBadRequest("malformed resource"),
+			wantPhase: pluginsCore.PhasePermanentFailure,
+			wantCode:  "InvalidResource",
+			wantKind:  core.ExecutionError_USER,
+		},
+		{
+			name:      "forbidden is a retryable failure",
+			createErr: k8serrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "test-pod", errors.New("exceeded quota")),
+			wantPhase: pluginsCore.PhaseRetryableFailure,
+			wantCode:  "RuntimeFailure",
+			wantKind:  core.ExecutionError_USER,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm, tCtx := newLaunchTestPluginManager(t, tt.createErr)
+
+			transition, err := pm.launchResource(t.Context(), tCtx)
+			require.NoError(t, err)
+
+			info := transition.Info()
+			assert.Equal(t, tt.wantPhase, info.Phase())
+			require.NotNil(t, info.Err())
+			assert.Equal(t, tt.wantCode, info.Err().GetCode())
+			assert.Equal(t, tt.wantKind, info.Err().GetKind())
+		})
+	}
+}
+
+func TestLaunchResourceOtherCreateErrorsAreSystemErrors(t *testing.T) {
+	pm, tCtx := newLaunchTestPluginManager(t, k8serrors.NewInternalError(errors.New("etcd unavailable")))
+
+	_, err := pm.launchResource(t.Context(), tCtx)
+	require.Error(t, err)
+}
+
+func TestLaunchResourceSuccess(t *testing.T) {
+	pm, tCtx := newLaunchTestPluginManager(t, nil)
+
+	transition, err := pm.launchResource(t.Context(), tCtx)
+	require.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseQueued, transition.Info().Phase())
+}


### PR DESCRIPTION
## Tracking issue

Related to [RUN-53](https://linear.app/unionai/issue/RUN-53/run-with-invalid-pod-spec-shows-queued-but-error-and-burns-30-system)

## Why are the changes needed?

A run submitted with a deterministically invalid pod spec (e.g. an empty container image, as in `playground/flytesnacks/development/run-labels-smoke-6a40e9`) is rejected by K8s with 422 on every create attempt:

```
Pod "..." is invalid: spec.containers[0].image: Required value
```

`launchResource` only special-cases `IsForbidden` and `IsRequestEntityTooLargeError`; `IsInvalid` falls through to the generic system-error path. Leasor then system-retries up to `max_system_retries` (30) at ~1/min, and each retry flips the action back to Queued while the previous attempt's error is still on the record — the run shows "Queued but error" in the UI for ~35 minutes before permanently failing, and inflates active-run counts in queue metrics.

Since the same spec is rejected on every attempt, retrying can never succeed.

## What changes were proposed in this pull request?

In `executor/pkg/plugin/k8s/plugin_manager.go` `launchResource`, handle `k8serrors.IsInvalid` and `k8serrors.IsBadRequest` on resource create the same way as `IsRequestEntityTooLargeError`: a permanent user failure (`PhaseInfoFailure`, code `InvalidResource`) that fails the action immediately instead of burning system retries.

This mirrors upstream flyte1's `transitionFromError` `IsBadRequest || IsInvalid` branch (where the permanent-failure transition is commented out), and acts as the catch-all for all K8s plugins and dynamically spawned child actions. Front-door validation of the task spec at CreateRun is tracked separately in RUN-53.

## How was this patch tested?

Added `plugin_manager_test.go` covering `launchResource` create-error handling: Invalid and BadRequest → permanent USER failure with code `InvalidResource`; Forbidden → retryable failure (unchanged); other errors (e.g. internal) → system error (unchanged); successful create → Queued.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.