### PR TITLE
[Feat] support pause actions only field in list runs

### DIFF
--- a/runs/migrations/sql/20260722100000_add_actions_paused_idx.sql
+++ b/runs/migrations/sql/20260722100000_add_actions_paused_idx.sql
@@ -1,0 +1,7 @@
+-- Partial index supporting the "has paused action" run filter (ListRuns).
+-- phase 9 = ACTION_PHASE_PAUSED (e.g. human-in-the-loop gate node awaiting input).
+-- Paused actions are rare, so this partial index stays small and turns the
+-- correlated EXISTS subquery into an index lookup keyed on the run's PK prefix.
+CREATE INDEX IF NOT EXISTS idx_actions_paused
+    ON actions (project, domain, run_name)
+    WHERE phase = 9;

--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -452,6 +452,41 @@ func TestListRuns(t *testing.T) {
 	}
 }
 
+func TestListRuns_HasPausedActionFilter(t *testing.T) {
+	db := setupActionDB(t)
+	defer func() { db.Exec("DELETE FROM actions") }()
+	actionRepo, err := NewActionRepo(db, testDbConfig)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// run-paused: RUNNING root with a PAUSED child (HITL gate awaiting input).
+	// run-plain: RUNNING root whose child is also RUNNING.
+	for _, a := range []*models.Action{
+		{Project: "proj1", Domain: "domain1", RunName: "run-paused", Name: rootActionName,
+			Phase: int32(common.ActionPhase_ACTION_PHASE_RUNNING)},
+		{Project: "proj1", Domain: "domain1", RunName: "run-paused", Name: "gate-node",
+			ParentActionName: sql.NullString{String: rootActionName, Valid: true},
+			Phase:            int32(common.ActionPhase_ACTION_PHASE_PAUSED)},
+		{Project: "proj1", Domain: "domain1", RunName: "run-plain", Name: rootActionName,
+			Phase: int32(common.ActionPhase_ACTION_PHASE_RUNNING)},
+		{Project: "proj1", Domain: "domain1", RunName: "run-plain", Name: "worker-node",
+			ParentActionName: sql.NullString{String: rootActionName, Valid: true},
+			Phase:            int32(common.ActionPhase_ACTION_PHASE_RUNNING)},
+	} {
+		_, err := actionRepo.CreateAction(ctx, a, false)
+		require.NoError(t, err)
+	}
+
+	runs, err := actionRepo.ListActions(ctx, interfaces.ListResourceInput{
+		Filter: NewIsRootActionFilter().And(NewHasPausedActionFilter()),
+		Limit:  50,
+	})
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	assert.Equal(t, "run-paused", runs[0].RunName)
+	assert.False(t, runs[0].ParentActionName.Valid, "only the root action should be returned")
+}
+
 // TestListActions_KeysetPagination covers the O(n) keyset paging used by the
 // WatchActions snapshot: pages continue after the previous page's (created_at, name)
 // instead of by OFFSET. It forces tied created_at (the bulk-created map-task case) so

--- a/runs/repository/impl/filters.go
+++ b/runs/repository/impl/filters.go
@@ -16,6 +16,19 @@ func NewIsRootActionFilter() interfaces.Filter {
 	return &nullFilter{field: "parent_action_name", isNull: true}
 }
 
+// NewHasPausedActionFilter matches root actions whose run contains at least one
+// action in the PAUSED phase (e.g. a human-in-the-loop gate node awaiting input).
+func NewHasPausedActionFilter() interfaces.Filter {
+	return NewRawFilter(
+		`EXISTS (SELECT 1 FROM actions a2 `+
+			`WHERE a2.project = actions.project `+
+			`AND a2.domain = actions.domain `+
+			`AND a2.run_name = actions.run_name `+
+			`AND a2.phase = ?)`,
+		int32(common.ActionPhase_ACTION_PHASE_PAUSED),
+	)
+}
+
 // NewRunActionsFilter creates a filter for all actions belonging to a specific run.
 func NewRunActionsFilter(runID *common.RunIdentifier) interfaces.Filter {
 	return NewEqualFilter("project", runID.GetProject()).
@@ -116,6 +129,31 @@ func (f *nullFilter) And(filter interfaces.Filter) interfaces.Filter {
 }
 
 func (f *nullFilter) Or(filter interfaces.Filter) interfaces.Filter {
+	return &compositeFilter{left: f, right: filter, operator: "OR"}
+}
+
+// rawFilter implements the Filter interface for hand-written SQL predicates that
+// the field/expression filters cannot express (e.g. correlated EXISTS subqueries).
+// The query must qualify its own columns; the table argument is ignored.
+type rawFilter struct {
+	query string
+	args  []interface{}
+}
+
+// NewRawFilter creates a filter from a raw SQL predicate and its bind arguments.
+func NewRawFilter(query string, args ...interface{}) interfaces.Filter {
+	return &rawFilter{query: query, args: args}
+}
+
+func (f *rawFilter) QueryExpression(table string) (interfaces.QueryExpr, error) {
+	return interfaces.QueryExpr{Query: f.query, Args: f.args}, nil
+}
+
+func (f *rawFilter) And(filter interfaces.Filter) interfaces.Filter {
+	return &compositeFilter{left: f, right: filter, operator: "AND"}
+}
+
+func (f *rawFilter) Or(filter interfaces.Filter) interfaces.Filter {
 	return &compositeFilter{left: f, right: filter, operator: "OR"}
 }
 

--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -914,6 +914,12 @@ func (s *RunService) ListRuns(
 		scopeFilter = scopeFilter.And(impl.NewRunTaskIdFilter(scope.TaskId))
 	}
 
+	// Restrict to runs that contain at least one PAUSED action (e.g. a
+	// human-in-the-loop gate node awaiting input) when requested.
+	if req.Msg.PausedActionsOnly {
+		scopeFilter = scopeFilter.And(impl.NewHasPausedActionFilter())
+	}
+
 	// Parse pagination, sort, and user-supplied filters from the common ListRequest.
 	listInput, err := impl.NewListResourceInputFromProto(req.Msg.Request, models.ActionColumnsSet)
 	if err != nil {


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

Enable to filter runs with at least one paused action (human-in-the-loop) in list runs page.

## What changes were proposed in this pull request?

Check `PausedActionsOnly` from the list runs request and add query to filter runs with paused action exists.

## How was this patch tested?

Start devbox and run a human in the loop task. The runs can be filtered correctly

<img width="3424" height="956" alt="image" src="https://github.com/user-attachments/assets/125fc95e-66cf-4ce3-be04-b11b199d34da" />


### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
