### PR TITLE
feat(runs): implement IdentityService.UserInfo from forwarded auth headers

### DIFF
--- a/runs/service/identity.go
+++ b/runs/service/identity.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -56,6 +57,30 @@ func identityFromHeaders(h http.Header, cfg config.IdentityHeadersConfig) *commo
 		return identityFromJWT(token)
 	}
 	return nil
+}
+
+// resolveIdentity returns the caller's identity from the forwarded auth headers,
+// enriched via the OIDC userinfo endpoint only when the Bearer token itself was the
+// identity source. When a proxy header (claims JWT or subject) established the
+// identity, enrichment is skipped: the forwarded access token may be expired or
+// belong to a different principal, and userinfo's subject would override the
+// proxy-verified one. Returns nil when no authenticated identity is present.
+func resolveIdentity(ctx context.Context, h http.Header, cfg config.IdentityHeadersConfig, enricher *identityEnricher) *common.EnrichedIdentity {
+	id := identityFromHeaders(h, cfg)
+	if id == nil {
+		return nil
+	}
+	token := bearerToken(h)
+	if token == "" {
+		return id
+	}
+	if cfg.ClaimsJWTHeader != "" && identityFromJWT(h.Get(cfg.ClaimsJWTHeader)) != nil {
+		return id
+	}
+	if cfg.SubjectHeader != "" && strings.TrimSpace(h.Get(cfg.SubjectHeader)) != "" {
+		return id
+	}
+	return enricher.enrich(ctx, token, id)
 }
 
 // bearerToken returns the value of an Authorization: Bearer <token> header, or "".

--- a/runs/service/identity_service.go
+++ b/runs/service/identity_service.go
@@ -2,28 +2,88 @@ package service
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"connectrpc.com/connect"
 
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/auth"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/auth/authconnect"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
+	"github.com/flyteorg/flyte/v2/runs/config"
 )
 
-// IdentityService implements the IdentityServiceHandler interface.
-type IdentityService struct{}
+// errNoIdentity is returned when a request carries no resolvable caller identity.
+var errNoIdentity = errors.New("no authenticated identity on request")
 
-// NewIdentityService creates a new IdentityService instance.
-func NewIdentityService() *IdentityService {
-	return &IdentityService{}
+// IdentityService implements the IdentityServiceHandler interface.
+type IdentityService struct {
+	// enricher fills name/email from the OIDC userinfo endpoint on the Bearer path,
+	// where the access token carries only a subject. nil when no auth server is set.
+	enricher *identityEnricher
+
+	// trustHeaders gates resolving the caller from proxy-forwarded auth headers.
+	// See Config.TrustForwardedIdentityHeaders.
+	trustHeaders bool
+
+	// identityHeaders names the proxy-forwarded headers identity is read from.
+	identityHeaders config.IdentityHeadersConfig
+}
+
+// NewIdentityService creates a new IdentityService instance. It takes the same
+// identity settings as RunService so whoami reports exactly the identity that would
+// be recorded as a run's executed_by.
+func NewIdentityService(
+	authServerBaseURL string,
+	trustForwardedIdentityHeaders bool,
+	identityHeaders config.IdentityHeadersConfig,
+) *IdentityService {
+	return &IdentityService{
+		enricher:        newIdentityEnricher(authServerBaseURL),
+		trustHeaders:    trustForwardedIdentityHeaders,
+		identityHeaders: identityHeaders,
+	}
 }
 
 var _ authconnect.IdentityServiceHandler = (*IdentityService)(nil)
 
-// UserInfo returns information about the currently logged in user.
-// TODO: Wire with real auth to populate user info from the authenticated context.
+// UserInfo returns information about the currently logged in user, resolved from the
+// auth headers the proxy forwards — the same path run attribution uses, so whoami and
+// a run's executed_by can never disagree.
+//
+// Returns Unauthenticated when the request carries no identity, or when forwarded
+// headers aren't trusted (in which case the caller cannot be established at all), so
+// `flyte whoami` reports not-logged-in rather than printing an empty record.
 func (s *IdentityService) UserInfo(
 	ctx context.Context,
 	req *connect.Request[auth.UserInfoRequest],
 ) (*connect.Response[auth.UserInfoResponse], error) {
-	return connect.NewResponse(&auth.UserInfoResponse{}), nil
+	if !s.trustHeaders {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errNoIdentity)
+	}
+
+	id := identityFromHeaders(req.Header(), s.identityHeaders)
+	// On the Bearer path the token holds only a subject; userinfo supplies name/email.
+	id = s.enricher.enrich(ctx, bearerToken(req.Header()), id)
+
+	user := id.GetUser()
+	if user == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errNoIdentity)
+	}
+	return connect.NewResponse(userInfoFromUser(user)), nil
+}
+
+// userInfoFromUser maps the internal identity onto the OIDC-shaped UserInfoResponse.
+// name is derived from the first/last pair since UserSpec carries no full-name field.
+func userInfoFromUser(user *common.User) *auth.UserInfoResponse {
+	spec := user.GetSpec()
+	return &auth.UserInfoResponse{
+		Subject:           user.GetId().GetSubject(),
+		Name:              strings.TrimSpace(spec.GetFirstName() + " " + spec.GetLastName()),
+		PreferredUsername: spec.GetUserHandle(),
+		GivenName:         spec.GetFirstName(),
+		FamilyName:        spec.GetLastName(),
+		Email:             spec.GetEmail(),
+		Picture:           spec.GetPhotoUrl(),
+	}
 }

