### PR TITLE
feat(chart): allow setting env vars on the console container

### DIFF
--- a/charts/flyte-binary/README.md
+++ b/charts/flyte-binary/README.md
@@ -69,6 +69,7 @@ Chart for basic single Flyte executable deployment
 | console.affinity | object | `{}` |  |
 | console.basePath | string | `"/v2"` |  |
 | console.containerPort | int | `8080` |  |
+| console.env | list | `[]` |  |
 | console.image.pullPolicy | string | `"IfNotPresent"` |  |
 | console.image.repository | string | `"ghcr.io/unionai-oss/flyteconsole-v2"` |  |
 | console.image.tag | string | `"latest"` |  |

--- a/charts/flyte-binary/templates/console/deployment.yaml
+++ b/charts/flyte-binary/templates/console/deployment.yaml
@@ -44,6 +44,9 @@ spec:
             - name: http
               containerPort: {{ .Values.console.containerPort }}
               protocol: TCP
+          {{- with .Values.console.env }}
+          env: {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: {{ .Values.console.basePath }}

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -333,6 +333,10 @@ console:
   basePath: /v2
   # containerPort Port the console container listens on
   containerPort: 8080
+  # env Environment variables for the console container. Set `OIDC_LOGOUT_URL` to your
+  # identity provider's logout endpoint so Sign out ends the IdP session, not just the
+  # proxy session cookie (e.g. `https://<okta-org>/login/signout`).
+  env: []
   # service Configure service for the console
   service:
     # type Kubernetes service type

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -337,7 +337,9 @@ console:
   # `OIDC_LOGOUT_URL` — your identity provider's logout endpoint, so Sign out ends the
   # IdP session and not just the proxy's (e.g. `https://<okta-org>/login/signout`).
   # `LOGOUT_CLEAR_COOKIES` — comma-separated session cookies Sign out expires. Defaults
-  # to AWS ALB's `AWSELBAuthSessionCookie-0..3`. Proxies with their own sign-out endpoint
+  # to AWS ALB's `AWSELBAuthSessionCookie-0..3` (its documented maximum: 4K per shard,
+  # 16K total); override if the listener rule sets a custom `SessionCookieName`.
+  # Proxies with their own sign-out endpoint
   # (oauth2-proxy, GCP IAP, Cloudflare Access) clear their cookie themselves: point
   # `OIDC_LOGOUT_URL` at that endpoint and set this to `""`.
   env: []

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -333,9 +333,13 @@ console:
   basePath: /v2
   # containerPort Port the console container listens on
   containerPort: 8080
-  # env Environment variables for the console container. Set `OIDC_LOGOUT_URL` to your
-  # identity provider's logout endpoint so Sign out ends the IdP session, not just the
-  # proxy session cookie (e.g. `https://<okta-org>/login/signout`).
+  # env Environment variables for the console container.
+  # `OIDC_LOGOUT_URL` — your identity provider's logout endpoint, so Sign out ends the
+  # IdP session and not just the proxy's (e.g. `https://<okta-org>/login/signout`).
+  # `LOGOUT_CLEAR_COOKIES` — comma-separated session cookies Sign out expires. Defaults
+  # to AWS ALB's `AWSELBAuthSessionCookie-0..3`. Proxies with their own sign-out endpoint
+  # (oauth2-proxy, GCP IAP, Cloudflare Access) clear their cookie themselves: point
+  # `OIDC_LOGOUT_URL` at that endpoint and set this to `""`.
   env: []
   # service Configure service for the console
   service:


### PR DESCRIPTION
## Tracking issue

Related to unionai-oss/flyte2-ui#28

## Why are the changes needed?

The console's Sign out action needs `OIDC_LOGOUT_URL` set to the identity provider's logout endpoint. Without it, signing out expires the proxy's session cookie only — if the IdP session is still live, the next request re-authenticates silently and the user looks signed back in.

`templates/console/deployment.yaml` had no env passthrough, so the value could only be set out-of-band (`kubectl set env`), which the next `helm upgrade` reverts.

## What changes were proposed in this pull request?

Adds `console.env`, empty by default and rendered only when set — the same `{{- with }}` shape the chart already uses for `resources`, `nodeSelector`, and friends. Nothing changes for existing installs.

```yaml
console:
  env:
    - name: OIDC_LOGOUT_URL
      value: https://<okta-org>/login/signout
```

## How was this patch tested?

`helm template` with and without the value:

```console
$ helm template t charts/flyte-binary -s templates/console/deployment.yaml | grep -c 'env:'
0
$ helm template t charts/flyte-binary \
    --set 'console.env[0].name=OIDC_LOGOUT_URL' \
    --set 'console.env[0].value=https://x/login/signout' \
    -s templates/console/deployment.yaml
...
          env:
            - name: OIDC_LOGOUT_URL
              value: https://x/login/signout
```

Deployed on `flyte-development`: the console redirects `/v2/logout` to the configured endpoint and expires the `AWSELBAuthSessionCookie-*` shards.

README regenerated with helm-docs.

### Labels

added

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

- unionai-oss/flyte2-ui#28 — the console side: user name in the header, Sign out, and the `/v2/logout` route that reads `OIDC_LOGOUT_URL`.