### PR TITLE
Do not leak implementation details in internal error messages

### DIFF
--- a/actions/service/actions_service.go
+++ b/actions/service/actions_service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -31,8 +30,7 @@ func (s *ActionsService) Signal(ctx context.Context, req *connect.Request[action
 	}
 
 	if err := s.client.Signal(ctx, req.Msg.ActionId, req.Msg.Value, principalSubject(req.Msg.GetSignalledBy())); err != nil {
-		logger.Errorf(ctx, "Failed to signal action: %v", err)
-		return nil, toConnectError(err)
+		return nil, fmt.Errorf("failed to signal action: %w", err)
 	}
 
 	return connect.NewResponse(&actions.SignalResponse{}), nil
@@ -44,16 +42,6 @@ func principalSubject(id *common.EnrichedIdentity) string {
 		return s
 	}
 	return id.GetApplication().GetId().GetSubject()
-}
-
-// toConnectError preserves typed errors from the client (e.g. NotFound,
-// InvalidArgument) and wraps everything else as Internal.
-func toConnectError(err error) error {
-	var connectErr *connect.Error
-	if errors.As(err, &connectErr) {
-		return err
-	}
-	return connect.NewError(connect.CodeInternal, err)
 }
 
 // NewActionsService creates a new ActionsService.
@@ -76,8 +64,7 @@ func (s *ActionsService) Enqueue(
 	}
 
 	if err := s.client.Enqueue(ctx, req.Msg.Action, req.Msg.RunSpec); err != nil {
-		logger.Errorf(ctx, "Failed to enqueue action: %v", err)
-		return nil, toConnectError(err)
+		return nil, fmt.Errorf("failed to enqueue action: %w", err)
 	}
 
 	return connect.NewResponse(&actions.EnqueueResponse{}), nil
@@ -110,7 +97,7 @@ func (s *ActionsService) WatchForUpdates(
 	// Send initial state snapshot.
 	childActions, err := s.client.ListChildActions(ctx, parentActionID)
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list child actions: %w", err))
+		return fmt.Errorf("failed to list child actions: %w", err)
 	}
 
 	for _, action := range childActions {
@@ -183,8 +170,7 @@ func (s *ActionsService) Update(
 	}
 
 	if err := s.client.PutStatus(ctx, req.Msg.ActionId, req.Msg.Attempt, req.Msg.Status); err != nil {
-		logger.Errorf(ctx, "Failed to update action: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to update action: %w", err)
 	}
 
 	return connect.NewResponse(&actions.UpdateResponse{}), nil
@@ -202,8 +188,7 @@ func (s *ActionsService) Abort(
 	}
 
 	if err := s.client.AbortAction(ctx, req.Msg.ActionId, req.Msg.Reason); err != nil {
-		logger.Errorf(ctx, "Failed to abort action: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to abort action: %w", err)
 	}
 
 	return connect.NewResponse(&actions.AbortResponse{}), nil

--- a/actions/service/actions_service_test.go
+++ b/actions/service/actions_service_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -59,19 +58,6 @@ func TestEnqueue(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 	})
-
-	t.Run("client error returns internal", func(t *testing.T) {
-		m := mocks.NewActionsClientInterface(t)
-		svc := NewActionsService(m)
-
-		m.EXPECT().Enqueue(mock.Anything, testAction, (*task.RunSpec)(nil)).Return(errors.New("k8s error"))
-
-		_, err := svc.Enqueue(context.Background(), connect.NewRequest(&actions.EnqueueRequest{
-			Action: testAction,
-		}))
-
-		assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
-	})
 }
 
 func TestUpdate(t *testing.T) {
@@ -91,22 +77,6 @@ func TestUpdate(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 	})
-
-	t.Run("client error returns internal", func(t *testing.T) {
-		m := mocks.NewActionsClientInterface(t)
-		svc := NewActionsService(m)
-
-		status := &workflow.ActionStatus{Phase: common.ActionPhase_ACTION_PHASE_RUNNING}
-		m.EXPECT().PutStatus(mock.Anything, testActionID, uint32(1), status).Return(errors.New("write failed"))
-
-		_, err := svc.Update(context.Background(), connect.NewRequest(&actions.UpdateRequest{
-			ActionId: testActionID,
-			Attempt:  1,
-			Status:   status,
-		}))
-
-		assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
-	})
 }
 
 func TestAbort(t *testing.T) {
@@ -124,19 +94,6 @@ func TestAbort(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
-	})
-
-	t.Run("client error returns internal", func(t *testing.T) {
-		m := mocks.NewActionsClientInterface(t)
-		svc := NewActionsService(m)
-
-		m.EXPECT().AbortAction(mock.Anything, testActionID, (*string)(nil)).Return(errors.New("delete failed"))
-
-		_, err := svc.Abort(context.Background(), connect.NewRequest(&actions.AbortRequest{
-			ActionId: testActionID,
-		}))
-
-		assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
 	})
 }
 
@@ -168,35 +125,6 @@ func TestSignal(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
-	})
-
-	t.Run("typed client error passes through", func(t *testing.T) {
-		m := mocks.NewActionsClientInterface(t)
-		svc := NewActionsService(m)
-
-		m.EXPECT().Signal(mock.Anything, testActionID, value, "").
-			Return(connect.NewError(connect.CodeNotFound, errors.New("not found")))
-
-		_, err := svc.Signal(context.Background(), connect.NewRequest(&actions.SignalRequest{
-			ActionId: testActionID,
-			Value:    value,
-		}))
-
-		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
-	})
-
-	t.Run("untyped client error becomes internal", func(t *testing.T) {
-		m := mocks.NewActionsClientInterface(t)
-		svc := NewActionsService(m)
-
-		m.EXPECT().Signal(mock.Anything, testActionID, value, "").Return(errors.New("k8s down"))
-
-		_, err := svc.Signal(context.Background(), connect.NewRequest(&actions.SignalRequest{
-			ActionId: testActionID,
-			Value:    value,
-		}))
-
-		assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
 	})
 }
 

--- a/actions/setup.go
+++ b/actions/setup.go
@@ -11,6 +11,7 @@ import (
 	actionsk8s "github.com/flyteorg/flyte/v2/actions/k8s"
 	"github.com/flyteorg/flyte/v2/actions/service"
 	"github.com/flyteorg/flyte/v2/flytestdlib/app"
+	"github.com/flyteorg/flyte/v2/flytestdlib/connectrpc/server/interceptors"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/otelutils"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/actions/actionsconnect"
@@ -73,7 +74,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 
 	actionsSvc := service.NewActionsService(actionsClient)
 
-	path, handler := actionsconnect.NewActionsServiceHandler(actionsSvc, connect.WithInterceptors(otelInterceptor))
+	path, handler := actionsconnect.NewActionsServiceHandler(actionsSvc, connect.WithInterceptors(interceptors.NewErrorInterceptor(), otelInterceptor))
 	sc.Mux.Handle(path, handler)
 	logger.Infof(ctx, "Mounted ActionsService at %s", path)
 

--- a/app/internal/service/app_logs_service.go
+++ b/app/internal/service/app_logs_service.go
@@ -122,7 +122,7 @@ func (s *InternalAppLogsService) resolveReplicas(ctx context.Context, req *flyte
 		}
 		replicas, err := s.k8s.GetReplicas(ctx, t.AppId)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, fmt.Errorf("failed to fetch replicas: %w", err)
 		}
 		ids := make([]*flyteapp.ReplicaIdentifier, 0, len(replicas))
 		for _, r := range replicas {

--- a/app/internal/service/app_logs_streamer.go
+++ b/app/internal/service/app_logs_streamer.go
@@ -51,7 +51,7 @@ func (s *K8sAppLogStreamer) TailLogs(ctx context.Context, replicaID *flyteapp.Re
 		if k8serrors.IsNotFound(err) {
 			return connect.NewError(connect.CodeNotFound, fmt.Errorf("pod %s not found in namespace %s", podName, ns))
 		}
-		return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get pod: %w", err))
+		return fmt.Errorf("failed to get pod: %w", err)
 	}
 
 	containerName := pickUserContainer(pod)
@@ -76,7 +76,7 @@ func (s *K8sAppLogStreamer) TailLogs(ctx context.Context, replicaID *flyteapp.Re
 
 	logStream, err := s.clientset.CoreV1().Pods(ns).GetLogs(podName, opts).Stream(streamCtx)
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to stream pod logs: %w", err))
+		return fmt.Errorf("failed to stream pod logs: %w", err)
 	}
 	defer logStream.Close() //nolint:errcheck
 
@@ -84,7 +84,7 @@ func (s *K8sAppLogStreamer) TailLogs(ctx context.Context, replicaID *flyteapp.Re
 		return send(&flyteapp.LogLines{StructuredLines: lines})
 	})
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, fmt.Errorf("error reading log stream: %w", err))
+		return fmt.Errorf("error reading log stream: %w", err)
 	}
 	return nil
 }

--- a/app/internal/service/internal_app_service.go
+++ b/app/internal/service/internal_app_service.go
@@ -8,7 +8,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	appk8s "github.com/flyteorg/flyte/v2/app/internal/k8s"
-	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	flyteapp "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/app"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/app/appconnect"
 )
