### PR TITLE
feat(secret): invalidate webhook secret cache on write

### DIFF
--- a/app/internal/k8s/app_client.go
+++ b/app/internal/k8s/app_client.go
@@ -142,7 +142,7 @@ func NewAppK8sClient(k8sClient client.WithWatch, cache ctrlcache.Cache, namespac
 
 // defaultOrg is the org returned for apps that have no org persisted on the KService.
 // we always surface a non-empty value for callers (e.g. the UI) that expect one.
-const defaultOrg = "flyte"
+const defaultOrg = secret.DefaultOrganization
 
 // Deploy creates or updates the KService for the given app.
 func (c *AppK8sClient) Deploy(ctx context.Context, app *flyteapp.App) error {
@@ -615,7 +615,7 @@ func (c *AppK8sClient) buildKService(app *flyteapp.App) (*servingv1.Service, err
 	var templateLabels map[string]string
 	if securityContext := spec.GetSecurityContext(); securityContext != nil && len(securityContext.GetSecrets()) > 0 {
 		templateLabels = map[string]string{
-			secret.OrganizationLabel: "flyte",
+			secret.OrganizationLabel: secret.DefaultOrganization,
 			secret.ProjectLabel:      appID.GetProject(),
 			secret.DomainLabel:       appID.GetDomain(),
 			secretUtils.PodLabel:     secretUtils.PodLabelValue,

--- a/charts/flyte-binary/README.md
+++ b/charts/flyte-binary/README.md
@@ -140,6 +140,7 @@ Chart for basic single Flyte executable deployment
 | flyte-core-components.secret.kubernetes.namespace | string | `"{{ .Release.Namespace }}"` |  |
 | flyte-core-components.secret.kubernetes.qps | int | `100` |  |
 | flyte-core-components.secret.kubernetes.timeout | string | `"30s"` |  |
+| flyte-core-components.secret.webhookURL | string | `"http://{{ include \"flyte-binary.webhook.headlessServiceName\" . }}.{{ .Release.Namespace }}.svc:9444"` |  |
 | fullnameOverride | string | `""` |  |
 | ingress.apiJwtIngress.annotations | object | `{}` |  |
 | ingress.apiJwtIngress.enabled | bool | `false` |  |

--- a/charts/flyte-binary/templates/_helpers.tpl
+++ b/charts/flyte-binary/templates/_helpers.tpl
@@ -220,6 +220,10 @@ Get the Flyte webhook service name.
 {{- printf "%s-webhook" (include "flyte-binary.fullname" .) -}}
 {{- end -}}
 
+{{- define "flyte-binary.webhook.headlessServiceName" -}}
+{{- printf "%s-webhook-headless" (include "flyte-binary.fullname" .) -}}
+{{- end -}}
+
 {{/*
 Get the Flyte webhook secret name.
 */}}

--- a/charts/flyte-binary/templates/configmap.yaml
+++ b/charts/flyte-binary/templates/configmap.yaml
@@ -35,10 +35,6 @@ data:
         type: K8s
         k8sConfig:
           namespace: {{ .Release.Namespace }}
-    secret:
-      # Headless Service, so the secret service resolves it to every webhook pod and invalidates
-      # all of their caches. A ClusterIP Service would reach exactly one replica.
-      cacheInvalidationURL: http://{{ include "flyte-binary.webhook.headlessServiceName" . }}.{{ .Release.Namespace }}.svc:9444
 {{ tpl ( index .Values "flyte-core-components" | toYaml ) . | nindent 4 }}
   001-plugins.yaml: |
     tasks:

--- a/charts/flyte-binary/templates/configmap.yaml
+++ b/charts/flyte-binary/templates/configmap.yaml
@@ -35,6 +35,10 @@ data:
         type: K8s
         k8sConfig:
           namespace: {{ .Release.Namespace }}
+    secret:
+      # Headless Service, so the secret service resolves it to every webhook pod and invalidates
+      # all of their caches. A ClusterIP Service would reach exactly one replica.
+      cacheInvalidationURL: http://{{ include "flyte-binary.webhook.headlessServiceName" . }}.{{ .Release.Namespace }}.svc:9444
 {{ tpl ( index .Values "flyte-core-components" | toYaml ) . | nindent 4 }}
   001-plugins.yaml: |
     tasks:

--- a/charts/flyte-binary/templates/deployment.yaml
+++ b/charts/flyte-binary/templates/deployment.yaml
@@ -140,6 +140,9 @@ spec:
               containerPort: 8090
             - name: webhook
               containerPort: 9443
+            - name: cache-internal
+              containerPort: 9444
+              protocol: TCP
           {{- if .Values.deployment.startupProbe }}
           startupProbe: {{- tpl ( .Values.deployment.startupProbe | toYaml ) . | nindent 12 }}
           {{- end }}

--- a/charts/flyte-binary/templates/service/webhook-headless.yaml
+++ b/charts/flyte-binary/templates/service/webhook-headless.yaml
@@ -1,0 +1,24 @@
+{{/*
+Headless Service for secret cache invalidation. Resolves to every webhook pod IP rather than a
+single virtual IP, so a caller can fan invalidation out to all replicas — a ClusterIP Service
+would load-balance to exactly one, leaving the rest serving stale secrets until their TTL.
+
+Separate from the main webhook Service on purpose: that one is what the
+MutatingWebhookConfiguration points the API server at for admission, and it needs to stay
+ClusterIP. Do not merge the two.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "flyte-binary.webhook.headlessServiceName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "flyte-binary.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector: {{- include "flyte-binary.selectorLabels" . | nindent 4 }}
+  ports:
+    # Plain HTTP, unauthenticated: cluster-internal only, never routed through an ingress.
+    - name: cache-internal
+      port: 9444
+      targetPort: 9444
+      protocol: TCP

--- a/charts/flyte-binary/templates/service/webhook.yaml
+++ b/charts/flyte-binary/templates/service/webhook.yaml
@@ -11,8 +11,3 @@ spec:
       port: 443
       targetPort: 9443
       protocol: TCP
-    # Plain HTTP, unauthenticated: cluster-internal only, never routed through an ingress.
-    - name: cache-internal
-      port: 9444
-      targetPort: 9444
-      protocol: TCP

--- a/charts/flyte-binary/templates/service/webhook.yaml
+++ b/charts/flyte-binary/templates/service/webhook.yaml
@@ -11,3 +11,8 @@ spec:
       port: 443
       targetPort: 9443
       protocol: TCP
+    # Plain HTTP, unauthenticated: cluster-internal only, never routed through an ingress.
+    - name: cache-internal
+      port: 9444
+      targetPort: 9444
+      protocol: TCP

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -45,6 +45,12 @@ flyte-core-components:
   # in the ConfigMap template). Keep the two in sync. Rendered through tpl, so it
   # defaults to the release namespace.
   secret:
+    # webhookURL Where the secret service posts to drop the pod webhook's cached secret values
+    # after a write, so the next admitted pod sees the new value instead of waiting out the
+    # cache TTL. This is the webhook's cache invalidation port (9444), not admission (9443).
+    # The headless Service resolves to every webhook pod, so all replicas are invalidated; a
+    # ClusterIP Service would reach exactly one. Set to "" to disable invalidation.
+    webhookURL: 'http://{{ include "flyte-binary.webhook.headlessServiceName" . }}.{{ .Release.Namespace }}.svc:9444'
     kubernetes:
       namespace: '{{ .Release.Namespace }}'
       kubeconfig: ""

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -7792,6 +7792,7 @@ data:
         namespace: 'flyte'
         qps: 100
         timeout: 30s
+      webhookURL: http://flyte-binary-webhook-headless.flyte.svc:9444
   001-plugins.yaml: |
     tasks:
       task-plugins:
@@ -8298,6 +8299,32 @@ spec:
     port: 443
     protocol: TCP
     targetPort: 9443
+  - name: cache-internal
+    port: 9444
+    protocol: TCP
+    targetPort: 9444
+  selector:
+    app.kubernetes.io/component: flyte-binary
+    app.kubernetes.io/instance: flyte-devbox
+    app.kubernetes.io/name: flyte-binary
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: flyte-devbox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: flyte-binary
+    helm.sh/chart: flyte-binary-v0.2.0
+  name: flyte-binary-webhook-headless
+  namespace: flyte
+spec:
+  clusterIP: None
+  ports:
+  - name: cache-internal
+    port: 9444
+    protocol: TCP
+    targetPort: 9444
   selector:
     app.kubernetes.io/component: flyte-binary
     app.kubernetes.io/instance: flyte-devbox
@@ -8706,7 +8733,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 806913c16fd28512aaf60eccab4c1f3bf9aa6689da8474f4458a833c8dad3b94
+        checksum/configuration: 49e259b5181cecd91e406f5453b471831e41529923b6c290ae9a3c38ac124337
         checksum/configuration-secret: 800f306f43701bd39e3b42e0d756f4627643cf3cee6dbd050a5a57a08052c280
       labels:
         app.kubernetes.io/component: flyte-binary
@@ -8738,6 +8765,9 @@ spec:
           name: http
         - containerPort: 9443
           name: webhook
+        - containerPort: 9444
+          name: cache-internal
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz

--- a/executor/pkg/plugin/task_exec_metadata.go
+++ b/executor/pkg/plugin/task_exec_metadata.go
@@ -82,7 +82,7 @@ func NewTaskExecutionMetadata(ta *flyteorgv1.TaskAction) (pluginsCore.TaskExecut
 		// Flyte OSS v2 has no organization concept, but the secret fetcher
 		// still requires an organization label on the pod. Inject a stable
 		// dummy value so scoped secret lookups succeed.
-		flytesecret.OrganizationLabel: "flyte",
+		flytesecret.OrganizationLabel: flytesecret.DefaultOrganization,
 		flytesecret.ProjectLabel:      ta.Spec.Project,
 		flytesecret.DomainLabel:       ta.Spec.Domain,
 	}

--- a/executor/pkg/webhook/cache_invalidation_server.go
+++ b/executor/pkg/webhook/cache_invalidation_server.go
@@ -1,0 +1,72 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret"
+	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
+)
+
+// InvalidateSecretPath is the HTTP path for the cache invalidation endpoint.
+const InvalidateSecretPath = "/invalidate-secret"
+
+// InvalidateRequest is the body of a POST to InvalidateSecretPath.
+type InvalidateRequest struct {
+	Org     string `json:"org"`
+	Domain  string `json:"domain"`
+	Project string `json:"project"`
+	Name    string `json:"name"`
+}
+
+// StartCacheInvalidationServer starts a plain HTTP server that listens for cache invalidation
+// requests. It exposes POST /invalidate-secret so other services (the secret service) can drop
+// secret values cached in the webhook process instead of waiting out the cache TTL.
+//
+// The server is plain HTTP and unauthenticated, so it must stay cluster-internal: it is bound to
+// its own port and never routed through an ingress. Blocks until ctx is cancelled.
+func StartCacheInvalidationServer(ctx context.Context, port int, mutator *secret.SecretsPodMutator) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc(InvalidateSecretPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req InvalidateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		if req.Name == "" {
+			http.Error(w, "name is required", http.StatusBadRequest)
+			return
+		}
+
+		mutator.InvalidateCache(r.Context(), req.Org, req.Domain, req.Project, req.Name)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	addr := fmt.Sprintf(":%d", port)
+	server := &http.Server{ // #nosec G112 -- internal-only server, not exposed outside the cluster
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	go func() {
+		<-ctx.Done()
+		if err := server.Shutdown(context.Background()); err != nil {
+			logger.Errorf(ctx, "Failed to shutdown cache invalidation server: %v", err)
+		}
+	}()
+
+	logger.Infof(ctx, "Starting cache invalidation server on %s", addr)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("cache invalidation server failed: %w", err)
+	}
+
+	return nil
+}

--- a/executor/pkg/webhook/cache_invalidation_server_test.go
+++ b/executor/pkg/webhook/cache_invalidation_server_test.go
@@ -1,0 +1,98 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret/config"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
+)
+
+// startTestServer brings the invalidation server up on a free port and returns its base URL.
+func startTestServer(t *testing.T, mutator *secret.SecretsPodMutator) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- StartCacheInvalidationServer(ctx, port, mutator) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			assert.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Error("cache invalidation server did not shut down")
+		}
+	})
+
+	url := fmt.Sprintf("http://127.0.0.1:%d", port)
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		return conn.Close() == nil
+	}, 5*time.Second, 20*time.Millisecond, "server never started listening")
+
+	return url
+}
+
+func post(t *testing.T, url string, body []byte) *http.Response {
+	t.Helper()
+	resp, err := http.Post(url+InvalidateSecretPath, "application/json", bytes.NewReader(body)) // nolint: noctx
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+func TestCacheInvalidationServer(t *testing.T) {
+	// A mutator with only the global injector: it caches nothing, so InvalidateCache is a no-op
+	// and this exercises the server's routing/decoding rather than the cache itself.
+	mutator, err := secret.NewSecretsMutator(context.Background(),
+		&config.Config{SecretManagerTypes: []config.SecretManagerType{config.SecretManagerTypeGlobal}},
+		"flyte", promutils.NewTestScope())
+	require.NoError(t, err)
+	url := startTestServer(t, mutator)
+
+	t.Run("accepts a valid request", func(t *testing.T) {
+		body, err := json.Marshal(InvalidateRequest{
+			Org: "flyte", Domain: "development", Project: "flytesnacks", Name: "my-secret",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, post(t, url, body).StatusCode)
+	})
+
+	// Name is the one field that must be present: without it the request identifies no secret
+	// and would clear whatever happens to be cached at the bare scope keys.
+	t.Run("rejects a missing name", func(t *testing.T) {
+		body, err := json.Marshal(InvalidateRequest{Org: "flyte", Domain: "development"})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, post(t, url, body).StatusCode)
+	})
+
+	t.Run("rejects a malformed body", func(t *testing.T) {
+		assert.Equal(t, http.StatusBadRequest, post(t, url, []byte("{not json")).StatusCode)
+	})
+
+	t.Run("rejects a GET", func(t *testing.T) {
+		resp, err := http.Get(url + InvalidateSecretPath) // nolint: noctx
+		require.NoError(t, err)
+		defer resp.Body.Close() // nolint: errcheck
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+}

--- a/executor/pkg/webhook/entrypoint.go
+++ b/executor/pkg/webhook/entrypoint.go
@@ -23,30 +23,31 @@ const (
 
 // Setup initializes the webhook: generates certs, registers MutatingWebhookConfiguration, and registers the HTTP handler.
 // It is called before mgr.Start() so that the webhook server is ready to receive requests.
+// The returned PodMutator owns the secret cache and can be used to invalidate it.
 func Setup(ctx context.Context, kubeClient kubernetes.Interface, cfg *webhookConfig.Config,
-	defaultNamespace string, scope promutils.Scope, mgr manager.Manager) error {
+	defaultNamespace string, scope promutils.Scope, mgr manager.Manager) (*PodMutator, error) {
 
 	if err := InitCerts(ctx, kubeClient, cfg, defaultNamespace); err != nil {
-		return fmt.Errorf("webhook: failed to initialize certs: %w", err)
+		return nil, fmt.Errorf("webhook: failed to initialize certs: %w", err)
 	}
 
 	podMutator, err := NewPodMutator(ctx, cfg, defaultNamespace, mgr.GetScheme(), scope)
 	if err != nil {
-		return fmt.Errorf("webhook: failed to create pod mutator: %w", err)
+		return nil, fmt.Errorf("webhook: failed to create pod mutator: %w", err)
 	}
 
 	if cfg.DisableCreateMutatingWebhookConfig {
 		logger.Infof(ctx, "Skipping MutatingWebhookConfiguration creation, disabled by config")
 	} else if err := createMutationConfig(ctx, kubeClient, podMutator, defaultNamespace); err != nil {
-		return fmt.Errorf("webhook: failed to create MutatingWebhookConfiguration: %w", err)
+		return nil, fmt.Errorf("webhook: failed to create MutatingWebhookConfiguration: %w", err)
 	}
 
 	if err := podMutator.Register(ctx, mgr); err != nil {
-		return fmt.Errorf("webhook: failed to register handler: %w", err)
+		return nil, fmt.Errorf("webhook: failed to register handler: %w", err)
 	}
 
 	logger.Infof(ctx, "Webhook setup complete")
-	return nil
+	return podMutator, nil
 }
 
 func createMutationConfig(ctx context.Context, kubeClient kubernetes.Interface, webhookObj *PodMutator, defaultNamespace string) error {

--- a/executor/pkg/webhook/pod.go
+++ b/executor/pkg/webhook/pod.go
@@ -59,10 +59,10 @@ func (pm PodMutator) Handle(ctx context.Context, request admission.Request) admi
 	return admission.Allowed("No changes")
 }
 
-// InvalidateCache implements app.SecretCacheInvalidator, letting the secret service drop
-// cached secret values as soon as they are written.
-func (pm PodMutator) InvalidateCache(ctx context.Context, org, domain, project, secretName string) {
-	pm.secretsMutator.InvalidateCache(ctx, org, domain, project, secretName)
+// SecretsMutator returns the mutator that owns the secret caches, so the cache invalidation
+// server can clear them.
+func (pm PodMutator) SecretsMutator() *secret.SecretsPodMutator {
+	return pm.secretsMutator
 }
 
 func (pm PodMutator) Register(ctx context.Context, mgr manager.Manager) error {

--- a/executor/pkg/webhook/pod.go
+++ b/executor/pkg/webhook/pod.go
@@ -59,6 +59,12 @@ func (pm PodMutator) Handle(ctx context.Context, request admission.Request) admi
 	return admission.Allowed("No changes")
 }
 
+// InvalidateCache implements app.SecretCacheInvalidator, letting the secret service drop
+// cached secret values as soon as they are written.
+func (pm PodMutator) InvalidateCache(ctx context.Context, org, domain, project, secretName string) {
+	pm.secretsMutator.InvalidateCache(ctx, org, domain, project, secretName)
+}
+
 func (pm PodMutator) Register(ctx context.Context, mgr manager.Manager) error {
 	wh := &admission.Webhook{Handler: pm}
 	mutatePath := getPodMutatePath()

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -162,9 +162,13 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	if err != nil {
 		return fmt.Errorf("executor: webhook setup failed: %w", err)
 	}
-	// Let services set up later in this process (the secret service) invalidate the webhook's
-	// secret cache on write.
-	sc.SecretCacheInvalidator = podMutator
+
+	// Serve cache invalidation so the secret service can drop cached secret values on write.
+	if wCfg.CacheInvalidationPort > 0 {
+		sc.AddWorker("secret-cache-invalidation", func(ctx context.Context) error {
+			return webhookPkg.StartCacheInvalidationServer(ctx, wCfg.CacheInvalidationPort, podMutator.SecretsMutator())
+		})
+	}
 
 	dataStore, err := storage.NewDataStore(storage.GetConfig(), promutils.NewScope("executor:storage"))
 	if err != nil {

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -158,9 +158,13 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 
 	executorScope := promutils.NewScope("executor")
 
-	if err := webhookPkg.Setup(ctx, kubeClient, wCfg, podNamespace, executorScope.NewSubScope("webhook"), mgr); err != nil {
+	podMutator, err := webhookPkg.Setup(ctx, kubeClient, wCfg, podNamespace, executorScope.NewSubScope("webhook"), mgr)
+	if err != nil {
 		return fmt.Errorf("executor: webhook setup failed: %w", err)
 	}
+	// Let services set up later in this process (the secret service) invalidate the webhook's
+	// secret cache on write.
+	sc.SecretCacheInvalidator = podMutator
 
 	dataStore, err := storage.NewDataStore(storage.GetConfig(), promutils.NewScope("executor:storage"))
 	if err != nil {

--- a/flyteplugins/go/tasks/pluginmachinery/secret/aws_secret_manager.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/aws_secret_manager.go
@@ -148,3 +148,6 @@ func NewAWSSecretManagerInjector(cfg config.AWSSecretManagerConfig) AWSSecretMan
 		cfg: cfg,
 	}
 }
+
+// InvalidateCache is a no-op: this injector resolves secrets on every Inject and caches nothing.
+func (i AWSSecretManagerInjector) InvalidateCache(_ context.Context, _, _, _, _ string) {}

--- a/flyteplugins/go/tasks/pluginmachinery/secret/azure_secret_manager.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/azure_secret_manager.go
@@ -154,3 +154,6 @@ func NewAzureSecretManagerInjector(cfg config.AzureSecretManagerConfig) AzureSec
 		cfg: cfg,
 	}
 }
+
+// InvalidateCache is a no-op: this injector resolves secrets on every Inject and caches nothing.
+func (a AzureSecretManagerInjector) InvalidateCache(_ context.Context, _, _, _, _ string) {}

--- a/flyteplugins/go/tasks/pluginmachinery/secret/config/config.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/config/config.go
@@ -28,14 +28,15 @@ const (
 
 var (
 	DefaultConfig = &Config{
-		SecretName:        "flyte-pod-webhook",
-		ServiceName:       "flyte-pod-webhook",
-		ServicePort:       443,
-		MetricsPrefix:     "flyte:",
-		CertDir:           "/etc/webhook/certs",
-		LocalCert:         false,
-		ListenPort:        9443,
-		SecretManagerType: SecretManagerTypeEmbedded,
+		SecretName:            "flyte-pod-webhook",
+		ServiceName:           "flyte-pod-webhook",
+		ServicePort:           443,
+		MetricsPrefix:         "flyte:",
+		CertDir:               "/etc/webhook/certs",
+		LocalCert:             false,
+		ListenPort:            9443,
+		CacheInvalidationPort: 9444,
+		SecretManagerType:     SecretManagerTypeEmbedded,
 		AWSSecretManagerConfig: AWSSecretManagerConfig{
 			SidecarImage: "docker.io/amazon/aws-secrets-manager-secret-sidecar:v0.1.4",
 			Resources: corev1.ResourceRequirements{
@@ -165,9 +166,12 @@ type Config struct {
 	CertDir       string `json:"certDir" pflag:",Certificate directory to use to write generated certs. Defaults to /etc/webhook/certs/"`
 	LocalCert     bool   `json:"localCert" pflag:",write certs locally. Defaults to false"`
 	ListenPort    int    `json:"listenPort" pflag:",The port to use to listen to webhook calls. Defaults to 9443"`
-	ServiceName   string `json:"serviceName" pflag:",The name of the webhook service."`
-	ServicePort   int32  `json:"servicePort" pflag:",The port on the service that hosting webhook."`
-	SecretName    string `json:"secretName" pflag:",Secret name to write generated certs to."`
+	// CacheInvalidationPort is the port of the plain-HTTP server that lets other services drop
+	// cached secret values in this process. Set to 0 to disable.
+	CacheInvalidationPort int    `json:"cacheInvalidationPort" pflag:",The port to use for the cache invalidation HTTP server. Defaults to 9444"`
+	ServiceName           string `json:"serviceName" pflag:",The name of the webhook service."`
+	ServicePort           int32  `json:"servicePort" pflag:",The port on the service that hosting webhook."`
+	SecretName            string `json:"secretName" pflag:",Secret name to write generated certs to."`
 	// Deprecated: use SecretManagerTypes instead.
 	SecretManagerType           SecretManagerType           `json:"secretManagerType" pflag:"-,Deprecated. Secret manager type to use if secrets are not found in global secrets. Ignored if secretManagerTypes is set."`
 	SecretManagerTypes          []SecretManagerType         `json:"secretManagerTypes" pflag:"-,List of secret manager types to use if secrets are not found in global secrets. In order of preference. Overrides secretManagerType if set."`

--- a/flyteplugins/go/tasks/pluginmachinery/secret/config/config_flags.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/config/config_flags.go
@@ -54,6 +54,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "certDir"), DefaultConfig.CertDir, "Certificate directory to use to write generated certs. Defaults to /etc/webhook/certs/")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "localCert"), DefaultConfig.LocalCert, "write certs locally. Defaults to false")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "listenPort"), DefaultConfig.ListenPort, "The port to use to listen to webhook calls. Defaults to 9443")
+	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "cacheInvalidationPort"), DefaultConfig.CacheInvalidationPort, "The port to use for the cache invalidation HTTP server. Defaults to 9444")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "serviceName"), DefaultConfig.ServiceName, "The name of the webhook service.")
 	cmdFlags.Int32(fmt.Sprintf("%v%v", prefix, "servicePort"), DefaultConfig.ServicePort, "The port on the service that hosting webhook.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "secretName"), DefaultConfig.SecretName, "Secret name to write generated certs to.")

--- a/flyteplugins/go/tasks/pluginmachinery/secret/config/config_flags_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/config/config_flags_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/flyteplugins/go/tasks/pluginmachinery/secret/config/config_flags_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/config/config_flags_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-viper/mapstructure/v2"
+	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -149,6 +149,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			cmdFlags.Set("listenPort", testValue)
 			if vInt, err := cmdFlags.GetInt("listenPort"); err == nil {
 				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt), &actual.ListenPort)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_cacheInvalidationPort", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("cacheInvalidationPort", testValue)
+			if vInt, err := cmdFlags.GetInt("cacheInvalidationPort"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt), &actual.CacheInvalidationPort)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/flyteplugins/go/tasks/pluginmachinery/secret/config/embeddedsecretmanagertype_enumer.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/config/embeddedsecretmanagertype_enumer.go
@@ -5,11 +5,14 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 const _EmbeddedSecretManagerTypeName = "AWSGCPAzureK8s"
 
 var _EmbeddedSecretManagerTypeIndex = [...]uint8{0, 3, 6, 11, 14}
+
+const _EmbeddedSecretManagerTypeLowerName = "awsgcpazurek8s"
 
 func (i EmbeddedSecretManagerType) String() string {
 	if i >= EmbeddedSecretManagerType(len(_EmbeddedSecretManagerTypeIndex)-1) {
@@ -18,13 +21,34 @@ func (i EmbeddedSecretManagerType) String() string {
 	return _EmbeddedSecretManagerTypeName[_EmbeddedSecretManagerTypeIndex[i]:_EmbeddedSecretManagerTypeIndex[i+1]]
 }
 
-var _EmbeddedSecretManagerTypeValues = []EmbeddedSecretManagerType{0, 1, 2, 3}
+// An "invalid array index" compiler error signifies that the constant values have changed.
+// Re-run the stringer command to generate them again.
+func _EmbeddedSecretManagerTypeNoOp() {
+	var x [1]struct{}
+	_ = x[EmbeddedSecretManagerTypeAWS-(0)]
+	_ = x[EmbeddedSecretManagerTypeGCP-(1)]
+	_ = x[EmbeddedSecretManagerTypeAzure-(2)]
+	_ = x[EmbeddedSecretManagerTypeK8s-(3)]
+}
+
+var _EmbeddedSecretManagerTypeValues = []EmbeddedSecretManagerType{EmbeddedSecretManagerTypeAWS, EmbeddedSecretManagerTypeGCP, EmbeddedSecretManagerTypeAzure, EmbeddedSecretManagerTypeK8s}
 
 var _EmbeddedSecretManagerTypeNameToValueMap = map[string]EmbeddedSecretManagerType{
-	_EmbeddedSecretManagerTypeName[0:3]:   0,
-	_EmbeddedSecretManagerTypeName[3:6]:   1,
-	_EmbeddedSecretManagerTypeName[6:11]:  2,
-	_EmbeddedSecretManagerTypeName[11:14]: 3,
+	_EmbeddedSecretManagerTypeName[0:3]:        EmbeddedSecretManagerTypeAWS,
+	_EmbeddedSecretManagerTypeLowerName[0:3]:   EmbeddedSecretManagerTypeAWS,
+	_EmbeddedSecretManagerTypeName[3:6]:        EmbeddedSecretManagerTypeGCP,
+	_EmbeddedSecretManagerTypeLowerName[3:6]:   EmbeddedSecretManagerTypeGCP,
+	_EmbeddedSecretManagerTypeName[6:11]:       EmbeddedSecretManagerTypeAzure,
+	_EmbeddedSecretManagerTypeLowerName[6:11]:  EmbeddedSecretManagerTypeAzure,
+	_EmbeddedSecretManagerTypeName[11:14]:      EmbeddedSecretManagerTypeK8s,
+	_EmbeddedSecretManagerTypeLowerName[11:14]: EmbeddedSecretManagerTypeK8s,
+}
+
+var _EmbeddedSecretManagerTypeNames = []string{
+	_EmbeddedSecretManagerTypeName[0:3],
+	_EmbeddedSecretManagerTypeName[3:6],
+	_EmbeddedSecretManagerTypeName[6:11],
+	_EmbeddedSecretManagerTypeName[11:14],
 }
 
 // EmbeddedSecretManagerTypeString retrieves an enum value from the enum constants string name.
@@ -33,12 +57,23 @@ func EmbeddedSecretManagerTypeString(s string) (EmbeddedSecretManagerType, error
 	if val, ok := _EmbeddedSecretManagerTypeNameToValueMap[s]; ok {
 		return val, nil
 	}
+
+	if val, ok := _EmbeddedSecretManagerTypeNameToValueMap[strings.ToLower(s)]; ok {
+		return val, nil
+	}
 	return 0, fmt.Errorf("%s does not belong to EmbeddedSecretManagerType values", s)
 }
 
 // EmbeddedSecretManagerTypeValues returns all values of the enum
 func EmbeddedSecretManagerTypeValues() []EmbeddedSecretManagerType {
 	return _EmbeddedSecretManagerTypeValues
+}
+
+// EmbeddedSecretManagerTypeStrings returns a slice of all String values of the enum
+func EmbeddedSecretManagerTypeStrings() []string {
+	strs := make([]string, len(_EmbeddedSecretManagerTypeNames))
+	copy(strs, _EmbeddedSecretManagerTypeNames)
+	return strs
 }
 
 // IsAEmbeddedSecretManagerType returns "true" if the value is listed in the enum definition. "false" otherwise

--- a/flyteplugins/go/tasks/pluginmachinery/secret/config/kvversion_enumer.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/config/kvversion_enumer.go
@@ -5,11 +5,14 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 const _KVVersionName = "12"
 
 var _KVVersionIndex = [...]uint8{0, 1, 2}
+
+const _KVVersionLowerName = "12"
 
 func (i KVVersion) String() string {
 	if i < 0 || i >= KVVersion(len(_KVVersionIndex)-1) {
@@ -18,11 +21,26 @@ func (i KVVersion) String() string {
 	return _KVVersionName[_KVVersionIndex[i]:_KVVersionIndex[i+1]]
 }
 
-var _KVVersionValues = []KVVersion{0, 1}
+// An "invalid array index" compiler error signifies that the constant values have changed.
+// Re-run the stringer command to generate them again.
+func _KVVersionNoOp() {
+	var x [1]struct{}
+	_ = x[KVVersion1-(0)]
+	_ = x[KVVersion2-(1)]
+}
+
+var _KVVersionValues = []KVVersion{KVVersion1, KVVersion2}
 
 var _KVVersionNameToValueMap = map[string]KVVersion{
-	_KVVersionName[0:1]: 0,
-	_KVVersionName[1:2]: 1,
+	_KVVersionName[0:1]:      KVVersion1,
+	_KVVersionLowerName[0:1]: KVVersion1,
+	_KVVersionName[1:2]:      KVVersion2,
+	_KVVersionLowerName[1:2]: KVVersion2,
+}
+
+var _KVVersionNames = []string{
+	_KVVersionName[0:1],
+	_KVVersionName[1:2],
 }
 
 // KVVersionString retrieves an enum value from the enum constants string name.
@@ -31,12 +49,23 @@ func KVVersionString(s string) (KVVersion, error) {
 	if val, ok := _KVVersionNameToValueMap[s]; ok {
 		return val, nil
 	}
+
+	if val, ok := _KVVersionNameToValueMap[strings.ToLower(s)]; ok {
+		return val, nil
+	}
 	return 0, fmt.Errorf("%s does not belong to KVVersion values", s)
 }
 
 // KVVersionValues returns all values of the enum
 func KVVersionValues() []KVVersion {
 	return _KVVersionValues
+}
+
+// KVVersionStrings returns a slice of all String values of the enum
+func KVVersionStrings() []string {
+	strs := make([]string, len(_KVVersionNames))
+	copy(strs, _KVVersionNames)
+	return strs
 }
 
 // IsAKVVersion returns "true" if the value is listed in the enum definition. "false" otherwise

--- a/flyteplugins/go/tasks/pluginmachinery/secret/config/secretmanagertype_enumer.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/config/secretmanagertype_enumer.go
@@ -5,11 +5,14 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 const _SecretManagerTypeName = "GlobalK8sAWSGCPVaultEmbeddedAzure"
 
 var _SecretManagerTypeIndex = [...]uint8{0, 6, 9, 12, 15, 20, 28, 33}
+
+const _SecretManagerTypeLowerName = "globalk8sawsgcpvaultembeddedazure"
 
 func (i SecretManagerType) String() string {
 	if i < 0 || i >= SecretManagerType(len(_SecretManagerTypeIndex)-1) {
@@ -18,16 +21,46 @@ func (i SecretManagerType) String() string {
 	return _SecretManagerTypeName[_SecretManagerTypeIndex[i]:_SecretManagerTypeIndex[i+1]]
 }
 
-var _SecretManagerTypeValues = []SecretManagerType{0, 1, 2, 3, 4, 5, 6}
+// An "invalid array index" compiler error signifies that the constant values have changed.
+// Re-run the stringer command to generate them again.
+func _SecretManagerTypeNoOp() {
+	var x [1]struct{}
+	_ = x[SecretManagerTypeGlobal-(0)]
+	_ = x[SecretManagerTypeK8s-(1)]
+	_ = x[SecretManagerTypeAWS-(2)]
+	_ = x[SecretManagerTypeGCP-(3)]
+	_ = x[SecretManagerTypeVault-(4)]
+	_ = x[SecretManagerTypeEmbedded-(5)]
+	_ = x[SecretManagerTypeAzure-(6)]
+}
+
+var _SecretManagerTypeValues = []SecretManagerType{SecretManagerTypeGlobal, SecretManagerTypeK8s, SecretManagerTypeAWS, SecretManagerTypeGCP, SecretManagerTypeVault, SecretManagerTypeEmbedded, SecretManagerTypeAzure}
 
 var _SecretManagerTypeNameToValueMap = map[string]SecretManagerType{
-	_SecretManagerTypeName[0:6]:   0,
-	_SecretManagerTypeName[6:9]:   1,
-	_SecretManagerTypeName[9:12]:  2,
-	_SecretManagerTypeName[12:15]: 3,
-	_SecretManagerTypeName[15:20]: 4,
-	_SecretManagerTypeName[20:28]: 5,
-	_SecretManagerTypeName[28:33]: 6,
+	_SecretManagerTypeName[0:6]:        SecretManagerTypeGlobal,
+	_SecretManagerTypeLowerName[0:6]:   SecretManagerTypeGlobal,
+	_SecretManagerTypeName[6:9]:        SecretManagerTypeK8s,
+	_SecretManagerTypeLowerName[6:9]:   SecretManagerTypeK8s,
+	_SecretManagerTypeName[9:12]:       SecretManagerTypeAWS,
+	_SecretManagerTypeLowerName[9:12]:  SecretManagerTypeAWS,
+	_SecretManagerTypeName[12:15]:      SecretManagerTypeGCP,
+	_SecretManagerTypeLowerName[12:15]: SecretManagerTypeGCP,
+	_SecretManagerTypeName[15:20]:      SecretManagerTypeVault,
+	_SecretManagerTypeLowerName[15:20]: SecretManagerTypeVault,
+	_SecretManagerTypeName[20:28]:      SecretManagerTypeEmbedded,
+	_SecretManagerTypeLowerName[20:28]: SecretManagerTypeEmbedded,
+	_SecretManagerTypeName[28:33]:      SecretManagerTypeAzure,
+	_SecretManagerTypeLowerName[28:33]: SecretManagerTypeAzure,
+}
+
+var _SecretManagerTypeNames = []string{
+	_SecretManagerTypeName[0:6],
+	_SecretManagerTypeName[6:9],
+	_SecretManagerTypeName[9:12],
+	_SecretManagerTypeName[12:15],
+	_SecretManagerTypeName[15:20],
+	_SecretManagerTypeName[20:28],
+	_SecretManagerTypeName[28:33],
 }
 
 // SecretManagerTypeString retrieves an enum value from the enum constants string name.
@@ -36,12 +69,23 @@ func SecretManagerTypeString(s string) (SecretManagerType, error) {
 	if val, ok := _SecretManagerTypeNameToValueMap[s]; ok {
 		return val, nil
 	}
+
+	if val, ok := _SecretManagerTypeNameToValueMap[strings.ToLower(s)]; ok {
+		return val, nil
+	}
 	return 0, fmt.Errorf("%s does not belong to SecretManagerType values", s)
 }
 
 // SecretManagerTypeValues returns all values of the enum
 func SecretManagerTypeValues() []SecretManagerType {
 	return _SecretManagerTypeValues
+}
+
+// SecretManagerTypeStrings returns a slice of all String values of the enum
+func SecretManagerTypeStrings() []string {
+	strs := make([]string, len(_SecretManagerTypeNames))
+	copy(strs, _SecretManagerTypeNames)
+	return strs
 }
 
 // IsASecretManagerType returns "true" if the value is listed in the enum definition. "false" otherwise

--- a/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go
@@ -77,6 +77,24 @@ func (i *EmbeddedSecretManagerInjector) Type() config.SecretManagerType {
 	return config.SecretManagerTypeEmbedded
 }
 
+// InvalidateCache drops the cached value(s) for a secret so the next pod admission re-reads it
+// from the fetchers. lookUpSecret caches under whichever cascade scope the fetcher resolved the
+// secret at (project+domain, domain, or org), and the caller has no way to know which one that
+// was, so all three keys are cleared.
+func (i *EmbeddedSecretManagerInjector) InvalidateCache(ctx context.Context, org, domain, project, secretName string) {
+	for _, cacheKey := range []string{
+		EncodeSecretName(org, domain, project, secretName),
+		EncodeSecretName(org, domain, EmptySecretScope, secretName),
+		EncodeSecretName(org, EmptySecretScope, EmptySecretScope, secretName),
+	} {
+		if err := i.secretCache.Delete(ctx, cacheKey); err != nil {
+			logger.Debugf(ctx, "Failed to delete cache entry [%s]: %v", cacheKey, err)
+		}
+	}
+
+	logger.Infof(ctx, "Invalidated cache entries for secret [%s/%s/%s/%s]", org, domain, project, secretName)
+}
+
 func GetSecretID(secretKey string, labels map[string]string) (string, error) {
 	return EncodeSecretName(labels[OrganizationLabel], labels[DomainLabel], labels[ProjectLabel], secretKey), nil
 }

--- a/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go
@@ -42,6 +42,13 @@ const (
 	OrganizationLabel = "organization"
 	EmptySecretScope  = ""
 
+	// DefaultOrganization is the placeholder org for Flyte OSS v2, which has no organization
+	// concept, but whose secret fetcher still requires one. Everything that stamps the
+	// OrganizationLabel on a pod, encodes a secret name, or invalidates a cached secret must
+	// use this same value: the org is part of the cache key, so a mismatch between any two of
+	// them silently resolves to a different secret or clears a key nobody reads.
+	DefaultOrganization = "flyte"
+
 	// All of the namespace, group and key cannot contain '/' so it is safe to use '/' as a delimiter.
 	NamespaceGroupKeyDelimiter = "/"
 	rawK8sSecretsStorageFormat = valueFormatter + NamespaceGroupKeyDelimiter + valueFormatter + NamespaceGroupKeyDelimiter + valueFormatter

--- a/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -798,4 +799,37 @@ func (f secretFetcherMock) GetSecretValue(ctx context.Context, secretID string) 
 	}
 
 	return &v, nil
+}
+
+// A secret cached at a broader scope than the one being invalidated must still be dropped:
+// lookUpSecret caches under whichever scope the fetcher resolved at, so invalidating only the
+// (org, domain, project) key would leave a shadowing org- or domain-scoped entry behind and the
+// cascade would keep serving the stale value until TTL eviction.
+func TestEmbeddedSecretManagerInjector_InvalidateCache_ClearsAllCascadeScopes(t *testing.T) {
+	ctx := context.Background()
+
+	org, domain, project, name := "o-apple", "d-cherry", "p-banana", "secret1"
+	wantKeys := []string{
+		EncodeSecretName(org, domain, project, name),
+		EncodeSecretName(org, domain, EmptySecretScope, name),
+		EncodeSecretName(org, EmptySecretScope, EmptySecretScope, name),
+	}
+
+	var deleted []string
+	secretCache := cacheMocks.NewCacheInterface[SecretValue](t)
+	secretCache.EXPECT().Delete(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, key any) { deleted = append(deleted, key.(string)) }).
+		Return(nil).Times(len(wantKeys))
+
+	injector := NewEmbeddedSecretManagerInjector(
+		config.EmbeddedSecretManagerConfig{}, nil,
+		&mocks.MockableControllerRuntimeClient{}, testReferenceNamespace, secretCache,
+		&config.Config{SecretEnvVarPrefix: config.DefaultSecretEnvVarPrefix},
+	)
+
+	invalidator, ok := injector.(cacheInvalidator)
+	require.True(t, ok, "embedded injector must implement cacheInvalidator")
+
+	invalidator.InvalidateCache(ctx, org, domain, project, name)
+	assert.ElementsMatch(t, wantKeys, deleted)
 }

--- a/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -827,9 +826,6 @@ func TestEmbeddedSecretManagerInjector_InvalidateCache_ClearsAllCascadeScopes(t 
 		&config.Config{SecretEnvVarPrefix: config.DefaultSecretEnvVarPrefix},
 	)
 
-	invalidator, ok := injector.(cacheInvalidator)
-	require.True(t, ok, "embedded injector must implement cacheInvalidator")
-
-	invalidator.InvalidateCache(ctx, org, domain, project, name)
+	injector.InvalidateCache(ctx, org, domain, project, name)
 	assert.ElementsMatch(t, wantKeys, deleted)
 }

--- a/flyteplugins/go/tasks/pluginmachinery/secret/gcp_secret_manager.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/gcp_secret_manager.go
@@ -141,3 +141,6 @@ func NewGCPSecretManagerInjector(cfg config.GCPSecretManagerConfig) GCPSecretMan
 		cfg: cfg,
 	}
 }
+
+// InvalidateCache is a no-op: this injector resolves secrets on every Inject and caches nothing.
+func (i GCPSecretManagerInjector) InvalidateCache(_ context.Context, _, _, _, _ string) {}

--- a/flyteplugins/go/tasks/pluginmachinery/secret/global_secrets.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/global_secrets.go
@@ -76,3 +76,6 @@ func NewGlobalSecrets(provider GlobalSecretProvider, cfg *config.Config) GlobalS
 		cfg:              cfg,
 	}
 }
+
+// InvalidateCache is a no-op: this injector resolves secrets on every Inject and caches nothing.
+func (g GlobalSecrets) InvalidateCache(_ context.Context, _, _, _, _ string) {}

--- a/flyteplugins/go/tasks/pluginmachinery/secret/k8s_secrets.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/k8s_secrets.go
@@ -121,3 +121,6 @@ func NewK8sSecretsInjector(cfg *config.Config) K8sSecretInjector {
 		cfg: cfg,
 	}
 }
+
+// InvalidateCache is a no-op: this injector resolves secrets on every Inject and caches nothing.
+func (i K8sSecretInjector) InvalidateCache(_ context.Context, _, _, _, _ string) {}

--- a/flyteplugins/go/tasks/pluginmachinery/secret/mocks/mocks.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/mocks/mocks.go
@@ -1512,6 +1512,70 @@ func (_c *SecretsInjector_Inject_Call) RunAndReturn(run func(ctx context.Context
 	return _c
 }
 
+// InvalidateCache provides a mock function for the type SecretsInjector
+func (_mock *SecretsInjector) InvalidateCache(ctx context.Context, org string, domain string, project string, secretName string) {
+	_mock.Called(ctx, org, domain, project, secretName)
+	return
+}
+
+// SecretsInjector_InvalidateCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InvalidateCache'
+type SecretsInjector_InvalidateCache_Call struct {
+	*mock.Call
+}
+
+// InvalidateCache is a helper method to define mock.On call
+//   - ctx context.Context
+//   - org string
+//   - domain string
+//   - project string
+//   - secretName string
+func (_e *SecretsInjector_Expecter) InvalidateCache(ctx interface{}, org interface{}, domain interface{}, project interface{}, secretName interface{}) *SecretsInjector_InvalidateCache_Call {
+	return &SecretsInjector_InvalidateCache_Call{Call: _e.mock.On("InvalidateCache", ctx, org, domain, project, secretName)}
+}
+
+func (_c *SecretsInjector_InvalidateCache_Call) Run(run func(ctx context.Context, org string, domain string, project string, secretName string)) *SecretsInjector_InvalidateCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *SecretsInjector_InvalidateCache_Call) Return() *SecretsInjector_InvalidateCache_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *SecretsInjector_InvalidateCache_Call) RunAndReturn(run func(ctx context.Context, org string, domain string, project string, secretName string)) *SecretsInjector_InvalidateCache_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Type provides a mock function for the type SecretsInjector
 func (_mock *SecretsInjector) Type() config.SecretManagerType {
 	ret := _mock.Called()

--- a/flyteplugins/go/tasks/pluginmachinery/secret/secrets_injector.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/secrets_injector.go
@@ -20,11 +20,6 @@ import (
 type SecretsInjector interface {
 	Type() config.SecretManagerType
 	Inject(ctx context.Context, secrets *core.Secret, p *corev1.Pod) (newP *corev1.Pod, injected bool, err error)
-
-	// InvalidateCache drops any cached value for the named secret so the next Inject re-reads
-	// it. Injectors that read through to their backend on every Inject implement this as a
-	// no-op. It is on the interface rather than an optional one so that adding a caching
-	// injector without wiring up invalidation is a compile error, not a stale-secret bug.
 	InvalidateCache(ctx context.Context, org, domain, project, secretName string)
 }
 

--- a/flyteplugins/go/tasks/pluginmachinery/secret/secrets_injector.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/secrets_injector.go
@@ -20,6 +20,12 @@ import (
 type SecretsInjector interface {
 	Type() config.SecretManagerType
 	Inject(ctx context.Context, secrets *core.Secret, p *corev1.Pod) (newP *corev1.Pod, injected bool, err error)
+
+	// InvalidateCache drops any cached value for the named secret so the next Inject re-reads
+	// it. Injectors that read through to their backend on every Inject implement this as a
+	// no-op. It is on the interface rather than an optional one so that adding a caching
+	// injector without wiring up invalidation is a compile error, not a stale-secret bug.
+	InvalidateCache(ctx context.Context, org, domain, project, secretName string)
 }
 
 func newSecretsInjector(

--- a/flyteplugins/go/tasks/pluginmachinery/secret/secrets_pod_mutator.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/secrets_pod_mutator.go
@@ -67,6 +67,23 @@ func (s *SecretsPodMutator) Mutate(ctx context.Context, pod *corev1.Pod) (newP *
 	return pod, len(secrets) > 0, nil
 }
 
+// cacheInvalidator is implemented by injectors that cache secret values. Injectors that read
+// through to their backend on every admission (k8s, vault, cloud CSI drivers, ...) don't
+// implement it and are skipped.
+type cacheInvalidator interface {
+	InvalidateCache(ctx context.Context, org, domain, project, secretName string)
+}
+
+// InvalidateCache asks every caching injector to drop its copy of the named secret, so a
+// subsequent pod admission picks up the new value instead of waiting out the cache TTL.
+func (s *SecretsPodMutator) InvalidateCache(ctx context.Context, org, domain, project, secretName string) {
+	for _, secretManagerType := range s.enabledSecretManagerTypes {
+		if invalidator, ok := s.injectors[secretManagerType].(cacheInvalidator); ok {
+			invalidator.InvalidateCache(ctx, org, domain, project, secretName)
+		}
+	}
+}
+
 func (s *SecretsPodMutator) LabelSelector() *metav1.LabelSelector {
 	return &metav1.LabelSelector{
 		MatchLabels: map[string]string{

--- a/flyteplugins/go/tasks/pluginmachinery/secret/secrets_pod_mutator.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/secrets_pod_mutator.go
@@ -67,20 +67,11 @@ func (s *SecretsPodMutator) Mutate(ctx context.Context, pod *corev1.Pod) (newP *
 	return pod, len(secrets) > 0, nil
 }
 
-// cacheInvalidator is implemented by injectors that cache secret values. Injectors that read
-// through to their backend on every admission (k8s, vault, cloud CSI drivers, ...) don't
-// implement it and are skipped.
-type cacheInvalidator interface {
-	InvalidateCache(ctx context.Context, org, domain, project, secretName string)
-}
-
-// InvalidateCache asks every caching injector to drop its copy of the named secret, so a
+// InvalidateCache asks every enabled injector to drop its copy of the named secret, so a
 // subsequent pod admission picks up the new value instead of waiting out the cache TTL.
 func (s *SecretsPodMutator) InvalidateCache(ctx context.Context, org, domain, project, secretName string) {
 	for _, secretManagerType := range s.enabledSecretManagerTypes {
-		if invalidator, ok := s.injectors[secretManagerType].(cacheInvalidator); ok {
-			invalidator.InvalidateCache(ctx, org, domain, project, secretName)
-		}
+		s.injectors[secretManagerType].InvalidateCache(ctx, org, domain, project, secretName)
 	}
 }
 

--- a/flyteplugins/go/tasks/pluginmachinery/secret/vault_secret_manager.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/vault_secret_manager.go
@@ -89,3 +89,6 @@ func NewVaultSecretManagerInjector(cfg config.VaultSecretManagerConfig) VaultSec
 		cfg: cfg,
 	}
 }
+
+// InvalidateCache is a no-op: this injector resolves secrets on every Inject and caches nothing.
+func (i VaultSecretManagerInjector) InvalidateCache(_ context.Context, _, _, _, _ string) {}

--- a/flytestdlib/app/context.go
+++ b/flytestdlib/app/context.go
@@ -25,14 +25,6 @@ type namedWorker struct {
 	fn   WorkerFunc
 }
 
-// SecretCacheInvalidator drops any cached copy of a secret value. It is implemented by the
-// executor's pod webhook (which caches resolved secrets across pod admissions) and consumed by
-// the secret service so that writing a secret takes effect immediately instead of after the
-// cache TTL. Only valid when both run in the same process, i.e. the unified `flyte` binary.
-type SecretCacheInvalidator interface {
-	InvalidateCache(ctx context.Context, org, domain, project, secretName string)
-}
-
 // SetupContext carries shared resources to service Setup functions.
 // New fields can be added here without changing any Setup() signature.
 type SetupContext struct {
@@ -54,10 +46,6 @@ type SetupContext struct {
 
 	// K8sCache is an optional shared controller-runtime cache.
 	K8sCache cache.Cache
-
-	// SecretCacheInvalidator is set by the executor when its pod webhook runs in this process
-	// (nil otherwise, e.g. in the standalone secret-service binary).
-	SecretCacheInvalidator SecretCacheInvalidator
 
 	// DataStore is the object storage client (may be nil).
 	DataStore *storage.DataStore

--- a/flytestdlib/app/context.go
+++ b/flytestdlib/app/context.go
@@ -25,6 +25,14 @@ type namedWorker struct {
 	fn   WorkerFunc
 }
 
+// SecretCacheInvalidator drops any cached copy of a secret value. It is implemented by the
+// executor's pod webhook (which caches resolved secrets across pod admissions) and consumed by
+// the secret service so that writing a secret takes effect immediately instead of after the
+// cache TTL. Only valid when both run in the same process, i.e. the unified `flyte` binary.
+type SecretCacheInvalidator interface {
+	InvalidateCache(ctx context.Context, org, domain, project, secretName string)
+}
+
 // SetupContext carries shared resources to service Setup functions.
 // New fields can be added here without changing any Setup() signature.
 type SetupContext struct {
@@ -46,6 +54,10 @@ type SetupContext struct {
 
 	// K8sCache is an optional shared controller-runtime cache.
 	K8sCache cache.Cache
+
+	// SecretCacheInvalidator is set by the executor when its pod webhook runs in this process
+	// (nil otherwise, e.g. in the standalone secret-service binary).
+	SecretCacheInvalidator SecretCacheInvalidator
 
 	// DataStore is the object storage client (may be nil).
 	DataStore *storage.DataStore

--- a/secret/config/config.go
+++ b/secret/config/config.go
@@ -15,6 +15,7 @@ var defaultConfig = &Config{
 		Port: 8093,
 		Host: "0.0.0.0",
 	},
+	CacheInvalidationURL: "http://localhost:9444",
 	Kubernetes: app.K8sConfig{
 		Namespace:   webhookconfig.DefaultSecretsNamespace,
 		QPS:         100,
@@ -30,6 +31,13 @@ var configSection = config.MustRegisterSection(configSectionKey, defaultConfig)
 type Config struct {
 	// HTTP server configuration
 	Server ServerConfig `json:"server"`
+
+	// CacheInvalidationURL is the base URL of the pod webhook's cache invalidation server. After
+	// a secret is written, the service posts there so pods admitted next pick up the new value
+	// instead of waiting out the webhook's cache TTL. Defaults to localhost, which is correct
+	// while the webhook shares this pod; point it at the webhook Service when they are split.
+	// Empty disables invalidation (writes then take effect after the TTL).
+	CacheInvalidationURL string `json:"cacheInvalidationURL" pflag:",Base URL of the pod webhook's secret cache invalidation server"`
 
 	// Kubernetes client configuration (also carries ClusterName for status reporting).
 	Kubernetes app.K8sConfig `json:"kubernetes"`

--- a/secret/config/config.go
+++ b/secret/config/config.go
@@ -15,7 +15,7 @@ var defaultConfig = &Config{
 		Port: 8093,
 		Host: "0.0.0.0",
 	},
-	CacheInvalidationURL: "http://localhost:9444",
+	WebhookURL: "http://localhost:9444",
 	Kubernetes: app.K8sConfig{
 		Namespace:   webhookconfig.DefaultSecretsNamespace,
 		QPS:         100,
@@ -32,12 +32,15 @@ type Config struct {
 	// HTTP server configuration
 	Server ServerConfig `json:"server"`
 
-	// CacheInvalidationURL is the base URL of the pod webhook's cache invalidation server. After
-	// a secret is written, the service posts there so pods admitted next pick up the new value
-	// instead of waiting out the webhook's cache TTL. Defaults to localhost, which is correct
-	// while the webhook shares this pod; point it at the webhook Service when they are split.
+	// WebhookURL is the base URL of the pod webhook's cache invalidation server. After a secret
+	// is written, the service posts there so pods admitted next pick up the new value instead of
+	// waiting out the webhook's cache TTL.
+	//
+	// This is the webhook's cache invalidation port (9444), NOT its admission port (9443).
+	// Defaults to localhost, correct while the webhook shares this pod; point it at the headless
+	// webhook Service once they are split, so every replica's cache is cleared rather than one.
 	// Empty disables invalidation (writes then take effect after the TTL).
-	CacheInvalidationURL string `json:"cacheInvalidationURL" pflag:",Base URL of the pod webhook's secret cache invalidation server"`
+	WebhookURL string `json:"webhookURL" pflag:",Base URL of the pod webhook's secret cache invalidation server (its 9444 port, not the 9443 admission port)"`
 
 	// Kubernetes client configuration (also carries ClusterName for status reporting).
 	Kubernetes app.K8sConfig `json:"kubernetes"`

--- a/secret/config/config_flags.go
+++ b/secret/config/config_flags.go
@@ -52,6 +52,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "server.port"), defaultConfig.Server.Port, "Port to bind the HTTP server")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "server.host"), defaultConfig.Server.Host, "Host to bind the HTTP server")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cacheInvalidationURL"), defaultConfig.CacheInvalidationURL, "Base URL of the pod webhook's secret cache invalidation server")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "kubernetes.kubeconfig"), defaultConfig.Kubernetes.KubeConfig, "Path to kubeconfig file (optional)")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "kubernetes.namespace"), defaultConfig.Kubernetes.Namespace, "Kubernetes namespace")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "kubernetes.qps"), defaultConfig.Kubernetes.QPS, "Maximum queries per second to the Kubernetes API server")

--- a/secret/config/config_flags.go
+++ b/secret/config/config_flags.go
@@ -52,7 +52,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "server.port"), defaultConfig.Server.Port, "Port to bind the HTTP server")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "server.host"), defaultConfig.Server.Host, "Host to bind the HTTP server")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cacheInvalidationURL"), defaultConfig.CacheInvalidationURL, "Base URL of the pod webhook's secret cache invalidation server")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "webhookURL"), defaultConfig.WebhookURL, "Base URL of the pod webhook's secret cache invalidation server (its 9444 port,  not the 9443 admission port)")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "kubernetes.kubeconfig"), defaultConfig.Kubernetes.KubeConfig, "Path to kubeconfig file (optional)")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "kubernetes.namespace"), defaultConfig.Kubernetes.Namespace, "Kubernetes namespace")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "kubernetes.qps"), defaultConfig.Kubernetes.QPS, "Maximum queries per second to the Kubernetes API server")

--- a/secret/config/config_flags_test.go
+++ b/secret/config/config_flags_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/secret/config/config_flags_test.go
+++ b/secret/config/config_flags_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-viper/mapstructure/v2"
+	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -121,6 +121,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			cmdFlags.Set("server.host", testValue)
 			if vString, err := cmdFlags.GetString("server.host"); err == nil {
 				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Server.Host)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_cacheInvalidationURL", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("cacheInvalidationURL", testValue)
+			if vString, err := cmdFlags.GetString("cacheInvalidationURL"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.CacheInvalidationURL)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/secret/config/config_flags_test.go
+++ b/secret/config/config_flags_test.go
@@ -127,14 +127,14 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
-	t.Run("Test_cacheInvalidationURL", func(t *testing.T) {
+	t.Run("Test_webhookURL", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := "1"
 
-			cmdFlags.Set("cacheInvalidationURL", testValue)
-			if vString, err := cmdFlags.GetString("cacheInvalidationURL"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.CacheInvalidationURL)
+			cmdFlags.Set("webhookURL", testValue)
+			if vString, err := cmdFlags.GetString("webhookURL"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.WebhookURL)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -114,10 +114,7 @@ func (s *SecretService) invalidateWebhookSecretCache(ctx context.Context, id *se
 
 // invalidationTargets resolves the configured host to one URL per webhook pod.
 //
-// Resolution rather than a single request is what makes this correct against a headless Service:
-// its DNS returns an A record per pod, and every replica caches independently, so a request to
-// the name alone would reach one arbitrary pod and leave the others stale. A ClusterIP Service or
-// a bare host resolves to exactly one address, so the same code path handles both.
+// Resolution rather than a single request is what makes this correct against a headless Service.
 func (s *SecretService) invalidationTargets(ctx context.Context) ([]string, error) {
 	base, err := url.Parse(strings.TrimSuffix(s.webhookURL, "/"))
 	if err != nil {

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	flytesecret "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret"
+	"github.com/flyteorg/flyte/v2/flytestdlib/app"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	commonpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
 	secretpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/secret"
@@ -37,11 +38,25 @@ var _ secretconnect.SecretServiceHandler = (*SecretService)(nil)
 // SecretService implements the SecretService gRPC API.
 type SecretService struct {
 	k8sClient client.Client
+
+	// cacheInvalidator drops the pod webhook's cached copy of a secret after a write so tasks
+	// pick up the new value immediately. Nil when the webhook isn't running in this process.
+	cacheInvalidator app.SecretCacheInvalidator
 }
 
 // NewSecretService creates a new SecretService.
-func NewSecretService(k8sClient client.Client) *SecretService {
-	return &SecretService{k8sClient: k8sClient}
+func NewSecretService(k8sClient client.Client, cacheInvalidator app.SecretCacheInvalidator) *SecretService {
+	return &SecretService{k8sClient: k8sClient, cacheInvalidator: cacheInvalidator}
+}
+
+// invalidateCache drops any cached value for id. Called after every write (create, update,
+// delete): a create can shadow a broader-scoped secret that is already cached, so it needs
+// invalidation just as much as an update does.
+func (s *SecretService) invalidateCache(ctx context.Context, id *secretpb.SecretIdentifier) {
+	if s.cacheInvalidator == nil {
+		return
+	}
+	s.cacheInvalidator.InvalidateCache(ctx, defaultOrganization, id.GetDomain(), id.GetProject(), id.GetName())
 }
 
 // validateScope enforces the valid scope combinations supported by the secret
@@ -97,6 +112,8 @@ func (s *SecretService) CreateSecret(ctx context.Context, req *connect.Request[s
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
+	s.invalidateCache(ctx, req.Msg.GetId())
+
 	return connect.NewResponse(&secretpb.CreateSecretResponse{}), nil
 }
 
@@ -141,6 +158,8 @@ func (s *SecretService) UpdateSecret(ctx context.Context, req *connect.Request[s
 		logger.Errorf(ctx, "failed to update secret %v: %v", encodedName, err)
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
+
+	s.invalidateCache(ctx, req.Msg.GetId())
 
 	return connect.NewResponse(&secretpb.UpdateSecretResponse{}), nil
 }
@@ -207,6 +226,8 @@ func (s *SecretService) DeleteSecret(ctx context.Context, req *connect.Request[s
 	}
 
 	logger.Debugf(ctx, "deleted k8s secret %v", k8sSecretName)
+	s.invalidateCache(ctx, req.Msg.GetId())
+
 	return connect.NewResponse(&secretpb.DeleteSecretResponse{}), nil
 }
 

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -1,8 +1,13 @@
 package service
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -11,8 +16,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/flyteorg/flyte/v2/executor/pkg/webhook"
 	flytesecret "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret"
-	"github.com/flyteorg/flyte/v2/flytestdlib/app"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	commonpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
 	secretpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/secret"
@@ -25,6 +30,10 @@ const (
 	managedSecretLabelValue = "true"
 	projectLabelKey         = "app.flyte.org/project"
 	domainLabelKey          = "app.flyte.org/domain"
+
+	// cacheInvalidationTimeout bounds the best-effort call to the webhook's invalidation
+	// endpoint so a wedged webhook can't stall secret writes.
+	cacheInvalidationTimeout = 5 * time.Second
 
 	// defaultOrganization is a placeholder org used in the encoded secret ID
 	// because Flyte OSS v2 has no organization concept. It must match the
@@ -39,24 +48,65 @@ var _ secretconnect.SecretServiceHandler = (*SecretService)(nil)
 type SecretService struct {
 	k8sClient client.Client
 
-	// cacheInvalidator drops the pod webhook's cached copy of a secret after a write so tasks
-	// pick up the new value immediately. Nil when the webhook isn't running in this process.
-	cacheInvalidator app.SecretCacheInvalidator
+	// cacheInvalidationURL is the base URL of the pod webhook's cache invalidation server.
+	// Empty disables invalidation, in which case writes take effect after the webhook's TTL.
+	cacheInvalidationURL string
+	httpClient           *http.Client
 }
 
-// NewSecretService creates a new SecretService.
-func NewSecretService(k8sClient client.Client, cacheInvalidator app.SecretCacheInvalidator) *SecretService {
-	return &SecretService{k8sClient: k8sClient, cacheInvalidator: cacheInvalidator}
+// NewSecretService creates a new SecretService. cacheInvalidationURL is the base URL of the pod
+// webhook's cache invalidation server; pass "" to disable cache invalidation.
+func NewSecretService(k8sClient client.Client, cacheInvalidationURL string) *SecretService {
+	return &SecretService{
+		k8sClient:            k8sClient,
+		cacheInvalidationURL: cacheInvalidationURL,
+		httpClient:           &http.Client{Timeout: cacheInvalidationTimeout},
+	}
 }
 
-// invalidateCache drops any cached value for id. Called after every write (create, update,
-// delete): a create can shadow a broader-scoped secret that is already cached, so it needs
-// invalidation just as much as an update does.
+// invalidateCache asks the pod webhook to drop any cached value for id. Called after every write
+// (create, update, delete): a create can shadow a broader-scoped secret that is already cached,
+// so it needs invalidation just as much as an update does.
+//
+// Best-effort. The secret is already durably written at this point, so a failure here must not
+// fail the RPC — it only means the old value lingers until the webhook's cache TTL expires.
 func (s *SecretService) invalidateCache(ctx context.Context, id *secretpb.SecretIdentifier) {
-	if s.cacheInvalidator == nil {
+	if s.cacheInvalidationURL == "" {
 		return
 	}
-	s.cacheInvalidator.InvalidateCache(ctx, defaultOrganization, id.GetDomain(), id.GetProject(), id.GetName())
+
+	body, err := json.Marshal(webhook.InvalidateRequest{
+		Org:     defaultOrganization,
+		Domain:  id.GetDomain(),
+		Project: id.GetProject(),
+		Name:    id.GetName(),
+	})
+	if err != nil {
+		logger.Warnf(ctx, "failed to encode cache invalidation request for %v: %v", id.GetName(), err)
+		return
+	}
+
+	url := strings.TrimSuffix(s.cacheInvalidationURL, "/") + webhook.InvalidateSecretPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		logger.Warnf(ctx, "failed to build cache invalidation request for %v: %v", id.GetName(), err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		logger.Warnf(ctx, "failed to invalidate secret cache for %v: %v; the old value may be served until the webhook cache TTL expires", id.GetName(), err)
+		return
+	}
+	defer resp.Body.Close() // nolint: errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		logger.Warnf(ctx, "secret cache invalidation for %v returned %s; the old value may be served until the webhook cache TTL expires", id.GetName(), resp.Status)
+		return
+	}
+
+	logger.Debugf(ctx, "invalidated webhook secret cache for %v", id.GetName())
 }
 
 // validateScope enforces the valid scope combinations supported by the secret

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -119,7 +119,15 @@ func (s *SecretService) invalidateWebhookSecretCache(ctx context.Context, id *se
 //
 // Resolution rather than a single request is what makes this correct against a headless Service.
 func (s *SecretService) invalidationTargets(ctx context.Context) ([]string, error) {
-	base, err := url.Parse(strings.TrimSuffix(s.webhookURL, "/"))
+	raw := strings.TrimSuffix(s.webhookURL, "/")
+	// Tolerate a scheme-less value like "webhook-headless.flyte.svc:9444". url.Parse reads that
+	// as scheme "webhook-headless.flyte.svc" with opaque "9444" and an empty Host, so without
+	// this the config would be rejected and invalidation would quietly degrade to TTL.
+	if !strings.Contains(raw, "://") {
+		raw = "http://" + raw
+	}
+
+	base, err := url.Parse(raw)
 	if err != nil {
 		return nil, fmt.Errorf("parsing %q: %w", s.webhookURL, err)
 	}

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -267,6 +267,12 @@ func (s *SecretService) DeleteSecret(ctx context.Context, req *connect.Request[s
 		},
 	}
 
+	// Invalidate on every exit path, not just the happy one. If the Secret is already gone
+	// (deleted out-of-band) this returns NotFound, but the webhook may still be serving the
+	// old value from cache — leaving a secret the user believes is deleted injected into pods
+	// for up to the cache TTL. Deferred so the NotFound and error paths are covered too.
+	defer s.invalidateCache(ctx, req.Msg.GetId())
+
 	if err := s.k8sClient.Delete(ctx, k8sSecret); err != nil {
 		if k8sErrors.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("secret %v not found", req.Msg.GetId().GetName()))
@@ -276,7 +282,6 @@ func (s *SecretService) DeleteSecret(ctx context.Context, req *connect.Request[s
 	}
 
 	logger.Debugf(ctx, "deleted k8s secret %v", k8sSecretName)
-	s.invalidateCache(ctx, req.Msg.GetId())
 
 	return connect.NewResponse(&secretpb.DeleteSecretResponse{}), nil
 }

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -38,7 +38,7 @@ const (
 	// defaultOrganization is a placeholder org used in the encoded secret ID
 	// because Flyte OSS v2 has no organization concept. It must match the
 	// organization label stamped on task pods by the executor.
-	defaultOrganization = "flyte"
+	defaultOrganization = flytesecret.DefaultOrganization
 )
 
 // Ensure SecretService implements SecretServiceHandler at compile time.

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -42,9 +42,6 @@ const (
 	defaultCacheInvalidationPort = "9444"
 
 	// schemeSeparator and defaultWebhookScheme fill in a scheme when webhookURL omits one.
-	// url.Parse reads "host:9444" as scheme "host" with an empty Host, so a scheme-less value
-	// would otherwise be rejected. Plain HTTP because the invalidation endpoint is
-	// cluster-internal and unauthenticated by design.
 	schemeSeparator      = "://"
 	defaultWebhookScheme = "http" + schemeSeparator
 

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -34,6 +36,12 @@ const (
 	// cacheInvalidationTimeout bounds the best-effort call to the webhook's invalidation
 	// endpoint so a wedged webhook can't stall secret writes.
 	cacheInvalidationTimeout = 5 * time.Second
+
+	// defaultCacheInvalidationPort is used when cacheInvalidationURL names no port. Must match
+	// the webhook's cacheInvalidationPort.
+	defaultCacheInvalidationPort = "9444"
+
+	staleWarning = "the old value may be served until the webhook cache TTL expires"
 
 	// defaultOrganization is a placeholder org used in the encoded secret ID
 	// because Flyte OSS v2 has no organization concept. It must match the
@@ -89,36 +97,86 @@ func (s *SecretService) invalidateWebhookSecretCache(ctx context.Context, id *se
 		return
 	}
 
-	// Single target: flyte-binary runs one replica, so the configured URL reaches the only
-	// webhook there is.
-	//
-	// TODO: once the webhook runs with multiple replicas, point cacheInvalidationURL at the
-	// headless Service (<release>-flyte-binary-webhook-headless:9444) and fan out with
-	// net.DefaultResolver.LookupHost, POSTing every pod IP — what cloud's operator-proxy does.
-	// Repointing the URL at the headless name WITHOUT that change is worse than leaving it:
-	// Go's client picks a single A record, so one arbitrary replica gets invalidated and the
-	// rest keep serving stale secrets.
-	url := strings.TrimSuffix(s.cacheInvalidationURL, "/") + webhook.InvalidateSecretPath
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	targets, err := s.invalidationTargets(ctx)
 	if err != nil {
-		logger.Warnf(ctx, "failed to build cache invalidation request for %v: %v", id.GetName(), err)
+		logger.Warnf(ctx, "failed to resolve webhook cache invalidation targets for %v: %v; %s", id.GetName(), err, staleWarning)
 		return
+	}
+
+	failed := 0
+	for _, target := range targets {
+		if err := s.postInvalidation(ctx, target, body); err != nil {
+			failed++
+			logger.Warnf(ctx, "failed to invalidate secret cache for %v on %s: %v", id.GetName(), target, err)
+		}
+	}
+
+	if failed > 0 {
+		logger.Warnf(ctx, "secret cache invalidation for %v failed on %d/%d webhook pod(s); %s", id.GetName(), failed, len(targets), staleWarning)
+		return
+	}
+
+	logger.Debugf(ctx, "invalidated webhook secret cache for %v across %d pod(s)", id.GetName(), len(targets))
+}
+
+// invalidationTargets resolves the configured host to one URL per webhook pod.
+//
+// Resolution rather than a single request is what makes this correct against a headless Service:
+// its DNS returns an A record per pod, and every replica caches independently, so a request to
+// the name alone would reach one arbitrary pod and leave the others stale. A ClusterIP Service or
+// a bare host resolves to exactly one address, so the same code path handles both.
+func (s *SecretService) invalidationTargets(ctx context.Context) ([]string, error) {
+	base, err := url.Parse(strings.TrimSuffix(s.cacheInvalidationURL, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %w", s.cacheInvalidationURL, err)
+	}
+
+	host := base.Hostname()
+	if host == "" {
+		return nil, fmt.Errorf("no host in %q", s.cacheInvalidationURL)
+	}
+	port := base.Port()
+	if port == "" {
+		port = defaultCacheInvalidationPort
+	}
+
+	// LookupHost passes IP literals straight through, so an explicitly configured address works.
+	ips, err := net.DefaultResolver.LookupHost(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no webhook pods resolved for %q", host)
+	}
+
+	targets := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		targets = append(targets, (&url.URL{
+			Scheme: base.Scheme,
+			Host:   net.JoinHostPort(ip, port),
+			Path:   webhook.InvalidateSecretPath,
+		}).String())
+	}
+	return targets, nil
+}
+
+func (s *SecretService) postInvalidation(ctx context.Context, target string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("building request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		logger.Warnf(ctx, "failed to invalidate secret cache for %v: %v; the old value may be served until the webhook cache TTL expires", id.GetName(), err)
-		return
+		return err
 	}
 	defer resp.Body.Close() // nolint: errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		logger.Warnf(ctx, "secret cache invalidation for %v returned %s; the old value may be served until the webhook cache TTL expires", id.GetName(), resp.Status)
-		return
+		return fmt.Errorf("returned %s", resp.Status)
 	}
-
-	logger.Debugf(ctx, "invalidated webhook secret cache for %v", id.GetName())
+	return nil
 }
 
 // validateScope enforces the valid scope combinations supported by the secret

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -89,6 +89,15 @@ func (s *SecretService) invalidateWebhookSecretCache(ctx context.Context, id *se
 		return
 	}
 
+	// Single target: flyte-binary runs one replica, so the configured URL reaches the only
+	// webhook there is.
+	//
+	// TODO: once the webhook runs with multiple replicas, point cacheInvalidationURL at the
+	// headless Service (<release>-flyte-binary-webhook-headless:9444) and fan out with
+	// net.DefaultResolver.LookupHost, POSTing every pod IP — what cloud's operator-proxy does.
+	// Repointing the URL at the headless name WITHOUT that change is worse than leaving it:
+	// Go's client picks a single A record, so one arbitrary replica gets invalidated and the
+	// rest keep serving stale secrets.
 	url := strings.TrimSuffix(s.cacheInvalidationURL, "/") + webhook.InvalidateSecretPath
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
@@ -270,7 +279,7 @@ func (s *SecretService) DeleteSecret(ctx context.Context, req *connect.Request[s
 		},
 	}
 
-	// Invalidate on every exit path, not just the happy one. If the Secret is already gone
+	// If the Secret is already gone
 	// (deleted out-of-band) this returns NotFound, but the webhook may still be serving the
 	// old value from cache — leaving a secret the user believes is deleted injected into pods
 	// for up to the cache TTL. Deferred so the NotFound and error paths are covered too.

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -72,15 +72,7 @@ func NewSecretService(k8sClient client.Client, cacheInvalidationURL string) *Sec
 	}
 }
 
-// invalidateWebhookSecretCache asks the pod webhook to drop any cached value for id. Named for
-// the cache it clears (the webhook's), not to be confused with the webhook-side
-// SecretsPodMutator.InvalidateCache this reaches over HTTP.
-//
-// Called after every write (create, update, delete): a create can shadow a broader-scoped secret
-// that is already cached, so it needs invalidation just as much as an update does.
-//
-// Best-effort. The secret is already durably written at this point, so a failure here must not
-// fail the RPC — it only means the old value lingers until the webhook's cache TTL expires.
+// invalidateWebhookSecretCache asks the pod webhook to drop any cached value for id.
 func (s *SecretService) invalidateWebhookSecretCache(ctx context.Context, id *secretpb.SecretIdentifier) {
 	if s.cacheInvalidationURL == "" {
 		return

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -79,11 +79,6 @@ func (s *SecretService) invalidateWebhookSecretCache(ctx context.Context, id *se
 		return
 	}
 
-	// Detach from the caller's cancellation. By the time this runs the secret is already
-	// persisted, so a client that hung up mid-request must not leave the webhook serving the
-	// old value until TTL — which is what happens if the cancelled context propagates into DNS
-	// resolution and the POSTs. WithoutCancel keeps the values (logging, tracing) and drops only
-	// the cancellation, so we re-impose our own deadline to stay bounded.
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheInvalidationTimeout)
 	defer cancel()
 
@@ -230,8 +225,7 @@ func (s *SecretService) CreateSecret(ctx context.Context, req *connect.Request[s
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	// Deferred so it survives any early return added between here and the response.
-	defer s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
+	s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
 
 	return connect.NewResponse(&secretpb.CreateSecretResponse{}), nil
 }
@@ -278,8 +272,7 @@ func (s *SecretService) UpdateSecret(ctx context.Context, req *connect.Request[s
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	// Deferred so it survives any early return added between here and the response.
-	defer s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
+	s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
 
 	return connect.NewResponse(&secretpb.UpdateSecretResponse{}), nil
 }

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -120,9 +120,6 @@ func (s *SecretService) invalidateWebhookSecretCache(ctx context.Context, id *se
 // Resolution rather than a single request is what makes this correct against a headless Service.
 func (s *SecretService) invalidationTargets(ctx context.Context) ([]string, error) {
 	raw := strings.TrimSuffix(s.webhookURL, "/")
-	// Tolerate a scheme-less value like "webhook-headless.flyte.svc:9444". url.Parse reads that
-	// as scheme "webhook-headless.flyte.svc" with opaque "9444" and an empty Host, so without
-	// this the config would be rejected and invalidation would quietly degrade to TTL.
 	if !strings.Contains(raw, "://") {
 		raw = "http://" + raw
 	}

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -41,6 +41,13 @@ const (
 	// the webhook's cacheInvalidationPort.
 	defaultCacheInvalidationPort = "9444"
 
+	// schemeSeparator and defaultWebhookScheme fill in a scheme when webhookURL omits one.
+	// url.Parse reads "host:9444" as scheme "host" with an empty Host, so a scheme-less value
+	// would otherwise be rejected. Plain HTTP because the invalidation endpoint is
+	// cluster-internal and unauthenticated by design.
+	schemeSeparator      = "://"
+	defaultWebhookScheme = "http" + schemeSeparator
+
 	staleWarning = "the old value may be served until the webhook cache TTL expires"
 
 	// defaultOrganization is a placeholder org used in the encoded secret ID
@@ -120,8 +127,8 @@ func (s *SecretService) invalidateWebhookSecretCache(ctx context.Context, id *se
 // Resolution rather than a single request is what makes this correct against a headless Service.
 func (s *SecretService) invalidationTargets(ctx context.Context) ([]string, error) {
 	raw := strings.TrimSuffix(s.webhookURL, "/")
-	if !strings.Contains(raw, "://") {
-		raw = "http://" + raw
+	if !strings.Contains(raw, schemeSeparator) {
+		raw = defaultWebhookScheme + raw
 	}
 
 	base, err := url.Parse(raw)

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -64,13 +64,16 @@ func NewSecretService(k8sClient client.Client, cacheInvalidationURL string) *Sec
 	}
 }
 
-// invalidateCache asks the pod webhook to drop any cached value for id. Called after every write
-// (create, update, delete): a create can shadow a broader-scoped secret that is already cached,
-// so it needs invalidation just as much as an update does.
+// invalidateWebhookSecretCache asks the pod webhook to drop any cached value for id. Named for
+// the cache it clears (the webhook's), not to be confused with the webhook-side
+// SecretsPodMutator.InvalidateCache this reaches over HTTP.
+//
+// Called after every write (create, update, delete): a create can shadow a broader-scoped secret
+// that is already cached, so it needs invalidation just as much as an update does.
 //
 // Best-effort. The secret is already durably written at this point, so a failure here must not
 // fail the RPC — it only means the old value lingers until the webhook's cache TTL expires.
-func (s *SecretService) invalidateCache(ctx context.Context, id *secretpb.SecretIdentifier) {
+func (s *SecretService) invalidateWebhookSecretCache(ctx context.Context, id *secretpb.SecretIdentifier) {
 	if s.cacheInvalidationURL == "" {
 		return
 	}
@@ -162,7 +165,7 @@ func (s *SecretService) CreateSecret(ctx context.Context, req *connect.Request[s
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	s.invalidateCache(ctx, req.Msg.GetId())
+	s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
 
 	return connect.NewResponse(&secretpb.CreateSecretResponse{}), nil
 }
@@ -209,7 +212,7 @@ func (s *SecretService) UpdateSecret(ctx context.Context, req *connect.Request[s
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	s.invalidateCache(ctx, req.Msg.GetId())
+	s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
 
 	return connect.NewResponse(&secretpb.UpdateSecretResponse{}), nil
 }
@@ -271,7 +274,7 @@ func (s *SecretService) DeleteSecret(ctx context.Context, req *connect.Request[s
 	// (deleted out-of-band) this returns NotFound, but the webhook may still be serving the
 	// old value from cache — leaving a secret the user believes is deleted injected into pods
 	// for up to the cache TTL. Deferred so the NotFound and error paths are covered too.
-	defer s.invalidateCache(ctx, req.Msg.GetId())
+	defer s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
 
 	if err := s.k8sClient.Delete(ctx, k8sSecret); err != nil {
 		if k8sErrors.IsNotFound(err) {

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -79,6 +79,14 @@ func (s *SecretService) invalidateWebhookSecretCache(ctx context.Context, id *se
 		return
 	}
 
+	// Detach from the caller's cancellation. By the time this runs the secret is already
+	// persisted, so a client that hung up mid-request must not leave the webhook serving the
+	// old value until TTL — which is what happens if the cancelled context propagates into DNS
+	// resolution and the POSTs. WithoutCancel keeps the values (logging, tracing) and drops only
+	// the cancellation, so we re-impose our own deadline to stay bounded.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheInvalidationTimeout)
+	defer cancel()
+
 	body, err := json.Marshal(webhook.InvalidateRequest{
 		Org:     defaultOrganization,
 		Domain:  id.GetDomain(),
@@ -222,7 +230,8 @@ func (s *SecretService) CreateSecret(ctx context.Context, req *connect.Request[s
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
+	// Deferred so it survives any early return added between here and the response.
+	defer s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
 
 	return connect.NewResponse(&secretpb.CreateSecretResponse{}), nil
 }
@@ -269,7 +278,8 @@ func (s *SecretService) UpdateSecret(ctx context.Context, req *connect.Request[s
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
+	// Deferred so it survives any early return added between here and the response.
+	defer s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
 
 	return connect.NewResponse(&secretpb.UpdateSecretResponse{}), nil
 }

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -37,7 +37,7 @@ const (
 	// endpoint so a wedged webhook can't stall secret writes.
 	cacheInvalidationTimeout = 5 * time.Second
 
-	// defaultCacheInvalidationPort is used when cacheInvalidationURL names no port. Must match
+	// defaultCacheInvalidationPort is used when webhookURL names no port. Must match
 	// the webhook's cacheInvalidationPort.
 	defaultCacheInvalidationPort = "9444"
 
@@ -56,25 +56,26 @@ var _ secretconnect.SecretServiceHandler = (*SecretService)(nil)
 type SecretService struct {
 	k8sClient client.Client
 
-	// cacheInvalidationURL is the base URL of the pod webhook's cache invalidation server.
-	// Empty disables invalidation, in which case writes take effect after the webhook's TTL.
-	cacheInvalidationURL string
-	httpClient           *http.Client
+	// webhookURL is the base URL of the pod webhook's cache invalidation server — its 9444
+	// port, not the 9443 admission port. Empty disables invalidation, in which case writes
+	// take effect after the webhook's TTL.
+	webhookURL string
+	httpClient *http.Client
 }
 
-// NewSecretService creates a new SecretService. cacheInvalidationURL is the base URL of the pod
+// NewSecretService creates a new SecretService. webhookURL is the base URL of the pod
 // webhook's cache invalidation server; pass "" to disable cache invalidation.
-func NewSecretService(k8sClient client.Client, cacheInvalidationURL string) *SecretService {
+func NewSecretService(k8sClient client.Client, webhookURL string) *SecretService {
 	return &SecretService{
-		k8sClient:            k8sClient,
-		cacheInvalidationURL: cacheInvalidationURL,
-		httpClient:           &http.Client{Timeout: cacheInvalidationTimeout},
+		k8sClient:  k8sClient,
+		webhookURL: webhookURL,
+		httpClient: &http.Client{Timeout: cacheInvalidationTimeout},
 	}
 }
 
 // invalidateWebhookSecretCache asks the pod webhook to drop any cached value for id.
 func (s *SecretService) invalidateWebhookSecretCache(ctx context.Context, id *secretpb.SecretIdentifier) {
-	if s.cacheInvalidationURL == "" {
+	if s.webhookURL == "" {
 		return
 	}
 
@@ -118,14 +119,14 @@ func (s *SecretService) invalidateWebhookSecretCache(ctx context.Context, id *se
 // the name alone would reach one arbitrary pod and leave the others stale. A ClusterIP Service or
 // a bare host resolves to exactly one address, so the same code path handles both.
 func (s *SecretService) invalidationTargets(ctx context.Context) ([]string, error) {
-	base, err := url.Parse(strings.TrimSuffix(s.cacheInvalidationURL, "/"))
+	base, err := url.Parse(strings.TrimSuffix(s.webhookURL, "/"))
 	if err != nil {
-		return nil, fmt.Errorf("parsing %q: %w", s.cacheInvalidationURL, err)
+		return nil, fmt.Errorf("parsing %q: %w", s.webhookURL, err)
 	}
 
 	host := base.Hostname()
 	if host == "" {
-		return nil, fmt.Errorf("no host in %q", s.cacheInvalidationURL)
+		return nil, fmt.Errorf("no host in %q", s.webhookURL)
 	}
 	port := base.Port()
 	if port == "" {

--- a/secret/service/secret_service_test.go
+++ b/secret/service/secret_service_test.go
@@ -384,6 +384,11 @@ func TestSecretService_InvalidationTargets(t *testing.T) {
 		"default port":   {"http://127.0.0.1", []string{"http://127.0.0.1:9444/invalidate-secret"}},
 		"trailing slash": {"http://127.0.0.1:9999/", []string{"http://127.0.0.1:9999/invalidate-secret"}},
 		"ipv6 literal":   {"http://[::1]:9999", []string{"http://[::1]:9999/invalidate-secret"}},
+
+		// Scheme-less forms: url.Parse reads "127.0.0.1:9999" as scheme "127.0.0.1" with an
+		// empty Host, so these would be rejected and invalidation would degrade to TTL.
+		"no scheme, with port": {"127.0.0.1:9999", []string{"http://127.0.0.1:9999/invalidate-secret"}},
+		"no scheme, no port":   {"127.0.0.1", []string{"http://127.0.0.1:9444/invalidate-secret"}},
 	} {
 		t.Run(name, func(t *testing.T) {
 			got, err := NewSecretService(nil, tc.url).invalidationTargets(context.Background())
@@ -393,7 +398,7 @@ func TestSecretService_InvalidationTargets(t *testing.T) {
 	}
 
 	t.Run("rejects a url with no host", func(t *testing.T) {
-		_, err := NewSecretService(nil, "not-a-url").invalidationTargets(context.Background())
+		_, err := NewSecretService(nil, "http://").invalidationTargets(context.Background())
 		assert.Error(t, err)
 	})
 }

--- a/secret/service/secret_service_test.go
+++ b/secret/service/secret_service_test.go
@@ -285,3 +285,27 @@ func TestSecretService_InvalidationFailureDoesNotFailWrite(t *testing.T) {
 		})
 	}
 }
+
+// A delete whose Secret is already gone (deleted out-of-band) still has to invalidate: the
+// webhook may be serving the old value from cache, so skipping it would keep a secret the user
+// believes is deleted injected into pods until the TTL expires.
+func TestSecretService_DeleteInvalidatesEvenWhenNotFound(t *testing.T) {
+	var got []webhook.InvalidateRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		var req webhook.InvalidateRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		got = append(got, req)
+	}))
+	defer srv.Close()
+
+	s := NewSecretService(newTestClient(t), srv.URL)
+	_, err := s.DeleteSecret(context.Background(), connect.NewRequest(&secretpb.DeleteSecretRequest{
+		Id: &secretpb.SecretIdentifier{Domain: "development", Name: "never-created"},
+	}))
+
+	require.Error(t, err, "deleting a missing secret should still report NotFound")
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	assert.Equal(t, []webhook.InvalidateRequest{
+		{Org: defaultOrganization, Domain: "development", Name: "never-created"},
+	}, got)
+}

--- a/secret/service/secret_service_test.go
+++ b/secret/service/secret_service_test.go
@@ -83,7 +83,7 @@ func TestGetK8sSecretName_ScopeHashesDiffer(t *testing.T) {
 
 func TestSecretService_CreateThenGet(t *testing.T) {
 	k := newTestClient(t)
-	s := NewSecretService(k)
+	s := NewSecretService(k, nil)
 	ctx := context.Background()
 	id := &secretpb.SecretIdentifier{
 		Project: "flytesnacks",
@@ -106,7 +106,7 @@ func TestSecretService_CreateThenGet(t *testing.T) {
 
 func TestSecretService_GetNotFound_UsesOriginalName(t *testing.T) {
 	k := newTestClient(t)
-	s := NewSecretService(k)
+	s := NewSecretService(k, nil)
 	ctx := context.Background()
 	_, err := s.GetSecret(ctx, connect.NewRequest(&secretpb.GetSecretRequest{
 		Id: &secretpb.SecretIdentifier{Name: "my-secret1"},
@@ -119,7 +119,7 @@ func TestSecretService_GetNotFound_UsesOriginalName(t *testing.T) {
 
 func TestSecretService_List_FiltersByScope(t *testing.T) {
 	k := newTestClient(t)
-	s := NewSecretService(k)
+	s := NewSecretService(k, nil)
 	ctx := context.Background()
 
 	// Write one secret at each scope.
@@ -165,7 +165,7 @@ func namesOf(secrets []*secretpb.Secret) []string {
 
 func TestSecretService_List_RejectsProjectWithoutDomain(t *testing.T) {
 	k := newTestClient(t)
-	s := NewSecretService(k)
+	s := NewSecretService(k, nil)
 	_, err := s.ListSecrets(context.Background(), connect.NewRequest(&secretpb.ListSecretsRequest{Project: "flytesnacks"}))
 	require.Error(t, err)
 }
@@ -221,4 +221,44 @@ func TestK8sSecretWrittenByServiceIsReadableByWebhookFetcher(t *testing.T) {
 			assert.Equal(t, expectedID, foundID, "secret created at %s scope was not found at the expected lookup scope", tc.scope)
 		})
 	}
+}
+
+type recordingInvalidator struct {
+	calls [][4]string
+}
+
+func (r *recordingInvalidator) InvalidateCache(_ context.Context, org, domain, project, name string) {
+	r.calls = append(r.calls, [4]string{org, domain, project, name})
+}
+
+// Every write path must invalidate the webhook's secret cache, otherwise a task admitted after
+// the write keeps getting the old value until the cache TTL expires. Create counts as a write:
+// a newly created narrow-scope secret can be shadowed by an already-cached broader-scope one.
+func TestSecretService_WritesInvalidateCache(t *testing.T) {
+	ctx := context.Background()
+	id := &secretpb.SecretIdentifier{Project: "flytesnacks", Domain: "development", Name: "my-secret"}
+	spec := &secretpb.SecretSpec{Value: &secretpb.SecretSpec_BinaryValue{BinaryValue: []byte("v")}}
+	want := [4]string{defaultOrganization, "development", "flytesnacks", "my-secret"}
+
+	inv := &recordingInvalidator{}
+	s := NewSecretService(newTestClient(t), inv)
+
+	_, err := s.CreateSecret(ctx, connect.NewRequest(&secretpb.CreateSecretRequest{Id: id, SecretSpec: spec}))
+	require.NoError(t, err)
+	_, err = s.UpdateSecret(ctx, connect.NewRequest(&secretpb.UpdateSecretRequest{Id: id, SecretSpec: spec}))
+	require.NoError(t, err)
+	_, err = s.DeleteSecret(ctx, connect.NewRequest(&secretpb.DeleteSecretRequest{Id: id}))
+	require.NoError(t, err)
+
+	assert.Equal(t, [][4]string{want, want, want}, inv.calls)
+}
+
+// The standalone secret-service binary has no in-process webhook; writes must still succeed.
+func TestSecretService_NilInvalidatorIsNoop(t *testing.T) {
+	s := NewSecretService(newTestClient(t), nil)
+	_, err := s.CreateSecret(context.Background(), connect.NewRequest(&secretpb.CreateSecretRequest{
+		Id:         &secretpb.SecretIdentifier{Domain: "development", Name: "s"},
+		SecretSpec: &secretpb.SecretSpec{Value: &secretpb.SecretSpec_BinaryValue{BinaryValue: []byte("v")}},
+	}))
+	require.NoError(t, err)
 }

--- a/secret/service/secret_service_test.go
+++ b/secret/service/secret_service_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/flyteorg/flyte/v2/executor/pkg/webhook"
 	flytesecret "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret"
 	secretpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/secret"
 )
@@ -83,7 +88,7 @@ func TestGetK8sSecretName_ScopeHashesDiffer(t *testing.T) {
 
 func TestSecretService_CreateThenGet(t *testing.T) {
 	k := newTestClient(t)
-	s := NewSecretService(k, nil)
+	s := NewSecretService(k, "")
 	ctx := context.Background()
 	id := &secretpb.SecretIdentifier{
 		Project: "flytesnacks",
@@ -106,7 +111,7 @@ func TestSecretService_CreateThenGet(t *testing.T) {
 
 func TestSecretService_GetNotFound_UsesOriginalName(t *testing.T) {
 	k := newTestClient(t)
-	s := NewSecretService(k, nil)
+	s := NewSecretService(k, "")
 	ctx := context.Background()
 	_, err := s.GetSecret(ctx, connect.NewRequest(&secretpb.GetSecretRequest{
 		Id: &secretpb.SecretIdentifier{Name: "my-secret1"},
@@ -119,7 +124,7 @@ func TestSecretService_GetNotFound_UsesOriginalName(t *testing.T) {
 
 func TestSecretService_List_FiltersByScope(t *testing.T) {
 	k := newTestClient(t)
-	s := NewSecretService(k, nil)
+	s := NewSecretService(k, "")
 	ctx := context.Background()
 
 	// Write one secret at each scope.
@@ -165,7 +170,7 @@ func namesOf(secrets []*secretpb.Secret) []string {
 
 func TestSecretService_List_RejectsProjectWithoutDomain(t *testing.T) {
 	k := newTestClient(t)
-	s := NewSecretService(k, nil)
+	s := NewSecretService(k, "")
 	_, err := s.ListSecrets(context.Background(), connect.NewRequest(&secretpb.ListSecretsRequest{Project: "flytesnacks"}))
 	require.Error(t, err)
 }
@@ -223,25 +228,25 @@ func TestK8sSecretWrittenByServiceIsReadableByWebhookFetcher(t *testing.T) {
 	}
 }
 
-type recordingInvalidator struct {
-	calls [][4]string
-}
-
-func (r *recordingInvalidator) InvalidateCache(_ context.Context, org, domain, project, name string) {
-	r.calls = append(r.calls, [4]string{org, domain, project, name})
-}
-
 // Every write path must invalidate the webhook's secret cache, otherwise a task admitted after
 // the write keeps getting the old value until the cache TTL expires. Create counts as a write:
 // a newly created narrow-scope secret can be shadowed by an already-cached broader-scope one.
 func TestSecretService_WritesInvalidateCache(t *testing.T) {
 	ctx := context.Background()
+	var got []webhook.InvalidateRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, webhook.InvalidateSecretPath, r.URL.Path)
+		var req webhook.InvalidateRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		got = append(got, req)
+	}))
+	defer srv.Close()
+
 	id := &secretpb.SecretIdentifier{Project: "flytesnacks", Domain: "development", Name: "my-secret"}
 	spec := &secretpb.SecretSpec{Value: &secretpb.SecretSpec_BinaryValue{BinaryValue: []byte("v")}}
-	want := [4]string{defaultOrganization, "development", "flytesnacks", "my-secret"}
-
-	inv := &recordingInvalidator{}
-	s := NewSecretService(newTestClient(t), inv)
+	s := NewSecretService(newTestClient(t), srv.URL)
 
 	_, err := s.CreateSecret(ctx, connect.NewRequest(&secretpb.CreateSecretRequest{Id: id, SecretSpec: spec}))
 	require.NoError(t, err)
@@ -250,15 +255,33 @@ func TestSecretService_WritesInvalidateCache(t *testing.T) {
 	_, err = s.DeleteSecret(ctx, connect.NewRequest(&secretpb.DeleteSecretRequest{Id: id}))
 	require.NoError(t, err)
 
-	assert.Equal(t, [][4]string{want, want, want}, inv.calls)
+	want := webhook.InvalidateRequest{Org: defaultOrganization, Domain: "development", Project: "flytesnacks", Name: "my-secret"}
+	assert.Equal(t, []webhook.InvalidateRequest{want, want, want}, got)
 }
 
-// The standalone secret-service binary has no in-process webhook; writes must still succeed.
-func TestSecretService_NilInvalidatorIsNoop(t *testing.T) {
-	s := NewSecretService(newTestClient(t), nil)
-	_, err := s.CreateSecret(context.Background(), connect.NewRequest(&secretpb.CreateSecretRequest{
-		Id:         &secretpb.SecretIdentifier{Domain: "development", Name: "s"},
-		SecretSpec: &secretpb.SecretSpec{Value: &secretpb.SecretSpec_BinaryValue{BinaryValue: []byte("v")}},
+// Invalidation is best-effort: the secret is already durably written when it runs, so an
+// unreachable or erroring webhook must not fail the RPC. It only means the old value is served
+// until the webhook cache TTL expires.
+func TestSecretService_InvalidationFailureDoesNotFailWrite(t *testing.T) {
+	spec := &secretpb.SecretSpec{Value: &secretpb.SecretSpec_BinaryValue{BinaryValue: []byte("v")}}
+
+	failing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
 	}))
-	require.NoError(t, err)
+	defer failing.Close()
+
+	for name, url := range map[string]string{
+		"disabled":     "",
+		"unreachable":  "http://127.0.0.1:1",
+		"server error": failing.URL,
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := NewSecretService(newTestClient(t), url)
+			_, err := s.CreateSecret(context.Background(), connect.NewRequest(&secretpb.CreateSecretRequest{
+				Id:         &secretpb.SecretIdentifier{Domain: "development", Name: "s"},
+				SecretSpec: spec,
+			}))
+			require.NoError(t, err)
+		})
+	}
 }

--- a/secret/service/secret_service_test.go
+++ b/secret/service/secret_service_test.go
@@ -5,8 +5,12 @@ import (
 	"testing"
 
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
@@ -308,4 +312,88 @@ func TestSecretService_DeleteInvalidatesEvenWhenNotFound(t *testing.T) {
 	assert.Equal(t, []webhook.InvalidateRequest{
 		{Org: defaultOrganization, Domain: "development", Name: "never-created"},
 	}, got)
+}
+
+// A headless Service resolves to one A record per webhook pod, and each replica caches
+// independently — so invalidation has to reach every one of them. Posting to the name and
+// letting the HTTP client pick an address would silently invalidate one pod and leave the rest
+// serving stale secrets. localhost is the stand-in here: it resolves to 127.0.0.1 and, on a
+// dual-stack host, ::1 as well.
+func TestSecretService_InvalidationFansOutToEveryResolvedAddress(t *testing.T) {
+	ips, err := net.DefaultResolver.LookupHost(context.Background(), "localhost")
+	require.NoError(t, err)
+
+	// One listener per resolved address, all on the same port, so a fan-out hits each exactly
+	// once and a single-target implementation hits exactly one.
+	port, listeners, hits := newPerAddressListeners(t, ips)
+	defer func() {
+		for _, l := range listeners {
+			_ = l.Close()
+		}
+	}()
+
+	s := NewSecretService(newTestClient(t), fmt.Sprintf("http://localhost:%s", port))
+	_, err = s.CreateSecret(context.Background(), connect.NewRequest(&secretpb.CreateSecretRequest{
+		Id:         &secretpb.SecretIdentifier{Domain: "development", Name: "fanout"},
+		SecretSpec: &secretpb.SecretSpec{Value: &secretpb.SecretSpec_BinaryValue{BinaryValue: []byte("v")}},
+	}))
+	require.NoError(t, err)
+
+	for _, ip := range ips {
+		assert.Equal(t, int32(1), hits[ip].Load(), "address %s should have been invalidated exactly once", ip)
+	}
+}
+
+// newPerAddressListeners binds one HTTP server per address on a shared free port and returns
+// that port plus a per-address hit counter.
+func newPerAddressListeners(t *testing.T, ips []string) (string, []net.Listener, map[string]*atomic.Int32) {
+	t.Helper()
+
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := strconv.Itoa(probe.Addr().(*net.TCPAddr).Port)
+	require.NoError(t, probe.Close())
+
+	hits := make(map[string]*atomic.Int32, len(ips))
+	listeners := make([]net.Listener, 0, len(ips))
+	for _, ip := range ips {
+		counter := &atomic.Int32{}
+		hits[ip] = counter
+
+		l, err := net.Listen("tcp", net.JoinHostPort(ip, port))
+		require.NoError(t, err, "binding %s", ip)
+		listeners = append(listeners, l)
+
+		srv := &http.Server{Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, webhook.InvalidateSecretPath, r.URL.Path)
+			counter.Add(1)
+		})}
+		go func() { _ = srv.Serve(l) }()
+	}
+	return port, listeners, hits
+}
+
+// Target construction is host-independent: an IP literal passes through the resolver untouched,
+// so these lock in the port defaulting and scheme/path assembly without depending on DNS.
+func TestSecretService_InvalidationTargets(t *testing.T) {
+	for name, tc := range map[string]struct {
+		url  string
+		want []string
+	}{
+		"explicit port":  {"http://127.0.0.1:9999", []string{"http://127.0.0.1:9999/invalidate-secret"}},
+		"default port":   {"http://127.0.0.1", []string{"http://127.0.0.1:9444/invalidate-secret"}},
+		"trailing slash": {"http://127.0.0.1:9999/", []string{"http://127.0.0.1:9999/invalidate-secret"}},
+		"ipv6 literal":   {"http://[::1]:9999", []string{"http://[::1]:9999/invalidate-secret"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := NewSecretService(nil, tc.url).invalidationTargets(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("rejects a url with no host", func(t *testing.T) {
+		_, err := NewSecretService(nil, "not-a-url").invalidationTargets(context.Background())
+		assert.Error(t, err)
+	})
 }

--- a/secret/service/secret_service_test.go
+++ b/secret/service/secret_service_test.go
@@ -397,3 +397,33 @@ func TestSecretService_InvalidationTargets(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+// A client that hangs up after the write is persisted must not leave the webhook serving the old
+// value: by then the secret is already durably changed, and the cancelled request context would
+// otherwise propagate into DNS resolution and the POST, failing invalidation for up to the cache
+// TTL. Fails without context.WithoutCancel in invalidateWebhookSecretCache.
+func TestSecretService_InvalidatesWithAlreadyCancelledContext(t *testing.T) {
+	got := make(chan webhook.InvalidateRequest, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		var req webhook.InvalidateRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		got <- req
+	}))
+	defer srv.Close()
+
+	// Cancelled before the call, standing in for a caller that hung up once the write landed.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	NewSecretService(newTestClient(t), srv.URL).invalidateWebhookSecretCache(ctx,
+		&secretpb.SecretIdentifier{Domain: "development", Project: "flytesnacks", Name: "hungup"})
+
+	select {
+	case req := <-got:
+		assert.Equal(t, webhook.InvalidateRequest{
+			Org: defaultOrganization, Domain: "development", Project: "flytesnacks", Name: "hungup",
+		}, req)
+	default:
+		t.Fatal("invalidation was not sent: a cancelled caller context suppressed it")
+	}
+}

--- a/secret/setup.go
+++ b/secret/setup.go
@@ -18,7 +18,7 @@ const otelServiceName = "secret-service"
 // Setup registers the SecretService handler on the SetupContext mux.
 // Requires sc.K8sClient and sc.Namespace to be set.
 func Setup(ctx context.Context, sc *app.SetupContext) error {
-	svc := service.NewSecretService(sc.K8sClient)
+	svc := service.NewSecretService(sc.K8sClient, sc.SecretCacheInvalidator)
 
 	otelCfg := otelutils.GetConfig()
 	if err := otelutils.RegisterProvidersWithContext(ctx, otelServiceName, otelCfg); err != nil {

--- a/secret/setup.go
+++ b/secret/setup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/otelutils"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/secret/secretconnect"
+	"github.com/flyteorg/flyte/v2/secret/config"
 	"github.com/flyteorg/flyte/v2/secret/service"
 )
 
@@ -18,7 +19,7 @@ const otelServiceName = "secret-service"
 // Setup registers the SecretService handler on the SetupContext mux.
 // Requires sc.K8sClient and sc.Namespace to be set.
 func Setup(ctx context.Context, sc *app.SetupContext) error {
-	svc := service.NewSecretService(sc.K8sClient, sc.SecretCacheInvalidator)
+	svc := service.NewSecretService(sc.K8sClient, config.GetConfig().CacheInvalidationURL)
 
 	otelCfg := otelutils.GetConfig()
 	if err := otelutils.RegisterProvidersWithContext(ctx, otelServiceName, otelCfg); err != nil {

--- a/secret/setup.go
+++ b/secret/setup.go
@@ -19,7 +19,7 @@ const otelServiceName = "secret-service"
 // Setup registers the SecretService handler on the SetupContext mux.
 // Requires sc.K8sClient and sc.Namespace to be set.
 func Setup(ctx context.Context, sc *app.SetupContext) error {
-	svc := service.NewSecretService(sc.K8sClient, config.GetConfig().CacheInvalidationURL)
+	svc := service.NewSecretService(sc.K8sClient, config.GetConfig().WebhookURL)
 
 	otelCfg := otelutils.GetConfig()
 	if err := otelutils.RegisterProvidersWithContext(ctx, otelServiceName, otelCfg); err != nil {


### PR DESCRIPTION
## Why are the changes needed?

The pod webhook's embedded secret manager caches resolved secret values so it doesn't hit the
backing store on every pod admission, with a **24h default TTL**. Nothing ever invalidated that
cache, so after a user wrote a secret through `SecretService`, task pods kept getting the **old**
value for up to a day. Users hit this as "I rotated my secret and my tasks still fail auth."

Two sharper cases fall out of the same gap:

**Cascade shadowing.** `lookUpSecret` resolves through a project+domain → domain → org cascade and
caches under whichever scope the fetcher hit. One logical secret can therefore be cached under any
of `(org, domain, project)`, `(org, domain, "")`, or `(org, "", "")`. Clearing only the exact tuple
misses a value cached at a broader scope, and the cascade keeps serving it. Concretely: an
org-scoped secret is cached, a user then creates a project-scoped override, the project key is
invalidated, the org key survives, and the cascade still returns the old value. This is why
**create** invalidates too, not just update.

**Deleted secrets staying live.** If the Secret is already gone from Kubernetes (deleted
out-of-band), `DeleteSecret` returns `NotFound`. Returning early there left the webhook serving the
cached value — a secret the user believes is deleted keeps being injected into pods until TTL.

## What changes were proposed in this pull request?

**Webhook side — clearing the cache**

- `InvalidateCache` is part of the `SecretsInjector` interface, so adding a caching injector
  without wiring up invalidation is a compile error rather than a silently reintroduced staleness
  bug. Read-through injectors (global, k8s, aws, gcp, azure, vault) implement it as a no-op.
- `EmbeddedSecretManagerInjector.InvalidateCache` clears all three cascade keys — the caller can't
  know which scope the cached copy lived at, and the deletes are cheap.
- `SecretsPodMutator.InvalidateCache` fans out across enabled injectors.
- A plain-HTTP server on its own port (`webhook.cacheInvalidationPort`, default 9444) exposes
  `POST /invalidate-secret`, so invalidation keeps working once the webhook no longer shares a
  process with the secret service. `0` disables it.

**Secret service side — triggering it**

- Posts to the webhook after every write: create, update, and delete. Delete invalidates on its
  `NotFound` path too, via `defer`.
- Resolves the configured host and posts to **every** address rather than issuing one request to
  the name. Against a headless Service the name yields an A record per pod and Go's client picks
  one, so a single request would invalidate one arbitrary replica and leave the rest stale — a
  failure that looks exactly like success. A ClusterIP Service or bare host resolves to one
  address, so both topologies share the path.
- Best-effort by design: the secret is already durably written when invalidation runs, so failures
  are logged with an `n/m` pod count and the write RPC still succeeds. The degraded state is
  "old value until TTL", which is exactly the pre-PR behavior.

**Chart**

- A headless Service (`clusterIP: None`, port 9444) resolving to every webhook pod. Added
  **alongside** the existing webhook Service rather than converting it — that one is what the
  `MutatingWebhookConfiguration` points the API server at for admission and must keep its
  ClusterIP.
- `flyte-core-components.secret.webhookURL` points at it; the Go default stays `localhost` so
  local and devbox runs need no DNS.

**Incidental**

- The org is part of the secret cache key, so the value stamped on pod labels, used to encode the
  secret name, and passed to `InvalidateCache` must agree. They were three independent `"flyte"`
  literals in three packages; hoisted to `flytesecret.DefaultOrganization`.

### Security note

`/invalidate-secret` is plain HTTP and unauthenticated. It is bound to its own port and included
only in the cluster-internal Services, never routed through an ingress. It carries no secret
material in either direction — the request names a secret, the response is a status code — but it
is a cache-eviction primitive and should stay cluster-internal.

### A naming trap worth knowing

The webhook now serves two ports: **9443 for admission, 9444 for invalidation**. `webhookURL` does
not say which, and a URL with no port defaults to 9444. The field comment, config comment, pflag
help, and values.yaml comment all state this explicitly.

## How was this patch tested?

**Unit tests**

- `InvalidateCache` clears exactly the three cascade keys.
- Create, update, and delete each invalidate with the right `(org, domain, project, name)`.
- Delete invalidates even when the Secret is missing, while still reporting `NotFound`.
- Invalidation failure (disabled, unreachable, 5xx) never fails the write.
- Fan-out reaches every resolved address; target construction covers port defaulting, IPv6
  bracketing, trailing slash, and no-host rejection.
- Server: valid request 200, missing name 400, malformed body 400, `GET` 405.

`go build ./...` and `go test ./flyteplugins/go/tasks/pluginmachinery/secret/... ./executor/... ./secret/...`
pass. `helm lint` and `helm template` clean; chart README regenerated with helm-docs.

**End-to-end on a live single-binary cluster**

Rotation, against the 24h TTL that would otherwise make a stale read permanent:

| Step | Action | Task saw |
|---|---|---|
| 1 | create secret `v1`, run task | `v1` (now cached) |
| 2 | rotate to `v2` via the API, run task | `v2` — invalidation worked |
| 3 | patch the k8s Secret directly to `v3`, bypassing the service | `v2` — **stale, proving the cache is real** |
| 4 | `POST /invalidate-secret` by hand, run task | `v3` |

Step 3 is the control; without it step 2 proves nothing.

Deleted-secret fix, same shape:

| Step | Action | Result |
|---|---|---|
| 1 | create secret, run task | value injected, now cached |
| 2 | `kubectl delete` the Secret out-of-band | k8s empty, cache warm |
| 3 | run task | **still injected** — the bug |
| 4 | `DeleteSecret` on the now-missing secret | `NotFound` returned **and** invalidation fired |
| 5 | run task | pod never created; admission denied |

Fan-out was verified against a headless Service with two endpoints — one real pod and one dead
address — since the binary is not yet multi-replica-ready (see below). A single write produced an
invalidation on the real pod *and* a connection attempt to the dead one, ending in
`failed on 1/2 webhook pod(s)`: both addresses attempted from one write, which a single-request
implementation cannot produce.

## Known limitations

- **Fan-out is not exercised by real replicas yet.** `flyte-binary` is hardcoded to `replicas: 1`,
  and running more today would be unsafe for unrelated reasons: leader election defaults to off,
  and with `localCert: true` each replica mints its own webhook cert and races on the
  `MutatingWebhookConfiguration` CA bundle. The headless Service and fan-out are in place so
  invalidation is already correct when those are fixed; they are not a claim that multi-replica
  works today.
- **Invalidation is best-effort.** A wedged or unreachable webhook degrades to TTL behavior with a
  warning log rather than failing the write.

### Labels

**added**, **fixed**

## Check all the applicable boxes

- [x] I updated the documentation accordingly. <!-- chart README regenerated; config documented via pflag help and comments -->
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

https://claude.ai/code/session_01AHoR3R93whTNKzGhP2Mi4w
