### PR TITLE
[V2][Bug] don't fire triggers immediately on registration

### DIFF
--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -7199,6 +7199,14 @@ rules:
   - get
 - apiGroups:
   - ""
+  resources:
+  - podtemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
   - events.k8s.io
   resources:
   - events
@@ -7739,6 +7747,12 @@ data:
       secretName: flyte-binary-webhook-secret
       serviceName: flyte-binary-webhook
       servicePort: 443
+      secretManagerTypes:
+        - Embedded
+      embeddedSecretManagerConfig:
+        type: K8s
+        k8sConfig:
+          namespace: flyte
 
     actions:
       kubernetes:
@@ -7764,7 +7778,7 @@ data:
         burst: 200
         clusterName: flyte-devbox
         kubeconfig: ""
-        namespace: flyte
+        namespace: 'flyte'
         qps: 100
         timeout: 30s
   001-plugins.yaml: |
@@ -8656,7 +8670,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: b3c98afcd1c1a1aca5040d049159f6a8683facf7875920987bab9a9df6dc8f97
+        checksum/configuration: 806913c16fd28512aaf60eccab4c1f3bf9aa6689da8474f4458a833c8dad3b94
         checksum/configuration-secret: 800f306f43701bd39e3b42e0d756f4627643cf3cee6dbd050a5a57a08052c280
       labels:
         app.kubernetes.io/component: flyte-binary

--- a/runs/scheduler/core/scheduler.go
+++ b/runs/scheduler/core/scheduler.go
@@ -87,6 +87,20 @@ func (s *GoCronScheduler) UpdateSchedules(ctx context.Context, triggers []*model
 			logger.Errorf(ctx, "scheduler: failed to compute start time for %s: %v", key, err)
 			continue
 		}
+		// StartTime returns the scheduling baseline (deploy/last-exec time), which is
+		// typically in the past. ScheduleTimedJob uses it verbatim as the job's first
+		// fire time, and the cron loop fires any entry whose next time is <= now
+		// immediately — so without advancing it, registering a job makes the trigger
+		// fire once right after deploy. Advance along the schedule to the first tick
+		// strictly after now; missed runs in (lastExec, now] are handled by CatchupAll.
+		now := time.Now().UTC()
+		for !startTime.After(now) {
+			next := sched.Next(startTime)
+			if next.IsZero() || !next.After(startTime) {
+				break // defensive: schedule no longer yields future times
+			}
+			startTime = next
+		}
 		job := NewGoCronJob(ctx, t, s.executor)
 		job.entryID = s.cron.ScheduleTimedJob(sched, job, startTime)
 		s.jobs[key] = job

--- a/runs/scheduler/core/scheduler_test.go
+++ b/runs/scheduler/core/scheduler_test.go
@@ -1,0 +1,105 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	cron "github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
+	"github.com/flyteorg/flyte/v2/runs/repository/models"
+)
+
+type recordingExecutor struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (r *recordingExecutor) Execute(_ context.Context, _ *models.Trigger, _ time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	return nil
+}
+
+func (r *recordingExecutor) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+// newCronTrigger builds a schedule trigger whose scheduling baseline (UpdatedAt)
+// is `baseline`. A baseline in the past is exactly the deploy-time situation that
+// used to make the job fire immediately on registration.
+func newCronTrigger(t *testing.T, name, expr string, baseline time.Time) *models.Trigger {
+	t.Helper()
+	spec := &task.TriggerAutomationSpec{
+		Type: task.TriggerAutomationSpecType_TYPE_SCHEDULE,
+		Automation: &task.TriggerAutomationSpec_Schedule{
+			Schedule: &task.Schedule{
+				Expression: &task.Schedule_Cron{Cron: &task.Cron{Expression: expr}},
+			},
+		},
+	}
+	b, err := proto.Marshal(spec)
+	require.NoError(t, err)
+	return &models.Trigger{
+		Project:        "p",
+		Domain:         "d",
+		TaskName:       "task",
+		Name:           name,
+		LatestRevision: 1,
+		AutomationSpec: b,
+		AutomationType: task.TriggerAutomationSpecType_TYPE_SCHEDULE.String(),
+		UpdatedAt:      baseline,
+	}
+}
+
+// TestUpdateSchedules_NoImmediateFireForPastBaseline locks in that registering a
+// trigger does not schedule its first fire in the past. StartTime returns the
+// deploy/last-exec baseline (in the past); the cron loop fires any entry whose
+// next time is <= now immediately, so without advancing it the trigger would run
+// once right after deploy. Missed runs in (lastExec, now] are handled by CatchupAll.
+func TestUpdateSchedules_NoImmediateFireForPastBaseline(t *testing.T) {
+	exec := &recordingExecutor{}
+	s := NewGoCronScheduler(exec)
+
+	// Hourly cron, baseline 10 minutes in the past.
+	trig := newCronTrigger(t, "k1", "0 * * * *", time.Now().Add(-10*time.Minute))
+	s.UpdateSchedules(context.Background(), []*models.Trigger{trig})
+
+	require.Len(t, s.jobs, 1)
+	var entryID cron.EntryID
+	for _, j := range s.jobs {
+		entryID = j.entryID
+	}
+
+	next := s.cron.Entry(entryID).Next
+	assert.False(t, next.IsZero(), "registered job must have a next fire time")
+	assert.True(t, next.After(time.Now()),
+		"registered job's first fire must be strictly in the future, got %s", next)
+}
+
+// TestUpdateSchedules_RunningSchedulerDoesNotFireImmediately is the behavioral
+// counterpart: start the cron loop, register a trigger with a past baseline, and
+// assert the executor is not invoked promptly (the next hourly tick is far away).
+func TestUpdateSchedules_RunningSchedulerDoesNotFireImmediately(t *testing.T) {
+	exec := &recordingExecutor{}
+	s := NewGoCronScheduler(exec)
+	s.Start()
+	defer s.Stop()
+
+	trig := newCronTrigger(t, "k1", "0 * * * *", time.Now().Add(-10*time.Minute))
+	s.UpdateSchedules(context.Background(), []*models.Trigger{trig})
+
+	// Give the run loop time to process the newly added entry. With the past
+	// baseline used verbatim it fired within milliseconds; the next real tick is
+	// up to an hour away, so no execution should happen here.
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, 0, exec.count(), "trigger must not fire immediately on registration")
+}


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->
#7703 

## Why are the changes needed?
Problem:
Deploying a schedule trigger caused it to fire once immediately, instead of waiting for its next scheduled time.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
In UpdateSchedules, advance the computed start time along the schedule to the first tick strictly after now before registering the job. This leaves the (lastExec, now] window to CatchupAll and starts the steady-state job at the next future tick.

- Cron and fixed-rate schedules: advanced via sched.Next, preserving alignment.
- Future start_time (fixed-rate): unchanged, since it's already after now.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
After the fix, the task will not be fired right after trigger deployed
<img width="1891" height="1012" alt="Screenshot 2026-07-23 at 8 53 57 PM" src="https://github.com/user-attachments/assets/b008094e-7094-443d-a042-b5f1e486be94" />

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
