### PR TITLE
Make the TaskAction requeue duration configurable

### DIFF
--- a/executor/pkg/config/config.go
+++ b/executor/pkg/config/config.go
@@ -26,6 +26,7 @@ var (
 		Cluster:                 "",
 		MaxSystemFailures:       3,
 		MaxConcurrentReconciles: 512,
+		RequeueDuration:         stdconfig.Duration{Duration: 10 * time.Second},
 		GC: GCConfig{
 			Interval: stdconfig.Duration{Duration: 30 * time.Minute},
 			MaxTTL:   stdconfig.Duration{Duration: 1 * time.Hour},
@@ -92,6 +93,13 @@ type Config struct {
 
 	// MaxConcurrentReconciles is the maximum number of concurrent reconcile loops for TaskActions.
 	MaxConcurrentReconciles int `json:"maxConcurrentReconciles" pflag:",Max concurrent reconcile loops for TaskActions"`
+
+	// RequeueDuration is how long the controller waits before reconciling a running
+	// TaskAction again. Lowering it makes task actions more responsive at the cost of
+	// more reconciles and more load on the plugin backends. It also sets the cache
+	// reservation heartbeat interval, so a reservation stays held until the next
+	// reconcile.
+	RequeueDuration stdconfig.Duration `json:"requeueDuration" pflag:",How long to wait before reconciling a running TaskAction again"`
 
 	// GC configures the garbage collector for terminal TaskActions.
 	GC GCConfig `json:"gc" pflag:",Garbage collector configuration for terminal TaskActions"`

--- a/executor/pkg/config/config.go
+++ b/executor/pkg/config/config.go
@@ -96,10 +96,15 @@ type Config struct {
 
 	// RequeueDuration is how long the controller waits before reconciling a running
 	// TaskAction again. Lowering it makes task actions more responsive at the cost of
-	// more reconciles and more load on the plugin backends. It also sets the cache
-	// reservation heartbeat interval, so a reservation stays held until the next
-	// reconcile.
-	RequeueDuration stdconfig.Duration `json:"requeueDuration" pflag:",How long to wait before reconciling a running TaskAction again"`
+	// more reconciles and more load on the plugin backends. 0 or unset means the
+	// built-in default of 10s.
+	//
+	// It is also the cache reservation heartbeat requested from cache_service. That
+	// service clamps the request to its own maxReservationHeartbeat, so raising this
+	// past cache_service's maxReservationHeartbeat times heartbeatGracePeriodMultiplier
+	// (10s times 3 by default) without raising that setting too can let a serializable
+	// cache reservation expire before the next reconcile.
+	RequeueDuration stdconfig.Duration `json:"requeueDuration" pflag:",How long to wait before reconciling a running TaskAction again. 0 means the default of 10s"`
 
 	// GC configures the garbage collector for terminal TaskActions.
 	GC GCConfig `json:"gc" pflag:",Garbage collector configuration for terminal TaskActions"`

--- a/executor/pkg/config/config.go
+++ b/executor/pkg/config/config.go
@@ -98,12 +98,6 @@ type Config struct {
 	// TaskAction again. Lowering it makes task actions more responsive at the cost of
 	// more reconciles and more load on the plugin backends. 0 or unset means the
 	// built-in default of 10s.
-	//
-	// It is also the cache reservation heartbeat requested from cache_service. That
-	// service clamps the request to its own maxReservationHeartbeat, so raising this
-	// past cache_service's maxReservationHeartbeat times heartbeatGracePeriodMultiplier
-	// (10s times 3 by default) without raising that setting too can let a serializable
-	// cache reservation expire before the next reconcile.
 	RequeueDuration stdconfig.Duration `json:"requeueDuration" pflag:",How long to wait before reconciling a running TaskAction again. 0 means the default of 10s"`
 
 	// GC configures the garbage collector for terminal TaskActions.

--- a/executor/pkg/config/config_flags.go
+++ b/executor/pkg/config/config_flags.go
@@ -66,8 +66,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cluster"), defaultConfig.Cluster, "Cluster identifier for action events")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultK8sServiceAccount"), defaultConfig.DefaultK8sServiceAccount, "Default Kubernetes service account for task pods when the task does not set one")
 	cmdFlags.Int32(fmt.Sprintf("%v%v", prefix, "maxSystemFailures"), defaultConfig.MaxSystemFailures, "Max consecutive system-level failures before forcing permanent failure")
-	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "maxConcurrentReconciles"), defaultConfig.MaxConcurrentReconciles, "Max concurrent reconcile loops for TaskActions")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "requeueDuration"), defaultConfig.RequeueDuration.String(), "How long to wait before reconciling a running TaskAction again")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "requeueDuration"), defaultConfig.RequeueDuration.String(), "How long to wait before reconciling a running TaskAction again. 0 means the default of 10s")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.interval"), defaultConfig.GC.Interval.String(), "How often the garbage collector runs. 0 disables GC.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.maxTTL"), defaultConfig.GC.MaxTTL.String(), "Time-to-live for terminal TaskActions before deletion.")
 	return cmdFlags

