### PR TITLE
treat nil variableMap as empty so no-input tasks can launch

### DIFF
--- a/dataproxy/converter/literal_json_converter.go
+++ b/dataproxy/converter/literal_json_converter.go
@@ -92,7 +92,12 @@ func TaskSpecToLaunchFormJson(ctx context.Context, taskSpec *task.TaskSpec) (*st
 //     }
 func JSONValuesToLiterals(ctx context.Context, variableMap *core.VariableMap, values *structpb.Struct) ([]*task.NamedLiteral, error) {
 	if variableMap == nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("variableMap cannot be nil"))
+		// A task with no declared inputs has no variableMap. There are no
+		// expected inputs, so treat it as empty rather than erroring: an empty
+		// payload yields no literals, and any provided values are unmapped and
+		// get ignored (debug-logged) below, consistent with how we handle
+		// unmapped fields elsewhere.
+		variableMap = &core.VariableMap{}
 	}
 	if values == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("values cannot be nil"))
@@ -164,7 +169,7 @@ func JSONValuesToLiterals(ctx context.Context, variableMap *core.VariableMap, va
 
 	if len(unmappedFields) > 0 {
 		// Extra fields in values that don't have corresponding variables in variableMap
-		// are allowed and will be ignored (with a warning). This is intentional to avoid
+		// are allowed and will be ignored (logged at debug). This is intentional to avoid
 		// hard failures when translating literals for a task version that has a different
 		// template than the original task these inputs were derived from.
 		logger.Debugf(ctx, "found unmapped fields in JSON payload that do not correspond to any variable (ignoring): %v", unmappedFields)
@@ -391,7 +396,7 @@ func LiteralsToLaunchFormJson(ctx context.Context, literals []*task.NamedLiteral
 			// This happens legitimately when re-converting a run's inputs against a
 			// different task version (e.g. the launch-form version selector switching
 			// versions): inputs the new task def dropped have nowhere to map. Skip
-			// them (with a warning) instead of failing the whole conversion, so the
+			// them (logged at debug) instead of failing the whole conversion, so the
 			// inputs the two versions *share* are still preserved. Mirrors the
 			// unmapped-field handling in JSONValuesToLiterals.
 			logger.Debugf(ctx, "skipping literal %q with no corresponding variable in the target interface (ignoring)", literal.GetName())

--- a/dataproxy/converter/literal_json_converter_test.go
+++ b/dataproxy/converter/literal_json_converter_test.go
@@ -560,13 +560,21 @@ func TestJSONValuesToLiterals(t *testing.T) {
 		assert.Contains(t, err.Error(), "missing value for variable")
 	})
 
-	t.Run("nil variableMap", func(t *testing.T) {
+	t.Run("nil variableMap is treated as empty (no inputs)", func(t *testing.T) {
+		// A task with no declared inputs has a nil variableMap; this should
+		// yield no literals rather than erroring.
+		empty, err := structpb.NewStruct(map[string]any{})
+		require.NoError(t, err)
+		literals, err := JSONValuesToLiterals(context.Background(), nil, empty)
+		require.NoError(t, err)
+		assert.Empty(t, literals)
+
+		// Any provided values have no matching variable, so they're ignored.
 		values, err := structpb.NewStruct(map[string]any{"foo": "bar"})
 		require.NoError(t, err)
-
-		_, err = JSONValuesToLiterals(context.Background(), nil, values)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "variableMap cannot be nil")
+		literals, err = JSONValuesToLiterals(context.Background(), nil, values)
+		require.NoError(t, err)
+		assert.Empty(t, literals)
 	})
 
 	t.Run("nil values", func(t *testing.T) {


### PR DESCRIPTION

## Why are the changes needed?

JSONValuesToLiterals errored with variableMap cannot be nil when passed a nil variableMap. That happens legitimately for a task with no declared inputs — its interface.inputs is unset, so callers (e.g. the launch form converting form values back to literals) pass a nil map. There are no expected inputs in that case, so it should produce zero literals rather than fail.



## What changes were proposed in this pull request?
In JSONValuesToLiterals, treat a nil variableMap as an empty one instead of erroring. An empty payload yields no literals, and any provided values are unmapped and ignored (debug-logged), consistent with the existing unmapped-field handling.



## How was this patch tested?

go test ./dataproxy/converter/... — passing. Updated the nil-variableMap test to assert an empty result with no error (both an empty payload and a payload whose values have no matching variable).


### Labels

fixed

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
