### PR TITLE
[V2][Copilot] Inject credential storage config into copilot with secret volume

### DIFF
--- a/charts/flyte-binary/templates/configmap.yaml
+++ b/charts/flyte-binary/templates/configmap.yaml
@@ -46,6 +46,26 @@ data:
           {{- with ( index .Values.configuration "co-pilot" ).image }}
           image: {{ printf "%s:%s" .repository .tag | quote }}
           {{- end }}
+          # Co-pilot reads the storage configuration from these objects, projected into
+          # its containers as files. Passing it on the command line instead would put the
+          # storage credentials into every task's pod spec, readable by anyone who can
+          # read pods. Only the storage keys are projected: co-pilot parses its config in
+          # strict mode and would fail on the other entries these objects carry.
+          storage-config:
+            mount-path: /etc/flyte/copilot
+            config-map-name: {{ include "flyte-binary.configuration.configMapName" . }}
+            config-map-keys:
+              - 003-storage.yaml
+            {{- if and (eq "s3" .Values.configuration.storage.provider) (eq "accesskey" .Values.configuration.storage.providerConfig.s3.authType) }}
+            {{- /*
+              Only named when the deployment actually renders credentials. With
+              authType=iam there is no 013-storage-secrets.yaml, and projecting a key that
+              was never written fails the mount for every task pod.
+            */}}
+            secret-name: {{ include "flyte-binary.configuration.configSecretName" . }}
+            secret-keys:
+              - 013-storage-secrets.yaml
+            {{- end }}
         # Env vars injected into every task pod, so it can reach the control plane
         # to enqueue child actions and watch their state.
         #

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -7813,6 +7813,19 @@ data:
       k8s:
         co-pilot:
           image: "flyte-binary-v2:sandbox"
+          # Co-pilot reads the storage configuration from these objects, projected into
+          # its containers as files. Passing it on the command line instead would put the
+          # storage credentials into every task's pod spec, readable by anyone who can
+          # read pods. Only the storage keys are projected: co-pilot parses its config in
+          # strict mode and would fail on the other entries these objects carry.
+          storage-config:
+            mount-path: /etc/flyte/copilot
+            config-map-name: flyte-binary-config
+            config-map-keys:
+              - 003-storage.yaml
+            secret-name: flyte-binary-config-secret
+            secret-keys:
+              - 013-storage-secrets.yaml
         # Env vars injected into every task pod, so it can reach the control plane
         # to enqueue child actions and watch their state.
         #
@@ -8299,10 +8312,6 @@ spec:
     port: 443
     protocol: TCP
     targetPort: 9443
-  - name: cache-internal
-    port: 9444
-    protocol: TCP
-    targetPort: 9444
   selector:
     app.kubernetes.io/component: flyte-binary
     app.kubernetes.io/instance: flyte-devbox
@@ -8733,7 +8742,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 49e259b5181cecd91e406f5453b471831e41529923b6c290ae9a3c38ac124337
+        checksum/configuration: 7c2f3008aba066bea2a253c53bf851d22afbc4f50088ffef38461f984a47110f
         checksum/configuration-secret: 800f306f43701bd39e3b42e0d756f4627643cf3cee6dbd050a5a57a08052c280
       labels:
         app.kubernetes.io/component: flyte-binary

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/config.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/config/config.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -48,6 +49,14 @@ var (
 			Memory:               "128Mi",
 			Timeout: config2.Duration{
 				Duration: time.Hour * 1,
+			},
+			// The object names are intentionally unset: they are deployment-specific, and
+			// leaving them empty makes pod construction fail loudly rather than fall back
+			// to putting storage credentials on the co-pilot command line.
+			StorageConfig: StorageConfigSources{
+				ConfigMapKeys: []string{"003-storage.yaml"},
+				SecretKeys:    []string{"013-storage-secrets.yaml"},
+				MountPath:     "/etc/flyte/copilot",
 			},
 		},
 		DefaultCPURequest:    defaultCPURequest,
