### PR TITLE
fix(connector): reuse persistent connections for ListConnectors polling

### DIFF
--- a/flyteplugins/go/tasks/plugins/webapi/connector/client.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/client.go
@@ -34,8 +34,6 @@ type Connector struct {
 }
 
 // ClientSet contains the clients exposed to communicate with various connector services.
-// Its maps are read/written from multiple goroutines (the connector poll loop and
-// concurrent task handlers), so all access must go through the mutex-guarded helpers.
 type ClientSet struct {
 	mu                       sync.RWMutex
 	asyncConnectorClients    map[string]connector.AsyncConnectorServiceClient    // map[endpoint] => AsyncConnectorServiceClient

--- a/flyteplugins/go/tasks/plugins/webapi/connector/client.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/client.go
@@ -63,8 +63,7 @@ func getGrpcConnection(ctx context.Context, connector *Deployment) (*grpc.Client
 		grpc.WithChainStreamInterceptor(clientMetrics.StreamClientInterceptor()),
 		// Keepalive lets gRPC notice a dead/half-open transport within seconds
 		// (via HTTP/2 PINGs during active RPCs) instead of relying on the OS TCP
-		// timeout. Conservative values so we don't trip a server's ping-rate
-		// enforcement; PermitWithoutStream is intentionally left false.
+		// timeout.
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:    30 * time.Second,
 			Timeout: 10 * time.Second,

--- a/flyteplugins/go/tasks/plugins/webapi/connector/client.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"strings"
+	"time"
 
 	"golang.org/x/exp/maps"
 	"google.golang.org/grpc"
@@ -11,6 +12,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/config"
@@ -59,6 +61,14 @@ func getGrpcConnection(ctx context.Context, connector *Deployment) (*grpc.Client
 	opts = append(opts,
 		grpc.WithChainUnaryInterceptor(clientMetrics.UnaryClientInterceptor()),
 		grpc.WithChainStreamInterceptor(clientMetrics.StreamClientInterceptor()),
+		// Keepalive lets gRPC notice a dead/half-open transport within seconds
+		// (via HTTP/2 PINGs during active RPCs) instead of relying on the OS TCP
+		// timeout. Conservative values so we don't trip a server's ping-rate
+		// enforcement; PermitWithoutStream is intentionally left false.
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:    30 * time.Second,
+			Timeout: 10 * time.Second,
+		}),
 	)
 
 	var err error
@@ -199,28 +209,29 @@ func getConnectorRegistry(ctx context.Context, cs *ClientSet) Registry {
 	return newConnectorRegistry
 }
 
+// allConnectorDeployments returns every configured connector endpoint: the
+// default connector, explicit deployments, and connector apps.
+func allConnectorDeployments(cfg *Config) []*Deployment {
+	var connectorDeployments []*Deployment
+	if len(cfg.DefaultConnector.Endpoint) != 0 {
+		connectorDeployments = append(connectorDeployments, &cfg.DefaultConnector)
+	}
+	for _, deployment := range cfg.ConnectorDeployments {
+		connectorDeployments = append(connectorDeployments, deployment)
+	}
+	for _, deployment := range cfg.ConnectorApps {
+		connectorDeployments = append(connectorDeployments, deployment)
+	}
+	return connectorDeployments
+}
+
 func getConnectorClientSets(ctx context.Context) *ClientSet {
 	clientSet := &ClientSet{
 		asyncConnectorClients:    make(map[string]connector.AsyncConnectorServiceClient),
 		connectorMetadataClients: make(map[string]connector.ConnectorMetadataServiceClient),
 	}
 
-	var connectorDeployments []*Deployment
-	cfg := GetConfig()
-
-	if len(cfg.DefaultConnector.Endpoint) != 0 {
-		connectorDeployments = append(connectorDeployments, &cfg.DefaultConnector)
-	}
-
-	for _, deployment := range cfg.ConnectorDeployments {
-		connectorDeployments = append(connectorDeployments, deployment)
-	}
-
-	for _, deployment := range cfg.ConnectorApps {
-		connectorDeployments = append(connectorDeployments, deployment)
-	}
-
-	for _, connectorDeployment := range connectorDeployments {
+	for _, connectorDeployment := range allConnectorDeployments(GetConfig()) {
 		if _, ok := clientSet.connectorMetadataClients[connectorDeployment.Endpoint]; ok {
 			logger.Infof(ctx, "Connector client already initialized for [%v]", connectorDeployment.Endpoint)
 			continue

--- a/flyteplugins/go/tasks/plugins/webapi/connector/client.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/exp/maps"
@@ -33,9 +34,54 @@ type Connector struct {
 }
 
 // ClientSet contains the clients exposed to communicate with various connector services.
+// Its maps are read/written from multiple goroutines (the connector poll loop and
+// concurrent task handlers), so all access must go through the mutex-guarded helpers.
 type ClientSet struct {
+	mu                       sync.RWMutex
 	asyncConnectorClients    map[string]connector.AsyncConnectorServiceClient    // map[endpoint] => AsyncConnectorServiceClient
 	connectorMetadataClients map[string]connector.ConnectorMetadataServiceClient // map[endpoint] => ConnectorMetadataServiceClient
+}
+
+// getOrDialAsyncClient returns the cached AsyncConnectorService client for the
+// endpoint, dialing (and caching) a persistent connection on first use.
+func (cs *ClientSet) getOrDialAsyncClient(ctx context.Context, deployment *Deployment) (connector.AsyncConnectorServiceClient, error) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if client, ok := cs.asyncConnectorClients[deployment.Endpoint]; ok {
+		return client, nil
+	}
+	conn, err := getGrpcConnection(ctx, deployment)
+	if err != nil {
+		return nil, err
+	}
+	client := connector.NewAsyncConnectorServiceClient(conn)
+	cs.asyncConnectorClients[deployment.Endpoint] = client
+	return client, nil
+}
+
+// getOrDialMetadataClient returns the cached ConnectorMetadataService client for
+// the endpoint, dialing (and caching) a persistent connection on first use.
+func (cs *ClientSet) getOrDialMetadataClient(ctx context.Context, deployment *Deployment) (connector.ConnectorMetadataServiceClient, error) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if client, ok := cs.connectorMetadataClients[deployment.Endpoint]; ok {
+		return client, nil
+	}
+	conn, err := getGrpcConnection(ctx, deployment)
+	if err != nil {
+		return nil, err
+	}
+	client := connector.NewConnectorMetadataServiceClient(conn)
+	cs.connectorMetadataClients[deployment.Endpoint] = client
+	return client, nil
+}
+
+// metadataClient returns the cached ConnectorMetadataService client for the endpoint.
+func (cs *ClientSet) metadataClient(endpoint string) (connector.ConnectorMetadataServiceClient, bool) {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	client, ok := cs.connectorMetadataClients[endpoint]
+	return client, ok
 }
 
 func getGrpcConnection(ctx context.Context, connector *Deployment) (*grpc.ClientConn, error) {
@@ -111,7 +157,7 @@ func updateRegistry(
 	isConnectorApp bool,
 ) {
 	for connectorID, connectorDeployment := range connectorDeployments {
-		client, ok := cs.connectorMetadataClients[connectorDeployment.Endpoint]
+		client, ok := cs.metadataClient(connectorDeployment.Endpoint)
 		if !ok {
 			logger.Warningf(ctx, "Connector client not found in the clientSet for the endpoint: %v", connectorDeployment.Endpoint)
 			continue

--- a/flyteplugins/go/tasks/plugins/webapi/connector/client.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/client.go
@@ -45,16 +45,29 @@ type ClientSet struct {
 func (cs *ClientSet) getOrDialAsyncClient(ctx context.Context, deployment *Deployment) (connector.AsyncConnectorServiceClient, error) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
+
+	if cs.asyncConnectorClients == nil {
+		cs.asyncConnectorClients = make(map[string]connector.AsyncConnectorServiceClient)
+	}
+	if cs.connectorMetadataClients == nil {
+		cs.connectorMetadataClients = make(map[string]connector.ConnectorMetadataServiceClient)
+	}
+
 	if client, ok := cs.asyncConnectorClients[deployment.Endpoint]; ok {
 		return client, nil
 	}
+
 	conn, err := getGrpcConnection(ctx, deployment)
 	if err != nil {
 		return nil, err
 	}
-	client := connector.NewAsyncConnectorServiceClient(conn)
-	cs.asyncConnectorClients[deployment.Endpoint] = client
-	return client, nil
+
+	asyncClient := connector.NewAsyncConnectorServiceClient(conn)
+	cs.asyncConnectorClients[deployment.Endpoint] = asyncClient
+	if _, ok := cs.connectorMetadataClients[deployment.Endpoint]; !ok {
+		cs.connectorMetadataClients[deployment.Endpoint] = connector.NewConnectorMetadataServiceClient(conn)
+	}
+	return asyncClient, nil
 }
 
 // getOrDialMetadataClient returns the cached ConnectorMetadataService client for

--- a/flyteplugins/go/tasks/plugins/webapi/connector/client_test.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/client_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	connectorpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/connector"
 )
 
 func TestInitializeClients(t *testing.T) {
@@ -25,4 +29,40 @@ func TestInitializeClients(t *testing.T) {
 	assert.True(t, ok)
 	_, ok = cs.asyncConnectorClients["x"]
 	assert.True(t, ok)
+}
+
+func TestAllConnectorDeployments(t *testing.T) {
+	cfg := defaultConfig
+	cfg.DefaultConnector = Deployment{Endpoint: "default"}
+	cfg.ConnectorDeployments = map[string]*Deployment{"x": {Endpoint: "x"}}
+	cfg.ConnectorApps = map[string]*Deployment{"app": {Endpoint: "app"}}
+
+	endpoints := make([]string, 0)
+	for _, d := range allConnectorDeployments(&cfg) {
+		endpoints = append(endpoints, d.Endpoint)
+	}
+	assert.ElementsMatch(t, []string{"default", "x", "app"}, endpoints)
+}
+
+func TestGetConnectorMetadataClientReusesConnection(t *testing.T) {
+	ctx := context.Background()
+
+	// A pre-existing cached client for endpoint "ep".
+	conn, err := grpc.NewClient("passthrough:///ep", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	assert.NoError(t, err)
+	existing := connectorpb.NewConnectorMetadataServiceClient(conn)
+
+	p := &Plugin{cs: &ClientSet{
+		asyncConnectorClients:    map[string]connectorpb.AsyncConnectorServiceClient{},
+		connectorMetadataClients: map[string]connectorpb.ConnectorMetadataServiceClient{"ep": existing},
+	}}
+
+	// Already cached -> must reuse the same client, not re-dial/replace it.
+	assert.NoError(t, p.getConnectorMetadataClient(ctx, &Deployment{Endpoint: "ep"}))
+	assert.True(t, existing == p.cs.connectorMetadataClients["ep"], "cached connection should be reused, not re-dialed")
+
+	// New endpoint -> dialed and cached.
+	assert.NoError(t, p.getConnectorMetadataClient(ctx, &Deployment{Endpoint: "new", Insecure: true}))
+	_, ok := p.cs.connectorMetadataClients["new"]
+	assert.True(t, ok, "new endpoint should be dialed and cached")
 }

--- a/flyteplugins/go/tasks/plugins/webapi/connector/client_test.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/client_test.go
@@ -45,11 +45,13 @@ func TestAllConnectorDeployments(t *testing.T) {
 }
 
 func TestGetConnectorMetadataClientReusesConnection(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// A pre-existing cached client for endpoint "ep".
 	conn, err := grpc.NewClient("passthrough:///ep", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
 	existing := connectorpb.NewConnectorMetadataServiceClient(conn)
 
 	p := &Plugin{cs: &ClientSet{
@@ -62,7 +64,7 @@ func TestGetConnectorMetadataClientReusesConnection(t *testing.T) {
 	assert.True(t, existing == p.cs.connectorMetadataClients["ep"], "cached connection should be reused, not re-dialed")
 
 	// New endpoint -> dialed and cached.
-	assert.NoError(t, p.getConnectorMetadataClient(ctx, &Deployment{Endpoint: "new", Insecure: true}))
-	_, ok := p.cs.connectorMetadataClients["new"]
+	assert.NoError(t, p.getConnectorMetadataClient(ctx, &Deployment{Endpoint: "passthrough:///new", Insecure: true}))
+	_, ok := p.cs.connectorMetadataClients["passthrough:///new"]
 	assert.True(t, ok, "new endpoint should be dialed and cached")
 }

--- a/flyteplugins/go/tasks/plugins/webapi/connector/client_test.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/client_test.go
@@ -44,25 +44,30 @@ func TestAllConnectorDeployments(t *testing.T) {
 	assert.ElementsMatch(t, []string{"default", "x", "app"}, endpoints)
 }
 
-func TestGetConnectorMetadataClientReusesConnection(t *testing.T) {
-	ctx := context.Background()
+func TestGetOrDialMetadataClientReusesConnection(t *testing.T) {
+	// Cancelable context so getGrpcConnection's close goroutine is cleaned up
+	// when the test finishes.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// A pre-existing cached client for endpoint "ep".
 	conn, err := grpc.NewClient("passthrough:///ep", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.NoError(t, err)
 	existing := connectorpb.NewConnectorMetadataServiceClient(conn)
 
-	p := &Plugin{cs: &ClientSet{
+	cs := &ClientSet{
 		asyncConnectorClients:    map[string]connectorpb.AsyncConnectorServiceClient{},
 		connectorMetadataClients: map[string]connectorpb.ConnectorMetadataServiceClient{"ep": existing},
-	}}
+	}
 
 	// Already cached -> must reuse the same client, not re-dial/replace it.
-	assert.NoError(t, p.getConnectorMetadataClient(ctx, &Deployment{Endpoint: "ep"}))
-	assert.True(t, existing == p.cs.connectorMetadataClients["ep"], "cached connection should be reused, not re-dialed")
+	got, err := cs.getOrDialMetadataClient(ctx, &Deployment{Endpoint: "ep"})
+	assert.NoError(t, err)
+	assert.True(t, existing == got, "cached connection should be reused, not re-dialed")
 
-	// New endpoint -> dialed and cached.
-	assert.NoError(t, p.getConnectorMetadataClient(ctx, &Deployment{Endpoint: "new", Insecure: true}))
-	_, ok := p.cs.connectorMetadataClients["new"]
+	// New endpoint -> dialed and cached. The passthrough scheme avoids DNS.
+	_, err = cs.getOrDialMetadataClient(ctx, &Deployment{Endpoint: "passthrough:///new", Insecure: true})
+	assert.NoError(t, err)
+	_, ok := cs.metadataClient("passthrough:///new")
 	assert.True(t, ok, "new endpoint should be dialed and cached")
 }

--- a/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
@@ -374,39 +374,18 @@ func (p *Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phas
 }
 
 func (p *Plugin) getAsyncConnectorClient(ctx context.Context, connector *Deployment) (connectorPb.AsyncConnectorServiceClient, error) {
-	client, ok := p.cs.asyncConnectorClients[connector.Endpoint]
-	if !ok {
-		conn, err := getGrpcConnection(ctx, connector)
-		if err != nil {
-			return nil, err
-		}
-		client = connectorPb.NewAsyncConnectorServiceClient(conn)
-		p.cs.asyncConnectorClients[connector.Endpoint] = client
-	}
-	return client, nil
-}
-
-// getConnectorMetadataClient returns a cached ConnectorMetadataService client for
-// the endpoint, dialing a persistent connection (bound to the plugin's context)
-// on first use.
-func (p *Plugin) getConnectorMetadataClient(ctx context.Context, deployment *Deployment) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if _, ok := p.cs.connectorMetadataClients[deployment.Endpoint]; ok {
-		return nil
-	}
-	conn, err := getGrpcConnection(ctx, deployment)
-	if err != nil {
-		return err
-	}
-	p.cs.connectorMetadataClients[deployment.Endpoint] = connectorPb.NewConnectorMetadataServiceClient(conn)
-	return nil
+	return p.cs.getOrDialAsyncClient(ctx, connector)
 }
 
 func (p *Plugin) watchConnectors(ctx context.Context, connectorService *ConnectorService) {
 	go wait.Until(func() {
+		// Reuse the persistent, keepalive'd connections held on p.cs; only dial
+		// connector endpoints we haven't connected to yet (e.g. newly-added
+		// deployments). Previously this re-dialed a throwaway connection every
+		// poll, so each ListConnectors paid a fresh TCP+HTTP/2 handshake through
+		// the ingress path.
 		for _, deployment := range allConnectorDeployments(GetConfig()) {
-			if err := p.getConnectorMetadataClient(ctx, deployment); err != nil {
+			if _, err := p.cs.getOrDialMetadataClient(ctx, deployment); err != nil {
 				logger.Errorf(ctx, "failed to connect to connector [%v]: %v", deployment.Endpoint, err)
 			}
 		}

--- a/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
@@ -390,6 +390,8 @@ func (p *Plugin) getAsyncConnectorClient(ctx context.Context, connector *Deploym
 // the endpoint, dialing a persistent connection (bound to the plugin's context)
 // on first use.
 func (p *Plugin) getConnectorMetadataClient(ctx context.Context, deployment *Deployment) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	if _, ok := p.cs.connectorMetadataClients[deployment.Endpoint]; ok {
 		return nil
 	}
@@ -403,11 +405,6 @@ func (p *Plugin) getConnectorMetadataClient(ctx context.Context, deployment *Dep
 
 func (p *Plugin) watchConnectors(ctx context.Context, connectorService *ConnectorService) {
 	go wait.Until(func() {
-		// Reuse the persistent, keepalive'd connections held on p.cs; only dial
-		// connector endpoints we haven't connected to yet (e.g. newly-added
-		// deployments). Previously this re-dialed a throwaway connection every
-		// poll, so each ListConnectors paid a fresh TCP+HTTP/2 handshake through
-		// the ingress path.
 		for _, deployment := range allConnectorDeployments(GetConfig()) {
 			if err := p.getConnectorMetadataClient(ctx, deployment); err != nil {
 				logger.Errorf(ctx, "failed to connect to connector [%v]: %v", deployment.Endpoint, err)

--- a/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
@@ -388,8 +388,7 @@ func (p *Plugin) getAsyncConnectorClient(ctx context.Context, connector *Deploym
 
 // getConnectorMetadataClient returns a cached ConnectorMetadataService client for
 // the endpoint, dialing a persistent connection (bound to the plugin's context)
-// on first use. Connections are reused across polls instead of being re-dialed
-// every PollInterval, so ListConnectors runs over a warm, keepalive'd channel.
+// on first use.
 func (p *Plugin) getConnectorMetadataClient(ctx context.Context, deployment *Deployment) error {
 	if _, ok := p.cs.connectorMetadataClients[deployment.Endpoint]; ok {
 		return nil

--- a/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
@@ -379,11 +379,6 @@ func (p *Plugin) getAsyncConnectorClient(ctx context.Context, connector *Deploym
 
 func (p *Plugin) watchConnectors(ctx context.Context, connectorService *ConnectorService) {
 	go wait.Until(func() {
-		// Reuse the persistent, keepalive'd connections held on p.cs; only dial
-		// connector endpoints we haven't connected to yet (e.g. newly-added
-		// deployments). Previously this re-dialed a throwaway connection every
-		// poll, so each ListConnectors paid a fresh TCP+HTTP/2 handshake through
-		// the ingress path.
 		for _, deployment := range allConnectorDeployments(GetConfig()) {
 			if _, err := p.cs.getOrDialMetadataClient(ctx, deployment); err != nil {
 				logger.Errorf(ctx, "failed to connect to connector [%v]: %v", deployment.Endpoint, err)

--- a/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
+++ b/flyteplugins/go/tasks/plugins/webapi/connector/plugin.go
@@ -386,12 +386,35 @@ func (p *Plugin) getAsyncConnectorClient(ctx context.Context, connector *Deploym
 	return client, nil
 }
 
+// getConnectorMetadataClient returns a cached ConnectorMetadataService client for
+// the endpoint, dialing a persistent connection (bound to the plugin's context)
+// on first use. Connections are reused across polls instead of being re-dialed
+// every PollInterval, so ListConnectors runs over a warm, keepalive'd channel.
+func (p *Plugin) getConnectorMetadataClient(ctx context.Context, deployment *Deployment) error {
+	if _, ok := p.cs.connectorMetadataClients[deployment.Endpoint]; ok {
+		return nil
+	}
+	conn, err := getGrpcConnection(ctx, deployment)
+	if err != nil {
+		return err
+	}
+	p.cs.connectorMetadataClients[deployment.Endpoint] = connectorPb.NewConnectorMetadataServiceClient(conn)
+	return nil
+}
+
 func (p *Plugin) watchConnectors(ctx context.Context, connectorService *ConnectorService) {
 	go wait.Until(func() {
-		childCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		clientSet := getConnectorClientSets(childCtx)
-		connectorRegistry := getConnectorRegistry(childCtx, clientSet)
+		// Reuse the persistent, keepalive'd connections held on p.cs; only dial
+		// connector endpoints we haven't connected to yet (e.g. newly-added
+		// deployments). Previously this re-dialed a throwaway connection every
+		// poll, so each ListConnectors paid a fresh TCP+HTTP/2 handshake through
+		// the ingress path.
+		for _, deployment := range allConnectorDeployments(GetConfig()) {
+			if err := p.getConnectorMetadataClient(ctx, deployment); err != nil {
+				logger.Errorf(ctx, "failed to connect to connector [%v]: %v", deployment.Endpoint, err)
+			}
+		}
+		connectorRegistry := getConnectorRegistry(ctx, p.cs)
 		p.setRegistry(connectorRegistry)
 		connectorService.SetSupportedTaskType(connectorRegistry.getSupportedTaskTypes())
 	}, p.cfg.PollInterval.Duration, ctx.Done())


### PR DESCRIPTION
## Why are the changes needed?

The connector metadata poll loop re-dials a brand-new gRPC connection to **every** connector endpoint on **every** `PollInterval` (default 10s) and tears it down at the end of each tick. So every `ListConnectors` call pays a full TCP + HTTP/2 handshake through the ingress path (for Knative connector apps this is `ExternalName → kourier-internal → activator → queue-proxy → pod`).

In contrast, `GetTask` already reuses a cached, long-lived `AsyncConnectorService` client (`getAsyncConnectorClient`), so it runs over a warm connection. Only the `ListConnectors` metadata path re-connects each poll.

This is wasteful (handshake churn every 10s per endpoint) and fragile: a fresh connection is fully exposed to any per-connection-setup latency on the ingress path, and the client had no keepalive, so a dead/half-open transport would only surface via the OS TCP timeout (~13 min on Linux) rather than seconds.

Note: this reduces the connection setup ListConnectors is exposed to and adds keepalive; it is a resilience/hygiene improvement. I'm being deliberate that it is **not** claimed as a proven fix for a specific production stall still under investigation — see "How was this patch tested".

## What changes were proposed in this pull request?

- `watchConnectors` now **reuses the persistent connections already held on `Plugin.cs`** (built once at init with the plugin's long-lived context) instead of building a throwaway `ClientSet` with a per-tick `context.WithCancel` that closes the connections at the end of each poll. It dials only endpoints not yet connected (e.g. newly-added connector deployments/apps), mirroring how `getAsyncConnectorClient` already caches.
- Added `getConnectorMetadataClient` (caches a `ConnectorMetadataService` client per endpoint) and `allConnectorDeployments` (extracts the endpoint-gathering that `getConnectorClientSets` duplicated).
- Added conservative client **keepalive** (`Time: 30s`, `Timeout: 10s`, `PermitWithoutStream` left false to avoid tripping server ping-rate enforcement) so a dead transport is detected in seconds.

Behavioral note: connector endpoints removed from config leave an idle cached client on `Plugin.cs` until plugin shutdown (a minor, rare leak); the registry is still rebuilt from current config each poll, so removed connectors stop being queried.

## How was this patch tested?

- `go build`, `go vet`, and the full `webapi/connector` package tests pass.
- Added unit tests:
  - `TestGetConnectorMetadataClientReusesConnection` — an already-cached endpoint reuses the same client (asserts no re-dial/replace); a new endpoint is dialed and cached.
  - `TestAllConnectorDeployments` — gathers default + deployments + apps.
- The keepalive values are conservative defaults and may warrant tuning against the connector server's HTTP/2 ping enforcement.

### Labels
fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

https://claude.ai/code/session_01DRW6WhuHfrCiAXPQ3W1YFA