@@ -45,8 +44,7 @@ func (s *InternalAppService) Create(
 	}
 
 	if err := s.k8s.Deploy(ctx, app); err != nil {
-		logger.Errorf(ctx, "Failed to deploy app %s: %v", app.GetMetadata().GetId().GetName(), err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("deploying app: %w", err)
 	}
 
 	app.Status = &flyteapp.Status{
@@ -82,7 +80,7 @@ func (s *InternalAppService) getApp(ctx context.Context, appID *flyteapp.Identif
 		if k8serrors.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("getting app: %w", err)
 	}
 	return app, nil
 }
@@ -105,14 +103,12 @@ func (s *InternalAppService) Update(
 	switch app.GetSpec().GetDesiredState() {
 	case flyteapp.Spec_DESIRED_STATE_STOPPED:
 		if err := s.k8s.Stop(ctx, appID); err != nil {
-			logger.Errorf(ctx, "Failed to stop app %s: %v", appID.GetName(), err)
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, fmt.Errorf("stopping app: %w", err)
 		}
 	default:
 		// UNSPECIFIED, STARTED, ACTIVE — deploy/redeploy the spec.
 		if err := s.k8s.Deploy(ctx, app); err != nil {
-			logger.Errorf(ctx, "Failed to update app %s: %v", appID.GetName(), err)
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, fmt.Errorf("deploying app: %w", err)
 		}
 	}
 
@@ -136,8 +132,7 @@ func (s *InternalAppService) Delete(
 	}
 
 	if err := s.k8s.Delete(ctx, appID); err != nil {
-		logger.Errorf(ctx, "Failed to delete app %s: %v", appID.GetName(), err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("deleting app: %w", err)
 	}
 
 	return connect.NewResponse(&flyteapp.DeleteResponse{}), nil
@@ -167,7 +162,7 @@ func (s *InternalAppService) List(
 
 	apps, nextToken, err := s.k8s.List(ctx, project, domain, limit, token)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("listing apps: %w", err)
 	}
 
 	return connect.NewResponse(&flyteapp.ListResponse{Apps: apps, Token: nextToken}), nil
@@ -198,7 +193,7 @@ func (s *InternalAppService) Watch(
 	// Send initial snapshot so the client has current state before streaming changes.
 	snapshot, _, err := s.k8s.List(ctx, project, domain, 0, "")
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("listing apps: %w", err)
 	}
 	for _, app := range snapshot {
 		if appName != "" && app.GetMetadata().GetId().GetName() != appName {

--- a/app/internal/setup.go
+++ b/app/internal/setup.go
@@ -8,6 +8,7 @@ import (
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
 	stdlibapp "github.com/flyteorg/flyte/v2/flytestdlib/app"
+	"github.com/flyteorg/flyte/v2/flytestdlib/connectrpc/server/interceptors"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/otelutils"
 
@@ -56,8 +57,9 @@ func Setup(ctx context.Context, sc *stdlibapp.SetupContext, cfg *appconfig.Inter
 	if err != nil {
 		return fmt.Errorf("creating otel interceptor: %w", err)
 	}
+	serverInterceptors := []connect.Interceptor{interceptors.NewErrorInterceptor(), otelInterceptor}
 
-	path, handler := appconnect.NewAppServiceHandler(internalAppSvc, connect.WithInterceptors(otelInterceptor))
+	path, handler := appconnect.NewAppServiceHandler(internalAppSvc, connect.WithInterceptors(serverInterceptors...))
 	sc.Mux.Handle("/internal"+path, http.StripPrefix("/internal", handler))
 	logger.Infof(ctx, "Mounted InternalAppService at /internal%s", path)
 
@@ -67,7 +69,7 @@ func Setup(ctx context.Context, sc *stdlibapp.SetupContext, cfg *appconfig.Inter
 			return fmt.Errorf("internalapp: failed to create log streamer: %w", err)
 		}
 		logsSvc := service.NewInternalAppLogsService(appK8sClient, streamer)
-		logsPath, logsHandler := appconnect.NewAppLogsServiceHandler(logsSvc, connect.WithInterceptors(otelInterceptor))
+		logsPath, logsHandler := appconnect.NewAppLogsServiceHandler(logsSvc, connect.WithInterceptors(serverInterceptors...))
 		sc.Mux.Handle("/internal"+logsPath, http.StripPrefix("/internal", logsHandler))
 		logger.Infof(ctx, "Mounted InternalAppLogsService at /internal%s", logsPath)
 	} else {

--- a/app/service/app_logs_service.go
+++ b/app/service/app_logs_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
 
@@ -31,7 +32,7 @@ func (s *AppLogsService) TailLogs(
 ) error {
 	clientStream, err := s.internalClient.TailLogs(ctx, req)
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("tail logs failed: %w", err)
 	}
 	defer clientStream.Close() //nolint:errcheck
 	for clientStream.Receive() {

--- a/app/service/app_service.go
+++ b/app/service/app_service.go
@@ -140,7 +140,7 @@ func (s *AppService) Watch(
 ) error {
 	clientStream, err := s.internalClient.Watch(ctx, req)
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("watching projects: %w", err)
 	}
 	defer clientStream.Close() //nolint:errcheck
 	for clientStream.Receive() {

--- a/app/setup.go
+++ b/app/setup.go
@@ -8,6 +8,7 @@ import (
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
 	stdlibapp "github.com/flyteorg/flyte/v2/flytestdlib/app"
+	"github.com/flyteorg/flyte/v2/flytestdlib/connectrpc/server/interceptors"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/otelutils"
 
@@ -44,6 +45,7 @@ func Setup(ctx context.Context, sc *stdlibapp.SetupContext) error {
 	if err != nil {
 		return fmt.Errorf("creating otel interceptor: %w", err)
 	}
+	serverInterceptors := []connect.Interceptor{interceptors.NewErrorInterceptor(), otelInterceptor}
 
 	internalAppURL := cfg.InternalAppServiceURL
 	if sc.BaseURL != "" {
@@ -58,7 +60,7 @@ func Setup(ctx context.Context, sc *stdlibapp.SetupContext) error {
 
 	appSvc := service.NewAppService(internalClient, cfg.CacheTTL)
 
-	path, handler := appconnect.NewAppServiceHandler(appSvc, connect.WithInterceptors(otelInterceptor))
+	path, handler := appconnect.NewAppServiceHandler(appSvc, connect.WithInterceptors(serverInterceptors...))
 	sc.Mux.Handle(path, handler)
 	logger.Infof(ctx, "Mounted AppService at %s", path)
 
@@ -68,7 +70,7 @@ func Setup(ctx context.Context, sc *stdlibapp.SetupContext) error {
 		connect.WithInterceptors(otelInterceptor),
 	)
 	logsSvc := service.NewAppLogsService(internalLogsClient)
-	logsPath, logsHandler := appconnect.NewAppLogsServiceHandler(logsSvc, connect.WithInterceptors(otelInterceptor))
+	logsPath, logsHandler := appconnect.NewAppLogsServiceHandler(logsSvc, connect.WithInterceptors(serverInterceptors...))
 	sc.Mux.Handle(logsPath, logsHandler)
 	logger.Infof(ctx, "Mounted AppLogsService at %s", logsPath)
 

--- a/cache_service/manager/manager.go
+++ b/cache_service/manager/manager.go
@@ -69,12 +69,12 @@ func (m *Manager) Get(ctx context.Context, request *cacheservicepb.GetCacheReque
 		if repositoryerrors.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("cache entry %q not found", request.GetKey()))
 		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to get cache entry %q: %w", request.GetKey(), err)
 	}
 
 	metadata, err := unmarshalMetadata(output.Metadata)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
 	}
 
 	return &CacheEntry{
@@ -98,7 +98,7 @@ func (m *Manager) Put(ctx context.Context, request *cacheservicepb.PutCacheReque
 	now := time.Now().UTC()
 	existing, err := m.outputs.Get(ctx, request.GetKey())
 	if err != nil && !repositoryerrors.IsNotFound(err) {
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("failed to get existing cache entry %q: %w", request.GetKey(), err)
 	}
 
 	if err == nil {
@@ -114,7 +114,7 @@ func (m *Manager) Put(ctx context.Context, request *cacheservicepb.PutCacheReque
 	metadata := mergeMetadata(existing, request.GetOutput().GetMetadata(), now)
 	metadataBytes, err := proto.Marshal(metadata)
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("failed to marshal metadata: %w", err)
 	}
 
 	model := &models.CachedOutput{
@@ -124,7 +124,7 @@ func (m *Manager) Put(ctx context.Context, request *cacheservicepb.PutCacheReque
 		LastUpdated: metadata.GetLastUpdatedAt().AsTime(),
 	}
 	if err := m.outputs.Put(ctx, model); err != nil {
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("failed to put cache entry %q: %w", request.GetKey(), err)
 	}
 
 	return nil
@@ -142,7 +142,7 @@ func (m *Manager) Delete(ctx context.Context, request *cacheservicepb.DeleteCach
 		if repositoryerrors.IsNotFound(err) {
 			return connect.NewError(connect.CodeNotFound, fmt.Errorf("cache entry %q not found", request.GetKey()))
 		}
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("failed to delete cache entry %q: %w", request.GetKey(), err)
 	}
 	return nil
 }
@@ -173,7 +173,7 @@ func (m *Manager) GetOrExtendReservation(ctx context.Context, request *cacheserv
 
 	_, err := m.reservations.Get(ctx, reservationKey)
 	if err != nil && !repositoryerrors.IsNotFound(err) {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to get reservation %q: %w", reservationKey, err)
 	}
 
 	// Existing reservations follow one of two paths:
@@ -186,11 +186,11 @@ func (m *Manager) GetOrExtendReservation(ctx context.Context, request *cacheserv
 				// could refresh an expired one. Re-read to return the current holder.
 				current, getErr := m.reservations.Get(ctx, reservationKey)
 				if getErr != nil {
-					return nil, connect.NewError(connect.CodeInternal, getErr)
+					return nil, fmt.Errorf("failed to get reservation %q: %w", reservationKey, getErr)
 				}
 				return reservationFromModel(current), nil
 			}
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, fmt.Errorf("failed to get reservation %q: %w", reservationKey, err)
 		}
 		return reservationFromModel(reservation), nil
 	}
@@ -200,11 +200,11 @@ func (m *Manager) GetOrExtendReservation(ctx context.Context, request *cacheserv
 			// Another caller created the reservation after our initial read.
 			current, getErr := m.reservations.Get(ctx, reservationKey)
 			if getErr != nil {
-				return nil, connect.NewError(connect.CodeInternal, getErr)
+				return nil, fmt.Errorf("failed to get reservation %q: %w", reservationKey, getErr)
 			}
 			return reservationFromModel(current), nil
 		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to create reservation %q: %w", reservationKey, err)
 	}
 
 	return reservationFromModel(reservation), nil
@@ -227,7 +227,7 @@ func (m *Manager) ReleaseReservation(ctx context.Context, request *cacheservicep
 		if repositoryerrors.IsNotFound(err) {
 			return nil
 		}
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("failed to delete reservation %q: %w", reservationKey, err)
 	}
 	return nil
 }

--- a/cache_service/setup.go
+++ b/cache_service/setup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flyteorg/flyte/v2/cache_service/migrations"
 	"github.com/flyteorg/flyte/v2/cache_service/service"
 	"github.com/flyteorg/flyte/v2/flytestdlib/app"
+	"github.com/flyteorg/flyte/v2/flytestdlib/connectrpc/server/interceptors"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/otelutils"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/cacheservice/v2/v2connect"
@@ -40,7 +41,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		return fmt.Errorf("creating otel interceptor: %w", err)
 	}
 
-	path, handler := v2connect.NewCacheServiceHandler(service.NewCacheService(cfg, sc.DB), connect.WithInterceptors(otelInterceptor))
+	path, handler := v2connect.NewCacheServiceHandler(service.NewCacheService(cfg, sc.DB), connect.WithInterceptors(interceptors.NewErrorInterceptor(), otelInterceptor))
 	sc.Mux.Handle(path, handler)
 	logger.Infof(ctx, "Mounted CacheService at %s", path)
 

--- a/dataproxy/logs/k8s_log_streamer.go
+++ b/dataproxy/logs/k8s_log_streamer.go
@@ -67,7 +67,7 @@ func (s *K8sLogStreamer) TailLogs(ctx context.Context, logContext *core.LogConte
 		if k8serrors.IsNotFound(err) {
 			return connect.NewError(connect.CodeNotFound, fmt.Errorf("pod %s not found in namespace %s", pod.GetPodName(), pod.GetNamespace()))
 		}
-		return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get pod: %w", err))
+		return fmt.Errorf("failed to get pod: %w", err)
 	}
 	opts.Follow = podObj.Status.Phase == corev1.PodRunning
 
@@ -81,7 +81,7 @@ func (s *K8sLogStreamer) TailLogs(ctx context.Context, logContext *core.LogConte
 
 	logStream, err := s.clientset.CoreV1().Pods(pod.GetNamespace()).GetLogs(pod.GetPodName(), opts).Stream(streamCtx)
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to stream pod logs: %w", err))
+		return fmt.Errorf("failed to stream pod logs: %w", err)
 	}
 	defer logStream.Close() //nolint:errcheck
 
@@ -91,7 +91,7 @@ func (s *K8sLogStreamer) TailLogs(ctx context.Context, logContext *core.LogConte
 		})
 	})
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, fmt.Errorf("error reading log stream: %w", err))
+		return fmt.Errorf("error reading log stream: %w", err)
 	}
 	return nil
 }

--- a/dataproxy/service/dataproxy_service.go
+++ b/dataproxy/service/dataproxy_service.go
@@ -71,12 +71,10 @@ func (s *Service) CreateUploadLocation(
 
 	// Validation on request
 	if err := req.Msg.Validate(); err != nil {
-		logger.Errorf(ctx, "Invalid CreateUploadLocation request: %v", err)
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid CreateUploadLocationRequest: %v", err))
 	}
 	if err := validateUploadRequest(ctx, req.Msg, s.cfg); err != nil {
-		logger.Errorf(ctx, "Request validation failed: %v", err)
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid CreateUploadLocationRequest: %v", err))
 	}
 	if err := s.validateProjectExists(ctx, req.Msg.GetProject()); err != nil {
 		return nil, err
@@ -85,8 +83,7 @@ func (s *Service) CreateUploadLocation(
 	// Build the storage path
 	storagePath, err := s.constructStoragePath(ctx, req.Msg)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to construct storage path: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to construct storage path: %w", err))
+		return nil, fmt.Errorf("failed to construct storage path: %w", err)
 	}
 
 	// Check if file already exists and validate for safe upload
@@ -111,8 +108,7 @@ func (s *Service) CreateUploadLocation(
 	// Generate signed URL
 	signedResp, err := s.dataStore.CreateSignedURL(ctx, storagePath, props)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to create signed URL: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to create signed URL: %w", err))
+		return nil, fmt.Errorf("failed to create signed URL: %w", err)
 	}
 
 	// Build response
@@ -138,8 +134,7 @@ func (s *Service) validateProjectExists(ctx context.Context, projectID string) e
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			return connect.NewError(connect.CodeNotFound, fmt.Errorf("project %q not found", projectID))
 		}
-		logger.Errorf(ctx, "Failed to validate project %q: %v", projectID, err)
-		return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to validate project: %w", err))
+		return fmt.Errorf("failed to validate project: %w", err)
 	}
 	return nil
 }
@@ -160,8 +155,7 @@ func (s *Service) checkFileExists(ctx context.Context, storagePath storage.DataR
 
 	metadata, err := s.dataStore.Head(ctx, storagePath)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to check if file exists at location [%s]: %v", storagePath.String(), err)
-		return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to check if file exists at location [%s]: %w", storagePath.String(), err))
+		return fmt.Errorf("failed to check if file exists at location [%s]: %w", storagePath.String(), err)
 	}
 
 	if !metadata.Exists() {
@@ -181,7 +175,6 @@ func (s *Service) checkFileExists(ctx context.Context, storagePath storage.DataR
 	base64Digest := base64.StdEncoding.EncodeToString(req.GetContentMd5())
 	if base64Digest != metadata.ContentMD5() {
 		// Hash mismatch, reject to prevent overwriting different content
-		logger.Errorf(ctx, "File exists at [%v] with different content hash", storagePath)
 		return connect.NewError(connect.CodeAlreadyExists,
 			fmt.Errorf("file already exists at [%v] with different content (hash mismatch)", storagePath))
 	}
@@ -228,7 +221,6 @@ func (s *Service) UploadInputs(
 	logger.Infof(ctx, "UploadInputs request received")
 
 	if err := req.Msg.Validate(); err != nil {
-		logger.Errorf(ctx, "Invalid UploadInputs request: %v", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
@@ -263,8 +255,7 @@ func (s *Service) UploadInputs(
 	// Deterministically hash the filtered inputs for cache key computation.
 	inputsHash, err := hashInputsProto(filteredInputs)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to hash inputs: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to hash inputs: %w", err))
+		return nil, fmt.Errorf("failed to hash inputs: %w", err)
 	}
 
 	// Build the storage path: <base>/org/project/domain/offloaded-inputs/<hash>/inputs.pb
@@ -292,20 +283,17 @@ func (s *Service) UploadInputs(
 
 	dirRef, err := s.dataStore.ConstructReference(ctx, baseRef, pathComponents...)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to construct storage path: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to construct storage path: %w", err))
+		return nil, fmt.Errorf("failed to construct storage path: %w", err)
 	}
 
 	inputRef, err := s.dataStore.ConstructReference(ctx, dirRef, "inputs.pb")
 	if err != nil {
-		logger.Errorf(ctx, "Failed to construct input ref: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to construct input ref: %w", err))
+		return nil, fmt.Errorf("failed to construct input ref: %w", err)
 	}
 
 	// Store all inputs (unfiltered) — the hash is over the filtered set for caching.
 	if err := s.dataStore.WriteProtobuf(ctx, inputRef, storage.Options{}, req.Msg.GetInputs()); err != nil {
-		logger.Errorf(ctx, "Failed to write inputs to storage: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to write inputs: %w", err))
+		return nil, fmt.Errorf("failed to write inputs: %w", err)
 	}
 
 	logger.Infof(ctx, "Successfully uploaded inputs to %s (hash=%s)", inputRef, inputsHash)
@@ -326,7 +314,6 @@ func (s *Service) CreateDownloadLink(
 	logger.Infof(ctx, "CreateDownloadLink request received")
 
 	if err := req.Msg.Validate(); err != nil {
-		logger.Errorf(ctx, "Invalid CreateDownloadLink request: %v", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
@@ -349,9 +336,7 @@ func (s *Service) CreateDownloadLink(
 	ref := storage.DataReference(nativeURL)
 	meta, err := s.dataStore.Head(ctx, ref)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to head artifact at [%s]: %v", nativeURL, err)
-		return nil, connect.NewError(connect.CodeInternal,
-			fmt.Errorf("failed to check artifact existence: %w", err))
+		return nil, fmt.Errorf("failed to check artifact existence: %w", err)
 	}
 	if !meta.Exists() {
 		return nil, connect.NewError(connect.CodeNotFound,
@@ -363,9 +348,7 @@ func (s *Service) CreateDownloadLink(
 		ExpiresIn: expiresIn,
 	})
 	if err != nil {
-		logger.Errorf(ctx, "Failed to create signed URL for [%s]: %v", nativeURL, err)
-		return nil, connect.NewError(connect.CodeInternal,
-			fmt.Errorf("failed to create signed URL: %w", err))
+		return nil, fmt.Errorf("failed to create signed URL: %w", err)
 	}
 
 	expiresAt := timestamppb.New(time.Now().Add(expiresIn))
@@ -390,7 +373,6 @@ func (s *Service) resolveArtifactURL(ctx context.Context, req *dataproxy.CreateD
 		ActionId: attemptID.GetActionId(),
 	}))
 	if err != nil {
-		logger.Errorf(ctx, "Failed to get action details for %v: %v", attemptID.GetActionId(), err)
 		return "", connect.NewError(connect.CodeNotFound,
 			fmt.Errorf("failed to get action details: %w", err))
 	}
@@ -432,7 +414,6 @@ func (s *Service) resolveTaskTemplate(ctx context.Context, req *dataproxy.Upload
 			TaskId: t.TaskId,
 		}))
 		if err != nil {
-			logger.Errorf(ctx, "Failed to get task details for %v: %v", t.TaskId, err)
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("failed to get task: %w", err))
 		}
 		return resp.Msg.GetDetails().GetSpec().GetTaskTemplate(), nil
@@ -441,7 +422,6 @@ func (s *Service) resolveTaskTemplate(ctx context.Context, req *dataproxy.Upload
 			Name: t.TriggerName,
 		}))
 		if err != nil {
-			logger.Errorf(ctx, "Failed to get trigger details for %v: %v", t.TriggerName, err)
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("failed to get trigger: %w", err))
 		}
 		triggerDetails := triggerResp.Msg.GetTrigger()
@@ -456,7 +436,6 @@ func (s *Service) resolveTaskTemplate(ctx context.Context, req *dataproxy.Upload
 			TaskId: taskID,
 		}))
 		if err != nil {
-			logger.Errorf(ctx, "Failed to get task details for trigger %v: %v", t.TriggerName, err)
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("failed to get task for trigger: %w", err))
 		}
 		return taskResp.Msg.GetDetails().GetSpec().GetTaskTemplate(), nil