--- a/executor/pkg/config/config_flags.go
+++ b/executor/pkg/config/config_flags.go
@@ -66,6 +66,8 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cluster"), defaultConfig.Cluster, "Cluster identifier for action events")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultK8sServiceAccount"), defaultConfig.DefaultK8sServiceAccount, "Default Kubernetes service account for task pods when the task does not set one")
 	cmdFlags.Int32(fmt.Sprintf("%v%v", prefix, "maxSystemFailures"), defaultConfig.MaxSystemFailures, "Max consecutive system-level failures before forcing permanent failure")
+	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "maxConcurrentReconciles"), defaultConfig.MaxConcurrentReconciles, "Max concurrent reconcile loops for TaskActions")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "requeueDuration"), defaultConfig.RequeueDuration.String(), "How long to wait before reconciling a running TaskAction again")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.interval"), defaultConfig.GC.Interval.String(), "How often the garbage collector runs. 0 disables GC.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.maxTTL"), defaultConfig.GC.MaxTTL.String(), "Time-to-live for terminal TaskActions before deletion.")
 	return cmdFlags

--- a/executor/pkg/config/config_flags_test.go
+++ b/executor/pkg/config/config_flags_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -317,20 +317,6 @@ func TestConfig_SetFlags(t *testing.T) {
 			cmdFlags.Set("maxSystemFailures", testValue)
 			if vInt32, err := cmdFlags.GetInt32("maxSystemFailures"); err == nil {
 				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt32), &actual.MaxSystemFailures)
