### PR TITLE
fix(secrets): deliver flyte-native secrets to task pods

### DIFF
--- a/charts/flyte-binary/README.md
+++ b/charts/flyte-binary/README.md
@@ -136,7 +136,7 @@ Chart for basic single Flyte executable deployment
 | flyte-core-components.secret.kubernetes.burst | int | `200` |  |
 | flyte-core-components.secret.kubernetes.clusterName | string | `"flyte-devbox"` |  |
 | flyte-core-components.secret.kubernetes.kubeconfig | string | `""` |  |
-| flyte-core-components.secret.kubernetes.namespace | string | `"flyte"` |  |
+| flyte-core-components.secret.kubernetes.namespace | string | `"{{ .Release.Namespace }}"` |  |
 | flyte-core-components.secret.kubernetes.qps | int | `100` |  |
 | flyte-core-components.secret.kubernetes.timeout | string | `"30s"` |  |
 | fullnameOverride | string | `""` |  |

--- a/charts/flyte-binary/templates/configmap.yaml
+++ b/charts/flyte-binary/templates/configmap.yaml
@@ -23,12 +23,23 @@ data:
     logger:
       show-source: true
       level: {{ default 1 .Values.configuration.logging.level }}
+    # Flyte-native secrets (flyte create secret): the secret service writes Kubernetes
+    # Secrets into this namespace, and the pod webhook's embedded secret manager reads
+    # them back from the same namespace. Keep the two in sync.
+    secret:
+      kubernetes:
+        namespace: {{ .Release.Namespace }}
     webhook:
       certDir: /var/run/flyte/certs
       localCert: true
       secretName: {{ include "flyte-binary.webhook.secretName" . }}
       serviceName: {{ include "flyte-binary.webhook.serviceName" . }}
       servicePort: 443
+      secretManagerType: Embedded
+      embeddedSecretManagerConfig:
+        type: K8s
+        k8sConfig:
+          namespace: {{ .Release.Namespace }}
 {{ tpl ( index .Values "flyte-core-components" | toYaml ) . | nindent 4 }}
   001-plugins.yaml: |
     tasks:

--- a/charts/flyte-binary/templates/configmap.yaml
+++ b/charts/flyte-binary/templates/configmap.yaml
@@ -29,7 +29,8 @@ data:
       secretName: {{ include "flyte-binary.webhook.secretName" . }}
       serviceName: {{ include "flyte-binary.webhook.serviceName" . }}
       servicePort: 443
-      secretManagerType: Embedded
+      secretManagerTypes:
+        - Embedded
       embeddedSecretManagerConfig:
         type: K8s
         k8sConfig:

--- a/charts/flyte-binary/templates/configmap.yaml
+++ b/charts/flyte-binary/templates/configmap.yaml
@@ -23,12 +23,6 @@ data:
     logger:
       show-source: true
       level: {{ default 1 .Values.configuration.logging.level }}
-    # Flyte-native secrets (flyte create secret): the secret service writes Kubernetes
-    # Secrets into this namespace, and the pod webhook's embedded secret manager reads
-    # them back from the same namespace. Keep the two in sync.
-    secret:
-      kubernetes:
-        namespace: {{ .Release.Namespace }}
     webhook:
       certDir: /var/run/flyte/certs
       localCert: true

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -39,9 +39,14 @@ flyte-core-components:
     download:
       maxExpiresIn: 1h
 
+  # Flyte-native secrets (flyte create secret): the secret service writes Kubernetes
+  # Secrets into this namespace, and the pod webhook's embedded secret manager reads
+  # them back from the same namespace (webhook.embeddedSecretManagerConfig.k8sConfig
+  # in the ConfigMap template). Keep the two in sync. Rendered through tpl, so it
+  # defaults to the release namespace.
   secret:
     kubernetes:
-      namespace: "flyte"
+      namespace: '{{ .Release.Namespace }}'
       kubeconfig: ""
       qps: 100
       burst: 200