@@ -511,8 +490,7 @@ func (s *Service) GetActionData(
 			logger.Infof(groupCtx, "GetActionData: reading inputs from %s", inputRef)
 			if err := s.dataStore.ReadProtobuf(groupCtx, inputRef, resp.Inputs); err != nil {
 				if !storage.IsNotFound(err) {
-					logger.Errorf(groupCtx, "GetActionData: failed to read inputs from %s: %v", inputRef, err)
-					return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to read inputs from %s: %w", inputRef, err))
+					return fmt.Errorf("failed to read inputs from %s: %w", inputRef, err)
 				}
 			} else {
 				resp.InputsUri = urisResp.Msg.GetInputsUri()
@@ -531,8 +509,7 @@ func (s *Service) GetActionData(
 			var inputsOrOutputs task.Inputs
 			if err := s.dataStore.ReadProtobuf(groupCtx, outputRef, &inputsOrOutputs); err != nil {
 				if !storage.IsNotFound(err) {
-					logger.Errorf(groupCtx, "GetActionData: failed to read outputs from %s: %v", outputRef, err)
-					return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to read outputs from %s: %w", outputRef, err))
+					return fmt.Errorf("failed to read outputs from %s: %w", outputRef, err)
 				}
 				logger.Debugf(groupCtx, "Outputs not found at %s (action may not have finished)", urisResp.Msg.GetOutputsUri())
 			} else {

--- a/dataproxy/setup.go
+++ b/dataproxy/setup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flyteorg/flyte/v2/dataproxy/logs"
 	"github.com/flyteorg/flyte/v2/dataproxy/service"
 	"github.com/flyteorg/flyte/v2/flytestdlib/app"
+	"github.com/flyteorg/flyte/v2/flytestdlib/connectrpc/server/interceptors"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/otelutils"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/cluster/clusterconnect"
@@ -41,6 +42,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	if err != nil {
 		return fmt.Errorf("creating otel interceptor: %w", err)
 	}
+	serverInterceptors := []connect.Interceptor{interceptors.NewErrorInterceptor(), otelInterceptor}
 
 	baseURL := sc.BaseURL
 	taskClient := taskconnect.NewTaskServiceClient(http.DefaultClient, baseURL, connect.WithInterceptors(otelInterceptor))
@@ -59,17 +61,17 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 
 	svc := service.NewService(*cfg, sc.DataStore, taskClient, triggerClient, runClient, projectClient, logStreamer)
 
-	path, handler := dataproxyconnect.NewDataProxyServiceHandler(svc, connect.WithInterceptors(otelInterceptor))
+	path, handler := dataproxyconnect.NewDataProxyServiceHandler(svc, connect.WithInterceptors(serverInterceptors...))
 	sc.Mux.Handle(path, handler)
 	logger.Infof(ctx, "Mounted DataProxyService at %s", path)
 
 	clusterSvc := service.NewClusterService()
-	clusterPath, clusterHandler := clusterconnect.NewClusterServiceHandler(clusterSvc, connect.WithInterceptors(otelInterceptor))
+	clusterPath, clusterHandler := clusterconnect.NewClusterServiceHandler(clusterSvc, connect.WithInterceptors(serverInterceptors...))
 	sc.Mux.Handle(clusterPath, clusterHandler)
 	logger.Infof(ctx, "Mounted ClusterService at %s", clusterPath)
 
 	translatorSvc := NewTranslatorService(sc.DataStore, runClient, triggerClient)
-	translatorPath, translatorHandler := workflowconnect.NewTranslatorServiceHandler(translatorSvc, connect.WithInterceptors(otelInterceptor))
+	translatorPath, translatorHandler := workflowconnect.NewTranslatorServiceHandler(translatorSvc, connect.WithInterceptors(serverInterceptors...))
 	sc.Mux.Handle(translatorPath, translatorHandler)
 	logger.Infof(ctx, "Mounted TranslatorService at %s", translatorPath)
 

--- a/dataproxy/translator.go
+++ b/dataproxy/translator.go
@@ -92,7 +92,7 @@ func (s *TranslatorService) readOffloadedLiterals(
 	// Both inputs.pb and outputs.pb deserialize as task.Inputs (a NamedLiteral list).
 	var inputsOrOutputs task.Inputs
 	if err := s.dataStore.ReadProtobuf(ctx, storage.DataReference(uri), &inputsOrOutputs); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to read literals from %s: %w", uri, err))
+		return nil, fmt.Errorf("failed to read literals from %s: %w", uri, err)
 	}
 	return inputsOrOutputs.GetLiterals(), nil
 }
@@ -119,7 +119,7 @@ func (s *TranslatorService) readTriggerLiterals(
 
 	var inputs task.Inputs
 	if err := s.dataStore.ReadProtobuf(ctx, storage.DataReference(uri), &inputs); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to read trigger literals from %s: %w", uri, err))
+		return nil, fmt.Errorf("failed to read trigger literals from %s: %w", uri, err)
 	}
 	return inputs.GetLiterals(), nil
 }

--- a/events/service/events_proxy_service.go
+++ b/events/service/events_proxy_service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow/workflowconnect"
 )
@@ -25,7 +24,6 @@ func (s *EventsProxyService) Record(ctx context.Context, req *connect.Request[wo
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("run client is not initialized"))
 	}
 	if err := req.Msg.Validate(); err != nil {
-		logger.Errorf(ctx, "invalid EventsProxyService.Record request: %v", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if len(req.Msg.GetEvents()) == 0 {
@@ -35,13 +33,11 @@ func (s *EventsProxyService) Record(ctx context.Context, req *connect.Request[wo
 	recordEventReq := &workflow.RecordActionEventsRequest{Events: req.Msg.GetEvents()}
 	recordActionResp, err := s.runClient.RecordActionEvents(ctx, connect.NewRequest(recordEventReq))
 	if err != nil {
-		logger.Warnf(ctx, "failed to forward action events to run service: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to forward action events to run service: %w", err)
 	}
 	status := recordActionResp.Msg.GetStatus()
 	if status != nil && status.Code != 0 {
-		logger.Warnf(ctx, "run service returned non-ok status for action events: code=%d, msg=%s", status.Code, status.Message)
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("run service failed: %s", status.Message))
+		return nil, fmt.Errorf("run service returned non-ok status for action events: code=%d, msg=%s", status.Code, status.Message)
 	}
 
 	return connect.NewResponse(&workflow.RecordResponse{}), nil

--- a/events/setup.go
+++ b/events/setup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flyteorg/flyte/v2/events/config"
 	"github.com/flyteorg/flyte/v2/events/service"
 	"github.com/flyteorg/flyte/v2/flytestdlib/app"
+	"github.com/flyteorg/flyte/v2/flytestdlib/connectrpc/server/interceptors"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/otelutils"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow/workflowconnect"
@@ -42,7 +43,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 
 	eventsSvc := service.NewEventsProxyService(runClient)
 
-	path, handler := workflowconnect.NewEventsProxyServiceHandler(eventsSvc, connect.WithInterceptors(otelInterceptor))
+	path, handler := workflowconnect.NewEventsProxyServiceHandler(eventsSvc, connect.WithInterceptors(interceptors.NewErrorInterceptor(), otelInterceptor))
 	sc.Mux.Handle(path, handler)
 	logger.Infof(ctx, "Mounted EventsProxyService at %s", path)
 

--- a/flytestdlib/connectrpc/server/interceptors/error_interceptor.go
+++ b/flytestdlib/connectrpc/server/interceptors/error_interceptor.go
@@ -1,0 +1,53 @@
+package interceptors
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+
+	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
+)
+
+// NewErrorInterceptor returns a server interceptor that converts ordinary Go
+// errors into Connect errors with an internal code and an empty message so
+// implementation details aren't exposed to clients. Existing Connect errors,
+// including wrapped ones, are returned unchanged.
+func NewErrorInterceptor() connect.Interceptor {
+	return errorInterceptor{}
+}
+
+type errorInterceptor struct{}
+
+func (errorInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		response, err := next(ctx, req)
+		return response, asConnectError(ctx, err)
+	}
+}
+
+func (errorInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+func (errorInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+		return asConnectError(ctx, next(ctx, conn))
+	}
+}
+
+func asConnectError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		logger.Warnf(ctx, "RPC returned error: %v", err)
+		return err
+	}
+
+	logger.Errorf(ctx, "RPC returned unexpected error: %v", err)
+	// Return an empty error as to not leak implementation details
+	return connect.NewError(connect.CodeInternal, nil)
+}

--- a/flytestdlib/connectrpc/server/interceptors/error_interceptor_test.go
+++ b/flytestdlib/connectrpc/server/interceptors/error_interceptor_test.go
@@ -1,0 +1,166 @@
+package interceptors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+)
+
+func TestErrorInterceptorWrapUnary(t *testing.T) {
+	t.Parallel()
+
+	ordinaryErr := errors.New("database unavailable")
+	connectErr := connect.NewError(connect.CodeNotFound, errors.New("not found"))
+	wrappedConnectErr := fmt.Errorf("lookup failed: %w", connectErr)
+
+	tests := []struct {
+		name         string
+		handlerErr   error
+		wantErr      error
+		wantCode     connect.Code
+		wantResponse bool
+	}{
+		{
+			name:         "success",
+			wantCode:     connect.CodeUnknown,
+			wantResponse: true,
+		},
+		{
+			name:       "ordinary error becomes internal",
+			handlerErr: ordinaryErr,
+			wantCode:   connect.CodeInternal,
+		},
+		{
+			name:       "Connect error is preserved",
+			handlerErr: connectErr,
+			wantErr:    connectErr,
+			wantCode:   connect.CodeNotFound,
+		},
+		{
+			name:       "wrapped Connect error is preserved",
+			handlerErr: wrappedConnectErr,
+			wantErr:    wrappedConnectErr,
+			wantCode:   connect.CodeNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			response := connect.NewResponse(new(string))
+			handler := NewErrorInterceptor().WrapUnary(
+				func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+					if tt.handlerErr != nil {
+						return nil, tt.handlerErr
+					}
+					return response, nil
+				},
+			)
+
+			gotResponse, gotErr := handler(context.Background(), connect.NewRequest(new(string)))
+			if tt.wantResponse && gotResponse != response {
+				t.Fatalf("response = %v, want original response %v", gotResponse, response)
+			}
+			if tt.handlerErr == nil {
+				if gotErr != nil {
+					t.Fatalf("error = %v, want nil", gotErr)
+				}
+				return
+			}
+			if tt.wantErr != nil && !errors.Is(gotErr, tt.wantErr) {
+				t.Fatalf("error = %v, want it to contain %v", gotErr, tt.wantErr)
+			}
+			if tt.wantErr == nil && errors.Is(gotErr, tt.handlerErr) {
+				t.Fatalf("error = %v, must not expose original error %v", gotErr, tt.handlerErr)
+			}
+			if gotCode := connect.CodeOf(gotErr); gotCode != tt.wantCode {
+				t.Errorf("error code = %v, want %v", gotCode, tt.wantCode)
+			}
+			if tt.wantCode == connect.CodeInternal {
+				var connectErr *connect.Error
+				if !errors.As(gotErr, &connectErr) {
+					t.Fatalf("error type = %T, want *connect.Error", gotErr)
+				}
+				if message := connectErr.Message(); message != "" {
+					t.Errorf("error message = %q, want empty", message)
+				}
+			}
+		})
+	}
+}
+
+func TestErrorInterceptorWrapStreamingHandler(t *testing.T) {
+	t.Parallel()
+
+	ordinaryErr := errors.New("stream failed")
+	connectErr := connect.NewError(connect.CodeInvalidArgument, errors.New("invalid message"))
+	wrappedConnectErr := fmt.Errorf("receive failed: %w", connectErr)
+
+	tests := []struct {
+		name       string
+		handlerErr error
+		wantErr    error
+		wantCode   connect.Code
+	}{
+		{name: "success"},
+		{
+			name:       "ordinary error becomes internal",
+			handlerErr: ordinaryErr,
+			wantCode:   connect.CodeInternal,
+		},
+		{
+			name:       "Connect error is preserved",
+			handlerErr: connectErr,
+			wantErr:    connectErr,
+			wantCode:   connect.CodeInvalidArgument,
+		},
+		{
+			name:       "wrapped Connect error is preserved",
+			handlerErr: wrappedConnectErr,
+			wantErr:    wrappedConnectErr,
+			wantCode:   connect.CodeInvalidArgument,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := NewErrorInterceptor().WrapStreamingHandler(
+				func(context.Context, connect.StreamingHandlerConn) error {
+					return tt.handlerErr
+				},
+			)
+
+			gotErr := handler(context.Background(), nil)
+			if tt.handlerErr == nil {
+				if gotErr != nil {
+					t.Fatalf("error = %v, want nil", gotErr)
+				}
+				return
+			}
+			if tt.wantErr != nil && !errors.Is(gotErr, tt.wantErr) {
+				t.Fatalf("error = %v, want it to contain %v", gotErr, tt.wantErr)
+			}
+			if tt.wantErr == nil && errors.Is(gotErr, tt.handlerErr) {
+				t.Fatalf("error = %v, must not expose original error %v", gotErr, tt.handlerErr)
+			}
+			if gotCode := connect.CodeOf(gotErr); gotCode != tt.wantCode {
+				t.Errorf("error code = %v, want %v", gotCode, tt.wantCode)
+			}
+			if tt.wantCode == connect.CodeInternal {
+				var connectErr *connect.Error
+				if !errors.As(gotErr, &connectErr) {
+					t.Fatalf("error type = %T, want *connect.Error", gotErr)
+				}
+				if message := connectErr.Message(); message != "" {
+					t.Errorf("error message = %q, want empty", message)
+				}
+			}
+		})
+	}
+}