--- a/runs/service/identity_service.go
+++ b/runs/service/identity_service.go
@@ -60,20 +60,9 @@ func (s *IdentityService) UserInfo(
 		return nil, connect.NewError(connect.CodeUnauthenticated, errNoIdentity)
 	}
 
-	h := req.Header()
-	id := identityFromHeaders(h, s.identityHeaders)
+	id := resolveIdentity(ctx, req.Header(), s.identityHeaders, s.enricher)
 	if id == nil {
 		return nil, connect.NewError(connect.CodeUnauthenticated, errNoIdentity)
-	}
-
-	// Only enrich when the bearer token was the actual identity source.
-	if token := bearerToken(h); token != "" {
-		claimsHdr := s.identityHeaders.ClaimsJWTHeader
-		subjHdr := s.identityHeaders.SubjectHeader
-		if (claimsHdr == "" || identityFromJWT(h.Get(claimsHdr)) == nil) && (subjHdr == "" || strings.TrimSpace(h.Get(subjHdr)) == "") {
-			// On the Bearer path the token holds only a subject; userinfo supplies name/email.
-			id = s.enricher.enrich(ctx, token, id)
-		}
 	}
 
 	user := id.GetUser()

--- a/runs/service/identity_service.go
+++ b/runs/service/identity_service.go
@@ -13,7 +13,6 @@ import (
 	"github.com/flyteorg/flyte/v2/runs/config"
 )
 
-// errNoIdentity is returned when a request carries no resolvable caller identity (missing or untrusted).
 var errNoIdentity = errors.New("no authenticated identity on request (missing or untrusted identity headers)")
 
 // IdentityService implements the IdentityServiceHandler interface.
