### PR TITLE
GetActionData: decode outputs.pb as Outputs to keep produced_artifacts

### DIFF
--- a/dataproxy/service/dataproxy_service.go
+++ b/dataproxy/service/dataproxy_service.go
@@ -528,11 +528,6 @@ func (s *Service) GetActionData(
 		group.Go(func() error {
 			outputRef := storage.DataReference(urisResp.Msg.GetOutputsUri())
 			logger.Infof(groupCtx, "GetActionData: reading outputs from %s", outputRef)
-			// The blob may be an Outputs proto or (for run-level data) an Inputs
-			// proto; the field-1 literals lists are wire-compatible, and Outputs
-			// field 3 (produced_artifacts) was numbered to not collide with Inputs
-			// field 2 (context), so decoding as Outputs is safe for both and keeps
-			// the produced-artifact declarations.
 			outputs := &task.Outputs{}
 			if err := s.dataStore.ReadProtobuf(groupCtx, outputRef, outputs); err != nil {
 				if !storage.IsNotFound(err) {

--- a/dataproxy/service/dataproxy_service.go
+++ b/dataproxy/service/dataproxy_service.go
@@ -528,17 +528,20 @@ func (s *Service) GetActionData(
 		group.Go(func() error {
 			outputRef := storage.DataReference(urisResp.Msg.GetOutputsUri())
 			logger.Infof(groupCtx, "GetActionData: reading outputs from %s", outputRef)
-			var inputsOrOutputs task.Inputs
-			if err := s.dataStore.ReadProtobuf(groupCtx, outputRef, &inputsOrOutputs); err != nil {
+			// The blob may be an Outputs proto or (for run-level data) an Inputs
+			// proto; the field-1 literals lists are wire-compatible, and Outputs
+			// field 3 (produced_artifacts) was numbered to not collide with Inputs
+			// field 2 (context), so decoding as Outputs is safe for both and keeps
+			// the produced-artifact declarations.
+			outputs := &task.Outputs{}
+			if err := s.dataStore.ReadProtobuf(groupCtx, outputRef, outputs); err != nil {
 				if !storage.IsNotFound(err) {
 					logger.Errorf(groupCtx, "GetActionData: failed to read outputs from %s: %v", outputRef, err)
 					return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to read outputs from %s: %w", outputRef, err))
 				}
 				logger.Debugf(groupCtx, "Outputs not found at %s (action may not have finished)", urisResp.Msg.GetOutputsUri())
 			} else {
-				resp.Outputs = &task.Outputs{
-					Literals: inputsOrOutputs.GetLiterals(),
-				}
+				resp.Outputs = outputs
 				resp.OutputsUri = urisResp.Msg.GetOutputsUri()
 				logger.Debugf(groupCtx, "Read %d output literals", len(resp.Outputs.Literals))
 			}

--- a/dataproxy/service/dataproxy_service_test.go
+++ b/dataproxy/service/dataproxy_service_test.go
@@ -13,6 +13,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -555,9 +556,12 @@ func TestGetActionData(t *testing.T) {
 			{Name: "x", Value: &core.Literal{Value: &core.Literal_Scalar{Scalar: &core.Scalar{Value: &core.Scalar_Primitive{Primitive: &core.Primitive{Value: &core.Primitive_Integer{Integer: 1}}}}}}},
 		},
 	}
-	storedOutputs := &task.Inputs{
+	storedOutputs := &task.Outputs{
 		Literals: []*task.NamedLiteral{
 			{Name: "o", Value: &core.Literal{Value: &core.Literal_Scalar{Scalar: &core.Scalar{Value: &core.Scalar_Primitive{Primitive: &core.Primitive{Value: &core.Primitive_StringValue{StringValue: "result"}}}}}}},
+		},
+		ProducedArtifacts: []*task.ProducedArtifact{
+			{Output: "o", Name: "my-model", Version: "v1"},
 		},
 	}
 
@@ -690,6 +694,9 @@ func TestGetActionData(t *testing.T) {
 			if tt.expectOutputsLen > 0 {
 				assert.Equal(t, "o", resp.Msg.GetOutputs().GetLiterals()[0].GetName())
 				assert.Equal(t, tt.outputsURI, resp.Msg.GetOutputsUri())
+				// The produced-artifact declarations survive the outputs read.
+				require.Len(t, resp.Msg.GetOutputs().GetProducedArtifacts(), 1)
+				assert.Equal(t, "my-model", resp.Msg.GetOutputs().GetProducedArtifacts()[0].GetName())
 			} else {
 				assert.Empty(t, resp.Msg.GetOutputsUri())
 			}


### PR DESCRIPTION
The display path in dataproxy `GetActionData` rebuilt `Outputs{Literals}` from a cross-decoded `task.Inputs`, silently dropping the `produced_artifacts` declarations added in #7749 — so clients (`flyte get io`, console) never saw which outputs were declared as artifacts.

`Outputs` field 3 (`produced_artifacts`) was deliberately numbered to not collide with `Inputs` field 2 (`context`), so decoding the blob as `Outputs` is wire-safe whether the stored proto is an `Outputs` or an `Inputs`, and keeps the declarations.