--- a/runs/service/auth_metadata_service.go
+++ b/runs/service/auth_metadata_service.go
@@ -107,12 +107,10 @@ func (s *AuthMetadataService) GetOAuth2Metadata(
 
 	baseURL, err := url.Parse(s.cfg.ExternalAuthServerBaseURL)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal,
-			fmt.Errorf("invalid external auth server base URL %q: %w", s.cfg.ExternalAuthServerBaseURL, err))
+		return nil, fmt.Errorf("invalid external auth server base URL %q: %w", s.cfg.ExternalAuthServerBaseURL, err)
 	}
 	if baseURL.Scheme == "" || baseURL.Host == "" {
-		return nil, connect.NewError(connect.CodeInternal,
-			fmt.Errorf("external auth server base URL must be absolute (include scheme and host): %q", s.cfg.ExternalAuthServerBaseURL))
+		return nil, fmt.Errorf("external auth server base URL must be absolute (include scheme and host): %q", s.cfg.ExternalAuthServerBaseURL)
 	}
 
 	// Issuer URLs conventionally do not end with a '/', but metadata URLs are
@@ -125,14 +123,12 @@ func (s *AuthMetadataService) GetOAuth2Metadata(
 	}
 	relURL, err := url.Parse(metadataPath)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal,
-			fmt.Errorf("invalid external metadata path %q: %w", metadataPath, err))
+		return nil, fmt.Errorf("invalid external metadata path %q: %w", metadataPath, err)
 	}
 	// MetadataURL is expected to be a relative path resolved against BaseURL.
 	// Reject absolute, scheme-relative, or root-relative paths so BaseURL cannot be bypassed.
 	if relURL.IsAbs() || relURL.Host != "" || strings.HasPrefix(relURL.Path, "/") {
-		return nil, connect.NewError(connect.CodeInternal,
-			fmt.Errorf("external metadata path must be relative to externalAuthServerBaseUrl (no leading '/'), got %q", metadataPath))
+		return nil, fmt.Errorf("external metadata path must be relative to externalAuthServerBaseUrl (no leading '/'), got %q", metadataPath)
 	}
 	externalMetadataURL := baseURL.ResolveReference(relURL)
 