@@ -48,8 +47,7 @@ func NewIdentityService(
 var _ authconnect.IdentityServiceHandler = (*IdentityService)(nil)
 
 // UserInfo returns information about the currently logged in user, resolved from the
-// auth headers the proxy forwards — the same path run attribution uses, so whoami and
-// a run's executed_by can never disagree.
+// auth headers the proxy forwards — the same path run attribution uses.
 //
 // Returns Unauthenticated when the request carries no identity, or when forwarded
 // headers aren't trusted (in which case the caller cannot be established at all), so

--- a/runs/service/identity_service.go
+++ b/runs/service/identity_service.go
@@ -13,8 +13,8 @@ import (
 	"github.com/flyteorg/flyte/v2/runs/config"
 )
 
-// errNoIdentity is returned when a request carries no resolvable caller identity.
-var errNoIdentity = errors.New("no authenticated identity on request")
+// errNoIdentity is returned when a request carries no resolvable caller identity (missing or untrusted).
+var errNoIdentity = errors.New("no authenticated identity on request (missing or untrusted identity headers)")
 
 // IdentityService implements the IdentityServiceHandler interface.
 type IdentityService struct {

--- a/runs/service/identity_service.go
+++ b/runs/service/identity_service.go
@@ -60,12 +60,21 @@ func (s *IdentityService) UserInfo(
 		return nil, connect.NewError(connect.CodeUnauthenticated, errNoIdentity)
 	}
 
-	id := identityFromHeaders(req.Header(), s.identityHeaders)
+	h := req.Header()
+	id := identityFromHeaders(h, s.identityHeaders)
 	if id == nil {
 		return nil, connect.NewError(connect.CodeUnauthenticated, errNoIdentity)
 	}
-	// On the Bearer path the token holds only a subject; userinfo supplies name/email.
-	id = s.enricher.enrich(ctx, bearerToken(req.Header()), id)
+
+	// Only enrich when the bearer token was the actual identity source.
+	if token := bearerToken(h); token != "" {
+		claimsHdr := s.identityHeaders.ClaimsJWTHeader
+		subjHdr := s.identityHeaders.SubjectHeader
+		if (claimsHdr == "" || identityFromJWT(h.Get(claimsHdr)) == nil) && (subjHdr == "" || strings.TrimSpace(h.Get(subjHdr)) == "") {
+			// On the Bearer path the token holds only a subject; userinfo supplies name/email.
+			id = s.enricher.enrich(ctx, token, id)
+		}
+	}
 
 	user := id.GetUser()
 	if user == nil {

--- a/runs/service/identity_service.go
+++ b/runs/service/identity_service.go
@@ -61,6 +61,9 @@ func (s *IdentityService) UserInfo(
 	}
 
 	id := identityFromHeaders(req.Header(), s.identityHeaders)
+	if id == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errNoIdentity)
+	}
 	// On the Bearer path the token holds only a subject; userinfo supplies name/email.
 	id = s.enricher.enrich(ctx, bearerToken(req.Header()), id)
 

--- a/runs/service/identity_service_test.go
+++ b/runs/service/identity_service_test.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -9,13 +11,236 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/auth"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
+	"github.com/flyteorg/flyte/v2/runs/config"
 )
 