-
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
-	})
-	t.Run("Test_maxConcurrentReconciles", func(t *testing.T) {
-
-		t.Run("Override", func(t *testing.T) {
-			testValue := "1"
-
-			cmdFlags.Set("maxConcurrentReconciles", testValue)
-			if vInt, err := cmdFlags.GetInt("maxConcurrentReconciles"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt), &actual.MaxConcurrentReconciles)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/executor/pkg/config/config_flags_test.go
+++ b/executor/pkg/config/config_flags_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-viper/mapstructure/v2"
+	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -317,6 +317,34 @@ func TestConfig_SetFlags(t *testing.T) {
 			cmdFlags.Set("maxSystemFailures", testValue)
 			if vInt32, err := cmdFlags.GetInt32("maxSystemFailures"); err == nil {
 				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt32), &actual.MaxSystemFailures)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_maxConcurrentReconciles", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("maxConcurrentReconciles", testValue)
+			if vInt, err := cmdFlags.GetInt("maxConcurrentReconciles"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt), &actual.MaxConcurrentReconciles)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_requeueDuration", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := defaultConfig.RequeueDuration.String()
+
+			cmdFlags.Set("requeueDuration", testValue)
+			if vString, err := cmdFlags.GetString("requeueDuration"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.RequeueDuration)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/executor/pkg/controller/taskaction_cache.go
+++ b/executor/pkg/controller/taskaction_cache.go
@@ -19,7 +19,13 @@ import (
 	corepb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 )
 
-const cacheReservationHeartbeatInterval = TaskActionDefaultRequeueDuration
+// cacheReservationHeartbeat is the reservation lease handed to the catalog. It
+// tracks the requeue duration so the reservation outlives the gap until the next
+// reconcile; a shorter lease would let another owner take the reservation while
+// this TaskAction is still waiting to be reconciled.
+func (r *TaskActionReconciler) cacheReservationHeartbeat() time.Duration {
+	return r.requeueDuration()
+}
 
 type taskCacheConfig struct {
 	key          catalog.Key
@@ -56,7 +62,7 @@ func (r *TaskActionReconciler) evaluateCacheBeforeExecution(
 	}
 
 	if cacheCfg.serializable {
-		reservation, err := r.Catalog.GetOrExtendReservation(ctx, cacheCfg.key, cacheCfg.ownerID, cacheReservationHeartbeatInterval)
+		reservation, err := r.Catalog.GetOrExtendReservation(ctx, cacheCfg.key, cacheCfg.ownerID, r.cacheReservationHeartbeat())
 		if err != nil {
 			return pluginsCore.UnknownTransition, false, fmt.Errorf("acquiring cache reservation: %w", err)
 		}

--- a/executor/pkg/controller/taskaction_cache.go
+++ b/executor/pkg/controller/taskaction_cache.go
@@ -19,10 +19,16 @@ import (
 	corepb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 )
 
-// cacheReservationHeartbeat is the reservation lease handed to the catalog. It
-// tracks the requeue duration so the reservation outlives the gap until the next
-// reconcile; a shorter lease would let another owner take the reservation while
-// this TaskAction is still waiting to be reconciled.
+// cacheReservationHeartbeat is the reservation lease requested from the catalog.
+// The reservation is only ever extended on the next reconcile, so the lease has
+// to track the requeue duration rather than a fixed interval.
+//
+// This is a request, not a guarantee. cache_service clamps it to its own
+// maxReservationHeartbeat (Manager.resolvedHeartbeat) and expires the
+// reservation after heartbeatGracePeriodMultiplier of the clamped value, which
+// defaults to 10s times 3. Raising requeueDuration past that window without also
+// raising cache_service's maxReservationHeartbeat leaves a gap in which another
+// owner can take the reservation before this TaskAction is reconciled again.
 func (r *TaskActionReconciler) cacheReservationHeartbeat() time.Duration {
 	return r.requeueDuration()
 }

--- a/executor/pkg/controller/taskaction_cache_test.go
+++ b/executor/pkg/controller/taskaction_cache_test.go
@@ -125,7 +125,9 @@ func TestHandleCacheBeforeExecutionWaitingForReservation(t *testing.T) {
 				return catalog.Entry{}, grpcstatus.Error(codes.NotFound, "miss")
 			},
 			getOrExtendReservationFunc: func(_ context.Context, _ catalog.Key, ownerID string, heartbeat time.Duration) (*cacheservice.Reservation, error) {
-				assert.Equal(t, cacheReservationHeartbeatInterval, heartbeat)
+				// This reconciler leaves RequeueDuration unset, so the heartbeat
+				// falls back to the default requeue duration.
+				assert.Equal(t, TaskActionDefaultRequeueDuration, heartbeat)
 				assert.Equal(t, "default/cacheable-action", ownerID)
 				return &cacheservice.Reservation{OwnerId: "default/other-action"}, nil
 			},
@@ -137,6 +139,58 @@ func TestHandleCacheBeforeExecutionWaitingForReservation(t *testing.T) {
 	require.True(t, handled)
 	assert.Equal(t, pluginsCore.PhaseWaitingForCache, transition.Info().Phase())
 	assert.Equal(t, corepb.CatalogCacheStatus_CACHE_MISS, transition.Info().Info().ExternalResources[0].CacheStatus)
+}
+
+// The reservation lease has to track the requeue duration. If it did not, an
+// operator who raised the requeue duration would have reservations expire before
+// the next reconcile and another owner could take them.
+func TestHandleCacheBeforeExecutionReservationHeartbeatTracksRequeueDuration(t *testing.T) {
+	ensureTestMetricKeys()
+	ctx := context.Background()
+	taskAction, dataStore := newCacheableTaskAction(t, true, true)
+	tCtx := newTaskExecutionContext(t, taskAction, dataStore)
+
+	const configuredRequeue = 45 * time.Second
+	var gotHeartbeat time.Duration
+
+	r := &TaskActionReconciler{
+		DataStore:       dataStore,
+		RequeueDuration: configuredRequeue,
+		Catalog: &stubCatalogClient{
+			getFunc: func(context.Context, catalog.Key) (catalog.Entry, error) {
+				return catalog.Entry{}, grpcstatus.Error(codes.NotFound, "miss")
+			},
+			getOrExtendReservationFunc: func(_ context.Context, _ catalog.Key, _ string, heartbeat time.Duration) (*cacheservice.Reservation, error) {
+				gotHeartbeat = heartbeat
+				return &cacheservice.Reservation{OwnerId: "default/other-action"}, nil
+			},
+		},
+	}
+
+	_, handled, err := r.evaluateCacheBeforeExecution(ctx, taskAction, tCtx, false)
+	require.NoError(t, err)
+	require.True(t, handled)
+	assert.Equal(t, configuredRequeue, gotHeartbeat)
+}
+
+func TestRequeueDurationFallsBackToDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		set  time.Duration
+		want time.Duration
+	}{
+		{name: "unset", set: 0, want: TaskActionDefaultRequeueDuration},
+		{name: "negative", set: -1 * time.Second, want: TaskActionDefaultRequeueDuration},
+		{name: "configured", set: 45 * time.Second, want: 45 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &TaskActionReconciler{RequeueDuration: tt.set}
+			assert.Equal(t, tt.want, r.requeueDuration())
+			assert.Equal(t, tt.want, r.cacheReservationHeartbeat())
+		})
+	}
 }
 
 func TestHandleCacheBeforeExecutionMissWithoutSerializableSkipsReservation(t *testing.T) {

--- a/executor/pkg/controller/taskaction_controller.go
+++ b/executor/pkg/controller/taskaction_controller.go
@@ -103,7 +103,7 @@ type TaskActionReconciler struct {
 	cluster           string
 	MaxSystemFailures uint32
 	// RequeueDuration overrides how long to wait before reconciling a running
-	// TaskAction again. Zero means TaskActionDefaultRequeueDuration.
+	// TaskAction again. Any non-positive value means TaskActionDefaultRequeueDuration.
 	RequeueDuration time.Duration
 	metrics         *taskActionMetrics
 }
@@ -153,8 +153,9 @@ func (r *TaskActionReconciler) maxSystemFailures() uint32 {
 }
 
 // requeueDuration is how long to wait before reconciling a running TaskAction
-// again. It also bounds the cache reservation heartbeat, so a serializable
-// reservation is held at least until the next reconcile.
+// again. Any non-positive value falls back to TaskActionDefaultRequeueDuration.
+// It is also the cache reservation heartbeat requested from cache_service; see
+// cacheReservationHeartbeat for what that does and does not guarantee.
 func (r *TaskActionReconciler) requeueDuration() time.Duration {
 	if r.RequeueDuration <= 0 {
 		return TaskActionDefaultRequeueDuration

--- a/executor/pkg/controller/taskaction_controller.go
+++ b/executor/pkg/controller/taskaction_controller.go
@@ -102,7 +102,10 @@ type TaskActionReconciler struct {
 	eventBatcher      *eventBatcher
 	cluster           string
 	MaxSystemFailures uint32
-	metrics           *taskActionMetrics
+	// RequeueDuration overrides how long to wait before reconciling a running
+	// TaskAction again. Zero means TaskActionDefaultRequeueDuration.
+	RequeueDuration time.Duration
+	metrics         *taskActionMetrics
 }
 
 // recordEvent persists a single ActionEvent, blocking until it is durably
@@ -147,6 +150,16 @@ func (r *TaskActionReconciler) maxSystemFailures() uint32 {
 		return DefaultMaxSystemFailures
 	}
 	return r.MaxSystemFailures
+}
+
+// requeueDuration is how long to wait before reconciling a running TaskAction
+// again. It also bounds the cache reservation heartbeat, so a serializable
+// reservation is held at least until the next reconcile.
+func (r *TaskActionReconciler) requeueDuration() time.Duration {
+	if r.RequeueDuration <= 0 {
+		return TaskActionDefaultRequeueDuration
+	}
+	return r.RequeueDuration
 }
 
 // resetPluginResource aborts any in-flight plugin resource and clears persisted
@@ -201,7 +214,7 @@ func (r *TaskActionReconciler) recordSystemError(
 			logger.Error(updErr, "failed to persist SystemFailures counter")
 		}
 	}
-	return ctrl.Result{RequeueAfter: TaskActionDefaultRequeueDuration}, nil
+	return ctrl.Result{RequeueAfter: r.requeueDuration()}, nil
 }
 
 // finalizePermanentFailure converts the TaskAction to a terminal PermanentFailure
@@ -362,7 +375,7 @@ func (r *TaskActionReconciler) reconcileTask(
 	)
 	if err != nil {
 		logger.Error(err, "failed to build task execution context")
-		return ctrl.Result{RequeueAfter: TaskActionDefaultRequeueDuration}, nil
+		return ctrl.Result{RequeueAfter: r.requeueDuration()}, nil
 	}
 	alreadyRunning := taskAction.Status.PluginPhase == pluginsCore.PhaseRunning.String()
 
@@ -372,7 +385,7 @@ func (r *TaskActionReconciler) reconcileTask(
 	transition, cacheShortCircuited, err := r.evaluateCacheBeforeExecution(ctx, taskAction, tCtx, alreadyRunning)
 	if err != nil {
 		logger.Error(err, "cache pre-execution handling failed")
-		return ctrl.Result{RequeueAfter: TaskActionDefaultRequeueDuration}, nil
+		return ctrl.Result{RequeueAfter: r.requeueDuration()}, nil
 	}
 	// Even when cache handling short-circuits execution, we still continue through the
 	// shared reconcile tail below so the derived transition updates conditions, status,
@@ -388,7 +401,7 @@ func (r *TaskActionReconciler) reconcileTask(
 
 	if transition, err = r.finalizeCacheAfterExecution(ctx, taskAction, tCtx, transition, cacheShortCircuited); err != nil {
 		logger.Error(err, "cache post-execution handling failed")
-		return ctrl.Result{RequeueAfter: TaskActionDefaultRequeueDuration}, nil
+		return ctrl.Result{RequeueAfter: r.requeueDuration()}, nil
 	}
 
 	// Map transition phase to TaskAction conditions
@@ -475,7 +488,7 @@ func (r *TaskActionReconciler) reconcileTask(
 		}
 	}
 
-	return ctrl.Result{RequeueAfter: TaskActionDefaultRequeueDuration}, nil
+	return ctrl.Result{RequeueAfter: r.requeueDuration()}, nil
 }
 
 // ensureTerminalLabels adds GC-related labels to a terminal TaskAction if not already present.
@@ -534,12 +547,12 @@ func (r *TaskActionReconciler) handleAbortAndFinalize(ctx context.Context, taskA
 
 	if err := p.Abort(ctx, tCtx); err != nil {
 		logger.Error(err, "plugin Abort failed, will retry")
-		return ctrl.Result{RequeueAfter: TaskActionDefaultRequeueDuration}, nil
+		return ctrl.Result{RequeueAfter: r.requeueDuration()}, nil
 	}
 
 	if err := p.Finalize(ctx, tCtx); err != nil {
 		logger.Error(err, "plugin Finalize failed, will retry")
-		return ctrl.Result{RequeueAfter: TaskActionDefaultRequeueDuration}, nil
+		return ctrl.Result{RequeueAfter: r.requeueDuration()}, nil
 	}
 
 	if cacheCfg, ok, err := buildTaskCacheConfig(ctx, taskAction, tCtx); err != nil {
@@ -558,7 +571,7 @@ func (r *TaskActionReconciler) handleAbortAndFinalize(ctx context.Context, taskA
 	actionEvent.UpdatedTime = timestamppb.New(abortTime)
 	if err := r.recordEvent(ctx, actionEvent); err != nil {
 		logger.Error(err, "failed to emit abort event, will retry")
-		return ctrl.Result{RequeueAfter: TaskActionDefaultRequeueDuration}, nil
+		return ctrl.Result{RequeueAfter: r.requeueDuration()}, nil
 	}
 
 	return r.removeFinalizer(ctx, taskAction)

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -236,6 +236,10 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		return fmt.Errorf("executor: maxSystemFailures must be non-negative, got %d", cfg.MaxSystemFailures)
 	}
 	reconciler.MaxSystemFailures = uint32(cfg.MaxSystemFailures)
+	if cfg.RequeueDuration.Duration < 0 {
+		return fmt.Errorf("executor: requeueDuration must not be negative, got %v", cfg.RequeueDuration.Duration)
+	}
+	reconciler.RequeueDuration = cfg.RequeueDuration.Duration
 	if err := reconciler.SetupWithManager(mgr, cfg.MaxConcurrentReconciles); err != nil {
 		return fmt.Errorf("executor: failed to setup controller: %w", err)
 	}


### PR DESCRIPTION
## Tracking issue

Closes #7740

## Why are the changes needed?

The TaskAction controller requeues running actions with `TaskActionDefaultRequeueDuration`, a const 10s, referenced directly by eight `RequeueAfter:` sites. Operators cannot trade responsiveness against reconcile load without rebuilding the executor, which is what #7740 asks for.

## What changes were proposed in this pull request?

A new executor config field, `requeueDuration`, shaped exactly like the existing `maxSystemFailures`:

| Step | maxSystemFailures | requeueDuration |
| --- | --- | --- |
| config field with pflag tag | `config.go` | `config.go` |
| validation | `setup.go` | `setup.go` |
| reconciler field | `TaskActionReconciler.MaxSystemFailures` | `TaskActionReconciler.RequeueDuration` |
| zero-value accessor | `maxSystemFailures()` | `requeueDuration()` |

The default stays 10s, so an executor that does not set the field behaves exactly as before.

**The cache reservation heartbeat moves with it.** `cacheReservationHeartbeatInterval` was a const aliased to the requeue duration. It has to keep tracking it, because the reservation is only ever extended on the next reconcile: a lease shorter than the gap to that reconcile lets another owner take a serializable cache reservation while this TaskAction is still waiting.

That said, the lease is a request, not a guarantee, and the code and config docs now say so. `cache_service` clamps it in `Manager.resolvedHeartbeat` to its own `maxReservationHeartbeat` and expires the reservation after `heartbeatGracePeriodMultiplier` of the clamped value, 10s times 3 by default. Raising `requeueDuration` past that window without also raising `maxReservationHeartbeat` still leaves a gap. I chose to document that rather than silently promise a guarantee that does not hold, but if you would rather the executor refuse or warn on that combination, say so and I will add it.

`taskaction_condition.go`'s `RequeueAfter: time.Until(deadline)` is deliberately untouched. That one wakes up at a timeout deadline rather than polling, so tying it to the poll interval would delay or miss the timeout.

### A note on the generated flags file

`config_flags.go` and `config_flags_test.go` are generated by `pflags`, and running the generator available in this tree produces two changes I did not include:

1. It reverts `config_flags_test.go` from `github.com/go-viper/mapstructure/v2` back to `github.com/mitchellh/mapstructure`. The generator comes from `boilerplate/flyte/golang_support_tools`, which pins `flytestdlib v1.11.0`, and that version's template still emits the old import. Every other `config_flags_test.go` in the tree moved to go-viper in #7486, so I kept the current import.
2. It emits a `maxConcurrentReconciles` flag. That field has a pflag tag in `config.go` but no flag in `config_flags.go` on main, so the generator is right that something is missing, but it is a pre-existing gap unrelated to this change and I left it alone.

So this diff contains only the generator's `requeueDuration` output. Happy to split the `maxConcurrentReconciles` gap into its own PR if that is useful. Worth flagging that `check-generate` runs `make buf` and does not cover `pflags`, so neither of these would be caught by CI.

## How was this patch tested?

New unit tests:

- `TestRequeueDurationFallsBackToDefault` covers unset, negative, and configured values, asserting both `requeueDuration()` and `cacheReservationHeartbeat()`.
- `TestHandleCacheBeforeExecutionReservationHeartbeatTracksRequeueDuration` asserts the lease actually handed to the catalog follows a configured requeue duration.

The second one is not tautological. Replacing `cacheReservationHeartbeat()` with a fixed 10s turns it red:

```
--- FAIL: TestHandleCacheBeforeExecutionReservationHeartbeatTracksRequeueDuration
    expected: 45s   actual: 10s
```

The existing assertion in `taskaction_cache_test.go` was updated to `TaskActionDefaultRequeueDuration`, since that reconciler leaves `RequeueDuration` unset and so exercises the fallback.

Full `go test ./executor/...`, compared against a clean `main` checkout at the same commit:

```
                                    this branch      clean main
executor                            ok               ok
executor/pkg/config                 ok               ok
executor/pkg/controller             FAIL             FAIL
executor/pkg/plugin                 ok               ok
executor/pkg/plugin/k8s             ok               ok
executor/pkg/webhook                ok               ok
executor/test/integration           FAIL             FAIL
```

Both failures are identical on main and are environmental: `exec: "\usr\local\kubebuilder\bin\etcd": executable file not found`. This machine has no envtest binaries. `go build ./executor/...` and `go vet` are clean.

### Labels

- **added**: For new features.

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

### What was not tested

The envtest reconcile loop, for the reason above, so there is no end-to-end run of the controller with a raised `requeueDuration`. The cross-service clamp described earlier is derived from reading `Manager.resolvedHeartbeat` and the `cache_service` defaults, not from running two executors against one serializable cache key.

---

_This change was developed with AI assistance from Claude. I reviewed and verified it before submitting._