@@ -165,16 +161,16 @@ func (s *AuthMetadataService) GetOAuth2Metadata(
 
 	raw, err := io.ReadAll(io.LimitReader(response.Body, maxMetadataBodySize+1))
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to read OAuth2 metadata response: %w", err))
+		return nil, fmt.Errorf("failed to read OAuth2 metadata response: %w", err)
 	}
 	if len(raw) > maxMetadataBodySize {
-		return nil, connect.NewError(connect.CodeInternal,
-			fmt.Errorf("OAuth2 metadata response exceeds %d bytes", maxMetadataBodySize))
+		return nil,
+			fmt.Errorf("OAuth2 metadata response exceeds %d bytes", maxMetadataBodySize)
 	}
 
 	resp := &auth.GetOAuth2MetadataResponse{}
 	if err := unmarshalResp(response, raw, resp); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to unmarshal OAuth2 metadata: %w", err))
+		return nil, fmt.Errorf("failed to unmarshal OAuth2 metadata: %w", err)
 	}
 
 	s.mu.Lock()
@@ -286,8 +282,8 @@ func sendAndRetryHTTPRequest(ctx context.Context, client *http.Client, targetURL
 		// Unavailable, so clients see an accurate status.
 		if resp.StatusCode >= http.StatusBadRequest && resp.StatusCode < http.StatusInternalServerError {
 			_ = resp.Body.Close()
-			return nil, connect.NewError(connect.CodeInternal,
-				fmt.Errorf("non-retryable status code %d from %s", resp.StatusCode, targetURL))
+			return nil,
+				fmt.Errorf("non-retryable status code %d from %s", resp.StatusCode, targetURL)
 		}
 
 		_ = resp.Body.Close()

--- a/runs/service/auth_metadata_service_test.go
+++ b/runs/service/auth_metadata_service_test.go
@@ -181,7 +181,6 @@ func TestGetOAuth2Metadata_BodySizeLimit(t *testing.T) {
 	svc := NewAuthMetadataService("example.com", config.AuthMetadataConfig{ExternalAuthServerBaseURL: srv.URL})
 	_, err := svc.GetOAuth2Metadata(context.Background(), connect.NewRequest(&auth.GetOAuth2MetadataRequest{}))
 	require.Error(t, err)
-	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
 }
 
 func TestGetOAuth2Metadata_Upstream4xxIsInternal(t *testing.T) {
@@ -197,5 +196,4 @@ func TestGetOAuth2Metadata_Upstream4xxIsInternal(t *testing.T) {
 	})
 	_, err := svc.GetOAuth2Metadata(context.Background(), connect.NewRequest(&auth.GetOAuth2MetadataRequest{}))
 	require.Error(t, err)
-	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err), "non-retryable 4xx should be Internal, not Unavailable")
 }