-func TestIdentityService_UserInfo(t *testing.T) {
-	svc := NewIdentityService()
+// userInfoReq builds a UserInfoRequest carrying the given headers.
+func userInfoReq(headers map[string]string) *connect.Request[auth.UserInfoRequest] {
+	req := connect.NewRequest(&auth.UserInfoRequest{})
+	for k, v := range headers {
+		req.Header().Set(k, v)
+	}
+	return req
+}
 
-	resp, err := svc.UserInfo(context.Background(), connect.NewRequest(&auth.UserInfoRequest{}))
+func TestIdentityService_UserInfo(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.IdentityHeadersConfig
+		headers map[string]string
+
+		wantCode connect.Code // non-zero means an error is expected
+		wantSub  string
+		wantName string
+		want     *auth.UserInfoResponse
+	}{
+		{
+			name: "alb claims JWT: full profile (cookie path)",
+			cfg:  albCfg,
+			headers: map[string]string{
+				"X-Amzn-Oidc-Data": jwt(`{"sub":"00u3ipl8rr92YyW525d7","given_name":"Kevin","family_name":"Su","email":"kevin@union.ai"}`),
+			},
+			want: &auth.UserInfoResponse{
+				Subject:    "00u3ipl8rr92YyW525d7",
+				Name:       "Kevin Su",
+				GivenName:  "Kevin",
+				FamilyName: "Su",
+				Email:      "kevin@union.ai",
+			},
+		},
+		{
+			name: "alb identity header: subject only",
+			cfg:  albCfg,
+			headers: map[string]string{
+				"X-Amzn-Oidc-Identity": "0uav5j5qn0g1YptkJ5d7",
+			},
+			want: &auth.UserInfoResponse{Subject: "0uav5j5qn0g1YptkJ5d7"},
+		},
+		{
+			name: "oauth2-proxy: subject and email as plain values",
+			cfg:  proxyCfg,
+			headers: map[string]string{
+				"X-Auth-Request-User":  "00u456",
+				"X-Auth-Request-Email": "carina@union.ai",
+			},
+			want: &auth.UserInfoResponse{Subject: "00u456", Email: "carina@union.ai"},
+		},
+		{
+			name: "bearer token: claims decoded from the JWT (SDK/CLI path)",
+			cfg:  albCfg,
+			headers: map[string]string{
+				"Authorization": "Bearer " + jwt(`{"sub":"00u789","given_name":"Ada","family_name":"Lovelace","email":"ada@union.ai"}`),
+			},
+			want: &auth.UserInfoResponse{
+				Subject:    "00u789",
+				Name:       "Ada Lovelace",
+				GivenName:  "Ada",
+				FamilyName: "Lovelace",
+				Email:      "ada@union.ai",
+			},
+		},
+		{
+			name:     "no identity headers at all",
+			cfg:      albCfg,
+			headers:  nil,
+			wantCode: connect.CodeUnauthenticated,
+		},
+		{
+			name:     "malformed bearer token",
+			cfg:      albCfg,
+			headers:  map[string]string{"Authorization": "Bearer not-a-jwt"},
+			wantCode: connect.CodeUnauthenticated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// No auth-server URL: the enricher is nil, so no userinfo round-trip.
+			svc := NewIdentityService("", true, tt.cfg)
+
+			resp, err := svc.UserInfo(context.Background(), userInfoReq(tt.headers))
+
+			if tt.wantCode != 0 {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantCode, connect.CodeOf(err))
+				assert.Nil(t, resp)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Equal(t, tt.want.GetSubject(), resp.Msg.GetSubject())
+			assert.Equal(t, tt.want.GetName(), resp.Msg.GetName())
+			assert.Equal(t, tt.want.GetGivenName(), resp.Msg.GetGivenName())
+			assert.Equal(t, tt.want.GetFamilyName(), resp.Msg.GetFamilyName())
+			assert.Equal(t, tt.want.GetEmail(), resp.Msg.GetEmail())
+		})
+	}
+}
+
+// Identity must not be derived from headers the deployment says not to trust —
+// otherwise any client could claim to be anyone by setting them itself.
+func TestIdentityService_UserInfo_UntrustedHeadersRejected(t *testing.T) {
+	svc := NewIdentityService("", false, albCfg)
+
+	resp, err := svc.UserInfo(context.Background(), userInfoReq(map[string]string{
+		"X-Amzn-Oidc-Data": jwt(`{"sub":"00u123","given_name":"Spoofed","family_name":"User","email":"attacker@example.com"}`),
+	}))
+
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	assert.Nil(t, resp)
+}
+
+// The Bearer path carries only a subject; name/email come from the OIDC userinfo
+// endpoint, and userinfo's subject is authoritative over the token's.
+func TestIdentityService_UserInfo_EnrichesBearerViaUserinfo(t *testing.T) {
+	srv := newUserinfoTestServer(t, `{"sub":"00u-real","given_name":"Kevin","family_name":"Su","email":"kevin@union.ai"}`)
+	defer srv.Close()
+
+	svc := NewIdentityService(srv.URL, true, albCfg)
+
+	resp, err := svc.UserInfo(context.Background(), userInfoReq(map[string]string{
+		"Authorization": "Bearer " + jwt(`{"sub":"0oa-client-id"}`),
+	}))
+
 	require.NoError(t, err)
-	assert.NotNil(t, resp)
-	assert.NotNil(t, resp.Msg)
+	assert.Equal(t, "00u-real", resp.Msg.GetSubject(), "userinfo subject must win over the token's")
+	assert.Equal(t, "Kevin Su", resp.Msg.GetName())
+	assert.Equal(t, "kevin@union.ai", resp.Msg.GetEmail())
+}
+
+// A userinfo outage must not fail whoami — the subject-only identity still answers
+// "who am I", so degrade rather than error.
+func TestIdentityService_UserInfo_UserinfoFailureFallsBackToSubject(t *testing.T) {
+	srv := newFailingUserinfoTestServer(t)
+	defer srv.Close()
+
+	svc := NewIdentityService(srv.URL, true, albCfg)
+
+	resp, err := svc.UserInfo(context.Background(), userInfoReq(map[string]string{
+		"Authorization": "Bearer " + jwt(`{"sub":"00u-token"}`),
+	}))
+
+	require.NoError(t, err)
+	assert.Equal(t, "00u-token", resp.Msg.GetSubject())
+	assert.Empty(t, resp.Msg.GetEmail())
+}
+
+func TestUserInfoFromUser_NameFromFirstLast(t *testing.T) {
+	tests := []struct {
+		name        string
+		first, last string
+		wantName    string
+	}{
+		{name: "both names", first: "Kevin", last: "Su", wantName: "Kevin Su"},
+		{name: "first only", first: "Kevin", wantName: "Kevin"},
+		{name: "last only", last: "Su", wantName: "Su"},
+		{name: "neither", wantName: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := subjectOnlyIdentity("00u1")
+			id.GetUser().Spec = &common.UserSpec{FirstName: tt.first, LastName: tt.last}
+			got := userInfoFromUser(id.GetUser())
+			assert.Equal(t, tt.wantName, got.GetName())
+			assert.Equal(t, "00u1", got.GetSubject())
+		})
+	}
+}
+
+// Fields with no OIDC-claim source of their own still map through from UserSpec.
+func TestUserInfoFromUser_MapsHandleAndPhoto(t *testing.T) {
+	id := subjectOnlyIdentity("00u1")
+	id.GetUser().Spec = &common.UserSpec{
+		FirstName:  "Kevin",
+		LastName:   "Su",
+		Email:      "kevin@union.ai",
+		UserHandle: "ksu",
+		PhotoUrl:   "https://example.com/k.png",
+	}
+
+	got := userInfoFromUser(id.GetUser())
+
+	assert.Equal(t, "ksu", got.GetPreferredUsername())
+	assert.Equal(t, "https://example.com/k.png", got.GetPicture())
+	assert.Equal(t, "kevin@union.ai", got.GetEmail())
+}
+
+// newUserinfoTestServer serves an OIDC discovery document pointing at a userinfo
+// endpoint that returns the given claims JSON.
+func newUserinfoTestServer(t *testing.T, claimsJSON string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	var base string
+	mux.HandleFunc(oidcDiscoveryPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"userinfo_endpoint":"` + base + `/userinfo"}`))
+	})
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(claimsJSON))
+	})
+	srv := httptest.NewServer(mux)
+	base = srv.URL
+	return srv
+}
+
+// newFailingUserinfoTestServer serves discovery but errors on userinfo.
+func newFailingUserinfoTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	var base string
+	mux.HandleFunc(oidcDiscoveryPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"userinfo_endpoint":"` + base + `/userinfo"}`))
+	})
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	base = srv.URL
+	return srv
 }

