### PR TITLE
fix(executor): populate DefaultPodTemplateStore so PodTemplates apply

### DIFF
--- a/charts/flyte-binary/templates/clusterrole.yaml
+++ b/charts/flyte-binary/templates/clusterrole.yaml
@@ -48,6 +48,14 @@ rules:
       - get
   - apiGroups:
       - ""
+    resources:
+      - podtemplates
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
       - events.k8s.io
     resources:
       - events

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -11,6 +11,7 @@ import (
 	"connectrpc.com/otelconnect"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -27,6 +28,7 @@ import (
 	webhookPkg "github.com/flyteorg/flyte/v2/executor/pkg/webhook"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/catalog"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	cachecatalog "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/catalog/cache_service"
 	webhookConfig "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret/config"
 	connectorplugin "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/webapi/connector"
@@ -54,6 +56,15 @@ func init() {
 // Useful for callers that need to pass the scheme to InitKubernetesClient.
 func Scheme() *runtime.Scheme {
 	return scheme
+}
+
+// watchPodTemplates wires a PodTemplate informer into the flytek8s.DefaultPodTemplateStore,
+// with defaultNamespace as the fallback namespace for template lookups.
+func watchPodTemplates(informerFactory informers.SharedInformerFactory, defaultNamespace string) error {
+	flytek8s.DefaultPodTemplateStore.SetDefaultNamespace(defaultNamespace)
+	_, err := informerFactory.Core().V1().PodTemplates().Informer().AddEventHandler(
+		flytek8s.GetPodTemplateUpdatesHandler(&flytek8s.DefaultPodTemplateStore))
+	return err
 }
 
 // Setup registers the executor as a background worker on the SetupContext.
@@ -122,6 +133,20 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	if podNamespace == "" {
 		podNamespace = sc.Namespace
 	}
+
+	// Populate the flytek8s.DefaultPodTemplateStore read during pod construction, so both the
+	// global plugins.k8s default-pod-template-name and per-task pod_template_name resolve.
+	// Uses a standalone informer rather than the manager cache so a missing `podtemplates`
+	// RBAC grant degrades to watch-error logs instead of failing manager cache sync.
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	if err := watchPodTemplates(informerFactory, podNamespace); err != nil {
+		return fmt.Errorf("executor: failed to register PodTemplate event handler: %w", err)
+	}
+	sc.AddWorker("podtemplate-informer", func(ctx context.Context) error {
+		informerFactory.Start(ctx.Done())
+		<-ctx.Done()
+		return nil
+	})
 
 	executorScope := promutils.NewScope("executor")
 

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	k8scache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -28,8 +30,8 @@ import (
 	webhookPkg "github.com/flyteorg/flyte/v2/executor/pkg/webhook"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/catalog"
-	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	cachecatalog "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/catalog/cache_service"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	webhookConfig "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret/config"
 	connectorplugin "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/webapi/connector"
 	"github.com/flyteorg/flyte/v2/flytestdlib/app"
@@ -46,6 +48,10 @@ import (
 var scheme = runtime.NewScheme()
 
 const otelServiceName = "executor"
+
+// podTemplateSyncTimeout bounds the initial PodTemplate informer sync; matches
+// controller-runtime's default cache sync timeout.
+const podTemplateSyncTimeout = 2 * time.Minute
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -136,14 +142,20 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 
 	// Populate the flytek8s.DefaultPodTemplateStore read during pod construction, so both the
 	// global plugins.k8s default-pod-template-name and per-task pod_template_name resolve.
-	// Uses a standalone informer rather than the manager cache so a missing `podtemplates`
-	// RBAC grant degrades to watch-error logs instead of failing manager cache sync.
+	// Failing to sync (e.g. a missing `podtemplates` RBAC grant) fails startup: silently
+	// running with an empty store is exactly the bug this wiring fixes.
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	if err := watchPodTemplates(informerFactory, podNamespace); err != nil {
 		return fmt.Errorf("executor: failed to register PodTemplate event handler: %w", err)
 	}
 	sc.AddWorker("podtemplate-informer", func(ctx context.Context) error {
 		informerFactory.Start(ctx.Done())
+		syncCtx, cancel := context.WithTimeout(ctx, podTemplateSyncTimeout)
+		defer cancel()
+		if !k8scache.WaitForCacheSync(syncCtx.Done(), informerFactory.Core().V1().PodTemplates().Informer().HasSynced) {
+			return fmt.Errorf("executor: PodTemplate informer failed to sync within %v; "+
+				"verify the service account can get/list/watch core/v1 podtemplates", podTemplateSyncTimeout)
+		}
 		<-ctx.Done()
 		return nil
 	})

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -140,10 +140,6 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		podNamespace = sc.Namespace
 	}
 
-	// Populate the flytek8s.DefaultPodTemplateStore read during pod construction, so both the
-	// global plugins.k8s default-pod-template-name and per-task pod_template_name resolve.
-	// Failing to sync (e.g. a missing `podtemplates` RBAC grant) fails startup: silently
-	// running with an empty store is exactly the bug this wiring fixes.
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	if err := watchPodTemplates(informerFactory, podNamespace); err != nil {
 		return fmt.Errorf("executor: failed to register PodTemplate event handler: %w", err)

--- a/executor/setup_test.go
+++ b/executor/setup_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestWatchPodTemplatesPopulatesDefaultStore(t *testing.T) {
+	flytek8s.DefaultPodTemplateStore = flytek8s.NewPodTemplateStore()
 	podTemplate := &v1.PodTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "flyte-template", Namespace: "flyte"},
 		Template: v1.PodTemplateSpec{
@@ -31,7 +32,7 @@ func TestWatchPodTemplatesPopulatesDefaultStore(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	informerFactory.Start(ctx.Done())
-	cache.WaitForCacheSync(ctx.Done(), informerFactory.Core().V1().PodTemplates().Informer().HasSynced)
+	require.True(t, cache.WaitForCacheSync(ctx.Done(), informerFactory.Core().V1().PodTemplates().Informer().HasSynced), "podtemplate informer cache never synced")
 
 	// direct hit in the pod's namespace
 	assert.NotNil(t, flytek8s.DefaultPodTemplateStore.LoadOrDefault("flyte", "flyte-template"))

--- a/executor/setup_test.go
+++ b/executor/setup_test.go
@@ -1,0 +1,41 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s"
+)
+
+func TestWatchPodTemplatesPopulatesDefaultStore(t *testing.T) {
+	podTemplate := &v1.PodTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "flyte-template", Namespace: "flyte"},
+		Template: v1.PodTemplateSpec{
+			Spec: v1.PodSpec{Containers: []v1.Container{{Name: "default", Image: "img"}}},
+		},
+	}
+	client := fake.NewSimpleClientset(podTemplate)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+	require.NoError(t, watchPodTemplates(informerFactory, "flyte"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	informerFactory.Start(ctx.Done())
+	cache.WaitForCacheSync(ctx.Done(), informerFactory.Core().V1().PodTemplates().Informer().HasSynced)
+
+	// direct hit in the pod's namespace
+	assert.NotNil(t, flytek8s.DefaultPodTemplateStore.LoadOrDefault("flyte", "flyte-template"))
+	// fallback to the default namespace for pods running elsewhere
+	assert.NotNil(t, flytek8s.DefaultPodTemplateStore.LoadOrDefault("other-ns", "flyte-template"))
+	assert.Nil(t, flytek8s.DefaultPodTemplateStore.LoadOrDefault("flyte", "missing"))
+}


### PR DESCRIPTION
## Why are the changes needed?

On flyte-binary v2, PodTemplates do not work at all — neither the global `plugins.k8s.default-pod-template-name` nor a per-task `pod_template_name` has any effect (the per-task form fails the task with `PodTemplate '<name>' does not exist`).

Root cause: pod construction reads the in-memory `flytek8s.DefaultPodTemplateStore` (`getBasePodTemplate` in `pod_helper.go`), but nothing in the v2 runtime ever populates it. In v1 flytepropeller's controller registered a PodTemplate informer wired to `flytek8s.GetPodTemplateUpdatesHandler`; that wiring was never carried over to the v2 executor, so every store lookup returns `nil`.

## What changes were proposed in this pull request?

- `executor/setup.go`: register a PodTemplate informer during executor setup, wired into `flytek8s.DefaultPodTemplateStore` via the existing `GetPodTemplateUpdatesHandler`, and set the executor pod namespace as the store's fallback namespace (matching v1 propeller semantics). If the informer fails its initial sync within 2 minutes (e.g. the `podtemplates` RBAC grant is missing), executor startup fails — silently running with an empty store is exactly the bug this fixes.
- `charts/flyte-binary/templates/clusterrole.yaml`: grant `get`/`list`/`watch` on `podtemplates`.

## How was this patch tested?

- New unit test `TestWatchPodTemplatesPopulatesDefaultStore` (fake clientset → informer → store): direct-namespace hit, default-namespace fallback, and miss.
- Reproduced and verified end-to-end on an EKS dev cluster:
  1. Created a `PodTemplate` (label + annotation + env on the `default` container) in the executor namespace and set `plugins.k8s.default-pod-template-name`.
  2. **Before the fix**: task pods came up without any of the template's label/annotation/env.
  3. **After deploying this branch's image**: task pods carry the template's label, annotation, and env — both with `default-pod-template-name` and with a per-task `pod_template="<name>"` (SDK `TaskEnvironment(pod_template=...)`).

### Labels

- **fixed**: PodTemplates (global `default-pod-template-name` and per-task `pod_template_name`) now apply on flyte-binary v2.