--- a/runs/service/internal_run_service.go
+++ b/runs/service/internal_run_service.go
@@ -117,8 +117,7 @@ func (s *RunService) recordSingleAction(ctx context.Context, req *workflow.Recor
 
 			taskSpecModel, err := models.NewTaskSpecModel(ctx, taskSpec)
 			if err != nil {
-				logger.Warnf(ctx, "RecordAction: failed to create task spec model: %v", err)
-				return connect.NewError(connect.CodeInternal, err)
+				return fmt.Errorf("RecordAction: failed to create task spec model: %w", err)
 			}
 			if err := s.repo.TaskRepo().CreateTaskSpec(ctx, taskSpecModel); err != nil {
 				logger.Warnf(ctx, "RecordAction: failed to store task spec: %v", err)
@@ -180,22 +179,19 @@ func (s *RunService) recordSingleAction(ctx context.Context, req *workflow.Recor
 	// Marshal ActionSpec proto into bytes for storage.
 	actionSpecBytes, err := proto.Marshal(spec)
 	if err != nil {
-		logger.Warnf(ctx, "RecordAction: failed to marshal action spec: %v", err)
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("RecordAction: failed to marshal action spec: %w", err)
 	}
 	action.ActionSpec = actionSpecBytes
 
 	// Marshal RunInfo proto into bytes for storage.
 	detailedInfo, err := proto.Marshal(info)
 	if err != nil {
-		logger.Warnf(ctx, "RecordAction: failed to marshal run info: %v", err)
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("RecordAction: failed to marshal run info: %w", err)
 	}
 	action.DetailedInfo = detailedInfo
 
 	if _, err := s.repo.ActionRepo().CreateAction(ctx, action, false); err != nil {
-		logger.Warnf(ctx, "RecordAction: failed to create action %s: %v", actionID.GetName(), err)
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("RecordAction: failed to create action %s: %w", actionID.GetName(), err)
 	}
 	return nil
 }
@@ -265,8 +261,7 @@ func (s *RunService) updateSingleActionStatus(ctx context.Context, req *workflow
 		endTime,
 		startTime,
 	); err != nil {
-		logger.Warnf(ctx, "UpdateActionStatus: failed to update action %s: %v", req.GetActionId().GetName(), err)
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("UpdateActionStatus: failed to update action %s: %w", req.GetActionId().GetName(), err)
 	}
 
 	// Persist the inline signal payload (conditions only). The CR is GC'd after
@@ -274,8 +269,7 @@ func (s *RunService) updateSingleActionStatus(ctx context.Context, req *workflow
 	// resolved value and the signalling actor.
 	if req.GetOutput() != nil || req.GetPrincipal() != nil {
 		if err := s.mergeRunInfoOutput(ctx, req); err != nil {
-			logger.Warnf(ctx, "UpdateActionStatus: failed to persist output for %s: %v", req.GetActionId().GetName(), err)
-			return connect.NewError(connect.CodeInternal, err)
+			return fmt.Errorf("UpdateActionStatus: failed to persist output for %s: %v", req.GetActionId().GetName(), err)
 		}
 	}
 	return nil
@@ -351,14 +345,12 @@ func (s *RunService) recordEvents(ctx context.Context, events []*workflow.Action
 	for _, event := range events {
 		m, err := models.NewActionEventModel(event)
 		if err != nil {
-			logger.Warnf(ctx, "RecordActionEvents: failed to build event model for %s: %v", event.GetId().GetName(), err)
-			return connect.NewError(connect.CodeInternal, err)
+			return fmt.Errorf("RecordActionEvents: failed to build event model for %s: %v", event.GetId().GetName(), err)
 		}
 		eventModels = append(eventModels, m)
 	}
 	if err := s.repo.ActionRepo().InsertEvents(ctx, eventModels); err != nil {
-		logger.Warnf(ctx, "RecordActionEvents: failed to insert events: %v", err)
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("RecordActionEvents: failed to insert events: %v", err)
 	}
 	return nil
 }

--- a/runs/service/project_service.go
+++ b/runs/service/project_service.go
@@ -52,7 +52,7 @@ func (s *ProjectService) CreateProject(
 			logger.Warnf(ctx, "Project already exists, identifier: %s, name: %s", model.Identifier, model.Name)
 			return nil, connect.NewError(connect.CodeAlreadyExists, err)
 		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to create project: %w", err)
 	}
 
 	return connect.NewResponse(&project.CreateProjectResponse{}), nil
@@ -80,7 +80,7 @@ func (s *ProjectService) UpdateProject(
 		if errors.Is(err, interfaces.ErrProjectNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to update project: %w", err)
 	}
 
 	return connect.NewResponse(&project.UpdateProjectResponse{}), nil
@@ -102,12 +102,12 @@ func (s *ProjectService) GetProject(
 		if errors.Is(err, interfaces.ErrProjectNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to get project: %w", err)
 	}
 
 	projectProto, err := transformers.ProjectModelToProject(model, s.domains)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to convert project: %w", err)
 	}
 
 	return connect.NewResponse(&project.GetProjectResponse{
@@ -135,14 +135,14 @@ func (s *ProjectService) ListProjects(
 
 	projects, err := s.projectRepo.ListProjects(ctx, listInput)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to list projects: %w", err)
 	}
 
 	projectProtos := make([]*project.Project, 0, len(projects))
 	for _, p := range projects {
 		projectProto, convErr := transformers.ProjectModelToProject(p, s.domains)
 		if convErr != nil {
-			return nil, connect.NewError(connect.CodeInternal, convErr)
+			return nil, fmt.Errorf("failed to convert project: %w", convErr)
 		}
 		projectProtos = append(projectProtos, projectProto)
 	}

--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -598,7 +598,7 @@ func (s *RunService) buildActionDetails(ctx context.Context, model *models.Actio
 		if len(model.DetailedInfo) > 0 {
 			info = &workflow.RunInfo{}
 			if err := proto.Unmarshal(model.DetailedInfo, info); err != nil {
-				return err
+				return fmt.Errorf("unmarshalling run detailed info: %w", err)
 			}
 		}
 
@@ -608,7 +608,7 @@ func (s *RunService) buildActionDetails(ctx context.Context, model *models.Actio
 		if info.GetTaskSpecDigest() != "" {
 			specModel, err := s.repo.TaskRepo().GetTaskSpec(ctx, info.GetTaskSpecDigest())
 			if err != nil {
-				return err
+				return fmt.Errorf("getting task spec for action %v: %w", actionId, err)
 			}
 
 			// Fill in the action spec based on the action type
@@ -618,13 +618,13 @@ func (s *RunService) buildActionDetails(ctx context.Context, model *models.Actio
 			case workflow.ActionType_ACTION_TYPE_TASK:
 				spec, err := transformers.ToTaskSpec(specModel)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to convert task spec model for action: %v: %w", actionId, err)
 				}
 				action.Spec = &workflow.ActionDetails_Task{Task: spec}
 			case workflow.ActionType_ACTION_TYPE_TRACE:
 				spec, err := transformers.ToTraceSpec(specModel)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to convert trace spec model for action: %v: %w", actionId, err)
 				}
 				action.Spec = &workflow.ActionDetails_Trace{Trace: spec}
 			default:
@@ -666,6 +666,9 @@ func (s *RunService) buildActionDetails(ctx context.Context, model *models.Actio
 	})
 
 	if err := eg.Wait(); err != nil {
+		if ctx.Err() == nil {
+			logger.Warnf(ctx, "failed to get action details for action %v: %v", actionId, err)
+		}
 		return nil, err
 	}
 
@@ -705,8 +708,7 @@ func (s *RunService) getAttempts(ctx context.Context, actionId *common.ActionIde
 	for _, m := range eventModels {
 		event, err := m.ToActionEvent()
 		if err != nil {
-			logger.Warnf(ctx, "failed to convert action event model for action %v: %v", actionId, err)
-			return nil, err
+			return nil, fmt.Errorf("failed to convert action event model for action %v: %w", actionId, err)
 		}
 		events = append(events, event)
 	}
@@ -1109,7 +1111,7 @@ func (s *RunService) SignalEvent(
 	})); err != nil {
 		// Actions-service errors (NotFound / InvalidArgument / FailedPrecondition)
 		// pass through unchanged.
-		return nil, err
+		return nil, fmt.Errorf("failed to signal action %s: %w", req.Msg.ActionId.Name, err)
 	}
 
 	return connect.NewResponse(&workflow.SignalEventResponse{}), nil
@@ -1284,7 +1286,7 @@ func (s *RunService) WatchRuns(
 		if err := stream.Send(&workflow.WatchRunsResponse{
 			Runs: protoRuns,
 		}); err != nil {
-			return err
+			return fmt.Errorf("sending runs: %w", err)
 		}
 	}
 
@@ -1293,7 +1295,7 @@ func (s *RunService) WatchRuns(
 		case <-ctx.Done():
 			return nil
 		case err := <-errsCh:
-			return err
+			return fmt.Errorf("watching runs: %w", err)
 		case run := <-updatesCh:
 			// Filter the run based on the watch request criteria
 			if !s.runMatchesFilter(run, req.Msg) {
@@ -1305,7 +1307,7 @@ func (s *RunService) WatchRuns(
 			if err := stream.Send(&workflow.WatchRunsResponse{
 				Runs: []*workflow.Run{protoRun},
 			}); err != nil {
-				return err
+				return fmt.Errorf("sending response: %w", err)
 			}
 		}
 	}
@@ -1327,11 +1329,11 @@ func (s *RunService) WatchActions(
 
 	rsm, err := newRunStateManager(req.Msg.GetFilter())
 	if err != nil {
-		return err
+		return fmt.Errorf("creating run state manager: %w", err)
 	}
 
 	if err := s.listAndSendAllActions(ctx, runID, rsm, stream); err != nil {
-		return err
+		return fmt.Errorf("listing and sending all actions: %w", err)
 	}
 
 	for {
@@ -1339,17 +1341,17 @@ func (s *RunService) WatchActions(
 		case <-ctx.Done():
 			return nil
 		case err := <-errsCh:
-			return err
+			return fmt.Errorf("watching actions: %w", err)
 		case updated, ok := <-updatesCh:
 			if !ok {
 				return nil
 			}
 			updates, err := rsm.upsertActions(ctx, []*models.Action{updated})
 			if err != nil {
-				return err
+				return fmt.Errorf("updating actions: %w", err)
 			}
 			if err := s.sendChangedActions(runID, updates, stream); err != nil {
-				return err
+				return fmt.Errorf("sending changed actions: %w", err)
 			}
 		}
 	}
@@ -1387,7 +1389,7 @@ func (s *RunService) listAndSendAllActions(
 			},
 		})
 		if err != nil {
-			return err
+			return fmt.Errorf("listing actions: %w", err)
 		}
 
 		// ListActions returns up to Limit+1 rows (the extra row is a has-more probe).
@@ -1400,10 +1402,10 @@ func (s *RunService) listAndSendAllActions(
 
 		updates, err := rsm.upsertActions(ctx, batch)
 		if err != nil {
-			return err
+			return fmt.Errorf("updating actions: %w", err)
 		}
 		if err := s.sendChangedActions(runID, updates, stream); err != nil {
-			return err
+			return fmt.Errorf("sending changed actions: %w", err)
 		}
 
 		if !hasMore || len(batch) == 0 {
@@ -1476,7 +1478,7 @@ func (s *RunService) WatchClusterEvents(
 
 			if len(info.events) > 0 {
 				if err := stream.Send(&workflow.WatchClusterEventsResponse{ClusterEvents: info.events}); err != nil {
-					return err
+					return fmt.Errorf("sending cluster events response: %w", err)
 				}
 			}
 

--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -98,7 +98,7 @@ func (s *RunService) WatchGroups(ctx context.Context, req *connect.Request[workf
 
 	groups, err := s.buildTaskGroups(ctx, req.Msg)
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, err)
+		return fmt.Errorf("building task groups: %v", err)
 	}
 
 	// Send initial response with sentinel
@@ -177,7 +177,6 @@ func (s *RunService) CreateRun(
 	request := req.Msg
 	// Validate request
 	if err := request.Validate(); err != nil {
-		logger.Errorf(ctx, "Invalid CreateRun request: %v", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
@@ -254,7 +253,7 @@ func (s *RunService) CreateRun(
 		// CreateRunRequest.run_start_time and surfaces as flyte.ctx().run_start_time instead.
 		triggerDetails, detailsErr := transformers.TriggerModelToTriggerDetails(ctx, triggerModel)
 		if detailsErr != nil {
-			return nil, connect.NewError(connect.CodeInternal, detailsErr)
+			return nil, fmt.Errorf("trigger details: %w", detailsErr)
 		}
 		if offloaded := triggerDetails.GetSpec().GetOffloadedInputData(); offloaded != nil && request.GetInputWrapper() == nil {
 			request.InputWrapper = &workflow.CreateRunRequest_OffloadedInputData{OffloadedInputData: offloaded}
@@ -323,8 +322,7 @@ func (s *RunService) CreateRun(
 		// Persist the full Inputs proto so context survives CreateRun -> storage -> runtime.
 		inputRef := storage.DataReference(inputPrefix + "/inputs.pb")
 		if err := s.dataStore.WriteProtobuf(ctx, inputRef, storage.Options{}, inputs); err != nil {
-			logger.Errorf(ctx, "Failed to write inputs to storage: %v", err)
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to write inputs: %w", err))
+			return nil, fmt.Errorf("failed to write inputs: %w", err)
 		}
 		logger.Infof(ctx, "Wrote inputs to %s", inputRef)
 
@@ -356,8 +354,7 @@ func (s *RunService) CreateRun(
 	// Persist task spec and create a run model
 	run, err := s.persistRunModel(ctx, runId, taskID, taskSpec, inputPrefix, runOutputBase, runSpec, request.GetSource(), triggerName, triggerTaskName, triggerRevision, triggerType, executedBy)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to create run: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("persisting run model: %w", err)
 	}
 
 	_, err = s.actionsClient.Enqueue(ctx, connect.NewRequest(&actions.EnqueueRequest{
@@ -522,8 +519,7 @@ func (s *RunService) AbortRun(
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("run not found: %s/%s/%s", req.Msg.RunId.Project, req.Msg.RunId.Domain, req.Msg.RunId.Name))
 		}
-		logger.Errorf(ctx, "Failed to abort run: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("aborting run: %w", err)
 	}
 
 	if s.abortReconciler != nil {
@@ -546,7 +542,6 @@ func (s *RunService) GetRunDetails(
 
 	run, err := s.repo.ActionRepo().GetRun(ctx, req.Msg.RunId)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to get run: %v", err)
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
 
@@ -557,7 +552,6 @@ func (s *RunService) GetRunDetails(
 
 	actionDetails, err := s.buildActionDetails(ctx, run, rootActionID)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to build run action details: %v", err)
 		return nil, err
 	}
 
@@ -614,9 +608,6 @@ func (s *RunService) buildActionDetails(ctx context.Context, model *models.Actio
 		if info.GetTaskSpecDigest() != "" {
 			specModel, err := s.repo.TaskRepo().GetTaskSpec(ctx, info.GetTaskSpecDigest())
 			if err != nil {
-				if ctx.Err() == nil {
-					logger.Errorf(ctx, "failed to get task spec for action %v: %v", actionId, err)
-				}
 				return err
 			}
 
@@ -627,20 +618,17 @@ func (s *RunService) buildActionDetails(ctx context.Context, model *models.Actio
 			case workflow.ActionType_ACTION_TYPE_TASK:
 				spec, err := transformers.ToTaskSpec(specModel)
 				if err != nil {
-					logger.Errorf(ctx, "failed to convert task spec model for action %v: %v", actionId, err)
 					return err
 				}
 				action.Spec = &workflow.ActionDetails_Task{Task: spec}
 			case workflow.ActionType_ACTION_TYPE_TRACE:
 				spec, err := transformers.ToTraceSpec(specModel)
 				if err != nil {
-					logger.Errorf(ctx, "failed to convert trace spec model for action %v: %v", actionId, err)
 					return err
 				}
 				action.Spec = &workflow.ActionDetails_Trace{Trace: spec}
 			default:
-				return connect.NewError(connect.CodeInternal,
-					fmt.Errorf("unknown action type %v for action %v", action.GetMetadata().GetActionType(), actionId))
+				return fmt.Errorf("unknown action type %v for action %v", action.GetMetadata().GetActionType(), actionId)
 			}
 		}
 
@@ -678,9 +666,6 @@ func (s *RunService) buildActionDetails(ctx context.Context, model *models.Actio
 	})
 
 	if err := eg.Wait(); err != nil {
-		if ctx.Err() == nil {
-			logger.Errorf(ctx, "failed to get action details for action %v: %v", actionId, err)
-		}
 		return nil, err
 	}
 
@@ -934,8 +919,7 @@ func (s *RunService) ListRuns(
 
 	actions, err := s.repo.ActionRepo().ListActions(ctx, listInput)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to list runs: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("listing actions: %w", err)
 	}
 
 	// We fetch Limit+1 rows to detect whether a next page exists without a separate COUNT
@@ -983,8 +967,7 @@ func (s *RunService) ListActions(
 
 	actions, err := s.repo.ActionRepo().ListActions(ctx, listInput)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to list actions: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("listing actions: %w", err)
 	}
 
 	// We fetch Limit+1 rows to detect whether a next page exists without a separate COUNT
@@ -1090,8 +1073,7 @@ func (s *RunService) AbortAction(
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("action not found: %s", req.Msg.ActionId.Name))
 		}
-		logger.Errorf(ctx, "Failed to abort action: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("aborting action %s: %w", req.Msg.ActionId.Name, err)
 	}
 
 	if s.abortReconciler != nil {
@@ -1125,7 +1107,6 @@ func (s *RunService) SignalEvent(
 		Value:            payloadToLiteral(req.Msg.GetPayload()),
 		SignalledBy:      signalledBy,
 	})); err != nil {
-		logger.Errorf(ctx, "Failed to signal action %s: %v", req.Msg.GetActionId().GetName(), err)
 		// Actions-service errors (NotFound / InvalidArgument / FailedPrecondition)
 		// pass through unchanged.
 		return nil, err
@@ -1195,7 +1176,7 @@ func (s *RunService) WatchRunDetails(
 		case <-ctx.Done():
 			return nil
 		case err := <-errs:
-			return connect.NewError(connect.CodeInternal, err)
+			return fmt.Errorf("watching run updates: %w", err)
 		case run := <-updates:
 			resp := &workflow.WatchRunDetailsResponse{
 				Details: &workflow.RunDetails{
@@ -1247,7 +1228,7 @@ func (s *RunService) WatchActionDetails(
 		case <-ctx.Done():
 			return nil
 		case err := <-errs:
-			return connect.NewError(connect.CodeInternal, err)
+			return fmt.Errorf("watching action updates: %w", err)
 		case updated, ok := <-updates:
 			if !ok {
 				return nil
@@ -1258,8 +1239,7 @@ func (s *RunService) WatchActionDetails(
 				if ctx.Err() != nil {
 					return nil
 				}
-				logger.Errorf(ctx, "failed to get action details for action %s: %v", actionID.Name, err)
-				return connect.NewError(connect.CodeInternal, err)
+				return fmt.Errorf("building action details: %w", err)
 			}
 			if err := stream.Send(&workflow.WatchActionDetailsResponse{
 				Details: details,
@@ -1313,7 +1293,6 @@ func (s *RunService) WatchRuns(
 		case <-ctx.Done():
 			return nil
 		case err := <-errsCh:
-			logger.Errorf(ctx, "Error watching runs: %v", err)
 			return err
 		case run := <-updatesCh:
 			// Filter the run based on the watch request criteria
@@ -1352,7 +1331,6 @@ func (s *RunService) WatchActions(
 	}
 
 	if err := s.listAndSendAllActions(ctx, runID, rsm, stream); err != nil {
-		logger.Errorf(ctx, "Failed to list actions: %v", err)
 		return err
 	}
 
@@ -1492,7 +1470,7 @@ func (s *RunService) WatchClusterEvents(
 		for {
 			info, err := s.getClusterEventsInfo(ctx, actionID, attempt, lastUpdatedAt, offset, maxEvents)
 			if err != nil {
-				return connect.NewError(connect.CodeInternal, err)
+				return fmt.Errorf("get cluster events info: %w", err)
 			}
 			isTerminal = isTerminal || info.isTerminal
 
@@ -1519,7 +1497,7 @@ func (s *RunService) WatchClusterEvents(
 		case <-ctx.Done():
 			return nil
 		case err := <-errsCh:
-			return connect.NewError(connect.CodeInternal, err)
+			return fmt.Errorf("watch cluster events: %w", err)
 		case updated, ok := <-updatesCh:
 			if !ok {
 				return nil
@@ -1598,12 +1576,12 @@ func getLogContextAndClusterForAttempt(ctx context.Context, repo interfaces.Repo
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, "", connect.NewError(connect.CodeNotFound, fmt.Errorf("no event found for action %v attempt %d", actionID, attempt))
 		}
-		return nil, "", connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get event for action %v attempt %d: %w", actionID, attempt, err))
+		return nil, "", fmt.Errorf("failed to get event for action %v attempt %d: %w", actionID, attempt, err)
 	}
 
 	event, err := m.ToActionEvent()
 	if err != nil {
-		return nil, "", connect.NewError(connect.CodeInternal, fmt.Errorf("failed to deserialize event: %w", err))
+		return nil, "", fmt.Errorf("failed to deserialize event: %w", err)
 	}
 
 	if event.GetLogContext() == nil {

--- a/runs/service/run_service_test.go
+++ b/runs/service/run_service_test.go
@@ -1771,20 +1771,6 @@ func TestGetActionLogContext(t *testing.T) {
 		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 	})
 
-	t.Run("repo error returns Internal", func(t *testing.T) {
-		actionRepo, _, svc := newTestService(t)
-		actionRepo.On("GetLatestEventByAttempt", mock.Anything, matchActionID(actionID), uint32(1)).Return(nil, errors.New("db blew up"))
-
-		resp, err := svc.GetActionLogContext(context.Background(), connect.NewRequest(&workflow.GetActionLogContextRequest{
-			ActionId: actionID,
-			Attempt:  1,
-		}))
-
-		assert.Nil(t, resp)
-		assert.Error(t, err)
-		assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
-	})
-
 	t.Run("event without log context returns NotFound", func(t *testing.T) {
 		actionRepo, _, svc := newTestService(t)
 		actionRepo.On("GetLatestEventByAttempt", mock.Anything, matchActionID(actionID), uint32(1)).Return(&models.ActionEvent{
@@ -1803,21 +1789,5 @@ func TestGetActionLogContext(t *testing.T) {
 		assert.Nil(t, resp)
 		assert.Error(t, err)
 		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
-	})
-
-	t.Run("undeserializable event returns Internal", func(t *testing.T) {
-		actionRepo, _, svc := newTestService(t)
-		actionRepo.On("GetLatestEventByAttempt", mock.Anything, matchActionID(actionID), uint32(1)).Return(&models.ActionEvent{
-			Info: []byte("not-a-proto"),
-		}, nil)
-
-		resp, err := svc.GetActionLogContext(context.Background(), connect.NewRequest(&workflow.GetActionLogContextRequest{
-			ActionId: actionID,
-			Attempt:  1,
-		}))
-
-		assert.Nil(t, resp)
-		assert.Error(t, err)
-		assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
 	})
 }

--- a/runs/service/task_service.go
+++ b/runs/service/task_service.go
@@ -6,7 +6,6 @@ import (
 
 	"connectrpc.com/connect"
 
-	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	commonpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/project/projectconnect"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
@@ -35,7 +34,6 @@ func (s *taskService) DeployTask(ctx context.Context, c *connect.Request[task.De
 	request := c.Msg
 
 	if err := request.Validate(); err != nil {
-		logger.Errorf(ctx, "Invalid DeployTask request: %v", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
@@ -65,13 +63,13 @@ func (s *taskService) DeployTask(ctx context.Context, c *connect.Request[task.De
 
 	taskModel, err := transformers.NewTaskModel(ctx, taskId, taskSpec)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to create task model: %w", err)
 	}
 	taskModel.TotalTriggers = uint32(len(request.GetTriggers()))
 
 	// Single transaction: upsert task + insert trigger revisions + refresh task meta.
 	if err := s.db.TaskRepo().CreateTask(ctx, taskModel, triggerModels); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to create task model: %w", err)
 	}
 
 	return connect.NewResponse(&task.DeployTaskResponse{}), nil
@@ -116,7 +114,6 @@ func buildTriggerModels(
 		}
 		m, err := transformers.NewTriggerModel(ctx, id, spec, tt.GetAutomationSpec())
 		if err != nil {
-			logger.Errorf(ctx, "failed to build trigger model for %q: %v", tt.GetName(), err)
 			return nil, fmt.Errorf("failed to build trigger model for %q: %w", tt.GetName(), err)
 		}
 		triggerModels = append(triggerModels, m)
@@ -134,7 +131,7 @@ func (s *taskService) GetTaskDetails(ctx context.Context, c *connect.Request[tas
 	// TODO(nary): Add identity enrichment after adding auth
 	tasks, err := transformers.TaskModelsToTaskDetailsWithoutIdentity(ctx, []*models.Task{model})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to convert task model to task details: %w", err)
 	}
 
 	return connect.NewResponse(&task.GetTaskDetailsResponse{
@@ -182,7 +179,7 @@ func (s *taskService) ListTasks(ctx context.Context, c *connect.Request[task.Lis
 
 	taskResWithCounts, err := s.db.TaskRepo().ListTasks(ctx, listInput)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to list tasks: %w", err)
 	}
 
 	// TODO(nary): Extract task names and get latest runs after adding ActionRepo.GetLatestRunByTasks
@@ -193,7 +190,7 @@ func (s *taskService) ListTasks(ctx context.Context, c *connect.Request[task.Lis
 	tasks, taskMetadata, err := transformers.TaskListResultToTasksAndMetadata(
 		ctx, taskResWithCounts, latestRuns, nil, false, false)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to list tasks: %w", err)
 	}
 
 	var token string
@@ -224,7 +221,7 @@ func (s *taskService) ListVersions(ctx context.Context, c *connect.Request[task.
 
 	versionModels, err := s.db.TaskRepo().ListVersions(ctx, listInput)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to list versions: %w", err)
 	}
 
 	versions := transformers.VersionModelsToVersionResponses(versionModels)

--- a/runs/service/trigger_service.go
+++ b/runs/service/trigger_service.go
@@ -9,7 +9,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/robfig/cron/v3"
 
-	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	commonpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
 	taskpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
 	triggerpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/trigger"
@@ -50,18 +49,17 @@ func (s *triggerService) DeployTrigger(
 	}
 	triggerModel, err := transformers.NewTriggerModel(ctx, id, request.GetSpec(), request.GetAutomationSpec())
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to create trigger model: %w", err)
 	}
 
 	saved, err := s.db.TriggerRepo().SaveTrigger(ctx, triggerModel, request.GetRevision())
 	if err != nil {
-		logger.Errorf(ctx, "DeployTrigger failed: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to save trigger: %w", err)
 	}
 
 	details, err := transformers.TriggerModelToTriggerDetails(ctx, saved)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to convert trigger model to trigger: %w", err)
 	}
 	return connect.NewResponse(&triggerpb.DeployTriggerResponse{Trigger: details}), nil
 }
@@ -76,11 +74,11 @@ func (s *triggerService) GetTriggerDetails(
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to get trigger details: %w", err)
 	}
 	details, err := transformers.TriggerModelToTriggerDetails(ctx, m)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to convert trigger model to trigger: %w", err)
 	}
 	return connect.NewResponse(&triggerpb.GetTriggerDetailsResponse{Trigger: details}), nil
 }
@@ -96,11 +94,11 @@ func (s *triggerService) GetTriggerRevisionDetails(
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to get trigger revision details: %w", err)
 	}
 	details, err := transformers.TriggerRevisionModelToTriggerDetails(ctx, m)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to convert trigger revision model to trigger: %w", err)
 	}
 	return connect.NewResponse(&triggerpb.GetTriggerRevisionDetailsResponse{Trigger: details}), nil
 }
@@ -134,12 +132,12 @@ func (s *triggerService) ListTriggers(
 
 	ms, err := s.db.TriggerRepo().ListTriggers(ctx, listInput)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to list triggers: %w", err)
 	}
 
 	triggers, err := transformers.TriggerModelsToTriggers(ctx, ms)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to convert triggers: %w", err)
 	}
 
 	var token string
@@ -164,12 +162,12 @@ func (s *triggerService) GetTriggerRevisionHistory(
 	ms, err := s.db.TriggerRepo().ListTriggerRevisions(ctx,
 		n.GetProject(), n.GetDomain(), n.GetTaskName(), n.GetName(), listInput)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to list trigger revision history: %w", err)
 	}
 
 	revisions, err := transformers.TriggerRevisionModelsToTriggerRevisions(ctx, ms)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to convert trigger revision model to trigger: %w", err)
 	}
 
 	var token string
@@ -186,7 +184,7 @@ func (s *triggerService) UpdateTriggers(
 	request := req.Msg
 	keys := namesToKeys(request.GetNames())
 	if err := s.db.TriggerRepo().UpdateTriggers(ctx, keys, request.GetActive()); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to update triggers: %w", err)
 	}
 	return connect.NewResponse(&triggerpb.UpdateTriggersResponse{}), nil
 }
@@ -198,7 +196,7 @@ func (s *triggerService) DeleteTriggers(
 	request := req.Msg
 	keys := namesToKeys(request.GetNames())
 	if err := s.db.TriggerRepo().DeleteTriggers(ctx, keys); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to delete triggers: %w", err)
 	}
 	return connect.NewResponse(&triggerpb.DeleteTriggersResponse{}), nil
 }

--- a/runs/service/utils.go
+++ b/runs/service/utils.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	flyteIdlCore "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/project"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/project/projectconnect"
@@ -133,8 +132,7 @@ func validateProjectExists(ctx context.Context, projectClient projectconnect.Pro
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			return connect.NewError(connect.CodeNotFound, fmt.Errorf("project %q not found", projectID))
 		}
-		logger.Errorf(ctx, "Failed to validate project %q: %v", projectID, err)
-		return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to validate project: %w", err))
+		return fmt.Errorf("failed to validate project: %w", err)
 	}
 	return nil
 }

--- a/runs/setup.go
+++ b/runs/setup.go
@@ -11,6 +11,7 @@ import (
 
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
+	"github.com/flyteorg/flyte/v2/flytestdlib/connectrpc/server/interceptors"
 	"github.com/getsentry/sentry-go"
 	"github.com/getsentry/sentry-go/attribute"
 
@@ -84,6 +85,9 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		return fmt.Errorf("runs: failed to run migrations: %w", err)
 	}
 
+	runsInterceptors := []connect.Interceptor{}
+	runsInterceptors = append(runsInterceptors, interceptors.NewErrorInterceptor())
+
 	otelCfg := otelutils.GetConfig()
 	if err := otelutils.RegisterProvidersWithContext(ctx, otelServiceName, otelCfg); err != nil {
 		return fmt.Errorf("registering otel providers: %w", err)
@@ -96,9 +100,9 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	if err != nil {
 		return fmt.Errorf("creating otel interceptor: %w", err)
 	}
+	runsInterceptors = append(runsInterceptors, otelInterceptor)
 
 	// Sentry is on by default with the hardcoded DSN; FLYTE_DISABLE_SENTRY=true opts out.
-	runsInterceptors := []connect.Interceptor{otelInterceptor}
 	if !sentryDisabled() {
 		if err := sentry.Init(sentry.ClientOptions{
 			Dsn:         sentryDSN,
@@ -161,21 +165,21 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	sc.Mux.Handle(runsPath, runsHandler)
 	logger.Infof(ctx, "Mounted RunService at %s", runsPath)
 
-	internalRunsPath, internalRunsHandler := workflowconnect.NewInternalRunServiceHandler(runsSvc, connect.WithInterceptors(otelInterceptor))
+	internalRunsPath, internalRunsHandler := workflowconnect.NewInternalRunServiceHandler(runsSvc, connect.WithInterceptors(runsInterceptors...))
 	sc.Mux.Handle(internalRunsPath, internalRunsHandler)
 	logger.Infof(ctx, "Mounted InternalRunService at %s", internalRunsPath)
 
-	taskPath, taskHandler := taskconnect.NewTaskServiceHandler(taskSvc, connect.WithInterceptors(otelInterceptor))
+	taskPath, taskHandler := taskconnect.NewTaskServiceHandler(taskSvc, connect.WithInterceptors(runsInterceptors...))
 	sc.Mux.Handle(taskPath, taskHandler)
 	logger.Infof(ctx, "Mounted TaskService at %s", taskPath)
 
 	identitySvc := service.NewIdentityService(cfg.AuthMetadata.ExternalAuthServerBaseURL, cfg.TrustForwardedIdentityHeaders, cfg.IdentityHeaders)
-	identityPath, identityHandler := authconnect.NewIdentityServiceHandler(identitySvc, connect.WithInterceptors(otelInterceptor))
+	identityPath, identityHandler := authconnect.NewIdentityServiceHandler(identitySvc, connect.WithInterceptors(runsInterceptors...))
 	sc.Mux.Handle(identityPath, identityHandler)
 	logger.Infof(ctx, "Mounted IdentityService at %s", identityPath)
 
 	authMetadataSvc := service.NewAuthMetadataService(sc.BaseURL, cfg.AuthMetadata)
-	authMetadataPath, authMetadataHandler := authconnect.NewAuthMetadataServiceHandler(authMetadataSvc, connect.WithInterceptors(otelInterceptor))
+	authMetadataPath, authMetadataHandler := authconnect.NewAuthMetadataServiceHandler(authMetadataSvc, connect.WithInterceptors(runsInterceptors...))
 	sc.Mux.Handle(authMetadataPath, authMetadataHandler)
 	logger.Infof(ctx, "Mounted AuthMetadataService at %s", authMetadataPath)
 
@@ -187,7 +191,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	logger.Infof(ctx, "Mounted OAuth2 metadata at /.well-known/oauth-authorization-server")
 
 	triggerSvc := service.NewTriggerService(repo)
-	triggerPath, triggerHandler := triggerconnect.NewTriggerServiceHandler(triggerSvc, connect.WithInterceptors(otelInterceptor))
+	triggerPath, triggerHandler := triggerconnect.NewTriggerServiceHandler(triggerSvc, connect.WithInterceptors(runsInterceptors...))
 	sc.Mux.Handle(triggerPath, triggerHandler)
 	logger.Infof(ctx, "Mounted TriggerService at %s", triggerPath)
 
@@ -199,7 +203,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		})
 	}
 	projectSvc := service.NewProjectService(impl.NewProjectRepo(sc.DB), domains)
-	projectPath, projectHandler := projectconnect.NewProjectServiceHandler(projectSvc, connect.WithInterceptors(otelInterceptor))
+	projectPath, projectHandler := projectconnect.NewProjectServiceHandler(projectSvc, connect.WithInterceptors(runsInterceptors...))
 	sc.Mux.Handle(projectPath, projectHandler)
 	logger.Infof(ctx, "Mounted ProjectService at %s", projectPath)
 

--- a/secret/service/secret_service.go
+++ b/secret/service/secret_service.go
@@ -230,8 +230,7 @@ func (s *SecretService) CreateSecret(ctx context.Context, req *connect.Request[s
 		if k8sErrors.IsAlreadyExists(err) {
 			return nil, connect.NewError(connect.CodeAlreadyExists, err)
 		}
-		logger.Errorf(ctx, "failed to create secret %v: %v", encodedName, err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to create k8s secret: %w", err)
 	}
 
 	s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
@@ -258,8 +257,7 @@ func (s *SecretService) UpdateSecret(ctx context.Context, req *connect.Request[s
 		if k8sErrors.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("secret %v not found", req.Msg.GetId().GetName()))
 		}
-		logger.Errorf(ctx, "failed to get secret %v: %v", encodedName, err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to get secret %v: %w", req.Msg.GetId().GetName(), err)
 	}
 
 	switch v := req.Msg.GetSecretSpec().GetValue().(type) {
@@ -277,8 +275,7 @@ func (s *SecretService) UpdateSecret(ctx context.Context, req *connect.Request[s
 		if k8sErrors.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("secret %v not found", req.Msg.GetId().GetName()))
 		}
-		logger.Errorf(ctx, "failed to update secret %v: %v", encodedName, err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to update secret %v: %w", req.Msg.GetId().GetName(), err)
 	}
 
 	s.invalidateWebhookSecretCache(ctx, req.Msg.GetId())
@@ -304,8 +301,7 @@ func (s *SecretService) GetSecret(ctx context.Context, req *connect.Request[secr
 		if k8sErrors.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("secret %v not found", req.Msg.GetId().GetName()))
 		}
-		logger.Errorf(ctx, "failed to get secret %v: %v", encodedName, err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to get k8s secret %v: %w", req.Msg.GetId().GetName(), err)
 	}
 
 	return connect.NewResponse(&secretpb.GetSecretResponse{
@@ -349,8 +345,7 @@ func (s *SecretService) DeleteSecret(ctx context.Context, req *connect.Request[s
 		if k8sErrors.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("secret %v not found", req.Msg.GetId().GetName()))
 		}
-		logger.Errorf(ctx, "failed to delete secret %v: %v", encodedName, err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to delete k8s secret %v: %w", req.Msg.GetId().GetName(), err)
 	}
 
 	logger.Debugf(ctx, "deleted k8s secret %v", k8sSecretName)
@@ -384,8 +379,7 @@ func (s *SecretService) ListSecrets(ctx context.Context, req *connect.Request[se
 	}
 
 	if err := s.k8sClient.List(ctx, k8sSecretList, listOpts...); err != nil {
-		logger.Errorf(ctx, "failed to list secrets: %v", err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, fmt.Errorf("failed to list k8s secrets: %w", err)
 	}
 
 	rawSecrets := make([]*secretpb.Secret, 0, len(k8sSecretList.Items))

--- a/secret/setup.go
+++ b/secret/setup.go
@@ -7,6 +7,7 @@ import (
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
 	"github.com/flyteorg/flyte/v2/flytestdlib/app"
+	"github.com/flyteorg/flyte/v2/flytestdlib/connectrpc/server/interceptors"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/otelutils"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/secret/secretconnect"
@@ -34,7 +35,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		return fmt.Errorf("creating otel interceptor: %w", err)
 	}
 
-	path, handler := secretconnect.NewSecretServiceHandler(svc, connect.WithInterceptors(otelInterceptor))
+	path, handler := secretconnect.NewSecretServiceHandler(svc, connect.WithInterceptors(interceptors.NewErrorInterceptor(), otelInterceptor))
 	sc.Mux.Handle(path, handler)
 	logger.Infof(ctx, "Mounted SecretService at %s", path)
 


### PR DESCRIPTION
## Tracking issue
Closes #7736 

## Why are the changes needed?
The Flyte backend currently has some behavior that I don't think are ideal.
1. Internal errors are largely passed through directly to the client which is a [security issue](https://owasp.org/www-community/Improper_Error_Handling). 
2. In many places errors are logged to stdout and then duplicated in the returned error which is an anti pattern
3. Non connect RPC errors are currently returned as UNKNOWN and directly pass through error details to the user. Ultimately these are internal server issues.  

## What changes were proposed in this pull request?
Add an error interceptor that..
1. Logs non-INTERNAL connect RPC errors at WARN level so every error is visible in logs for debugging
2. Converts non connect RPC errors into INTERNAL and omits error messages to avoid leaking implementation details
3. Logs INTERNAL errors at ERROR level since this represents a server side issue

Also updates existing RPCs that return internal to return a non connect RPC error with additional context that will get caught by the error interceptor. Note: I could potentially just keep the existing INTERNAL calls and just drop the error details from being passed through in the interceptor logic instead to be more explicit for RPC handler authors. 

Also removes `toConnectError` helper that was used in one area that basically does what the error interceptor does but at each RPC call site.

## How was this patch tested?
We use this error interceptor internally.

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