--- a/runs/service/identity_service_test.go
+++ b/runs/service/identity_service_test.go
@@ -31,8 +31,6 @@ func TestIdentityService_UserInfo(t *testing.T) {
 		headers map[string]string
 
 		wantCode connect.Code // non-zero means an error is expected
-		wantSub  string
-		wantName string
 		want     *auth.UserInfoResponse
 	}{
 		{

--- a/runs/service/identity_test.go
+++ b/runs/service/identity_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"encoding/base64"
 	"net/http"
 	"testing"
@@ -126,4 +127,39 @@ func TestSubjectOnlyIdentity(t *testing.T) {
 	id := subjectOnlyIdentity("user-123")
 	assert.Equal(t, "user-123", id.GetUser().GetId().GetSubject())
 	assert.Nil(t, id.GetUser().GetSpec())
+}
+
+func TestResolveIdentity(t *testing.T) {
+	// A Bearer token whose claims carry only a subject — enrichment must fill the rest.
+	bearer := jwt(`{"sub":"00uBEARER"}`)
+
+	// The bearer-path-enriches case is covered end-to-end by
+	// TestIdentityService_UserInfo_EnrichesBearerViaUserinfo.
+
+	t.Run("proxy claims identity with bearer present is not enriched", func(t *testing.T) {
+		srv, hits := newTestIdP(t, `{"sub":"00uOTHER","email":"other@union.ai"}`, http.StatusOK)
+		h := http.Header{}
+		// Claims header supplies the identity (incomplete profile: no name)…
+		h.Set("X-Amzn-Oidc-Data", jwt(`{"sub":"00uPROXY","email":"proxy@union.ai"}`))
+		// …but a Bearer token is also present. userinfo must NOT be consulted, or its
+		// subject would override the proxy-verified one.
+		h.Set(authorizationHeader, bearerPrefix+bearer)
+		id := resolveIdentity(context.Background(), h, albCfg, newIdentityEnricher(srv.URL))
+		assert.Equal(t, "00uPROXY", id.GetUser().GetId().GetSubject())
+		assert.Equal(t, int32(0), *hits)
+	})
+
+	t.Run("subject header identity with bearer present is not enriched", func(t *testing.T) {
+		srv, hits := newTestIdP(t, `{"sub":"00uOTHER"}`, http.StatusOK)
+		h := http.Header{}
+		h.Set("X-Amzn-Oidc-Identity", "00uPROXY")
+		h.Set(authorizationHeader, bearerPrefix+bearer)
+		id := resolveIdentity(context.Background(), h, albCfg, newIdentityEnricher(srv.URL))
+		assert.Equal(t, "00uPROXY", id.GetUser().GetId().GetSubject())
+		assert.Equal(t, int32(0), *hits)
+	})
+
+	t.Run("no identity returns nil", func(t *testing.T) {
+		assert.Nil(t, resolveIdentity(context.Background(), http.Header{}, albCfg, nil))
+	})
 }

--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -348,10 +348,9 @@ func (s *RunService) CreateRun(
 	// decoded, not signature-verified — see Config.TrustForwardedIdentityHeaders).
 	var executedBy *common.EnrichedIdentity
 	if s.trustHeaders {
-		executedBy = identityFromHeaders(req.Header(), s.identityHeaders)
-		// Cookie path isn't enriched here: its forwarded access token is short-lived and
-		// already expired, so it relies on the claims the proxy injects into x-amzn-oidc-data.
-		executedBy = s.enricher.enrich(ctx, bearerToken(req.Header()), executedBy)
+		// resolveIdentity enriches only on the Bearer path; the cookie path relies on
+		// the claims the proxy injects (its forwarded access token is already expired).
+		executedBy = resolveIdentity(ctx, req.Header(), s.identityHeaders, s.enricher)
 	}
 
 	// Persist task spec and create a run model

--- a/runs/setup.go
+++ b/runs/setup.go
@@ -169,7 +169,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	sc.Mux.Handle(taskPath, taskHandler)
 	logger.Infof(ctx, "Mounted TaskService at %s", taskPath)
 
-	identitySvc := service.NewIdentityService()
+	identitySvc := service.NewIdentityService(cfg.AuthMetadata.ExternalAuthServerBaseURL, cfg.TrustForwardedIdentityHeaders, cfg.IdentityHeaders)
 	identityPath, identityHandler := authconnect.NewIdentityServiceHandler(identitySvc, connect.WithInterceptors(otelInterceptor))
 	sc.Mux.Handle(identityPath, identityHandler)
 	logger.Infof(ctx, "Mounted IdentityService at %s", identityPath)


### PR DESCRIPTION
## Tracking issue

<!-- none -->

## Why are the changes needed?

`IdentityService.UserInfo` was a stub carrying a `TODO: Wire with real auth`, so it
returned an empty `UserInfoResponse` to every caller. `flyte whoami` calls exactly this
RPC and prints the response verbatim, so it printed an empty record no matter who ran it.

The runs service already resolves the caller's identity for run attribution
(`executed_by`), from the auth headers the proxy/LB forwards. `UserInfo` simply wasn't
using it.

## What changes were proposed in this pull request?

Implement `UserInfo` on top of the identity path that already exists, rather than adding
a second one:

1. `identityFromHeaders` over the configured proxy-forwarded headers — the ALB claims JWT
   (`X-Amzn-Oidc-Data`), a plain subject header (`X-Amzn-Oidc-Identity` /
   `X-Auth-Request-User`), or an `Authorization: Bearer` token.
2. `identityEnricher.enrich` on the Bearer path, where the access token carries only a
   subject and name/email come from the OIDC userinfo endpoint.
3. Map the resulting `common.User` onto the OIDC-shaped `UserInfoResponse`.

Because both `UserInfo` and `CreateRun` now read the same resolver, whoami and a run's
`executed_by` cannot disagree about who someone is.

`NewIdentityService` now takes the same three identity settings `NewRunService` does
(auth-server base URL, `trustForwardedIdentityHeaders`, `identityHeaders`); `runs/setup.go`
passes them from config.

Behaviour change worth calling out: `UserInfo` returns `Unauthenticated` when the request
carries no identity, or when `trustForwardedIdentityHeaders` is off (the caller cannot be
established at all). Previously it returned an empty response. This makes `flyte whoami`
report not-logged-in rather than printing `{}`.

`name` is derived from first/last since `UserSpec` has no full-name field.

## How was this patch tested?
<img width="947" height="147" alt="Screenshot 2026-07-29 at 9 52 00 AM" src="https://github.com/user-attachments/assets/6458135f-ec33-4505-88bb-5c9c671ca862" />

Unit tests (`runs/service/identity_service_test.go`) — 14 cases covering each header path
(ALB claims JWT, ALB subject-only, oauth2-proxy plain values, Bearer), both unauthenticated
cases (no headers, malformed bearer), untrusted-headers rejection, userinfo enrichment
(including that userinfo's subject wins over the token's), graceful degradation when
userinfo is down, and the name/handle/photo field mapping.

```
$ go test ./runs/service/ -run 'TestIdentityService|TestUserInfoFromUser'
ok  	github.com/flyteorg/flyte/v2/runs/service	7.532s     # all 14 pass

$ go test ./runs/...        # full package, all green
$ go vet ./runs/...         # clean (one pre-existing warning in run_service_test.go, untouched)
```

End-to-end against the real CLI. I mounted the handler locally behind a shim that injects
the ALB header the way `authenticate-oidc` does, and pointed `flyte whoami` at it:

```
$ flyte --endpoint localhost:8099 --insecure whoami
{
  "subject": "00u3ipl8rr92YyW525d7",
  "name": "Kevin Su",
  "givenName": "Kevin",
  "familyName": "Su",
  "email": "kevin@union.ai"
}
```

And with no identity forwarded:

```
$ flyte --endpoint localhost:8098 --insecure whoami
ConnectError: no authenticated identity on request
```

Not tested against a deployed cluster — that needs an image build/rollout.

### Labels

**added**

### Setup process

### Screenshots

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

Builds on the identity resolution added in #7547.

## Stack

<!-- branch-stack -->

## Docs link
