### PR TITLE
Allow storage S3 secretKey to be securely configured

### DIFF
--- a/charts/flyte-binary/README.md
+++ b/charts/flyte-binary/README.md
@@ -64,6 +64,7 @@ Chart for basic single Flyte executable deployment
 | configuration.storage.providerConfig.s3.endpoint | string | `""` |  |
 | configuration.storage.providerConfig.s3.region | string | `"us-east-1"` |  |
 | configuration.storage.providerConfig.s3.secretKey | string | `""` |  |
+| configuration.storage.providerConfig.s3.secretKeyPath | string | `""` |  |
 | configuration.storage.providerConfig.s3.v2Signing | bool | `false` |  |
 | console.affinity | object | `{}` |  |
 | console.basePath | string | `"/v2"` |  |

--- a/charts/flyte-binary/templates/config-secret.yaml
+++ b/charts/flyte-binary/templates/config-secret.yaml
@@ -34,7 +34,13 @@ stringData:
       stow:
         config:
           access_key_id: {{ required "Access key required for S3 storage provider" .Values.configuration.storage.providerConfig.s3.accessKey | quote }}
-          secret_key: {{ required "Secret key required for S3 storage provider" .Values.configuration.storage.providerConfig.s3.secretKey | quote }}
+          {{- if .Values.configuration.storage.providerConfig.s3.secretKey }}
+          secret_key: {{ .Values.configuration.storage.providerConfig.s3.secretKey | quote }}
+          {{- else if .Values.configuration.storage.providerConfig.s3.secretKeyPath}}
+          secret_key_path: {{ .Values.configuration.storage.providerConfig.s3.secretKeyPath | quote }}
+          {{- else }}
+          {{ fail "secretKey or secretKeyPath must be configured" }}
+          {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -104,6 +104,8 @@ configuration:
         accessKey: ""
         # secretKey Secret key for authenticating with S3-compatible service
         secretKey: ""
+        # secretKeyPath Path to a file containing the secret key for authenticating with S3-compatible service
+        secretKeyPath: ""
       # gcs Provider configuration for GCS object store
       gcs:
         # project Google Cloud project in which bucket resides

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -43,10 +43,15 @@ func FlyteCoPilotContainer(name string, cfg config.FlyteCoPilotConfig, args []st
 		storageCfg = storage.GetConfig()
 	}
 
+	command, err := CopilotCommandArgs(storageCfg)
+	if err != nil {
+		return v1.Container{}, err
+	}
+
 	return v1.Container{
 		Name:       cfg.NamePrefix + name,
 		Image:      cfg.Image,
-		Command:    CopilotCommandArgs(storageCfg),
+		Command:    command,
 		Args:       args,
 		WorkingDir: "/",
 		Resources: v1.ResourceRequirements{
@@ -65,7 +70,7 @@ func FlyteCoPilotContainer(name string, cfg config.FlyteCoPilotConfig, args []st
 	}, nil
 }
 
-func CopilotCommandArgs(storageConfig *storage.Config) []string {
+func CopilotCommandArgs(storageConfig *storage.Config) ([]string, error) {
 	var commands = []string{
 		"/bin/flyte-copilot",
 		"--storage.limits.maxDownloadMBs=0",
@@ -85,15 +90,10 @@ func CopilotCommandArgs(storageConfig *storage.Config) []string {
 			commands = append(commands, "--storage.stow.config")
 			commands = append(commands, fmt.Sprintf("%s=%s", key, val))
 		}
-		return append(commands, fmt.Sprintf("--storage.stow.kind=%s", storageConfig.Stow.Kind))
+		return append(commands, fmt.Sprintf("--storage.stow.kind=%s", storageConfig.Stow.Kind)), nil
 	}
-	return append(commands, []string{
-		fmt.Sprintf("--storage.connection.secret-key=%s", storageConfig.Connection.SecretKey),       //nolint: staticcheck
-		fmt.Sprintf("--storage.connection.access-key=%s", storageConfig.Connection.AccessKey),       //nolint: staticcheck
-		fmt.Sprintf("--storage.connection.auth-type=%s", storageConfig.Connection.AuthType),         //nolint: staticcheck
-		fmt.Sprintf("--storage.connection.region=%s", storageConfig.Connection.Region),              //nolint: staticcheck
-		fmt.Sprintf("--storage.connection.endpoint=%s", storageConfig.Connection.Endpoint.String()), //nolint: staticcheck
-	}...)
+
+	return commands, fmt.Errorf("no stow.config or stow.kind specified")
 }
 
 func SidecarCommandArgs(fromLocalPath string, outputPrefix, rawOutputPath storage.DataReference, uploadTimeout time.Duration, iface *core.TypedInterface) ([]string, error) {

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
@@ -45,19 +45,6 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 		Memory: "1024Mi",
 	}
 
-	t.Run("happy", func(t *testing.T) {
-		c, err := FlyteCoPilotContainer("x", cfg, []string{"hello"})
-		assert.NoError(t, err)
-		assert.Equal(t, "test-x", c.Name)
-		assert.Equal(t, "test", c.Image)
-		assert.Equal(t, CopilotCommandArgs(storage.GetConfig()), c.Command)
-		assert.Equal(t, []string{"hello"}, c.Args)
-		assert.Equal(t, 0, len(c.VolumeMounts))
-		assert.Equal(t, "/", c.WorkingDir)
-		assert.Equal(t, 2, len(c.Resources.Limits))
-		assert.Equal(t, 2, len(c.Resources.Requests))
-	})
-
 	t.Run("happy stow backend", func(t *testing.T) {
 		storage.GetConfig().Stow.Kind = "S3"
 		storage.GetConfig().Stow.Config = map[string]string{
@@ -65,9 +52,13 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 		}
 		c, err := FlyteCoPilotContainer("x", cfg, []string{"hello"})
 		assert.NoError(t, err)
+
+		expectedCommand, err := CopilotCommandArgs(storage.GetConfig())
+		assert.NoError(t, err)
+
 		assert.Equal(t, "test-x", c.Name)
 		assert.Equal(t, "test", c.Image)
-		assert.Equal(t, CopilotCommandArgs(storage.GetConfig()), c.Command)
+		assert.Equal(t, expectedCommand, c.Command)
 		assert.Equal(t, []string{"hello"}, c.Args)
 		assert.Equal(t, 0, len(c.VolumeMounts))
 		assert.Equal(t, "/", c.WorkingDir)
@@ -82,6 +73,9 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 	})
 
 	t.Run("happy stow GCP backend", func(t *testing.T) {
+		expectedCommand, err := CopilotCommandArgs(storage.GetConfig())
+		assert.NoError(t, err)
+
 		storage.GetConfig().Type = storage.TypeStow
 		storage.GetConfig().InitContainer = "bucket"
 		storage.GetConfig().Stow.Kind = "google"
@@ -90,7 +84,7 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 			"project_id": "flyte-gcp",
 			"scope":      "read_write",
 		}
-		assert.Equal(t, 12, len(CopilotCommandArgs(storage.GetConfig())))
+		assert.Equal(t, 7, len(expectedCommand))
 	})
 
 	t.Run("storage override", func(t *testing.T) {
@@ -110,7 +104,10 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(c.VolumeMounts))
 
-		assert.ElementsMatch(t, c.Command, CopilotCommandArgs(&storageConfigOverride))
+		expectedCommand, err := CopilotCommandArgs(&storageConfigOverride)
+		assert.NoError(t, err)
+
+		assert.ElementsMatch(t, c.Command, expectedCommand)
 	})
 
 	t.Run("bad-res-cpu", func(t *testing.T) {

--- a/flytestdlib/autorefreshcache/auto_refresh_example_test.go
+++ b/flytestdlib/autorefreshcache/auto_refresh_example_test.go
@@ -121,7 +121,7 @@ func ExampleNewAutoRefreshCache() {
 	// arguments and so have no *testing.T, while require.Eventually requires a require.TestingT to
 	// report failures. The deadline below bounds the wait and panics on timeout to surface a hang.
 	var item Item
-	var lastStatus ExampleItemStatus = ExampleStatusNotStarted
+	var lastStatus = ExampleStatusNotStarted
 	deadline := time.Now().Add(10 * time.Second)
 	for {
 		item, err = cache.Get(item1.ID())

--- a/flytestdlib/config/tests/accessor_test.go
+++ b/flytestdlib/config/tests/accessor_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"os/exec"
 	"path"
@@ -564,7 +564,7 @@ func newSymlinkedConfigFile(t *testing.T) (watchDir, configFile string, cleanup 
 	//    |_ data (symlink for data1)
 	//    |_ config.yaml (symlink for data/config.yaml -recursively a symlink of data1/config.yaml)
 
-	watchDir, err := ioutil.TempDir("", "config-test-")
+	watchDir, err := os.MkdirTemp("", "config-test-")
 	assert.NoError(t, err)
 
 	dataDir1 := path.Join(watchDir, "data1")

--- a/flytestdlib/database/postgres_test.go
+++ b/flytestdlib/database/postgres_test.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -52,7 +51,7 @@ func TestGetPostgresDsn(t *testing.T) {
 	})
 	t.Run("with password path", func(t *testing.T) {
 		password := "123abc"
-		tmpFile, err := ioutil.TempFile("", "prefix")
+		tmpFile, err := os.CreateTemp("", "prefix")
 		if err != nil {
 			t.Errorf("Couldn't open temp file: %v", err)
 		}
@@ -93,7 +92,7 @@ func TestGetPostgresReadDsn(t *testing.T) {
 	})
 	t.Run("with password path", func(t *testing.T) {
 		password := "1234abc"
-		tmpFile, err := ioutil.TempFile("", "prefix")
+		tmpFile, err := os.CreateTemp("", "prefix")
 		if err != nil {
 			t.Errorf("Couldn't open temp file: %v", err)
 		}

--- a/flytestdlib/ioutils/bytes_test.go
+++ b/flytestdlib/ioutils/bytes_test.go
@@ -1,7 +1,8 @@
 package ioutils
 
 import (
-	"io/ioutil"
+	"io"
+
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,7 @@ import (
 func TestNewBytesReadCloser(t *testing.T) {
 	i := []byte("abc")
 	r := NewBytesReadCloser(i)
-	o, e := ioutil.ReadAll(r)
+	o, e := io.ReadAll(r)
 	assert.NoError(t, e)
 	assert.Equal(t, o, i)
 	assert.NoError(t, r.Close())

--- a/flytestdlib/storage/cached_rawstore_test.go
+++ b/flytestdlib/storage/cached_rawstore_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"runtime/debug"
 	"testing"
@@ -116,12 +115,12 @@ func TestCachedRawStore(t *testing.T) {
 			writeCalled = true
 			switch reference {
 			case "k2":
-				b, err := ioutil.ReadAll(raw)
+				b, err := io.ReadAll(raw)
 				assert.NoError(t, err)
 				assert.Equal(t, d2, b)
 				return nil
 			case "bigK":
-				b, err := ioutil.ReadAll(raw)
+				b, err := io.ReadAll(raw)
 				assert.NoError(t, err)
 				assert.Equal(t, bigD, b)
 				return nil
@@ -169,14 +168,14 @@ func TestCachedRawStore(t *testing.T) {
 	t.Run("ReadCachePopulate", func(t *testing.T) {
 		o, err := cStore.ReadRaw(ctx, k1)
 		assert.NoError(t, err)
-		b, err := ioutil.ReadAll(o)
+		b, err := io.ReadAll(o)
 		assert.NoError(t, err)
 		assert.Equal(t, d1, b)
 		assert.True(t, readCalled)
 		readCalled = false
 		o, err = cStore.ReadRaw(ctx, k1)
 		assert.NoError(t, err)
-		b, err = ioutil.ReadAll(o)
+		b, err = io.ReadAll(o)
 		assert.NoError(t, err)
 		assert.Equal(t, d1, b)
 		assert.False(t, readCalled)
@@ -196,7 +195,7 @@ func TestCachedRawStore(t *testing.T) {
 
 		o, err := cStore.ReadRaw(ctx, k2)
 		assert.NoError(t, err)
-		b, err := ioutil.ReadAll(o)
+		b, err := io.ReadAll(o)
 		assert.NoError(t, err)
 		assert.Equal(t, d2, b)
 		assert.False(t, readCalled)
@@ -211,7 +210,7 @@ func TestCachedRawStore(t *testing.T) {
 
 		o, err := cStore.ReadRaw(ctx, bigK)
 		assert.True(t, IsFailedWriteToCache(err))
-		b, err := ioutil.ReadAll(o)
+		b, err := io.ReadAll(o)
 		assert.NoError(t, err)
 		assert.Equal(t, bigD, b)
 		assert.True(t, readCalled)

--- a/flytestdlib/storage/config.go
+++ b/flytestdlib/storage/config.go
@@ -34,12 +34,12 @@ var (
 	ConfigSection = config.MustRegisterSection(configSectionKey, defaultConfig)
 	defaultConfig = &Config{
 		Type: TypeS3,
+		Stow: StowConfig{
+			Kind:   "s3",
+			Config: map[string]string{},
+		},
 		Limits: LimitsConfig{
 			GetLimitMegabytes: 2,
-		},
-		Connection: ConnectionConfig{
-			Region:   "us-east-1",
-			AuthType: "iam",
 		},
 		DefaultHTTPClient: HTTPClientConfig{
 			MaxIdleConns:        1024,
@@ -52,11 +52,9 @@ var (
 
 // Config is a common storage config.
 type Config struct {
-	Type Type `json:"type" pflag:",Sets the type of storage [s3/minio/local/mem/stow/redis]."`
-	// Deprecated: Please use StowConfig instead
-	Connection ConnectionConfig `json:"connection"`
-	Stow       StowConfig       `json:"stow,omitempty" pflag:",Storage config for stow backend."`
-	Redis      RedisConfig      `json:"redis,omitempty" pflag:"-,Storage config for the redis backend."`
+	Type  Type        `json:"type" pflag:",Sets the type of storage [s3/minio/local/mem/stow/redis]."`
+	Stow  StowConfig  `json:"stow,omitempty" pflag:",Storage config for stow backend."`
+	Redis RedisConfig `json:"redis,omitempty" pflag:"-,Storage config for the redis backend."`
 
 	// Container here is misleading, it refers to a Bucket (AWS S3) like blobstore entity. In some terms it could be a table
 	InitContainer string `json:"container" pflag:",Initial container (in s3 a bucket) to create -if it doesn't exist-.'"`
@@ -95,16 +93,6 @@ type HTTPClientConfig struct {
 	MaxIdleConnsPerHost int             `json:"maxIdleConnsPerHost" pflag:",Maximum number of idle connections per host. Zero means use the http.DefaultTransport value."`
 	MaxConnsPerHost     int             `json:"maxConnsPerHost" pflag:",Maximum number of connections per host; new requests block at the limit. Zero means no limit."`
 	IdleConnTimeout     config.Duration `json:"idleConnTimeout" pflag:",Maximum amount of time an idle connection remains open. Zero means use the http.DefaultTransport value."`
-}
-
-// ConnectionConfig defines connection configurations.
-type ConnectionConfig struct {
-	Endpoint   config.URL `json:"endpoint" pflag:",URL for storage client to connect to."`
-	AuthType   string     `json:"auth-type" pflag:",Auth Type to use [iam,accesskey]."`
-	AccessKey  string     `json:"access-key" pflag:",Access key to use. Only required when authtype is set to accesskey."`
-	SecretKey  string     `json:"secret-key" pflag:",Secret to use when accesskey is set."`
-	Region     string     `json:"region" pflag:",Region to connect to."`
-	DisableSSL bool       `json:"disable-ssl" pflag:",Disables SSL connection. Should only be used for development."`
 }
 
 // RedisConfig defines the connection for a redis-backed raw store, selected with type: redis.

--- a/flytestdlib/storage/config.go
+++ b/flytestdlib/storage/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/config"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
+	"github.com/flyteorg/stow/s3"
 )
 
 //go:generate pflags Config --default-var=defaultConfig
@@ -33,10 +34,12 @@ const (
 var (
 	ConfigSection = config.MustRegisterSection(configSectionKey, defaultConfig)
 	defaultConfig = &Config{
-		Type: TypeS3,
+		Type: TypeStow,
 		Stow: StowConfig{
-			Kind:   "s3",
-			Config: map[string]string{},
+			Kind: s3.Kind,
+			Config: map[string]string{
+				s3.ConfigRegion: "us-east-1",
+			},
 		},
 		Limits: LimitsConfig{
 			GetLimitMegabytes: 2,

--- a/flytestdlib/storage/config_flags.go
+++ b/flytestdlib/storage/config_flags.go
@@ -51,12 +51,6 @@ func (Config) mustMarshalJSON(v json.Marshaler) string {
 func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "type"), defaultConfig.Type, "Sets the type of storage [s3/minio/local/mem/stow/redis].")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "connection.endpoint"), defaultConfig.Connection.Endpoint.String(), "URL for storage client to connect to.")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "connection.auth-type"), defaultConfig.Connection.AuthType, "Auth Type to use [iam, accesskey].")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "connection.access-key"), defaultConfig.Connection.AccessKey, "Access key to use. Only required when authtype is set to accesskey.")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "connection.secret-key"), defaultConfig.Connection.SecretKey, "Secret to use when accesskey is set.")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "connection.region"), defaultConfig.Connection.Region, "Region to connect to.")
-	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "connection.disable-ssl"), defaultConfig.Connection.DisableSSL, "Disables SSL connection. Should only be used for development.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "stow.kind"), defaultConfig.Stow.Kind, "Kind of Stow backend to use. Refer to github/flyteorg/stow")
 	cmdFlags.StringToString(fmt.Sprintf("%v%v", prefix, "stow.config"), defaultConfig.Stow.Config, "Configuration for stow backend. Refer to github/flyteorg/stow")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "container"), defaultConfig.InitContainer, "Initial container (in s3 a bucket) to create -if it doesn't exist-.'")

--- a/flytestdlib/storage/config_flags_test.go
+++ b/flytestdlib/storage/config_flags_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -107,90 +107,6 @@ func TestConfig_SetFlags(t *testing.T) {
 			cmdFlags.Set("type", testValue)
 			if vString, err := cmdFlags.GetString("type"); err == nil {
 				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Type)
-
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
-	})
-	t.Run("Test_connection.endpoint", func(t *testing.T) {
-
-		t.Run("Override", func(t *testing.T) {
-			testValue := defaultConfig.Connection.Endpoint.String()
-
-			cmdFlags.Set("connection.endpoint", testValue)
-			if vString, err := cmdFlags.GetString("connection.endpoint"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Connection.Endpoint)
-
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
-	})
-	t.Run("Test_connection.auth-type", func(t *testing.T) {
-
-		t.Run("Override", func(t *testing.T) {
-			testValue := "1"
-
-			cmdFlags.Set("connection.auth-type", testValue)
-			if vString, err := cmdFlags.GetString("connection.auth-type"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Connection.AuthType)
-
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
-	})
-	t.Run("Test_connection.access-key", func(t *testing.T) {
-
-		t.Run("Override", func(t *testing.T) {
-			testValue := "1"
-
-			cmdFlags.Set("connection.access-key", testValue)
-			if vString, err := cmdFlags.GetString("connection.access-key"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Connection.AccessKey)
-
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
-	})
-	t.Run("Test_connection.secret-key", func(t *testing.T) {
-
-		t.Run("Override", func(t *testing.T) {
-			testValue := "1"
-
-			cmdFlags.Set("connection.secret-key", testValue)
-			if vString, err := cmdFlags.GetString("connection.secret-key"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Connection.SecretKey)
-
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
-	})
-	t.Run("Test_connection.region", func(t *testing.T) {
-
-		t.Run("Override", func(t *testing.T) {
-			testValue := "1"
-
-			cmdFlags.Set("connection.region", testValue)
-			if vString, err := cmdFlags.GetString("connection.region"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Connection.Region)
-
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
-	})
-	t.Run("Test_connection.disable-ssl", func(t *testing.T) {
-
-		t.Run("Override", func(t *testing.T) {
-			testValue := "1"
-
-			cmdFlags.Set("connection.disable-ssl", testValue)
-			if vBool, err := cmdFlags.GetBool("connection.disable-ssl"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vBool), &actual.Connection.DisableSSL)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/flytestdlib/storage/config_test.go
+++ b/flytestdlib/storage/config_test.go
@@ -9,9 +9,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/flyteorg/flyte/v2/flytestdlib/config"
-	"github.com/flyteorg/flyte/v2/flytestdlib/internal/utils"
 )
 
 // Make sure existing config file(s) parse correctly before overriding them with this flag!
@@ -20,13 +17,16 @@ var update = flag.Bool("update", false, "Updates testdata")
 func TestMarshal(t *testing.T) {
 	expected := Config{
 		Type: "s3",
-		Connection: ConnectionConfig{
-			Endpoint:   config.URL{URL: utils.MustParseURL("http://minio:9000")},
-			AuthType:   "accesskey",
-			AccessKey:  "minio",
-			SecretKey:  "miniostorage",
-			Region:     "us-east-1",
-			DisableSSL: true,
+		Stow: StowConfig{
+			Kind: "s3",
+			Config: map[string]string{
+				"Endpoint":   "http://minio:9000",
+				"AuthType":   "accesskey",
+				"AccessKey":  "minio",
+				"SecretKey":  "miniostorage",
+				"Region":     "us-east-1",
+				"DisableSSL": "true",
+			},
 		},
 	}
 

--- a/flytestdlib/storage/config_test.go
+++ b/flytestdlib/storage/config_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/flyteorg/stow/s3"
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,9 +17,9 @@ var update = flag.Bool("update", false, "Updates testdata")
 
 func TestMarshal(t *testing.T) {
 	expected := Config{
-		Type: "s3",
+		Type: TypeStow,
 		Stow: StowConfig{
-			Kind: "s3",
+			Kind: s3.Kind,
 			Config: map[string]string{
 				"Endpoint":   "http://minio:9000",
 				"AuthType":   "accesskey",

--- a/flytestdlib/storage/routing_store_internal_test.go
+++ b/flytestdlib/storage/routing_store_internal_test.go
@@ -53,7 +53,7 @@ func newTestRoutingStore(t *testing.T, schemes ...string) (*routingStore, map[st
 	counts := map[string]*int32{}
 	registry := map[string]backendFactory{}
 	for _, sc := range schemes {
-		sc := sc
+
 		var n int32
 		counts[sc] = &n
 		registry[sc] = func(_ context.Context, scheme string, _ DataReference, _ *Config, _ *http.Client, m *dataStoreMetrics) (RawStore, error) {

--- a/flytestdlib/storage/stow_store.go
+++ b/flytestdlib/storage/stow_store.go
@@ -655,8 +655,8 @@ func newStowRawStore(_ context.Context, cfg *Config, metrics *dataStoreMetrics) 
 	kind := cfg.Stow.Kind
 
 	if kind == s3.Kind {
-		secretKeyVal, _ := cfgMap[s3.ConfigSecretKey]
-		secretKeyPath, _ := cfgMap[ConfigSecretKeyPath]
+		secretKeyVal := cfgMap[s3.ConfigSecretKey]
+		secretKeyPath := cfgMap[ConfigSecretKeyPath]
 
 		secretKey, err := resolveSecretKey(secretKeyVal, secretKeyPath)
 		if err != nil {
@@ -720,8 +720,8 @@ func stowFactory(_ context.Context, scheme string, _ DataReference, cfg *Config,
 			cfgMap[s3.ConfigAuthType] = "iam"
 		}
 
-		secretKeyVal, _ := cfgMap[s3.ConfigSecretKey]
-		secretKeyPath, _ := cfgMap[ConfigSecretKeyPath]
+		secretKeyVal := cfgMap[s3.ConfigSecretKey]
+		secretKeyPath := cfgMap[ConfigSecretKeyPath]
 
 		secretKey, err := resolveSecretKey(secretKeyVal, secretKeyPath)
 		if err != nil {

--- a/flytestdlib/storage/stow_store.go
+++ b/flytestdlib/storage/stow_store.go
@@ -716,9 +716,6 @@ func stowFactory(_ context.Context, scheme string, _ DataReference, cfg *Config,
 	// Seed an S3 region from the legacy connection config when no explicit one was given, so ambient
 	// S3 dials inherit the deployment's default region instead of failing region resolution.
 	if kind == s3.Kind {
-		if _, ok := cfgMap[s3.ConfigRegion]; !ok {
-			cfgMap[s3.ConfigRegion] = "us-east-1"
-		}
 		if _, ok := cfgMap[s3.ConfigAuthType]; !ok {
 			cfgMap[s3.ConfigAuthType] = "iam"
 		}

--- a/flytestdlib/storage/stow_store.go
+++ b/flytestdlib/storage/stow_store.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -651,14 +652,10 @@ func newStowRawStore(_ context.Context, cfg *Config, metrics *dataStoreMetrics) 
 
 	var cfgMap stow.ConfigMap
 	var kind string
+
 	if len(cfg.Stow.Kind) > 0 && len(cfg.Stow.Config) > 0 {
 		kind = cfg.Stow.Kind
 		cfgMap = cfg.Stow.Config
-	} else {
-		logger.Warnf(context.TODO(), "stow configuration section missing, defaulting to legacy s3/minio connection config")
-		// This is for supporting legacy configurations which configure S3 via connection config
-		kind = s3.Kind
-		cfgMap = legacyS3ConfigMap(cfg.Connection)
 	}
 
 	fn, ok := fQNFn[kind]
@@ -709,12 +706,13 @@ func stowFactory(_ context.Context, scheme string, _ DataReference, cfg *Config,
 	// Seed an S3 region from the legacy connection config when no explicit one was given, so ambient
 	// S3 dials inherit the deployment's default region instead of failing region resolution.
 	if kind == s3.Kind {
-		if _, ok := cfgMap[s3.ConfigRegion]; !ok && cfg.Connection.Region != "" {
-			cfgMap[s3.ConfigRegion] = cfg.Connection.Region
+		if _, ok := cfgMap[s3.ConfigRegion]; !ok {
+			cfgMap[s3.ConfigRegion] = "us-east-1"
 		}
 		if _, ok := cfgMap[s3.ConfigAuthType]; !ok {
 			cfgMap[s3.ConfigAuthType] = "iam"
 		}
+
 	}
 
 	// Unlike cloud backends, the local (file://) backend cannot be dialed with ambient credentials: it
@@ -736,29 +734,24 @@ func stowFactory(_ context.Context, scheme string, _ DataReference, cfg *Config,
 	return NewStowRawStore(DataReference(scheme+"://"), loc, nil, true, metrics)
 }
 
-func legacyS3ConfigMap(cfg ConnectionConfig) stow.ConfigMap {
-	// Non-nullable fields
-	stowConfig := stow.ConfigMap{
-		s3.ConfigAuthType: cfg.AuthType,
-		s3.ConfigRegion:   cfg.Region,
-	}
+func resolveSecretKey(secretKeyVal, secretKeyPath string) (string, error) {
+	secretKey := secretKeyVal
+	if len(secretKeyPath) > 0 {
+		_, err := os.Stat(secretKeyPath)
 
-	// Fields that differ between minio and real S3
-	if endpoint := cfg.Endpoint.String(); endpoint != "" {
-		stowConfig[s3.ConfigEndpoint] = endpoint
-	}
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", fmt.Errorf("secret key path does not exist")
+			}
 
-	if accessKey := cfg.AccessKey; accessKey != "" {
-		stowConfig[s3.ConfigAccessKeyID] = accessKey
-	}
+			return "", fmt.Errorf("getting secret key path file info: %w", err)
+		}
 
-	if secretKey := cfg.SecretKey; secretKey != "" {
-		stowConfig[s3.ConfigSecretKey] = secretKey
+		secretKeyFileVal, err := os.ReadFile(secretKeyPath)
+		if err != nil {
+			return "", fmt.Errorf("reading secret key file: %w", err)
+		}
+		secretKey = strings.TrimSpace(string(secretKeyFileVal))
 	}
-
-	if disableSsl := cfg.DisableSSL; disableSsl {
-		stowConfig[s3.ConfigDisableSSL] = "True"
-	}
-
-	return stowConfig
+	return secretKey, nil
 }

--- a/flytestdlib/storage/stow_store.go
+++ b/flytestdlib/storage/stow_store.go
@@ -32,6 +32,7 @@ import (
 
 const FailureTypeLabel contextutils.Key = "failure_type"
 const FlyteContentMD5 = "flyteContentMD5"
+const ConfigSecretKeyPath = "secret_key_path"
 
 // schemeToStowKind maps a URL scheme to the stow kind that serves it. It is the inverse of the
 // scheme prefixes produced by fQNFn and lets the multi-scheme DataStore lazily dial a stow backend
@@ -650,12 +651,21 @@ func newStowRawStore(_ context.Context, cfg *Config, metrics *dataStoreMetrics) 
 		return nil, fmt.Errorf("initContainer is required even with `enable-multicontainer`")
 	}
 
-	var cfgMap stow.ConfigMap
-	var kind string
+	var cfgMap stow.ConfigMap = cfg.Stow.Config
+	kind := cfg.Stow.Kind
 
-	if len(cfg.Stow.Kind) > 0 && len(cfg.Stow.Config) > 0 {
-		kind = cfg.Stow.Kind
-		cfgMap = cfg.Stow.Config
+	if kind == s3.Kind {
+		secretKeyVal, _ := cfgMap[s3.ConfigSecretKey]
+		secretKeyPath, _ := cfgMap[ConfigSecretKeyPath]
+
+		secretKey, err := resolveSecretKey(secretKeyVal, secretKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("resolving S3 secret key: %w", err)
+		}
+
+		if len(secretKey) > 0 {
+			cfgMap[s3.ConfigSecretKey] = secretKey
+		}
 	}
 
 	fn, ok := fQNFn[kind]
@@ -713,6 +723,17 @@ func stowFactory(_ context.Context, scheme string, _ DataReference, cfg *Config,
 			cfgMap[s3.ConfigAuthType] = "iam"
 		}
 
+		secretKeyVal, _ := cfgMap[s3.ConfigSecretKey]
+		secretKeyPath, _ := cfgMap[ConfigSecretKeyPath]
+
+		secretKey, err := resolveSecretKey(secretKeyVal, secretKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("resolving S3 secret key: %w", err)
+		}
+
+		if len(secretKey) > 0 {
+			cfgMap[s3.ConfigSecretKey] = secretKey
+		}
 	}
 
 	// Unlike cloud backends, the local (file://) backend cannot be dialed with ambient credentials: it

--- a/flytestdlib/storage/stow_store_test.go
+++ b/flytestdlib/storage/stow_store_test.go
@@ -6,7 +6,6 @@ import (
 	errors2 "errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -162,7 +161,7 @@ func (m mockStowItem) Size() (int64, error) {
 }
 
 func (mockStowItem) Open() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewReader([]byte{})), nil
+	return io.NopCloser(bytes.NewReader([]byte{})), nil
 }
 
 func (mockStowItem) ETag() (string, error) {
@@ -281,7 +280,7 @@ func TestStowStore_ReadRaw(t *testing.T) {
 		dataReference := writeTestFile(ctx, t, s, "s3://container/path")
 		raw, err := s.ReadRaw(ctx, dataReference)
 		assert.NoError(t, err)
-		rawBytes, err := ioutil.ReadAll(raw)
+		rawBytes, err := io.ReadAll(raw)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(rawBytes))
 		assert.Equal(t, DataReference("s3://container"), s.GetBaseContainerFQN(context.TODO()))
@@ -362,7 +361,7 @@ func TestStowStore_ReadRaw(t *testing.T) {
 		dataReference := writeTestFile(ctx, t, s, "s3://bad-container/path")
 		raw, err := s.ReadRaw(context.TODO(), dataReference)
 		assert.NoError(t, err)
-		rawBytes, err := ioutil.ReadAll(raw)
+		rawBytes, err := io.ReadAll(raw)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(rawBytes))
 		assert.Equal(t, DataReference("s3://container"), s.GetBaseContainerFQN(context.TODO()))
@@ -485,7 +484,7 @@ func TestNewLocalStore(t *testing.T) {
 	})
 
 	t.Run("Initialize container", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "stdlib_local")
+		tmpDir, err := os.MkdirTemp("", "stdlib_local")
 		assert.NoError(t, err)
 
 		stats, err := os.Stat(tmpDir)
@@ -513,7 +512,7 @@ func TestNewLocalStore(t *testing.T) {
 	})
 
 	t.Run("missing init container", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "stdlib_local")
+		tmpDir, err := os.MkdirTemp("", "stdlib_local")
 		assert.NoError(t, err)
 
 		stats, err := os.Stat(tmpDir)
@@ -534,7 +533,7 @@ func TestNewLocalStore(t *testing.T) {
 	})
 
 	t.Run("multi-container enabled", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "stdlib_local")
+		tmpDir, err := os.MkdirTemp("", "stdlib_local")
 		assert.NoError(t, err)
 
 		stats, err := os.Stat(tmpDir)

--- a/flytestdlib/storage/stow_store_test.go
+++ b/flytestdlib/storage/stow_store_test.go
@@ -21,9 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/flyteorg/flyte/v2/flytestdlib/config"
 	"github.com/flyteorg/flyte/v2/flytestdlib/contextutils"
-	"github.com/flyteorg/flyte/v2/flytestdlib/internal/utils"
 	"github.com/flyteorg/flyte/v2/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/stow"
 	"github.com/flyteorg/stow/azure"
@@ -587,8 +585,11 @@ func Test_newStowRawStore(t *testing.T) {
 		{"minio", args{&Config{
 			Type:          TypeMinio,
 			InitContainer: "some-container",
-			Connection: ConnectionConfig{
-				Endpoint: config.URL{URL: utils.MustParseURL("http://minio:9000")},
+			Stow: StowConfig{
+				Kind: local.Kind,
+				Config: map[string]string{
+					"endpoint": "http://minio:9000",
+				},
 			},
 		}}, true},
 	}

--- a/flytestdlib/storage/stow_store_test.go
+++ b/flytestdlib/storage/stow_store_test.go
@@ -589,7 +589,7 @@ func Test_newStowRawStore(t *testing.T) {
 			},
 		}}, true},
 		{"minio", args{&Config{
-			Type:          TypeMinio,
+			Type:          TypeStow,
 			InitContainer: "some-container",
 			Stow: StowConfig{
 				Kind: local.Kind,
@@ -599,10 +599,10 @@ func Test_newStowRawStore(t *testing.T) {
 			},
 		}}, true},
 		{"secretKeyPath", args{&Config{
-			Type:          TypeS3,
+			Type:          TypeStow,
 			InitContainer: "flyte",
 			Stow: StowConfig{
-				Kind: TypeS3,
+				Kind: s3.Kind,
 				Config: map[string]string{
 					s3.ConfigAccessKeyID: "my-access-key-id",
 					ConfigSecretKeyPath:  path,
@@ -610,10 +610,10 @@ func Test_newStowRawStore(t *testing.T) {
 			},
 		}}, false},
 		{"secretKeyPath not found", args{&Config{
-			Type:          TypeS3,
+			Type:          TypeStow,
 			InitContainer: "flyte",
 			Stow: StowConfig{
-				Kind: TypeS3,
+				Kind: s3.Kind,
 				Config: map[string]string{
 					s3.ConfigAccessKeyID: "my-access-key-id",
 					ConfigSecretKeyPath:  filepath.Join(t.TempDir(), "wrong"),

--- a/flytestdlib/storage/stow_store_test.go
+++ b/flytestdlib/storage/stow_store_test.go
@@ -20,6 +20,7 @@ import (
 	s32 "github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/contextutils"
 	"github.com/flyteorg/flyte/v2/flytestdlib/promutils/labeled"
@@ -563,6 +564,11 @@ func TestNewLocalStore(t *testing.T) {
 }
 
 func Test_newStowRawStore(t *testing.T) {
+	secretKey := "password"
+	path := filepath.Join(t.TempDir(), "secret-key-path")
+	err := os.WriteFile(path, []byte(secretKey), 0o600)
+	assert.NoError(t, err)
+
 	type args struct {
 		cfg *Config
 	}
@@ -592,15 +598,39 @@ func Test_newStowRawStore(t *testing.T) {
 				},
 			},
 		}}, true},
+		{"secretKeyPath", args{&Config{
+			Type:          TypeS3,
+			InitContainer: "flyte",
+			Stow: StowConfig{
+				Kind: TypeS3,
+				Config: map[string]string{
+					s3.ConfigAccessKeyID: "my-access-key-id",
+					ConfigSecretKeyPath:  path,
+				},
+			},
+		}}, false},
+		{"secretKeyPath not found", args{&Config{
+			Type:          TypeS3,
+			InitContainer: "flyte",
+			Stow: StowConfig{
+				Kind: TypeS3,
+				Config: map[string]string{
+					s3.ConfigAccessKeyID: "my-access-key-id",
+					ConfigSecretKeyPath:  filepath.Join(t.TempDir(), "wrong"),
+				},
+			},
+		}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := newStowRawStore(context.TODO(), tt.args.cfg, metrics)
 			if tt.wantErr {
-				assert.Error(t, err, "newStowRawStore() error = %v, wantErr %v", err, tt.wantErr)
+				require.Error(t, err, "newStowRawStore() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			assert.NotNil(t, got, "Expected rawstore, found nil!")
+
+			require.NoError(t, err, "newStowRawStore() error = %v, wantErr %v", err, tt.wantErr)
+			require.NotNil(t, got, "Expected rawstore, found nil!")
 		})
 	}
 }

--- a/flytestdlib/storage/testdata/config.yaml
+++ b/flytestdlib/storage/testdata/config.yaml
@@ -27,4 +27,4 @@ stow:
     Region: us-east-1
     SecretKey: miniostorage
   kind: s3
-type: s3
+type: stow

--- a/flytestdlib/storage/testdata/config.yaml
+++ b/flytestdlib/storage/testdata/config.yaml
@@ -1,20 +1,30 @@
 cache:
   max_size_mbs: 0
   target_gc_percent: 0
-connection:
-  access-key: minio
-  auth-type: accesskey
-  disable-ssl: true
-  endpoint: http://minio:9000
-  region: us-east-1
-  secret-key: miniostorage
 container: ""
 defaultHttpClient:
   headers: null
+  idleConnTimeout: 0s
+  maxConnsPerHost: 0
+  maxIdleConns: 0
+  maxIdleConnsPerHost: 0
   timeout: 0s
 enable-multicontainer: false
 limits:
   maxDownloadMBs: 0
+redis:
+  addr: ""
+  db: 0
+  password: ""
+  username: ""
 signedUrl: {}
-stow: {}
+stow:
+  config:
+    AccessKey: minio
+    AuthType: accesskey
+    DisableSSL: "true"
+    Endpoint: http://minio:9000
+    Region: us-east-1
+    SecretKey: miniostorage
+  kind: s3
 type: s3

--- a/flytestdlib/tests/config_test.go
+++ b/flytestdlib/tests/config_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/flyteorg/stow/s3"
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 
@@ -28,9 +29,9 @@ func TestStorageAndLoggerConfig(t *testing.T) {
 
 	expected := CompositeConfig{
 		Storage: storage.Config{
-			Type: "s3",
+			Type: storage.TypeStow,
 			Stow: storage.StowConfig{
-				Kind: "s3",
+				Kind: s3.Kind,
 				Config: map[string]string{
 					"endpoint":  "http://minio:9000",
 					"authType":  "accesskey",

--- a/flytestdlib/tests/config_test.go
+++ b/flytestdlib/tests/config_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/config"
 	"github.com/flyteorg/flyte/v2/flytestdlib/config/viper"
-	"github.com/flyteorg/flyte/v2/flytestdlib/internal/utils"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
 )
@@ -30,13 +29,15 @@ func TestStorageAndLoggerConfig(t *testing.T) {
 	expected := CompositeConfig{
 		Storage: storage.Config{
 			Type: "s3",
-			Connection: storage.ConnectionConfig{
-				Endpoint:   config.URL{URL: utils.MustParseURL("http://minio:9000")},
-				AuthType:   "accesskey",
-				AccessKey:  "minio",
-				SecretKey:  "miniostorage",
-				Region:     "us-east-1",
-				DisableSSL: true,
+			Stow: storage.StowConfig{
+				Kind: "s3",
+				Config: map[string]string{
+					"endpoint":  "http://minio:9000",
+					"authType":  "accesskey",
+					"accessKey": "minio",
+					"secretKey": "miniostorage",
+					"region":    "us-east-1",
+				},
 			},
 		},
 		Logger: logger.Config{

--- a/flytestdlib/tests/testdata/combined.yaml
+++ b/flytestdlib/tests/testdata/combined.yaml
@@ -33,4 +33,4 @@ storage:
       region: us-east-1
       secretKey: miniostorage
     kind: s3
-  type: s3
+  type: stow

--- a/flytestdlib/tests/testdata/combined.yaml
+++ b/flytestdlib/tests/testdata/combined.yaml
@@ -8,20 +8,29 @@ storage:
   cache:
     max_size_mbs: 0
     target_gc_percent: 0
-  connection:
-    access-key: minio
-    auth-type: accesskey
-    disable-ssl: true
-    endpoint: http://minio:9000
-    region: us-east-1
-    secret-key: miniostorage
   container: ""
   defaultHttpClient:
     headers: null
+    idleConnTimeout: 0s
+    maxConnsPerHost: 0
+    maxIdleConns: 0
+    maxIdleConnsPerHost: 0
     timeout: 0s
   enable-multicontainer: false
   limits:
     maxDownloadMBs: 0
+  redis:
+    addr: ""
+    db: 0
+    password: ""
+    username: ""
   signedUrl: {}
-  stow: {}
+  stow:
+    config:
+      accessKey: minio
+      authType: accesskey
+      endpoint: http://minio:9000
+      region: us-east-1
+      secretKey: miniostorage
+    kind: s3
   type: s3


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/7698
## Why are the changes needed?
There is no secure way of passing in S3 secret keys into the helm chart. 

## What changes were proposed in this pull request?
This pull request does a couple things. 
1. Removes deprecated storage.connection configuration. The current deployment guides do not use this deprecated configuration so it would be good to remove this before GA. 
2. Adds support for storage.stow.secretKeyPath, which can be a volume mount backed by a pre-existing Kubernetes secret. This follows the same pattern that is allowed for configuring the Postgres password. In order to support this, the secret key is retrieved from the secret key path during stow initialization, if the secret key path is configured. 

## How was this patch tested?
Currently untested beyond unit tests. 

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
