### PR TITLE
fix(dask): use unified dask scheduler/worker CLI

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/dask/dask.go
+++ b/flyteplugins/go/tasks/plugins/k8s/dask/dask.go
@@ -55,7 +55,7 @@ type daskResourceHandler struct {
 }
 
 // dashboardPrefixFromLogConfig returns the path that should be passed to
-// `dask-scheduler --dashboard-prefix` so Bokeh emits tab/WebSocket links that
+// `dask scheduler --dashboard-prefix` so Bokeh emits tab/WebSocket links that
 // resolve through the reverse-proxy chain. It reuses the existing dashboard
 // log-template (the same `linkType: dashboard` entry under
 // `plugins.dask.logs.templates` that powers the user-facing dashboard link)
@@ -206,7 +206,8 @@ func createWorkerSpec(cluster *plugins.DaskWorkerGroup, podSpec *v1.PodSpec, pri
 
 	// Set custom args
 	workerArgs := []string{
-		"dask-worker",
+		"dask",
+		"worker",
 		"--name",
 		"$(DASK_WORKER_NAME)",
 	}
@@ -272,7 +273,7 @@ func createSchedulerSpec(scheduler *plugins.DaskScheduler, clusterName string, p
 	// resolve through the reverse-proxy chain. Without this, Bokeh emits
 	// root-relative links like "/individual-task-stream" that 404 outside the
 	// dashboard mount point.
-	primaryContainer.Args = []string{"dask-scheduler"}
+	primaryContainer.Args = []string{"dask", "scheduler"}
 	if dashboardPrefix != "" {
 		primaryContainer.Args = append(primaryContainer.Args, "--dashboard-prefix", dashboardPrefix)
 	}

--- a/flyteplugins/go/tasks/plugins/k8s/dask/dask_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/dask/dask_test.go
@@ -366,7 +366,7 @@ func TestBuildResourceDaskHappyPath(t *testing.T) {
 	assert.Equal(t, v1.RestartPolicyAlways, schedulerSpec.RestartPolicy)
 	assert.Equal(t, defaultTestImage, schedulerSpec.Containers[0].Image)
 	assert.Equal(t, defaultResources, schedulerSpec.Containers[0].Resources)
-	assert.Equal(t, []string{"dask-scheduler"}, schedulerSpec.Containers[0].Args)
+	assert.Equal(t, []string{"dask", "scheduler"}, schedulerSpec.Containers[0].Args)
 	assert.Equal(t, expectedPorts, schedulerSpec.Containers[0].Ports)
 	// Flyte adds more environment variables to the scheduler
 	assert.Contains(t, schedulerSpec.Containers[0].Env, testEnvVars[0])
@@ -409,7 +409,8 @@ func TestBuildResourceDaskHappyPath(t *testing.T) {
 	assert.Equal(t, defaultNodeSelector, workerSpec.NodeSelector)
 	assert.Equal(t, defaultAffinity, workerSpec.Affinity)
 	assert.Equal(t, []string{
-		"dask-worker",
+		"dask",
+		"worker",
 		"--name",
 		"$(DASK_WORKER_NAME)",
 		"--nthreads",


### PR DESCRIPTION
## Tracking issue
Closes #7706

## Why are the changes needed?

The k8s dask plugin hardcodes the legacy `dask-scheduler` and `dask-worker` console scripts as cluster container args. Those scripts were removed in `distributed` 2026.6.0 (deprecated since 2022.10.0 in favour of `dask scheduler` / `dask worker`). Any task image with a current `dask[distributed]` crash-loops with `executable file not found in $PATH`. The SDK-side `<2026.6.0` cap is only a stopgap until the backend stops calling the removed binaries.

## What changes were proposed in this pull request?

In `flyteplugins/go/tasks/plugins/k8s/dask/dask.go`:
- `createSchedulerSpec`: `[]string{"dask-scheduler"}` → `[]string{"dask", "scheduler"}` (still appends `--dashboard-prefix` when set)
- `createWorkerSpec`: `[]string{"dask-worker", ...}` → `[]string{"dask", "worker", ...}` (keeps `--name` / `--nthreads` / `--memory-limit`)
- Left the k8s container name `dask-worker` unchanged

Updated exact arg-slice assertions in `dask_test.go`.

Flag names are identical between CLIs; the unified subcommands exist across the supported floor (`>=2022.10.2`).

Follow-up (separate repo): drop the `dask[distributed]<2026.6.0` cap in `flyteorg/flyte-sdk` once this ships.

## How was this patch tested?

```bash
go test ./flyteplugins/go/tasks/plugins/k8s/dask/...
```

All package tests passed (`ok … 1.251s`).

### Labels
- **fixed**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

Follow-up: remove `dask[distributed]<2026.6.0` from `flyteorg/flyte-sdk` (`plugins/dask/pyproject.toml` + `examples/plugins/dask_example.py`) after this backend change is released.