### PR TITLE
Remove deprecated db config

### DIFF
--- a/flytestdlib/autorefreshcache/auto_refresh_example_test.go
+++ b/flytestdlib/autorefreshcache/auto_refresh_example_test.go
@@ -121,7 +121,7 @@ func ExampleNewAutoRefreshCache() {
 	// arguments and so have no *testing.T, while require.Eventually requires a require.TestingT to
 	// report failures. The deadline below bounds the wait and panics on timeout to surface a hang.
 	var item Item
-	var lastStatus ExampleItemStatus = ExampleStatusNotStarted
+	var lastStatus = ExampleStatusNotStarted
 	deadline := time.Now().Add(10 * time.Second)
 	for {
 		item, err = cache.Get(item1.ID())

--- a/flytestdlib/config/tests/accessor_test.go
+++ b/flytestdlib/config/tests/accessor_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"os/exec"
 	"path"
@@ -564,7 +564,7 @@ func newSymlinkedConfigFile(t *testing.T) (watchDir, configFile string, cleanup 
 	//    |_ data (symlink for data1)
 	//    |_ config.yaml (symlink for data/config.yaml -recursively a symlink of data1/config.yaml)
 
-	watchDir, err := ioutil.TempDir("", "config-test-")
+	watchDir, err := os.MkdirTemp("", "config-test-")
 	assert.NoError(t, err)
 
 	dataDir1 := path.Join(watchDir, "data1")

--- a/flytestdlib/database/config.go
+++ b/flytestdlib/database/config.go
@@ -33,29 +33,10 @@ var configSection = config.MustRegisterSection(database, defaultConfig)
 // DbConfig is used to for initiating the database connection with the store that holds registered
 // entities (e.g. workflows, tasks, launch plans...)
 type DbConfig struct {
-	// deprecated: Please use Postgres.Host
-	DeprecatedHost string `json:"host" pflag:"-,deprecated"`
-	// deprecated: Please use Postgres.Port
-	DeprecatedPort int `json:"port" pflag:"-,deprecated"`
-	// deprecated: Please use Postgres.DbName
-	DeprecatedDbName string `json:"dbname" pflag:"-,deprecated"`
-	// deprecated: Please use Postgres.User
-	DeprecatedUser string `json:"username" pflag:"-,deprecated"`
-	// deprecated: Please use Postgres.Password
-	DeprecatedPassword string `json:"password" pflag:"-,deprecated"`
-	// deprecated: Please use Postgres.PasswordPath
-	DeprecatedPasswordPath string `json:"passwordPath" pflag:"-,deprecated"`
-	// deprecated: Please use Postgres.ExtraOptions
-	DeprecatedExtraOptions string `json:"options" pflag:"-,deprecated"`
-	// deprecated: Please use Postgres.Debug
-	DeprecatedDebug bool `json:"debug" pflag:"-,deprecated"`
-
-	// Deprecated: was GORM-specific, retained for config compatibility.
-	EnableForeignKeyConstraintWhenMigrating bool            `json:"enableForeignKeyConstraintWhenMigrating" pflag:",Whether to enable gorm foreign keys when migrating the db"`
-	MaxIdleConnections                      int             `json:"maxIdleConnections" pflag:",maxIdleConnections sets the maximum number of connections in the idle connection pool."`
-	MaxOpenConnections                      int             `json:"maxOpenConnections" pflag:",maxOpenConnections sets the maximum number of open connections to the database."`
-	ConnMaxLifeTime                         config.Duration `json:"connMaxLifeTime" pflag:",sets the maximum amount of time a connection may be reused"`
-	Postgres                                PostgresConfig  `json:"postgres,omitempty"`
+	MaxIdleConnections int             `json:"maxIdleConnections" pflag:",maxIdleConnections sets the maximum number of connections in the idle connection pool."`
+	MaxOpenConnections int             `json:"maxOpenConnections" pflag:",maxOpenConnections sets the maximum number of open connections to the database."`
+	ConnMaxLifeTime    config.Duration `json:"connMaxLifeTime" pflag:",sets the maximum amount of time a connection may be reused"`
+	Postgres           PostgresConfig  `json:"postgres,omitempty"`
 }
 
 // PostgresConfig includes specific config options for opening a connection to a postgres database.
@@ -80,29 +61,5 @@ func (s PostgresConfig) IsEmpty() bool {
 
 func GetConfig() *DbConfig {
 	databaseConfig := configSection.GetConfig().(*DbConfig)
-	if len(databaseConfig.DeprecatedHost) > 0 {
-		databaseConfig.Postgres.Host = databaseConfig.DeprecatedHost
-	}
-	if databaseConfig.DeprecatedPort != 0 {
-		databaseConfig.Postgres.Port = databaseConfig.DeprecatedPort
-	}
-	if len(databaseConfig.DeprecatedDbName) > 0 {
-		databaseConfig.Postgres.DbName = databaseConfig.DeprecatedDbName
-	}
-	if len(databaseConfig.DeprecatedUser) > 0 {
-		databaseConfig.Postgres.User = databaseConfig.DeprecatedUser
-	}
-	if len(databaseConfig.DeprecatedPassword) > 0 {
-		databaseConfig.Postgres.Password = databaseConfig.DeprecatedPassword
-	}
-	if len(databaseConfig.DeprecatedPasswordPath) > 0 {
-		databaseConfig.Postgres.PasswordPath = databaseConfig.DeprecatedPasswordPath
-	}
-	if len(databaseConfig.DeprecatedExtraOptions) > 0 {
-		databaseConfig.Postgres.ExtraOptions = databaseConfig.DeprecatedExtraOptions
-	}
-	if databaseConfig.DeprecatedDebug {
-		databaseConfig.Postgres.Debug = databaseConfig.DeprecatedDebug
-	}
 	return databaseConfig
 }

--- a/flytestdlib/database/db.go
+++ b/flytestdlib/database/db.go
@@ -25,22 +25,6 @@ func GetDB(ctx context.Context, dbConfig *DbConfig) (*sqlx.DB, error) {
 		if err != nil {
 			return nil, err
 		}
-
-	case len(dbConfig.DeprecatedHost) > 0 || len(dbConfig.DeprecatedUser) > 0 || len(dbConfig.DeprecatedDbName) > 0:
-		pgConfig := PostgresConfig{
-			Host:         dbConfig.DeprecatedHost,
-			Port:         dbConfig.DeprecatedPort,
-			DbName:       dbConfig.DeprecatedDbName,
-			User:         dbConfig.DeprecatedUser,
-			Password:     dbConfig.DeprecatedPassword,
-			PasswordPath: dbConfig.DeprecatedPasswordPath,
-			ExtraOptions: dbConfig.DeprecatedExtraOptions,
-			Debug:        dbConfig.DeprecatedDebug,
-		}
-		db, err = CreatePostgresDbIfNotExists(ctx, pgConfig)
-		if err != nil {
-			return nil, err
-		}
 	default:
 		return nil, fmt.Errorf("unrecognized database config, %v. Postgres config is required", dbConfig)
 	}

--- a/flytestdlib/database/dbconfig_flags.go
+++ b/flytestdlib/database/dbconfig_flags.go
@@ -50,7 +50,6 @@ func (DbConfig) mustMarshalJSON(v json.Marshaler) string {
 // flags is json-name.json-sub-name... etc.
 func (cfg DbConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("DbConfig", pflag.ExitOnError)
-	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "enableForeignKeyConstraintWhenMigrating"), defaultConfig.EnableForeignKeyConstraintWhenMigrating, "Whether to enable gorm foreign keys when migrating the db")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "maxIdleConnections"), defaultConfig.MaxIdleConnections, "maxIdleConnections sets the maximum number of connections in the idle connection pool.")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "maxOpenConnections"), defaultConfig.MaxOpenConnections, "maxOpenConnections sets the maximum number of open connections to the database.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "connMaxLifeTime"), defaultConfig.ConnMaxLifeTime.String(), "sets the maximum amount of time a connection may be reused")

--- a/flytestdlib/database/dbconfig_flags_test.go
+++ b/flytestdlib/database/dbconfig_flags_test.go
@@ -99,20 +99,6 @@ func TestDbConfig_SetFlags(t *testing.T) {
 	cmdFlags := actual.GetPFlagSet("")
 	assert.True(t, cmdFlags.HasFlags())
 
-	t.Run("Test_enableForeignKeyConstraintWhenMigrating", func(t *testing.T) {
-
-		t.Run("Override", func(t *testing.T) {
-			testValue := "1"
-
-			cmdFlags.Set("enableForeignKeyConstraintWhenMigrating", testValue)
-			if vBool, err := cmdFlags.GetBool("enableForeignKeyConstraintWhenMigrating"); err == nil {
-				testDecodeJson_DbConfig(t, fmt.Sprintf("%v", vBool), &actual.EnableForeignKeyConstraintWhenMigrating)
-
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
-	})
 	t.Run("Test_maxIdleConnections", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/flytestdlib/database/postgres_test.go
+++ b/flytestdlib/database/postgres_test.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -52,7 +51,7 @@ func TestGetPostgresDsn(t *testing.T) {
 	})
 	t.Run("with password path", func(t *testing.T) {
 		password := "123abc"
-		tmpFile, err := ioutil.TempFile("", "prefix")
+		tmpFile, err := os.CreateTemp("", "prefix")
 		if err != nil {
 			t.Errorf("Couldn't open temp file: %v", err)
 		}
@@ -93,7 +92,7 @@ func TestGetPostgresReadDsn(t *testing.T) {
 	})
 	t.Run("with password path", func(t *testing.T) {
 		password := "1234abc"
-		tmpFile, err := ioutil.TempFile("", "prefix")
+		tmpFile, err := os.CreateTemp("", "prefix")
 		if err != nil {
 			t.Errorf("Couldn't open temp file: %v", err)
 		}

--- a/flytestdlib/database/testdata/config.yaml
+++ b/flytestdlib/database/testdata/config.yaml
@@ -1,14 +1,9 @@
-port: 5432
-username: postgres
-host: postgres
-dbname: postgres
-options: "sslmode=disable"
-password: "password"
-passwordPath: "/etc/secret"
-debug: true
 postgres:
   port: 5432
   username: postgres
   host: postgres
   dbname: postgres
   options: "sslmode=disable"
+  password: password
+  passwordPath: "/etc/secret"
+  debug: true

--- a/flytestdlib/ioutils/bytes_test.go
+++ b/flytestdlib/ioutils/bytes_test.go
@@ -1,7 +1,8 @@
 package ioutils
 
 import (
-	"io/ioutil"
+	"io"
+
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,7 @@ import (
 func TestNewBytesReadCloser(t *testing.T) {
 	i := []byte("abc")
 	r := NewBytesReadCloser(i)
-	o, e := ioutil.ReadAll(r)
+	o, e := io.ReadAll(r)
 	assert.NoError(t, e)
 	assert.Equal(t, o, i)
 	assert.NoError(t, r.Close())

--- a/flytestdlib/storage/cached_rawstore_test.go
+++ b/flytestdlib/storage/cached_rawstore_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"runtime/debug"
 	"testing"
@@ -116,12 +115,12 @@ func TestCachedRawStore(t *testing.T) {
 			writeCalled = true
 			switch reference {
 			case "k2":
-				b, err := ioutil.ReadAll(raw)
+				b, err := io.ReadAll(raw)
 				assert.NoError(t, err)
 				assert.Equal(t, d2, b)
 				return nil
 			case "bigK":
-				b, err := ioutil.ReadAll(raw)
+				b, err := io.ReadAll(raw)
 				assert.NoError(t, err)
 				assert.Equal(t, bigD, b)
 				return nil
@@ -169,14 +168,14 @@ func TestCachedRawStore(t *testing.T) {
 	t.Run("ReadCachePopulate", func(t *testing.T) {
 		o, err := cStore.ReadRaw(ctx, k1)
 		assert.NoError(t, err)
-		b, err := ioutil.ReadAll(o)
+		b, err := io.ReadAll(o)
 		assert.NoError(t, err)
 		assert.Equal(t, d1, b)
 		assert.True(t, readCalled)
 		readCalled = false
 		o, err = cStore.ReadRaw(ctx, k1)
 		assert.NoError(t, err)
-		b, err = ioutil.ReadAll(o)
+		b, err = io.ReadAll(o)
 		assert.NoError(t, err)
 		assert.Equal(t, d1, b)
 		assert.False(t, readCalled)
@@ -196,7 +195,7 @@ func TestCachedRawStore(t *testing.T) {
 
 		o, err := cStore.ReadRaw(ctx, k2)
 		assert.NoError(t, err)
-		b, err := ioutil.ReadAll(o)
+		b, err := io.ReadAll(o)
 		assert.NoError(t, err)
 		assert.Equal(t, d2, b)
 		assert.False(t, readCalled)
@@ -211,7 +210,7 @@ func TestCachedRawStore(t *testing.T) {
 
 		o, err := cStore.ReadRaw(ctx, bigK)
 		assert.True(t, IsFailedWriteToCache(err))
-		b, err := ioutil.ReadAll(o)
+		b, err := io.ReadAll(o)
 		assert.NoError(t, err)
 		assert.Equal(t, bigD, b)
 		assert.True(t, readCalled)

--- a/flytestdlib/storage/config_flags_test.go
+++ b/flytestdlib/storage/config_flags_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/flytestdlib/storage/routing_store_internal_test.go
+++ b/flytestdlib/storage/routing_store_internal_test.go
@@ -53,7 +53,7 @@ func newTestRoutingStore(t *testing.T, schemes ...string) (*routingStore, map[st
 	counts := map[string]*int32{}
 	registry := map[string]backendFactory{}
 	for _, sc := range schemes {
-		sc := sc
+
 		var n int32
 		counts[sc] = &n
 		registry[sc] = func(_ context.Context, scheme string, _ DataReference, _ *Config, _ *http.Client, m *dataStoreMetrics) (RawStore, error) {

--- a/flytestdlib/storage/stow_store_test.go
+++ b/flytestdlib/storage/stow_store_test.go
@@ -6,7 +6,6 @@ import (
 	errors2 "errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -163,7 +162,7 @@ func (m mockStowItem) Size() (int64, error) {
 }
 
 func (mockStowItem) Open() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewReader([]byte{})), nil
+	return io.NopCloser(bytes.NewReader([]byte{})), nil
 }
 
 func (mockStowItem) ETag() (string, error) {
@@ -282,7 +281,7 @@ func TestStowStore_ReadRaw(t *testing.T) {
 		dataReference := writeTestFile(ctx, t, s, "s3://container/path")
 		raw, err := s.ReadRaw(ctx, dataReference)
 		assert.NoError(t, err)
-		rawBytes, err := ioutil.ReadAll(raw)
+		rawBytes, err := io.ReadAll(raw)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(rawBytes))
 		assert.Equal(t, DataReference("s3://container"), s.GetBaseContainerFQN(context.TODO()))
@@ -363,7 +362,7 @@ func TestStowStore_ReadRaw(t *testing.T) {
 		dataReference := writeTestFile(ctx, t, s, "s3://bad-container/path")
 		raw, err := s.ReadRaw(context.TODO(), dataReference)
 		assert.NoError(t, err)
-		rawBytes, err := ioutil.ReadAll(raw)
+		rawBytes, err := io.ReadAll(raw)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(rawBytes))
 		assert.Equal(t, DataReference("s3://container"), s.GetBaseContainerFQN(context.TODO()))
@@ -486,7 +485,7 @@ func TestNewLocalStore(t *testing.T) {
 	})
 
 	t.Run("Initialize container", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "stdlib_local")
+		tmpDir, err := os.MkdirTemp("", "stdlib_local")
 		assert.NoError(t, err)
 
 		stats, err := os.Stat(tmpDir)
@@ -514,7 +513,7 @@ func TestNewLocalStore(t *testing.T) {
 	})
 
 	t.Run("missing init container", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "stdlib_local")
+		tmpDir, err := os.MkdirTemp("", "stdlib_local")
 		assert.NoError(t, err)
 
 		stats, err := os.Stat(tmpDir)
@@ -535,7 +534,7 @@ func TestNewLocalStore(t *testing.T) {
 	})
 
 	t.Run("multi-container enabled", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "stdlib_local")
+		tmpDir, err := os.MkdirTemp("", "stdlib_local")
 		assert.NoError(t, err)
 
 		stats, err := os.Stat(tmpDir)

--- a/runs/config/config_flags.go
+++ b/runs/config/config_flags.go
@@ -52,7 +52,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "server.port"), defaultConfig.Server.Port, "Port to bind the HTTP server")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "server.host"), defaultConfig.Server.Host, "Host to bind the HTTP server")
-	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "database.enableForeignKeyConstraintWhenMigrating"), defaultConfig.Database.EnableForeignKeyConstraintWhenMigrating, "Whether to enable gorm foreign keys when migrating the db")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "database.maxIdleConnections"), defaultConfig.Database.MaxIdleConnections, "maxIdleConnections sets the maximum number of connections in the idle connection pool.")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "database.maxOpenConnections"), defaultConfig.Database.MaxOpenConnections, "maxOpenConnections sets the maximum number of open connections to the database.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "database.connMaxLifeTime"), defaultConfig.Database.ConnMaxLifeTime.String(), "sets the maximum amount of time a connection may be reused")

--- a/runs/config/config_flags_test.go
+++ b/runs/config/config_flags_test.go
@@ -127,20 +127,6 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
-	t.Run("Test_database.enableForeignKeyConstraintWhenMigrating", func(t *testing.T) {
-
-		t.Run("Override", func(t *testing.T) {
-			testValue := "1"
-
-			cmdFlags.Set("database.enableForeignKeyConstraintWhenMigrating", testValue)
-			if vBool, err := cmdFlags.GetBool("database.enableForeignKeyConstraintWhenMigrating"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vBool), &actual.Database.EnableForeignKeyConstraintWhenMigrating)
-
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
-	})
 	t.Run("Test_database.maxIdleConnections", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {


### PR DESCRIPTION
## Why are the changes needed?
These values have been deprecated for years. We have an opportunity to start fresh with v2 so we should clean these out. 

## What changes were proposed in this pull request?
Removed deprecated Postgres config keys. lint-fix.

## How was this patch tested?

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