--- a/flyteplugins/go/tasks/pluginmachinery/secret/config/config.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/config/config.go
@@ -29,8 +29,13 @@ var (
 		MetricsPrefix:     "flyte:",
 		CertDir:           "/etc/webhook/certs",
 		LocalCert:         false,
-		ListenPort:        9443,
-		SecretManagerType: SecretManagerTypeK8s,
+		ListenPort: 9443,
+		// Embedded + K8s fetcher matches the naming scheme the v2 secret service uses when
+		// `flyte create secret` writes Kubernetes Secrets (md5 of the org/domain/project/name
+		// encoded ID, value stored under the encoded ID key), including scope fallback
+		// (project+domain -> domain -> org). The plain K8s injector references secrets by
+		// md5(key)/key, which the secret service never creates.
+		SecretManagerType: SecretManagerTypeEmbedded,
 		AWSSecretManagerConfig: AWSSecretManagerConfig{
 			SidecarImage: "docker.io/amazon/aws-secrets-manager-secret-sidecar:v0.1.4",
 			Resources: corev1.ResourceRequirements{
@@ -75,6 +80,11 @@ var (
 			KVVersion: KVVersion2,
 		},
 		EmbeddedSecretManagerConfig: EmbeddedSecretManagerConfig{
+			Type: EmbeddedSecretManagerTypeK8s,
+			K8sConfig: K8sConfig{
+				// Must match the secret service's kubernetes.namespace (same default).
+				Namespace: "flyte",
+			},
 			FileMountInitContainer: FileMountInitContainerConfig{
 				Image: "public.ecr.aws/docker/library/busybox:latest",
 				Resources: corev1.ResourceRequirements{

--- a/flyteplugins/go/tasks/pluginmachinery/secret/config/config.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/config/config.go
@@ -19,6 +19,11 @@ import (
 const (
 	EmbeddedSecretsFileMountInitContainerName = "init-embedded-secret"
 	DefaultSecretEnvVarPrefix                 = "_UNION_"
+
+	// DefaultSecretsNamespace is the namespace flyte-native secrets are stored in by
+	// default. The secret service writes Kubernetes Secrets here, and the webhook's
+	// embedded K8s secret fetcher reads them back — both defaults must stay in sync.
+	DefaultSecretsNamespace = "flyte"
 )
 
 var (
@@ -77,8 +82,7 @@ var (
 		EmbeddedSecretManagerConfig: EmbeddedSecretManagerConfig{
 			Type: EmbeddedSecretManagerTypeK8s,
 			K8sConfig: K8sConfig{
-				// Must match the secret service's kubernetes.namespace (same default).
-				Namespace: "flyte",
+				Namespace: DefaultSecretsNamespace,
 			},
 			FileMountInitContainer: FileMountInitContainerConfig{
 				Image: "public.ecr.aws/docker/library/busybox:latest",

--- a/flyteplugins/go/tasks/pluginmachinery/secret/config/config.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/config/config.go
@@ -29,12 +29,7 @@ var (
 		MetricsPrefix:     "flyte:",
 		CertDir:           "/etc/webhook/certs",
 		LocalCert:         false,
-		ListenPort: 9443,
-		// Embedded + K8s fetcher matches the naming scheme the v2 secret service uses when
-		// `flyte create secret` writes Kubernetes Secrets (md5 of the org/domain/project/name
-		// encoded ID, value stored under the encoded ID key), including scope fallback
-		// (project+domain -> domain -> org). The plain K8s injector references secrets by
-		// md5(key)/key, which the secret service never creates.
+		ListenPort:        9443,
 		SecretManagerType: SecretManagerTypeEmbedded,
 		AWSSecretManagerConfig: AWSSecretManagerConfig{
 			SidecarImage: "docker.io/amazon/aws-secrets-manager-secret-sidecar:v0.1.4",

--- a/secret/config/config.go
+++ b/secret/config/config.go
@@ -16,8 +16,6 @@ var defaultConfig = &Config{
 		Host: "0.0.0.0",
 	},
 	Kubernetes: app.K8sConfig{
-		// Same constant the pod webhook's embedded K8s secret fetcher defaults to —
-		// the webhook reads back the Secrets this service writes.
 		Namespace:   webhookconfig.DefaultSecretsNamespace,
 		QPS:         100,
 		Burst:       200,

--- a/secret/config/config.go
+++ b/secret/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	webhookconfig "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret/config"
 	"github.com/flyteorg/flyte/v2/flytestdlib/app"
 	"github.com/flyteorg/flyte/v2/flytestdlib/config"
 )
@@ -15,7 +16,9 @@ var defaultConfig = &Config{
 		Host: "0.0.0.0",
 	},
 	Kubernetes: app.K8sConfig{
-		Namespace:   "flyte",
+		// Same constant the pod webhook's embedded K8s secret fetcher defaults to —
+		// the webhook reads back the Secrets this service writes.
+		Namespace:   webhookconfig.DefaultSecretsNamespace,
 		QPS:         100,
 		Burst:       200,
 		Timeout:     "30s",

--- a/secret/service/secret_service_test.go
+++ b/secret/service/secret_service_test.go
@@ -170,15 +170,15 @@ func TestSecretService_List_RejectsProjectWithoutDomain(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestServiceCreatedSecretIsReadableByWebhookFetcher(t *testing.T) {
+func TestK8sSecretWrittenByServiceIsReadableByWebhookFetcher(t *testing.T) {
 	// End-to-end naming compatibility: a Secret written by CreateSecret must be
 	// found by the K8sSecretFetcher the pod webhook's embedded secret manager
 	// uses, via the scope-fallback lookup IDs derived from task pod labels.
 	// This is the invariant that, when broken, silently delivers no secrets.
 	podLabels := map[string]string{
-		"organization": defaultOrganization,
-		"domain":       "development",
-		"project":      "flytesnacks",
+		flytesecret.OrganizationLabel: defaultOrganization,
+		flytesecret.DomainLabel:       "development",
+		flytesecret.ProjectLabel:      "flytesnacks",
 	}
 
 	for _, tc := range []struct {
@@ -192,15 +192,16 @@ func TestServiceCreatedSecretIsReadableByWebhookFetcher(t *testing.T) {
 		t.Run(tc.scope, func(t *testing.T) {
 			encoded, k8sName, err := getK8sSecretName(context.Background(), tc.id)
 			require.NoError(t, err)
-			k8sSecret, err := buildK8sSecret(encoded, k8sName, "flyte", tc.id,
+			ns := secretNamespace()
+			k8sSecret, err := buildK8sSecret(encoded, k8sName, ns, tc.id,
 				&secretpb.SecretSpec{Value: &secretpb.SecretSpec_StringValue{StringValue: "v"}})
 			require.NoError(t, err)
-			// fake typed clientset stores StringData as-is only via Data; mimic API server behavior
+			// Fake typed clientset does not merge StringData into Data; mimic apiserver behavior.
 			k8sSecret.Data = map[string][]byte{encoded: []byte("v")}
+			k8sSecret.StringData = nil
 
 			fetcher := flytesecret.NewK8sSecretFetcher(
-				k8sFake.NewSimpleClientset(k8sSecret).CoreV1().Secrets("flyte"))
-
+				k8sFake.NewSimpleClientset(k8sSecret).CoreV1().Secrets(ns))
 			// Walk scopes exactly like EmbeddedSecretManagerInjector.lookUpSecret.
 			ids := []string{
 				flytesecret.EncodeSecretName(podLabels["organization"], podLabels["domain"], podLabels["project"], "sec"),

--- a/secret/service/secret_service_test.go
+++ b/secret/service/secret_service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+	k8sFake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -167,4 +168,54 @@ func TestSecretService_List_RejectsProjectWithoutDomain(t *testing.T) {
 	s := NewSecretService(k)
 	_, err := s.ListSecrets(context.Background(), connect.NewRequest(&secretpb.ListSecretsRequest{Project: "flytesnacks"}))
 	require.Error(t, err)
+}
+
+func TestServiceCreatedSecretIsReadableByWebhookFetcher(t *testing.T) {
+	// End-to-end naming compatibility: a Secret written by CreateSecret must be
+	// found by the K8sSecretFetcher the pod webhook's embedded secret manager
+	// uses, via the scope-fallback lookup IDs derived from task pod labels.
+	// This is the invariant that, when broken, silently delivers no secrets.
+	podLabels := map[string]string{
+		"organization": defaultOrganization,
+		"domain":       "development",
+		"project":      "flytesnacks",
+	}
+
+	for _, tc := range []struct {
+		scope string
+		id    *secretpb.SecretIdentifier
+	}{
+		{"project", &secretpb.SecretIdentifier{Domain: "development", Project: "flytesnacks", Name: "sec"}},
+		{"domain", &secretpb.SecretIdentifier{Domain: "development", Name: "sec"}},
+		{"org", &secretpb.SecretIdentifier{Name: "sec"}},
+	} {
+		t.Run(tc.scope, func(t *testing.T) {
+			encoded, k8sName, err := getK8sSecretName(context.Background(), tc.id)
+			require.NoError(t, err)
+			k8sSecret, err := buildK8sSecret(encoded, k8sName, "flyte", tc.id,
+				&secretpb.SecretSpec{Value: &secretpb.SecretSpec_StringValue{StringValue: "v"}})
+			require.NoError(t, err)
+			// fake typed clientset stores StringData as-is only via Data; mimic API server behavior
+			k8sSecret.Data = map[string][]byte{encoded: []byte("v")}
+
+			fetcher := flytesecret.NewK8sSecretFetcher(
+				k8sFake.NewSimpleClientset(k8sSecret).CoreV1().Secrets("flyte"))
+
+			// Walk scopes exactly like EmbeddedSecretManagerInjector.lookUpSecret.
+			ids := []string{
+				flytesecret.EncodeSecretName(podLabels["organization"], podLabels["domain"], podLabels["project"], "sec"),
+				flytesecret.EncodeSecretName(podLabels["organization"], podLabels["domain"], "", "sec"),
+				flytesecret.EncodeSecretName(podLabels["organization"], "", "", "sec"),
+			}
+			var found bool
+			for _, id := range ids {
+				if v, err := fetcher.GetSecretValue(context.Background(), id); err == nil {
+					assert.Equal(t, "v", string(v.BinaryValue))
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "secret created at %s scope not found via any lookup scope", tc.scope)
+		})
+	}
 }

--- a/secret/service/secret_service_test.go
+++ b/secret/service/secret_service_test.go
@@ -208,15 +208,17 @@ func TestK8sSecretWrittenByServiceIsReadableByWebhookFetcher(t *testing.T) {
 				flytesecret.EncodeSecretName(podLabels["organization"], podLabels["domain"], "", "sec"),
 				flytesecret.EncodeSecretName(podLabels["organization"], "", "", "sec"),
 			}
-			var found bool
+			expectedID := flytesecret.EncodeSecretName(defaultOrganization, tc.id.GetDomain(), tc.id.GetProject(), tc.id.GetName())
+			var foundID string
 			for _, id := range ids {
-				if v, err := fetcher.GetSecretValue(context.Background(), id); err == nil {
+				v, err := fetcher.GetSecretValue(context.Background(), id)
+				if err == nil {
 					assert.Equal(t, "v", string(v.BinaryValue))
-					found = true
+					foundID = id
 					break
 				}
 			}
-			assert.True(t, found, "secret created at %s scope not found via any lookup scope", tc.scope)
+			assert.Equal(t, expectedID, foundID, "secret created at %s scope was not found at the expected lookup scope", tc.scope)
 		})
 	}
 }


### PR DESCRIPTION
## Why are the changes needed?

On flyte-binary v2, secrets created via `flyte create secret` are never delivered to task pods — at every scope (project+domain, domain, org). The task pod's injected env var / secret volume references a Kubernetes `Secret` name and data key that the secret service never creates:

- **Secret service writes**: `Secret` named `md5(EncodeSecretName(org, domain, project, name))` (e.g. `d6a91cc8…` for `u__org__flyte__domain____project____key__repro_secret`), value stored under the full encoded ID as data key.
- **Pod webhook references** (default `SecretManagerTypeK8s` injector, empty group fallback): `Secret` named `md5(bare key)` (e.g. `4d2e40ca…` for `repro_secret`), data key = bare key.

Neither the name nor the key match. Because the injected `secretKeyRef` / volume is `optional: true`, the pod starts with nothing mounted and fails later with an opaque downstream error (missing env var, `DefaultCredentialsError`, …) instead of a clear "secret not found".

## What changes were proposed in this pull request?

- Default the webhook to the **embedded secret manager with the K8s fetcher** (`flyteplugins/.../secret/config/config.go`). The embedded injector resolves the secret at pod admission using the same encoding as the secret service, including scope fallback (project+domain → domain → org) derived from the task pod's `organization`/`project`/`domain` labels, and rejects the pod with a clear admission error when the secret is genuinely missing. Its default K8s namespace is `flyte`, matching the secret service's `kubernetes.namespace` default.
- **flyte-binary chart**: render `secret.kubernetes.namespace` and `webhook.embeddedSecretManagerConfig.k8sConfig.namespace` as `{{ .Release.Namespace }}` so the writer and reader stay aligned in any install namespace.

## How was this patch tested?

- New test `TestServiceCreatedSecretIsReadableByWebhookFetcher`: for each scope, a Secret written by `CreateSecret` must be found by the `K8sSecretFetcher` via the webhook's scope-fallback lookup IDs — the invariant that, when broken, silently delivers no secrets.
- Reproduced and verified end-to-end on an EKS dev cluster:
  1. `flyte create secret repro_secret --value …`, then ran a task with `secrets=flyte.Secret(key="repro_secret", as_env_var="REPRO_SECRET")`.
  2. **Before**: pod env referenced `Secret` `4d2e40ca…`/key `repro_secret` (`optional: true`) while the real Secret was `d6a91cc8…` with the encoded-ID key → env var absent, task failed with an application-level error.
  3. **After deploying this branch's image**: the task receives the secret value and succeeds. *(verification run below)*

### Labels

- **fixed**: Flyte-native secrets (`flyte create secret`) are now delivered to task pods on flyte-binary v2.