@@ -331,6 +340,46 @@ type FlyteCoPilotConfig struct {
 	Memory                string          `json:"memory" pflag:",Used to set memory for co-pilot containers"`
 	Storage               string          `json:"storage" pflag:",Default storage limit for individual inputs / outputs"`
 	StorageConfigOverride *storage.Config `json:"storage-config-override" pflag:"-,Override for the storage config to use for co-pilot"`
+	// Sources of the storage configuration co-pilot reads at startup.
+	StorageConfig StorageConfigSources `json:"storage-config" pflag:"-,Sources of the storage config mounted into co-pilot containers"`
+}
+
+// StorageConfigSources names the ConfigMap and Secret holding co-pilot's storage
+// configuration. Both are projected into MountPath and co-pilot is pointed at them with
+// --config, so the storage credentials never appear in the pod spec: recovering them
+// requires access to the Secret rather than merely to pods.
+//
+// Two sources rather than one because the deployment already splits the configuration —
+// non-sensitive settings in a ConfigMap, credentials in a Secret — and a projected volume
+// can combine them, so that split is preserved instead of forcing everything into the
+// Secret. flytestdlib globs the mount directory and merges one viper per file, so the two
+// halves resolve to a single storage config.
+type StorageConfigSources struct {
+	// ConfigMapName holds the non-sensitive storage settings (endpoint, region, bucket).
+	ConfigMapName string `json:"config-map-name" pflag:",ConfigMap holding co-pilot's non-sensitive storage config"`
+	// ConfigMapKeys within ConfigMapName to project. Only these are mounted: the same
+	// ConfigMap carries unrelated entries, which must stay out of the co-pilot containers
+	// and out of co-pilot's strict-mode config parsing, which rejects unknown sections.
+	ConfigMapKeys []string `json:"config-map-keys" pflag:"-,Keys within the ConfigMap to project"`
+	// SecretName holds the storage credentials. Empty for credential-less setups such as
+	// S3 with authType=iam, where the deployment renders no credential file at all.
+	SecretName string `json:"secret-name" pflag:",Secret holding co-pilot's storage credentials"`
+	// SecretKeys within SecretName to project. Listing a key that does not exist fails
+	// the mount, so a deployment without credentials must leave this empty rather than
+	// naming a file it never renders.
+	SecretKeys []string `json:"secret-keys" pflag:"-,Keys within the Secret to project"`
+	// MountPath is the directory both sources are projected into.
+	MountPath string `json:"mount-path" pflag:",Directory the storage config is mounted at"`
+}
+
+// ConfigGlob returns the --config argument co-pilot is started with: a glob matching every
+// projected key. Empty when nothing is configured, which callers treat as an error rather
+// than falling back to rendering the configuration into the command line.
+func (c StorageConfigSources) ConfigGlob() string {
+	if c.MountPath == "" || (c.ConfigMapName == "" && c.SecretName == "") {
+		return ""
+	}
+	return filepath.Join(c.MountPath, "*.yaml")
 }
 
 type AcceleratorDeviceClassConfig struct {

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -23,6 +23,7 @@ import (
 const (
 	flyteSidecarContainerName    = "uploader"
 	flyteDownloaderContainerName = "downloader"
+	copilotConfigVolumeName      = "flyte-copilot-config"
 )
 
 func FlyteCoPilotContainer(name string, cfg config.FlyteCoPilotConfig, args []string, volumeMounts ...v1.VolumeMount) (v1.Container, error) {
@@ -43,7 +44,7 @@ func FlyteCoPilotContainer(name string, cfg config.FlyteCoPilotConfig, args []st
 		storageCfg = storage.GetConfig()
 	}
 
-	command, err := CopilotCommandArgs(storageCfg)
+	command, err := CopilotCommandArgs(storageCfg, cfg.StorageConfig.ConfigGlob())
 	if err != nil {
 		return v1.Container{}, err
 	}
@@ -70,7 +71,23 @@ func FlyteCoPilotContainer(name string, cfg config.FlyteCoPilotConfig, args []st
 	}, nil
 }
 
-func CopilotCommandArgs(storageConfig *storage.Config) ([]string, error) {
+// CopilotCommandArgs builds the co-pilot entrypoint. The stow configuration — kind,
+// endpoint, and credentials alike — is deliberately NOT passed here; co-pilot reads it
+// from the files AddCoPilotToPod mounts. Rendering it into the command would publish the
+// storage credentials in every task's pod spec, where any principal that can read pods
+// could recover them without access to the Secret holding them.
+//
+// The whole stow config must travel together via those files. Splitting it — non-sensitive
+// keys as flags, credentials in the file — does not work: `storage.stow.config` binds to
+// a pflag StringToString, and once that flag is set viper resolves the key entirely from
+// it rather than merging into the file's map, silently dropping the credentials.
+func CopilotCommandArgs(storageConfig *storage.Config, storageConfigGlob string) ([]string, error) {
+	if storageConfigGlob == "" {
+		return nil, fmt.Errorf("co-pilot storage-config is not configured: set mount-path and at least " +
+			"one of config-map-name/secret-name so the storage config reaches co-pilot as mounted files " +
+			"instead of on the command line")
+	}
+
 	var commands = []string{
 		"/bin/flyte-copilot",
 		"--storage.limits.maxDownloadMBs=0",
@@ -85,15 +102,7 @@ func CopilotCommandArgs(storageConfig *storage.Config) ([]string, error) {
 	}
 	commands = append(commands, fmt.Sprintf("--storage.type=%s", storageConfig.Type))
 
-	if len(storageConfig.Stow.Config) > 0 && len(storageConfig.Stow.Kind) > 0 {
-		for key, val := range storageConfig.Stow.Config {
-			commands = append(commands, "--storage.stow.config")
-			commands = append(commands, fmt.Sprintf("%s=%s", key, val))
-		}
-		return append(commands, fmt.Sprintf("--storage.stow.kind=%s", storageConfig.Stow.Kind)), nil
-	}
-
-	return commands, fmt.Errorf("no stow.config or stow.kind specified")
+	return append(commands, "--config", storageConfigGlob), nil
 }
 
 func SidecarCommandArgs(fromLocalPath string, outputPrefix, rawOutputPath storage.DataReference, uploadTimeout time.Duration, iface *core.TypedInterface) ([]string, error) {
@@ -142,6 +151,72 @@ func DownloadCommandArgs(fromInputsPath, outputPrefix storage.DataReference, toL
 		"--input-interface",
 		base64.StdEncoding.EncodeToString(b),
 	}, nil
+}
+
+// keyToPaths projects each key under its own name, so the mounted filenames match the
+// keys the deployment already uses and their numeric prefixes keep ordering the merge.
+func keyToPaths(keys []string) []v1.KeyToPath {
+	if len(keys) == 0 {
+		return nil
+	}
+	items := make([]v1.KeyToPath, 0, len(keys))
+	for _, k := range keys {
+		items = append(items, v1.KeyToPath{Key: k, Path: k})
+	}
+	return items
+}
+
+// storageConfigVolume projects co-pilot's storage configuration into a read-only volume.
+// Both sources are combined here rather than merged into one object, preserving the
+// deployment's split of non-sensitive settings (ConfigMap) from credentials (Secret).
+//
+// Only the configured keys are projected. Both objects carry unrelated entries — plugin
+// config, database credentials — which must neither reach the co-pilot containers nor be
+// parsed by co-pilot's strict-mode config loader, which rejects sections it does not
+// recognise. A source with no name is omitted entirely: a deployment using instance
+// credentials (S3 authType=iam) renders no credential file, and naming a key that is
+// never written would fail the mount.
+func storageConfigVolume(cfg config.StorageConfigSources) v1.Volume {
+	// Read-only for the owner: co-pilot only reads this, and the containers run as
+	// whatever user the image declares.
+	mode := int32(0400)
+	sources := make([]v1.VolumeProjection, 0, 2)
+	if cfg.ConfigMapName != "" {
+		sources = append(sources, v1.VolumeProjection{
+			ConfigMap: &v1.ConfigMapProjection{
+				LocalObjectReference: v1.LocalObjectReference{Name: cfg.ConfigMapName},
+				Items:                keyToPaths(cfg.ConfigMapKeys),
+			},
+		})
+	}
+	if cfg.SecretName != "" {
+		sources = append(sources, v1.VolumeProjection{
+			Secret: &v1.SecretProjection{
+				LocalObjectReference: v1.LocalObjectReference{Name: cfg.SecretName},
+				Items:                keyToPaths(cfg.SecretKeys),
+			},
+		})
+	}
+	return v1.Volume{
+		Name: copilotConfigVolumeName,
+		VolumeSource: v1.VolumeSource{
+			Projected: &v1.ProjectedVolumeSource{
+				Sources:     sources,
+				DefaultMode: &mode,
+			},
+		},
+	}
+}
+
+// storageConfigMount is the mount matching storageConfigVolume. It is attached to the
+// co-pilot containers only — never to the primary container, which runs user code and
+// must not be able to read the storage credentials.
+func storageConfigMount(cfg config.StorageConfigSources) v1.VolumeMount {
+	return v1.VolumeMount{
+		Name:      copilotConfigVolumeName,
+		MountPath: cfg.MountPath,
+		ReadOnly:  true,
+	}
 }
 
 func DataVolume(name string, size *resource.Quantity) v1.Volume {
@@ -217,8 +292,19 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 
 	taskName := taskExecMetadata.GetTaskExecutionID().GetID().GetTaskId().GetName()
 	logger.Infof(ctx, "CoPilot Enabled for task [%s]", taskName)
+
+	cfgMount := storageConfigMount(cfg.StorageConfig)
+
 	if iFace != nil {
-		if iFace.Inputs != nil && len(iFace.Inputs.Variables) > 0 {
+		needsDownloader := iFace.Inputs != nil && len(iFace.Inputs.Variables) > 0
+		needsUploader := iFace.Outputs != nil && len(iFace.Outputs.Variables) > 0
+
+		// We only mount the volume when either downloader or uploader is required
+		if needsDownloader || needsUploader {
+			coPilotPod.Volumes = append(coPilotPod.Volumes, storageConfigVolume(cfg.StorageConfig))
+		}
+
+		if needsDownloader {
 			inPath := cfg.DefaultInputDataPath
 			if pilot.GetInputPath() != "" {
 				inPath = pilot.GetInputPath()
@@ -241,14 +327,14 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 			if err != nil {
 				return err
 			}
-			downloader, err := FlyteCoPilotContainer(flyteDownloaderContainerName, cfg, args, inputsVolumeMount)
+			downloader, err := FlyteCoPilotContainer(flyteDownloaderContainerName, cfg, args, inputsVolumeMount, cfgMount)
 			if err != nil {
 				return err
 			}
 			coPilotPod.InitContainers = append(coPilotPod.InitContainers, downloader)
 		}
 
-		if iFace.Outputs != nil && len(iFace.Outputs.Variables) > 0 {
+		if needsUploader {
 			outPath := cfg.DefaultOutputPath
 			if pilot.GetOutputPath() != "" {
 				outPath = pilot.GetOutputPath()
@@ -270,7 +356,7 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 			if err != nil {
 				return err
 			}
-			sidecar, err := FlyteCoPilotContainer(flyteSidecarContainerName, cfg, args, outputsVolumeMount)
+			sidecar, err := FlyteCoPilotContainer(flyteSidecarContainerName, cfg, args, outputsVolumeMount, cfgMount)
 			// Make it into sidecar container
 			restartPolicy := v1.ContainerRestartPolicyAlways
 			sidecar.RestartPolicy = &restartPolicy

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
@@ -3,6 +3,7 @@ package flytek8s
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -43,6 +44,13 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 		},
 		CPU:    "1024m",
 		Memory: "1024Mi",
+		StorageConfig: config.StorageConfigSources{
+			ConfigMapName: "flyte-config",
+			ConfigMapKeys: []string{"003-storage.yaml"},
+			SecretName:    "flyte-config-secret",
+			SecretKeys:    []string{"013-storage-secrets.yaml"},
+			MountPath:     "/etc/flyte/copilot",
+		},
 	}
 
 	t.Run("happy stow backend", func(t *testing.T) {
@@ -53,7 +61,7 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 		c, err := FlyteCoPilotContainer("x", cfg, []string{"hello"})
 		assert.NoError(t, err)
 
-		expectedCommand, err := CopilotCommandArgs(storage.GetConfig())
+		expectedCommand, err := CopilotCommandArgs(storage.GetConfig(), cfg.StorageConfig.ConfigGlob())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "test-x", c.Name)
@@ -73,18 +81,41 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 	})
 
 	t.Run("happy stow GCP backend", func(t *testing.T) {
-		expectedCommand, err := CopilotCommandArgs(storage.GetConfig())
-		assert.NoError(t, err)
-
 		storage.GetConfig().Type = storage.TypeStow
 		storage.GetConfig().InitContainer = "bucket"
 		storage.GetConfig().Stow.Kind = "google"
 		storage.GetConfig().Stow.Config = map[string]string{
-			"json":       "",
+			"json":       "service-account-key",
 			"project_id": "flyte-gcp",
 			"scope":      "read_write",
 		}
-		assert.Equal(t, 7, len(expectedCommand))
+
+		command, err := CopilotCommandArgs(storage.GetConfig(), cfg.StorageConfig.ConfigGlob())
+		assert.NoError(t, err)
+
+		// Every backend keeps its credentials off the command line, not just S3: the
+		// stow config is never rendered here, so a backend whose secret lives under a
+		// different key (GCP's service-account JSON) is covered without enumerating it.
+		assert.NotContains(t, command, "--storage.stow.config")
+		for _, val := range storage.GetConfig().Stow.Config {
+			for _, arg := range command {
+				assert.NotContains(t, arg, val)
+			}
+		}
+		assert.Contains(t, command, "--config")
+		assert.Contains(t, command, "/etc/flyte/copilot/*.yaml")
+	})
+
+	t.Run("unconfigured storage config secret is rejected", func(t *testing.T) {
+		// Failing loudly is deliberate: falling back to the old flag-rendered config
+		// would put the storage credentials back into every task's pod spec.
+		_, err := CopilotCommandArgs(storage.GetConfig(), "")
+		assert.Error(t, err)
+
+		bare := cfg
+		bare.StorageConfig = config.StorageConfigSources{}
+		_, err = FlyteCoPilotContainer("x", bare, []string{"hello"})
+		assert.Error(t, err)
 	})
 
 	t.Run("storage override", func(t *testing.T) {
@@ -104,7 +135,7 @@ func TestFlyteCoPilotContainer(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(c.VolumeMounts))
 
-		expectedCommand, err := CopilotCommandArgs(&storageConfigOverride)
+		expectedCommand, err := CopilotCommandArgs(&storageConfigOverride, cfg.StorageConfig.ConfigGlob())
 		assert.NoError(t, err)
 
 		assert.ElementsMatch(t, c.Command, expectedCommand)
@@ -235,6 +266,121 @@ func assertContainerHasVolumeMounts(t *testing.T, cfg config.FlyteCoPilotConfig,
 		}
 	} else {
 		assert.Len(t, c.VolumeMounts, 0)
+	}
+}
+
+// TestAddCoPilotToPod_StorageCredentialsNeverInPodSpec is the regression guard for the
+// credential leak: the rendered pod must not contain any value from the stow config,
+// whichever backend is configured. It scans the serialized spec for the values rather
+// than checking known field names, so a backend whose secret lives under a key nobody
+// thought to exclude (Azure's "key", GCP's "json") is covered too.
+func TestAddCoPilotToPod_StorageCredentialsNeverInPodSpec(t *testing.T) {
+	ctx := context.TODO()
+	cfg := config.FlyteCoPilotConfig{
+		NamePrefix:           "test-",
+		Image:                "test",
+		DefaultInputDataPath: "/in",
+		DefaultOutputPath:    "/out",
+		InputVolumeName:      "inp",
+		OutputVolumeName:     "out",
+		CPU:                  "1024m",
+		Memory:               "1024Mi",
+		StorageConfig: config.StorageConfigSources{
+			ConfigMapName: "flyte-config",
+			ConfigMapKeys: []string{"003-storage.yaml"},
+			SecretName:    "flyte-config-secret",
+			SecretKeys:    []string{"013-storage-secrets.yaml"},
+			MountPath:     "/etc/flyte/copilot",
+		},
+	}
+
+	secrets := map[string]string{
+		"access_key_id": "AKIAEXAMPLE12345",
+		"secret_key":    "s3-secret-value",
+		"key":           "azure-account-key",
+		"json":          "gcp-service-account-json",
+		"password":      "oracle-password",
+	}
+	original := storage.GetConfig().Stow.Config
+	defer func() { storage.GetConfig().Stow.Config = original }()
+	storage.GetConfig().Stow.Config = secrets
+	storage.GetConfig().Stow.Kind = "s3"
+
+	taskMetadata := &pluginsCoreMock.TaskExecutionMetadata{}
+	overrides := &pluginsCoreMock.TaskOverrides{}
+	overrides.EXPECT().GetResources().Return(resourceRequirements)
+	taskMetadata.EXPECT().GetOverrides().Return(overrides)
+	taskExecutionID := &pluginsCoreMock.TaskExecutionID{}
+	taskExecutionID.EXPECT().GetID().Return(&core.TaskExecutionIdentifier{
+		TaskId: &core.Identifier{Name: "task"},
+	})
+	taskMetadata.EXPECT().GetTaskExecutionID().Return(taskExecutionID)
+
+	inputPaths := &pluginsIOMock.InputFilePaths{}
+	inputPaths.EXPECT().GetInputPath().Return("s3://input/inputs.pb")
+	opath := &pluginsIOMock.OutputFilePaths{}
+	opath.EXPECT().GetRawOutputPrefix().Return("s3://raw")
+	opath.EXPECT().GetOutputPrefixPath().Return("s3://output")
+
+	pod := v1.PodSpec{}
+	iface := &core.TypedInterface{
+		Inputs: &core.VariableMap{Variables: []*core.VariableEntry{
+			{Key: "x", Value: &core.Variable{Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_INTEGER}}}},
+		}},
+		Outputs: &core.VariableMap{Variables: []*core.VariableEntry{
+			{Key: "o", Value: &core.Variable{Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_INTEGER}}}},
+		}},
+	}
+	pilot := &core.DataLoadingConfig{Enabled: true, InputPath: "in", OutputPath: "out"}
+
+	assert.NoError(t, AddCoPilotToPod(ctx, cfg, &pod, iface, taskMetadata, inputPaths, opath, pilot))
+
+	rendered, err := json.Marshal(pod)
+	assert.NoError(t, err)
+	for name, value := range secrets {
+		assert.NotContains(t, string(rendered), value,
+			"stow config value for %q leaked into the pod spec", name)
+	}
+
+	// The credentials are absent because co-pilot reads them from a mounted Secret, and
+	// that mount must reach the co-pilot containers only.
+	// Exactly one. This task has both inputs and outputs, so both co-pilot containers are
+	// added and each needs the config; adding the volume per container instead of per pod
+	// would be a duplicate volume name and the API server would reject the whole pod.
+	var volume *v1.Volume
+	volumeCount := 0
+	for i := range pod.Volumes {
+		if pod.Volumes[i].Name == copilotConfigVolumeName {
+			volume = &pod.Volumes[i]
+			volumeCount++
+		}
+	}
+	assert.Equal(t, 1, volumeCount, "storage config volume must be added exactly once")
+	if assert.NotNil(t, volume, "storage config volume missing") {
+		if assert.NotNil(t, volume.Projected, "both config sources must be projected together") {
+			assert.Len(t, volume.Projected.Sources, 2)
+			cm := volume.Projected.Sources[0].ConfigMap
+			sec := volume.Projected.Sources[1].Secret
+			assert.Equal(t, cfg.StorageConfig.ConfigMapName, cm.Name)
+			assert.Equal(t, cfg.StorageConfig.SecretName, sec.Name)
+			// Only the listed keys: both objects also hold entries co-pilot must not see
+			// (plugin config, database credentials) and cannot parse under strict mode.
+			assert.Len(t, cm.Items, len(cfg.StorageConfig.ConfigMapKeys))
+			assert.Len(t, sec.Items, len(cfg.StorageConfig.SecretKeys))
+		}
+	}
+	for _, c := range pod.InitContainers {
+		mounts := make([]string, 0, len(c.VolumeMounts))
+		for _, m := range c.VolumeMounts {
+			mounts = append(mounts, m.Name)
+		}
+		assert.Contains(t, mounts, copilotConfigVolumeName, "co-pilot container %q cannot read its config", c.Name)
+	}
+	for _, c := range pod.Containers {
+		for _, m := range c.VolumeMounts {
+			assert.NotEqual(t, copilotConfigVolumeName, m.Name,
+				"primary container %q must not be able to read the storage credentials", c.Name)
+		}
 	}
 }
 
@@ -453,6 +599,13 @@ func TestAddCoPilotToPod(t *testing.T) {
 		},
 		CPU:    "1024m",
 		Memory: "1024Mi",
+		StorageConfig: config.StorageConfigSources{
+			ConfigMapName: "flyte-config",
+			ConfigMapKeys: []string{"003-storage.yaml"},
+			SecretName:    "flyte-config-secret",
+			SecretKeys:    []string{"013-storage-secrets.yaml"},
+			MountPath:     "/etc/flyte/copilot",
+		},
 	}
 
 	taskMetadata := &pluginsCoreMock.TaskExecutionMetadata{}
@@ -613,6 +766,24 @@ func TestAddCoPilotToPod(t *testing.T) {
 		}
 		assert.NoError(t, AddCoPilotToPod(ctx, cfg, &pod, iface, taskMetadata, inputPaths, opath, pilot))
 		assertPodHasCoPilot(t, cfg, pilot, iface, &pod)
+	})
+
+	t.Run("empty-iface-adds-no-config-volume", func(t *testing.T) {
+		// A non-nil interface with neither inputs nor outputs adds no co-pilot container,
+		// so it must add no storage config volume either — otherwise the pod would depend
+		// on a Secret that nothing mounts, and would fail to start if it were absent.
+		pod := v1.PodSpec{}
+		iface := &core.TypedInterface{}
+		pilot := &core.DataLoadingConfig{
+			Enabled:    true,
+			InputPath:  "in",
+			OutputPath: "out",
+		}
+		assert.NoError(t, AddCoPilotToPod(ctx, cfg, &pod, iface, taskMetadata, inputPaths, opath, pilot))
+		assert.Empty(t, pod.InitContainers)
+		for _, v := range pod.Volumes {
+			assert.NotEqual(t, copilotConfigVolumeName, v.Name)
+		}
 	})
 
 	t.Run("disabled", func(t *testing.T) {


### PR DESCRIPTION
## Tracking issue
Closes #7747 

<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?
Copilot currently injecting credential storage config with container command, which exposed the credential data like secret key
<img width="888" height="463" alt="Screenshot 2026-08-04 at 3 49 16 PM" src="https://github.com/user-attachments/assets/3b280b70-c8c6-4578-bc7c-ecc2bf091605" />

This PR fixed this by mounting secret data into copilot sidecar with secret volume.


<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Copilot code and helm charts.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Test in devbox, we will pass in a secret volume into copilot now.
<img width="685" height="634" alt="Screenshot 2026-08-05 at 9 52 17 AM" src="https://github.com/user-attachments/assets/792f6b11-191a-4e6a-aef7-1ac8dcdfd51d" />


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
