### PR TITLE
docs(flyte-binary): clarify s3 endpoint for compatible stores

### DIFF
--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -97,6 +97,8 @@ configuration:
         # Useful for s3-compatible blob stores (e.g. minio)
         v2Signing: false
         # endpoint URL of S3-compatible service
+        # Leave empty for Amazon S3; for other s3-compatible blob stores (e.g. Backblaze B2,
+        # Cloudflare R2, MinIO) set the provider URL, for example https://s3.example-region.example.com
         endpoint: ""
         # authType Type of authentication to use for connecting to S3-compatible service (Supported values: iam, accesskey)
         authType: "iam"


### PR DESCRIPTION
## Why are the changes needed?

`configuration.storage.providerConfig.s3.endpoint` already drives the stow S3 `endpoint` config key (see `charts/flyte-binary/templates/configmap.yaml`), which is what lets a deployment point its metadata and user-data buckets at an S3-compatible object store instead of Amazon S3. The current one-line comment, "URL of S3-compatible service", does not say that the value stays empty for Amazon S3, and does not show what shape the value takes, so it is easy to guess wrong (bare hostname vs full URL) on a first install. The devbox chart already relies on this key for a non-AWS store (`charts/flyte-devbox/values.yaml`), so the behavior is established and this only documents it.

## What changes were proposed in this pull request?

Two comment lines above `endpoint` in `charts/flyte-binary/values.yaml`, following the existing two-line `v2Signing` comment style a few lines above: leave it empty for Amazon S3, otherwise set the provider URL, with an example URL shape and a few S3-compatible stores named as examples.

No values, templates, or defaults change.

## How was this patch tested?

No tests were added, since the change is comment-only. Two local checks:

1. `helm-docs --chart-search-root=charts/flyte-binary` with helm-docs v1.8.0 installed via `go install`, matching `.github/workflows/check-helm-docs.yml`, regenerates `charts/flyte-binary/README.md` with no diff. These are plain comments, not helm-docs `# --` comments, so the generated table is unaffected.
2. `values.yaml` parsed with `yaml.safe_load` and compared against `main`: the resulting tree is identical, so rendered manifests are unchanged.

### Labels

**changed**

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed. (comment-only change, no test run; the helm-docs check was verified locally)
- [x] All commits are signed-off.