### PR TITLE
Don't drop shared inputs when switching task versions in the launch form

### DIFF
--- a/dataproxy/converter/literal_json_converter.go
+++ b/dataproxy/converter/literal_json_converter.go
@@ -387,8 +387,15 @@ func LiteralsToLaunchFormJson(ctx context.Context, literals []*task.NamedLiteral
 	for _, literal := range literals {
 		variable, ok := varMap[literal.GetName()]
 		if !ok {
-			logger.Errorf(ctx, "variable not found in variable map for literal: %s", literal.GetName())
-			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("variable not found in variable map for literal: %s", literal.GetName()))
+			// The literal has no corresponding variable in the target interface.
+			// This happens legitimately when re-converting a run's inputs against a
+			// different task version (e.g. the launch-form version selector switching
+			// versions): inputs the new task def dropped have nowhere to map. Skip
+			// them (with a warning) instead of failing the whole conversion, so the
+			// inputs the two versions *share* are still preserved. Mirrors the
+			// unmapped-field handling in JSONValuesToLiterals.
+			logger.Warnf(ctx, "skipping literal %q with no corresponding variable in the target interface (ignoring)", literal.GetName())
+			continue
 		}
 		fieldName := literal.GetName()
 

--- a/dataproxy/converter/literal_json_converter_test.go
+++ b/dataproxy/converter/literal_json_converter_test.go
@@ -53,6 +53,29 @@ func TestLiteralsToJsonSchema(t *testing.T) {
 		assert.Equal(t, "description", testField["description"])
 	})
 
+	t.Run("literal with no matching variable is skipped, shared ones preserved", func(t *testing.T) {
+		// Re-converting a run's inputs against a *different* task version (the
+		// launch-form version selector). The original run had {name, count}; the
+		// target version only declares {name}. The extra `count` literal must be
+		// skipped rather than failing the whole conversion, so `name` survives the
+		// switch. Regression guard for the asymmetric version-switch input loss.
+		literals := []*task.NamedLiteral{
+			{Name: "name", Value: &core.Literal{Value: &core.Literal_Scalar{Scalar: &core.Scalar{Value: &core.Scalar_Primitive{Primitive: &core.Primitive{Value: &core.Primitive_StringValue{StringValue: "kept"}}}}}}},
+			{Name: "count", Value: &core.Literal{Value: &core.Literal_Scalar{Scalar: &core.Scalar{Value: &core.Scalar_Primitive{Primitive: &core.Primitive{Value: &core.Primitive_Integer{Integer: 5}}}}}}},
+		}
+		variableMap := makeVariableMap(map[string]*core.Variable{
+			"name": {Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRING}}},
+		})
+
+		resp, err := LiteralsToLaunchFormJson(context.Background(), literals, variableMap)
+		require.NoError(t, err)
+
+		properties := resp.AsMap()["properties"].(map[string]any)
+		require.Contains(t, properties, "name")
+		assert.Equal(t, "kept", properties["name"].(map[string]any)["default"])
+		assert.NotContains(t, properties, "count")
+	})
+
 	t.Run("string literal", func(t *testing.T) {
 		literals := []*task.NamedLiteral{
 			{


### PR DESCRIPTION

## Why are the changes needed?
When rerunning a run in the launch form and switching to a different task version, the form re-converts the original run's inputs against the selected version's interface via LiteralsToLaunchFormJson. That function returned an error the moment it hit a literal whose variable didn't exist in the target interface — which failed the entire conversion, so every input got dropped rather than just the one that no longer applies.

This produced an asymmetry when the two versions declare different inputs. For example, v3 has {name, count} and v17 has {name}:

- v17 → v3: name is preserved and count is left empty to fill in — as expected.
- v3 → v17: both clear, even though name exists in both versions.

The sibling conversion (JSONValuesToLiterals) already handles the analogous mismatch gracefully by ignoring unmapped fields with a warning. This change makes LiteralsToLaunchFormJson consistent: it skips literals that have no corresponding variable in the target interface (logging a warning) instead of erroring, so inputs shared between the two versions survive the switch in both directions.

## What changes were proposed in this pull request?

LiteralsToLaunchFormJson no longer errors when a literal has no corresponding variable in the target VariableMap. Instead of returning CodeInvalidArgument and failing the whole conversion, it now skips that literal (logging a warning) and continues, so the literals that do map are still converted. This mirrors the existing unmapped-field handling in JSONValuesToLiterals.

Added a regression test that converts {name, count} against a {name}-only interface and asserts name is preserved with its value while count is dropped.



## How was this patch tested?

Unit test in runs/service/converter/literal_json_converter_test.go — a new TestLiteralsToJsonSchema subtest converts a run's {name, count} literals against a target interface that only declares {name}, and asserts the call succeeds, name is preserved with its value, and the unmapped count is dropped. Ran go test ./runs/service/converter/..., all passing.

Also verified manually in the launch form: rerunning a run and switching from a higher-input version to a lower-input version now keeps the values for the shared inputs instead of clearing everything.


### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
