### PR TITLE
perf(runs): don't block action writes on the NOTIFY pump

### DIFF
--- a/runs/repository/impl/action.go
+++ b/runs/repository/impl/action.go
@@ -36,10 +36,36 @@ type actionRepo struct {
 	actionSubscribers map[chan string]bool
 	mu                sync.RWMutex
 
-	// Dedicated channels for async NOTIFY to avoid pool contention
-	actionNotifyCh chan string
-	runNotifyCh    chan string
+	// Pending NOTIFY payloads, drained by a dedicated pump so that write RPCs
+	// never wait on a notification. A payload is an identity rather than a
+	// state and every listener re-reads from the database when it wakes, so
+	// repeated updates for the same key collapse into a single delivery. That
+	// makes a set the right structure: it bounds memory by the number of
+	// distinct pending actions instead of by update volume, and it lets a
+	// failed pg_notify be retried by merging the keys back in.
+	// The value is the number of times this payload has failed for a reason
+	// that was not the connection's fault, which bounds how long a payload
+	// Postgres will never accept can hold up everything else.
+	notifyMu       sync.Mutex
+	pendingActions map[string]int
+	pendingRuns    map[string]int
+	// pendingCh carries a single "something is pending" nudge. The sets above
+	// are the queue; this channel only wakes the pump.
+	pendingCh chan struct{}
 }
+
+const (
+	// Backoff bounds for retrying a pg_notify that failed, so a broken
+	// connection cannot turn the pump into a hot loop.
+	notifyRetryMinBackoff = 50 * time.Millisecond
+	notifyRetryMaxBackoff = 5 * time.Second
+	// notifyRetryLimit bounds retries of a payload that keeps failing while
+	// the connection is healthy, which means the payload itself is the
+	// problem. pg_notify rejects payloads of 8000 bytes or more permanently,
+	// for example. Retrying such a payload forever would hold every other
+	// watcher's wakeup behind it, which is worse than losing one hint.
+	notifyRetryLimit = 10
+)
 
 // NewActionRepo creates a new PostgreSQL repository
 func NewActionRepo(db *sqlx.DB, dbConfig database.DbConfig) (interfaces.ActionRepo, error) {
@@ -51,8 +77,9 @@ func NewActionRepo(db *sqlx.DB, dbConfig database.DbConfig) (interfaces.ActionRe
 		actionSubscribers: make(map[chan string]bool),
 	}
 
-	repo.actionNotifyCh = make(chan string, 256)
-	repo.runNotifyCh = make(chan string, 256)
+	repo.pendingActions = make(map[string]int)
+	repo.pendingRuns = make(map[string]int)
+	repo.pendingCh = make(chan struct{}, 1)
 
 	if err := repo.startPostgresListener(); err != nil {
 		return nil, fmt.Errorf("failed to start postgres listener: %w", err)
@@ -947,16 +974,84 @@ func (r *actionRepo) processNotifications() {
 	}
 }
 
-// notifyRunUpdate sends a notification about a run update via the
-// dedicated notify channel, avoiding connection pool contention.
-func (r *actionRepo) notifyRunUpdate(ctx context.Context, runID *common.RunIdentifier) {
+// notifyRunUpdate queues a notification about a run update for the dedicated
+// notify pump, avoiding connection pool contention.
+//
+// ctx is deliberately not consulted: the row is already committed by the time
+// this runs, and dropping the wakeup because the caller's request was
+// cancelled would leave other watchers looking at a stale phase.
+func (r *actionRepo) notifyRunUpdate(_ context.Context, runID *common.RunIdentifier) {
 	payload := fmt.Sprintf("%s/%s/%s", runID.Project, runID.Domain, runID.Name)
 
-	select {
-	case r.runNotifyCh <- payload:
-	case <-ctx.Done():
-		logger.Warnf(ctx, "Run NOTIFY send cancelled for %s: %v", payload, ctx.Err())
+	r.notifyMu.Lock()
+	markPending(r.pendingRuns, payload)
+	r.notifyMu.Unlock()
+
+	r.signalPending()
+}
+
+// markPending queues payload, keeping any attempt count it has already
+// accumulated. Resetting the count here would let a payload that can never be
+// delivered stay pending forever, since a busy action keeps re-queuing it.
+func markPending(pending map[string]int, payload string) {
+	if _, queued := pending[payload]; !queued {
+		pending[payload] = 0
 	}
+}
+
+// signalPending nudges the notify pump without ever blocking. A nudge that is
+// already buffered needs no second one: the pump re-reads the whole pending
+// set once it wakes, so one outstanding signal covers any number of keys.
+func (r *actionRepo) signalPending() {
+	select {
+	case r.pendingCh <- struct{}{}:
+	default:
+	}
+}
+
+// takePendingNotifications swaps the pending sets out for empty ones and
+// returns what was queued.
+func (r *actionRepo) takePendingNotifications() (actions, runs map[string]int) {
+	r.notifyMu.Lock()
+	defer r.notifyMu.Unlock()
+
+	actions, runs = r.pendingActions, r.pendingRuns
+	r.pendingActions = make(map[string]int)
+	r.pendingRuns = make(map[string]int)
+	return actions, runs
+}
+
+// requeuePendingNotifications merges undelivered payloads back so the pump can
+// retry them. Re-adding a key is idempotent, so a retry cannot duplicate work,
+// and updates that arrived meanwhile merge into the same entry.
+func (r *actionRepo) requeuePendingNotifications(actions, runs map[string]int) {
+	if len(actions) == 0 && len(runs) == 0 {
+		return
+	}
+
+	r.notifyMu.Lock()
+	r.pendingActions = mergePending(r.pendingActions, actions)
+	r.pendingRuns = mergePending(r.pendingRuns, runs)
+	r.notifyMu.Unlock()
+
+	r.signalPending()
+}
+
+// mergePending folds src into dst and returns the map to keep. It copies the
+// smaller side so that requeuing a large failed batch into a nearly empty
+// pending set holds the lock for the size of the smaller map, not the batch.
+// Where both sides hold a payload the higher attempt count wins, so a new
+// update arriving for a failing action cannot refill its retry budget.
+func mergePending(dst, src map[string]int) map[string]int {
+	if len(src) > len(dst) {
+		dst, src = src, dst
+	}
+	for payload, attempts := range src {
+		if existing, queued := dst[payload]; !queued || attempts > existing {
+			dst[payload] = attempts
+		}
+	}
+	return dst
 }
 
 // ListRootActions lists root actions (runs) matching scope and date filters.
@@ -1012,7 +1107,7 @@ func (r *actionRepo) startNotifyLoop() error {
 		return fmt.Errorf("acquire dedicated NOTIFY connection: %w", err)
 	}
 
-	go r.runNotifyLoop(sqlDB, conn)
+	go r.runNotifyLoop(context.Background(), sqlDB, conn)
 	return nil
 }
 
@@ -1033,10 +1128,13 @@ func isConnError(err error) bool {
 	return false
 }
 
-// runNotifyLoop processes notify channels using the given connection.
-// On connection errors it attempts to reconnect; if reconnection fails
-// the error is logged and the notification is skipped.
-func (r *actionRepo) runNotifyLoop(sqlDB *sql.DB, conn *sql.Conn) {
+// runNotifyLoop drains the pending notification sets using the given
+// connection. On connection errors it attempts to reconnect; payloads it could
+// not deliver stay pending and are retried with backoff, so a transient
+// database problem costs a delay rather than a lost wakeup.
+//
+// It returns when ctx is done.
+func (r *actionRepo) runNotifyLoop(ctx context.Context, sqlDB *sql.DB, conn *sql.Conn) {
 	defer func() {
 		if conn != nil {
 			conn.Close() //nolint:errcheck
@@ -1052,69 +1150,126 @@ func (r *actionRepo) runNotifyLoop(sqlDB *sql.DB, conn *sql.Conn) {
 			return
 		}
 		var err error
-		conn, err = sqlDB.Conn(context.Background())
+		conn, err = sqlDB.Conn(ctx)
 		if err != nil {
-			logger.Errorf(context.Background(), "Failed to re-acquire NOTIFY connection: %v", err)
+			logger.Errorf(ctx, "Failed to re-acquire NOTIFY connection: %v", err)
 			conn = nil
 		}
 	}
 
-	execNotify := func(channel, payload string) {
+	// execNotify reports whether the payload was delivered. A false result
+	// keeps the payload pending for the next attempt.
+	execNotify := func(channel, payload string) bool {
 		if conn == nil {
 			reconnect()
 		}
 		if conn == nil {
-			logger.Errorf(context.Background(), "No NOTIFY connection available, dropping %s notification", channel)
-			return
+			logger.Errorf(ctx, "No NOTIFY connection available, keeping %s notification pending", channel)
+			return false
 		}
-		if _, err := conn.ExecContext(context.Background(), "SELECT pg_notify($1, $2)", channel, payload); err != nil {
-			logger.Errorf(context.Background(), "Failed to NOTIFY %s: %v", channel, err)
+		if _, err := conn.ExecContext(ctx, "SELECT pg_notify($1, $2)", channel, payload); err != nil {
+			logger.Errorf(ctx, "Failed to NOTIFY %s: %v", channel, err)
 			if isConnError(err) {
 				reconnect()
 			}
+			return false
 		}
+		return true
 	}
 
-	drainAndExec := func(channel, firstPayload string, ch <-chan string) {
-		execNotify(channel, firstPayload)
-		for {
-			select {
-			case payload, ok := <-ch:
-				if !ok {
-					return
-				}
-				execNotify(channel, payload)
-			default:
-				return
+	// emit delivers every payload in the set. It returns the payloads worth
+	// another attempt, with their attempt counts advanced, and how many were
+	// delivered. A payload only spends its retry budget when the connection
+	// was healthy and it failed anyway, because that means the payload itself
+	// is what Postgres rejected.
+	emit := func(channel string, payloads map[string]int) (retry map[string]int, delivered int) {
+		keep := func(payload string, attempts int) {
+			if retry == nil {
+				retry = make(map[string]int, len(payloads))
 			}
+			retry[payload] = attempts
 		}
+
+		connectionLost := false
+		for payload, attempts := range payloads {
+			// Once the connection is gone, trying the rest would just make
+			// every remaining payload attempt its own reconnect. Keep them
+			// and let the backoff below handle recovery.
+			if connectionLost {
+				keep(payload, attempts)
+				continue
+			}
+			if execNotify(channel, payload) {
+				delivered++
+				continue
+			}
+			if conn == nil {
+				connectionLost = true
+				keep(payload, attempts)
+				continue
+			}
+
+			attempts++
+			if attempts >= notifyRetryLimit {
+				logger.Errorf(ctx, "Dropping %s notification after %d failed attempts: %s",
+					channel, attempts, payload)
+				continue
+			}
+			keep(payload, attempts)
+		}
+		return retry, delivered
 	}
 
+	backoff := notifyRetryMinBackoff
 	for {
 		select {
-		case payload, ok := <-r.actionNotifyCh:
-			if !ok {
-				return
-			}
-			drainAndExec("action_updates", payload, r.actionNotifyCh)
-		case payload, ok := <-r.runNotifyCh:
-			if !ok {
-				return
-			}
-			drainAndExec("run_updates", payload, r.runNotifyCh)
+		case <-ctx.Done():
+			return
+		case <-r.pendingCh:
+		}
+
+		actions, runs := r.takePendingNotifications()
+		retryActions, deliveredActions := emit("action_updates", actions)
+		retryRuns, deliveredRuns := emit("run_updates", runs)
+
+		if len(retryActions) == 0 && len(retryRuns) == 0 {
+			backoff = notifyRetryMinBackoff
+			continue
+		}
+
+		r.requeuePendingNotifications(retryActions, retryRuns)
+
+		// Delivering anything at all means the pump is healthy and something
+		// payload-specific failed, so do not slow every other watcher down.
+		if deliveredActions+deliveredRuns > 0 {
+			backoff = notifyRetryMinBackoff
+		}
+
+		// Wait before the retry so a broken connection cannot spin the pump.
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+		if backoff > notifyRetryMaxBackoff {
+			backoff = notifyRetryMaxBackoff
 		}
 	}
 }
 
-// notifyActionUpdate sends a notification about an action update via the
-// dedicated notify channel, avoiding connection pool contention.
-func (r *actionRepo) notifyActionUpdate(ctx context.Context, actionID *common.ActionIdentifier) {
+// notifyActionUpdate queues a notification about an action update for the
+// dedicated notify pump, avoiding connection pool contention.
+//
+// This is called from inside write RPCs, right after the row is committed, so
+// it must never block. ctx is deliberately not consulted; see notifyRunUpdate.
+func (r *actionRepo) notifyActionUpdate(_ context.Context, actionID *common.ActionIdentifier) {
 	payload := fmt.Sprintf("%s/%s/%s/%s",
 		actionID.Run.Project, actionID.Run.Domain, actionID.Run.Name, actionID.Name)
 
-	select {
-	case r.actionNotifyCh <- payload:
-	case <-ctx.Done():
-		logger.Errorf(ctx, "Action NOTIFY send cancelled for %s: %v", payload, ctx.Err())
-	}
+	r.notifyMu.Lock()
+	markPending(r.pendingActions, payload)
+	r.notifyMu.Unlock()
+
+	r.signalPending()
 }

--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -821,11 +823,7 @@ func TestInsertEvents_Empty(t *testing.T) {
 }
 
 func TestNotifyActionUpdate_PayloadWithSpecialChars(t *testing.T) {
-	r := &actionRepo{
-
-		actionNotifyCh: make(chan string, 256),
-		runNotifyCh:    make(chan string, 256),
-	}
+	r := newNotifyTestRepo()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -843,20 +841,12 @@ func TestNotifyActionUpdate_PayloadWithSpecialChars(t *testing.T) {
 
 	r.notifyActionUpdate(ctx, actionID)
 
-	select {
-	case payload := <-r.actionNotifyCh:
-		assert.Equal(t, "proj/domain/run'; DROP TABLE actions; --/action", payload)
-	case <-ctx.Done():
-		t.Fatal("timed out waiting for payload on actionNotifyCh")
-	}
+	actions, _ := r.takePendingNotifications()
+	assert.Contains(t, actions, "proj/domain/run'; DROP TABLE actions; --/action")
 }
 
 func TestNotifyRunUpdate_PayloadWithSpecialChars(t *testing.T) {
-	r := &actionRepo{
-
-		actionNotifyCh: make(chan string, 256),
-		runNotifyCh:    make(chan string, 256),
-	}
+	r := newNotifyTestRepo()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -870,12 +860,445 @@ func TestNotifyRunUpdate_PayloadWithSpecialChars(t *testing.T) {
 
 	r.notifyRunUpdate(ctx, runID)
 
-	select {
-	case payload := <-r.runNotifyCh:
-		assert.Equal(t, "proj/domain/run'); SELECT pg_sleep(10); --", payload)
-	case <-ctx.Done():
-		t.Fatal("timed out waiting for payload on runNotifyCh")
+	_, runs := r.takePendingNotifications()
+	assert.Contains(t, runs, "proj/domain/run'); SELECT pg_sleep(10); --")
+}
+
+// TestNotifyActionUpdate_CoalescesRepeats checks the property that makes a set
+// safe here: repeated updates to one action between drains collapse into a
+// single wakeup, because the listener re-reads the latest state anyway.
+func TestNotifyActionUpdate_CoalescesRepeats(t *testing.T) {
+	r := newNotifyTestRepo()
+	ctx := context.Background()
+
+	for i := 0; i < 500; i++ {
+		r.notifyActionUpdate(ctx, notifyTestActionID("same-action"))
 	}
+	r.notifyActionUpdate(ctx, notifyTestActionID("other-action"))
+
+	actions, _ := r.pendingCounts()
+	assert.Equal(t, 2, actions, "repeated updates to one action must collapse into one pending entry")
+}
+
+// TestNotifyActionUpdate_KeepsWakeupAfterContextCancel covers the loss path
+// that existed before: a client disconnecting mid-request used to discard a
+// wakeup that other watchers still needed.
+func TestNotifyActionUpdate_KeepsWakeupAfterContextCancel(t *testing.T) {
+	r := newNotifyTestRepo()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r.notifyActionUpdate(ctx, notifyTestActionID("cancelled-caller"))
+	r.notifyRunUpdate(ctx, &common.RunIdentifier{Project: "proj", Domain: "domain", Name: "run"})
+
+	actions, runs := r.takePendingNotifications()
+	assert.Contains(t, actions, "proj/domain/run/cancelled-caller")
+	assert.Contains(t, runs, "proj/domain/run")
+}
+
+// TestRunNotifyLoop_RetriesUndeliveredPayloads verifies that a failed
+// pg_notify keeps the payload pending instead of dropping it. A nil connection
+// with no database to reconnect to is the simplest permanent failure. The
+// whole batch must survive, not just the payload that failed first: a dead
+// connection aborts the drain rather than retrying the connection per payload.
+func TestRunNotifyLoop_RetriesUndeliveredPayloads(t *testing.T) {
+	r := newNotifyTestRepo()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for i := 0; i < 3; i++ {
+		r.notifyActionUpdate(ctx, notifyTestActionID(fmt.Sprintf("undeliverable-%d", i)))
+	}
+	for i := 0; i < 2; i++ {
+		r.notifyRunUpdate(ctx, &common.RunIdentifier{
+			Project: "proj", Domain: "domain", Name: fmt.Sprintf("run-%d", i),
+		})
+	}
+
+	loopDone := make(chan struct{})
+	go func() {
+		defer close(loopDone)
+		r.runNotifyLoop(ctx, nil, nil)
+	}()
+
+	// Let the pump take the payloads, fail to deliver them, and requeue.
+	assert.Eventually(t, func() bool {
+		actions, runs := r.pendingCounts()
+		return actions == 3 && runs == 2
+	}, 5*time.Second, 20*time.Millisecond, "undelivered payloads must stay pending for retry")
+
+	cancel()
+	select {
+	case <-loopDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runNotifyLoop did not return after its context was cancelled")
+	}
+}
+
+// newNotifyTestRepo builds a repo with the notify plumbing initialized but no
+// pump running, so the pending work is observable and nothing drains it.
+func newNotifyTestRepo() *actionRepo {
+	return &actionRepo{
+		pendingActions: make(map[string]int),
+		pendingRuns:    make(map[string]int),
+		pendingCh:      make(chan struct{}, 1),
+	}
+}
+
+// pendingCounts reports how many payloads are queued for the pump.
+func (r *actionRepo) pendingCounts() (actions, runs int) {
+	r.notifyMu.Lock()
+	defer r.notifyMu.Unlock()
+	return len(r.pendingActions), len(r.pendingRuns)
+}
+
+// pendingDropped reports when the given payload has been absent from the
+// pending set on enough consecutive checks to rule out the short window where
+// the pump is holding a taken batch and has not requeued it yet. A single
+// absent reading is not evidence of a drop.
+func (r *actionRepo) pendingDropped(payload string) func() bool {
+	const consecutive = 25
+	absent := 0
+	return func() bool {
+		r.notifyMu.Lock()
+		_, queued := r.pendingActions[payload]
+		r.notifyMu.Unlock()
+
+		if queued {
+			absent = 0
+			return false
+		}
+		absent++
+		return absent >= consecutive
+	}
+}
+
+// newNotifyRepoWithDB builds a repo wired to a real database and listener but
+// with no pump running, so a test can drive runNotifyLoop itself and watch
+// what actually reaches the wire.
+func newNotifyRepoWithDB(t *testing.T) (*actionRepo, *sql.DB, *sql.Conn) {
+	t.Helper()
+	db := setupActionDB(t)
+
+	r := &actionRepo{
+		db:                db,
+		dsn:               database.GetPostgresDsn(context.Background(), testDbConfig.Postgres),
+		runSubscribers:    make(map[chan string]bool),
+		actionSubscribers: make(map[chan string]bool),
+		pendingActions:    make(map[string]int),
+		pendingRuns:       make(map[string]int),
+		pendingCh:         make(chan struct{}, 1),
+	}
+	require.NoError(t, r.startPostgresListener())
+
+	conn, err := db.DB.Conn(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() }) //nolint:errcheck
+
+	return r, db.DB, conn
+}
+
+// subscribeActions registers a raw subscriber the way WatchActionUpdates does.
+func subscribeActions(t *testing.T, r *actionRepo, size int) chan string {
+	t.Helper()
+	ch := make(chan string, size)
+	r.mu.Lock()
+	r.actionSubscribers[ch] = true
+	r.mu.Unlock()
+	t.Cleanup(func() {
+		r.mu.Lock()
+		delete(r.actionSubscribers, ch)
+		r.mu.Unlock()
+	})
+	return ch
+}
+
+func notifyTestActionID(name string) *common.ActionIdentifier {
+	return &common.ActionIdentifier{
+		Run:  &common.RunIdentifier{Org: "org", Project: "proj", Domain: "domain", Name: "run"},
+		Name: name,
+	}
+}
+
+// TestNotifyActionUpdate_DoesNotBlockOnStalledPump pins the property the write
+// path depends on: the row is already committed by the time we notify, so a
+// stalled pump must never turn into RPC latency.
+func TestNotifyActionUpdate_DoesNotBlockOnStalledPump(t *testing.T) {
+	r := newNotifyTestRepo()
+
+	// No pump is running, so nothing consumes what the writer produces. Push
+	// far more updates than any fixed-size buffer would hold.
+	const updates = 5000
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < updates; i++ {
+			r.notifyActionUpdate(ctx, notifyTestActionID(fmt.Sprintf("action-%d", i)))
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("notifyActionUpdate blocked while the notify pump was stalled")
+	}
+}
+
+// TestNotifyRunUpdate_DoesNotBlockOnStalledPump is the run-side twin of the
+// test above; both notify paths share the same pump.
+func TestNotifyRunUpdate_DoesNotBlockOnStalledPump(t *testing.T) {
+	r := newNotifyTestRepo()
+
+	const updates = 5000
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < updates; i++ {
+			r.notifyRunUpdate(ctx, &common.RunIdentifier{
+				Org: "org", Project: "proj", Domain: "domain", Name: fmt.Sprintf("run-%d", i),
+			})
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("notifyRunUpdate blocked while the notify pump was stalled")
+	}
+}
+
+// TestWatchActionUpdates_DeliversPhaseChange exercises the full product path
+// against a real database: UpdateActionPhase writes the row, the notify pump
+// issues pg_notify, the listener fans out to subscribers, and the watcher
+// re-reads the action. It guards the other half of the contract, that making
+// the writer non-blocking must not lose a wakeup.
+func TestWatchActionUpdates_DeliversPhaseChange(t *testing.T) {
+	db := setupActionDB(t)
+	repo, err := NewActionRepo(db, testDbConfig)
+	require.NoError(t, err)
+	repoImpl, ok := repo.(*actionRepo)
+	require.True(t, ok)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	actionID := &common.ActionIdentifier{
+		Run:  &common.RunIdentifier{Project: "p", Domain: "d", Name: "run-watch"},
+		Name: "watched-action",
+	}
+	_, err = repo.CreateAction(ctx, models.NewActionModel(actionID), false)
+	require.NoError(t, err)
+
+	updates := make(chan *models.Action, 8)
+	errs := make(chan error, 8)
+	go repo.WatchActionUpdates(ctx, actionID, updates, errs)
+
+	require.Eventually(t, func() bool {
+		repoImpl.mu.RLock()
+		defer repoImpl.mu.RUnlock()
+		return len(repoImpl.actionSubscribers) > 0
+	}, 2*time.Second, 10*time.Millisecond, "timed out waiting for watcher registration")
+
+	require.NoError(t, repo.UpdateActionPhase(ctx, actionID,
+		common.ActionPhase_ACTION_PHASE_RUNNING, 0, core.CatalogCacheStatus_CACHE_DISABLED, nil, nil))
+
+	// CreateAction notifies as well, so the watcher can legitimately see the
+	// initial phase first. Wait for the transition we triggered.
+	deadline := time.After(15 * time.Second)
+	for {
+		select {
+		case got := <-updates:
+			if got.Phase == int32(common.ActionPhase_ACTION_PHASE_RUNNING) {
+				return
+			}
+		case err := <-errs:
+			t.Fatalf("watch reported an error: %v", err)
+		case <-deadline:
+			t.Fatal("phase change never reached the watcher")
+		}
+	}
+}
+
+// TestNotifyPump_ConcurrentWritersDeliverEveryAction runs many writers against
+// a live pump and a real database, and checks the delivery half of the
+// contract: every action that was notified reaches the wire. The stalled-pump
+// tests above own the "writers never block" half.
+func TestNotifyPump_ConcurrentWritersDeliverEveryAction(t *testing.T) {
+	db := setupActionDB(t)
+	repoIface, err := NewActionRepo(db, testDbConfig)
+	require.NoError(t, err)
+	repo, ok := repoIface.(*actionRepo)
+	require.True(t, ok)
+
+	const writers = 40
+	const perWriter = 25
+	const total = writers * perWriter
+
+	// Subscribe the way WatchActionUpdates does, so we observe what actually
+	// came back through pg_notify and the listener.
+	delivered := make(chan string, 4*total)
+	repo.mu.Lock()
+	repo.actionSubscribers[delivered] = true
+	repo.mu.Unlock()
+	defer func() {
+		repo.mu.Lock()
+		delete(repo.actionSubscribers, delivered)
+		repo.mu.Unlock()
+	}()
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				repo.notifyActionUpdate(ctx, notifyTestActionID(fmt.Sprintf("a-%d-%d", w, i)))
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	seen := make(map[string]struct{}, total)
+	deadline := time.After(60 * time.Second)
+	for len(seen) < total {
+		select {
+		case payload := <-delivered:
+			seen[payload] = struct{}{}
+		case <-deadline:
+			t.Fatalf("only %d of %d notifications were delivered", len(seen), total)
+		}
+	}
+
+	for w := 0; w < writers; w++ {
+		for i := 0; i < perWriter; i++ {
+			assert.Contains(t, seen, fmt.Sprintf("proj/domain/run/a-%d-%d", w, i))
+		}
+	}
+}
+
+// TestUpdateActionPhase_CompletesWithStalledPump is the acceptance criterion
+// the issue states directly: with the pump stalled the writer returns
+// immediately and the row is still written.
+func TestUpdateActionPhase_CompletesWithStalledPump(t *testing.T) {
+	db := setupActionDB(t)
+	r := &actionRepo{
+		db:             db,
+		pendingActions: make(map[string]int),
+		pendingRuns:    make(map[string]int),
+		pendingCh:      make(chan struct{}, 1),
+	}
+	// No pump is started, so nothing drains what the write path queues.
+
+	ctx := context.Background()
+	actionID := &common.ActionIdentifier{
+		Run:  &common.RunIdentifier{Project: "p", Domain: "d", Name: "run-stalled"},
+		Name: "stalled-action",
+	}
+	_, err := r.CreateAction(ctx, models.NewActionModel(actionID), false)
+	require.NoError(t, err)
+
+	// Back the queue up past what the old 256-slot buffer could hold.
+	for i := 0; i < 300; i++ {
+		r.notifyActionUpdate(ctx, notifyTestActionID(fmt.Sprintf("backlog-%d", i)))
+	}
+
+	start := time.Now()
+	require.NoError(t, r.UpdateActionPhase(ctx, actionID,
+		common.ActionPhase_ACTION_PHASE_RUNNING, 0, core.CatalogCacheStatus_CACHE_DISABLED, nil, nil))
+	assert.Less(t, time.Since(start), 2*time.Second, "the write must not wait on a stalled pump")
+
+	action, err := r.GetAction(ctx, actionID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(common.ActionPhase_ACTION_PHASE_RUNNING), action.Phase,
+		"the row must still be written while the pump is stalled")
+
+	actions, _ := r.pendingCounts()
+	assert.Equal(t, 301, actions, "the notification must be queued rather than dropped")
+}
+
+// TestNotifyPump_CoalescesRepeatsOnTheWire checks the collapse where it counts,
+// on the wire rather than in the map. Every update is queued before the pump
+// starts, so the whole burst is one drain.
+func TestNotifyPump_CoalescesRepeatsOnTheWire(t *testing.T) {
+	r, sqlDB, conn := newNotifyRepoWithDB(t)
+	delivered := subscribeActions(t, r, 64)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for i := 0; i < 500; i++ {
+		r.notifyActionUpdate(ctx, notifyTestActionID("busy-action"))
+	}
+
+	go r.runNotifyLoop(ctx, sqlDB, conn)
+
+	select {
+	case payload := <-delivered:
+		assert.Equal(t, "proj/domain/run/busy-action", payload)
+	case <-time.After(15 * time.Second):
+		t.Fatal("the coalesced notification was never delivered")
+	}
+
+	select {
+	case extra := <-delivered:
+		t.Fatalf("500 updates to one action must produce one notification, also got %q", extra)
+	case <-time.After(2 * time.Second):
+	}
+}
+
+// TestRunNotifyLoop_DropsPayloadPostgresWillNeverAccept covers the failure the
+// retry design would otherwise turn into a permanent stall. pg_notify rejects
+// a payload of 8000 bytes or more, and that is not a connection error, so it
+// fails identically on every attempt. Such a payload must be given up on, and
+// must not hold up notifications that are fine.
+func TestRunNotifyLoop_DropsPayloadPostgresWillNeverAccept(t *testing.T) {
+	r, sqlDB, conn := newNotifyRepoWithDB(t)
+	delivered := subscribeActions(t, r, 16)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	poison := strings.Repeat("x", 8000)
+	r.notifyMu.Lock()
+	markPending(r.pendingActions, poison)
+	r.notifyMu.Unlock()
+
+	go r.runNotifyLoop(ctx, sqlDB, conn)
+
+	// Keep ordinary traffic flowing alongside the bad payload.
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			case <-time.After(20 * time.Millisecond):
+				r.notifyActionUpdate(ctx, notifyTestActionID(fmt.Sprintf("healthy-%d", i)))
+			}
+		}
+	}()
+
+	select {
+	case payload := <-delivered:
+		assert.Contains(t, payload, "proj/domain/run/healthy-")
+	case <-time.After(15 * time.Second):
+		t.Fatal("a deliverable notification was held up behind an undeliverable one")
+	}
+
+	assert.Eventually(t, r.pendingDropped(poison), 15*time.Second, 20*time.Millisecond,
+		"a payload that can never be delivered must be dropped, not retried forever")
 }
 
 func TestIsConnError(t *testing.T) {
@@ -926,19 +1349,17 @@ func TestIsConnError(t *testing.T) {
 func TestRunNotifyLoop_NilConnNoPanic(t *testing.T) {
 	// Verify that runNotifyLoop handles a nil connection gracefully
 	// (e.g. after a failed reconnect) instead of panicking.
-	r := &actionRepo{
+	r := newNotifyTestRepo()
 
-		actionNotifyCh: make(chan string, 256),
-		runNotifyCh:    make(chan string, 256),
-	}
+	// Queue a notification, then cancel so the loop exits after one attempt.
+	r.notifyActionUpdate(context.Background(), notifyTestActionID("action"))
 
-	// Send a notification, then close the channel so the loop exits.
-	r.actionNotifyCh <- "proj/domain/run/action"
-	close(r.actionNotifyCh)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
 
-	// Pass a nil conn — should not panic.
+	// Pass a nil conn: should not panic.
 	assert.NotPanics(t, func() {
-		r.runNotifyLoop(nil, nil)
+		r.runNotifyLoop(ctx, nil, nil)
 	})
 }
 


### PR DESCRIPTION
## Tracking issue

Closes #7757

## Why are the changes needed?

`notifyActionUpdate` and `notifyRunUpdate` did a blocking send on a 256-slot channel from inside write RPCs, right after the row was already committed. When the pump falls behind, the buffer fills and the send blocks in the RPC handler, so a best-effort wakeup becomes user-visible write latency. The issue measures that as a p95 of 3085 ms on `UpdateActionStatus` while the database itself sat idle.

There is a second, quieter problem in the same six lines. The old `select` had a `<-ctx.Done()` arm, so a client that disconnected mid-request discarded a notification that other watchers still needed.

## What changes were proposed in this pull request?

The FIFO channels are replaced with a coalescing pending set per notification kind, plus one capacity-1 signal channel shared by both, as the issue proposes.

|  | before | after |
| --- | --- | --- |
| Blocks the write path | yes | no |
| Can lose a wakeup | yes, on `ctx.Done()` and on any `pg_notify` failure | no |
| Queue bounded by | 256 updates | distinct pending actions |

The writer takes the lock, inserts the payload as a key, unlocks, and does a non-blocking send on `pendingCh`. It cannot block and it cannot discard a key. A nudge that is already buffered needs no second one: the sets are the queue, the channel only wakes the pump.

Dropping a nudge is safe because of the ordering. The insert always happens before the signal attempt, and the pump always swaps the sets out after it has consumed a token. If the send finds the buffer full, a token was outstanding at that instant, so the pump has not yet woken for it; when it does, its swap happens after our insert and picks the key up. If the send succeeds, the same argument applies to the token we just put there. Either way a key cannot sit in the set with no pending wakeup.

The pump swaps both sets out under the lock and emits them. Payloads it could not deliver are merged back into the pending set and retried with backoff, so a transient database problem costs a delay rather than a lost wakeup. Re-adding a key is idempotent, so a retry cannot duplicate work, and updates that arrived meanwhile merge into the same entry.

### Retrying forever is its own failure mode

An earlier version of this patch retried unconditionally, which is what the issue asks for. That turns out to have a sharp edge, and I only found it because I went looking for a payload that fails for a reason other than a connection blip.

Postgres rejects a `pg_notify` payload of 8000 bytes or more, permanently. Measured against the package's own test database:

```
len=7999 err=<nil>
len=8000 err=ERROR: payload string too long (SQLSTATE 22023)
```

`isConnError` correctly says that is not a connection problem, so the connection stays up and the payload fails the same way on every attempt. With an unconditional retry the key never leaves the pending set, the success branch never runs, and the backoff pins at its 5 s ceiling. One such payload adds seconds of wakeup latency to every other watcher for the life of the process. That is worse than the old behaviour, which logged once and dropped it.

`RunIdentifier.Name` has no length validation (`identifier.pb.validate.go` says as much), and the root-action `notifyRunUpdate` in `UpdateActionPhase` is not gated on `rowsAffected`, so a caller can queue such a payload without a row existing. Reachable, not theoretical.

Two limits keep the retry honest:

A payload only spends its retry budget when the connection was healthy and it failed anyway, because that is the case where the payload itself is what Postgres rejected. Connection-level failures cost nothing, so a genuine outage still retries for as long as it lasts. After `notifyRetryLimit` payload-specific failures the key is dropped with an error log.

A drain that delivered anything resets the backoff. Otherwise one failing payload would slow every healthy notification behind it. The effect is measurable: the test covering this drops from 16.4 s to 1.0 s once the reset is in, because the poison key burns its budget at the minimum interval while ordinary traffic keeps flowing.

### Two smaller notes

A lost connection aborts the current drain. `execNotify` reconnects when `conn` is nil, so without an early exit a dead connection would make every remaining payload in a large batch trigger its own reconnect attempt, which is a storm precisely when the database is already unhappy. The undelivered payloads stay pending and the backoff handles recovery instead.

`runNotifyLoop` now takes a context rather than exiting when a channel is closed. Closing a channel that writers send on would panic the write path, and the loop still needs a stop condition the tests can drive. Production passes `context.Background()`, so the running behaviour is unchanged.

### Level of fix

Fixed at the notify layer inside `action.go`, which owns both writers and the pump, rather than at either call site. I enumerated the class of the same defect shape across `runs/`:

- `updates <- run` / `updates <- action` in the four `Watch*` methods (`action.go:707`, `:760`, `:826`, `:884`) block, but each runs in its own stream-serving goroutine. Blocking there is backpressure against a slow client and is correct. Not the same defect.
- `ch <- notif.Extra` in `processNotifications` is already non-blocking with a `default` that drops. That is the subscriber side, and #7643 is already open to instrument those drops. Left alone.
- `dedupeQueue.push` in `runs/service/abort_reconciler.go:70-88` **is the same defect and this PR does not fix it.** It has the same shape, a blocking send into a 1000-slot buffer guarded only by `<-ctx.Done()`, and `AbortRun` calls it at `run_service.go:530` after the row is already marked ABORTED at line 521. So a backed-up reconciler blocks that RPC too, and a disconnecting client drops the abort task *and* deletes its dedup key, so nothing re-pushes it. I left it alone because fixing it means touching a different subsystem and its tests in a PR scoped to the files this issue names. Happy to open a follow-up issue, or to fold it in here if you would rather see them land together.

So the write path has two members of this class and this PR fixes the notify one. I considered lifting a shared coalescing-pending-set type that both could use. The cost is a new internal package plus a rewrite of the reconciler's tests, which puts two subsystems in one review, so I would rather do it as a follow-up once the shape here has been reviewed.

Batching the pump's round trips (#7756) composes with this cleanly. The pump already hands `emit` a whole set, so batching becomes a change inside `emit` rather than a change to the structure. I have not touched instrumentation, since #7758 covers it.

## How was this patch tested?

The package brings up an embedded PostgreSQL on port 15432 by itself, so the delivery tests below issue real `pg_notify` statements and read them back through the real listener. The blocking, coalescing, and retry tests are white box and touch no database.

**Red then green.** Both new blocking tests fail on unmodified `main` at `2ad38dca6`:

```
=== RUN   TestNotifyActionUpdate_DoesNotBlockOnStalledPump
    action_test.go:921: notifyActionUpdate blocked while the notify pump was stalled
--- FAIL: TestNotifyActionUpdate_DoesNotBlockOnStalledPump (5.00s)
=== RUN   TestNotifyRunUpdate_DoesNotBlockOnStalledPump
    action_test.go:948: notifyRunUpdate blocked while the notify pump was stalled
--- FAIL: TestNotifyRunUpdate_DoesNotBlockOnStalledPump (5.00s)
```

and pass after the change, along with the rest of the new coverage:

```
--- PASS: TestNotifyActionUpdate_DoesNotBlockOnStalledPump (0.00s)
--- PASS: TestNotifyRunUpdate_DoesNotBlockOnStalledPump (0.00s)
--- PASS: TestUpdateActionPhase_CompletesWithStalledPump (0.00s)
--- PASS: TestNotifyActionUpdate_CoalescesRepeats (0.00s)
--- PASS: TestNotifyPump_CoalescesRepeatsOnTheWire (2.03s)
--- PASS: TestNotifyActionUpdate_KeepsWakeupAfterContextCancel (0.00s)
--- PASS: TestRunNotifyLoop_RetriesUndeliveredPayloads (0.00s)
--- PASS: TestRunNotifyLoop_DropsPayloadPostgresWillNeverAccept (1.00s)
--- PASS: TestNotifyPump_ConcurrentWritersDeliverEveryAction (0.20s)
--- PASS: TestWatchActionUpdates_DeliversPhaseChange (0.05s)
```

Mapping tests to the outcomes listed in the issue:

| Outcome | Test |
| --- | --- |
| Writer never blocks on a stalled pump | `TestNotifyActionUpdate_DoesNotBlockOnStalledPump`, `TestNotifyRunUpdate_DoesNotBlockOnStalledPump` |
| Pump stalled, writer returns and the row is still written | `TestUpdateActionPhase_CompletesWithStalledPump` |
| No wakeup lost, every updated action represented | `TestNotifyPump_ConcurrentWritersDeliverEveryAction` |
| Failed `pg_notify` retries rather than dropping | `TestRunNotifyLoop_RetriesUndeliveredPayloads` |
| N updates to one action produce one notification | `TestNotifyPump_CoalescesRepeatsOnTheWire` (on the wire), `TestNotifyActionUpdate_CoalescesRepeats` (in the set) |
| Context cancellation no longer discards | `TestNotifyActionUpdate_KeepsWakeupAfterContextCancel` |
| Product path still delivers | `TestWatchActionUpdates_DeliversPhaseChange` |
| Retry cannot become a permanent stall | `TestRunNotifyLoop_DropsPayloadPostgresWillNeverAccept` |

Two of these are worth a note.

`TestNotifyPump_CoalescesRepeatsOnTheWire` queues all 500 updates for one action before the pump starts, so the whole burst is guaranteed to be one drain. It then asserts one delivery arrives and that a second never does. That makes the collapse observable on the wire rather than by asserting that a Go map deduplicates.

`TestRunNotifyLoop_DropsPayloadPostgresWillNeverAccept` was the one that nearly fooled me. Its first version polled the pending set for the poison key's absence, and it passed even with the retry limit raised to 100000, because the pump briefly holds a taken batch outside the pending set and a 20 ms poll lands in that window eventually. It now requires 25 consecutive absent readings. Mutation checked both ways: with `notifyRetryLimit` raised to 100000 it fails after 15 s, and at 10 it passes in 1 s.

**Race detector**, since this is a concurrency change:

```
$ go test -race -count=2 ./runs/...
ok      github.com/flyteorg/flyte/v2/runs/config                  1.025s
ok      github.com/flyteorg/flyte/v2/runs/repository/impl        29.421s
ok      github.com/flyteorg/flyte/v2/runs/repository/transformers 1.025s
ok      github.com/flyteorg/flyte/v2/runs/scheduler/core          1.620s
ok      github.com/flyteorg/flyte/v2/runs/service                13.954s
ok      github.com/flyteorg/flyte/v2/runs/test/api               13.714s
```

**Full tree** without the race detector:

```
$ go test -count=1 ./runs/...
ok      github.com/flyteorg/flyte/v2/runs/config                  0.718s
ok      github.com/flyteorg/flyte/v2/runs/repository/impl        21.284s
ok      github.com/flyteorg/flyte/v2/runs/repository/transformers 1.365s
ok      github.com/flyteorg/flyte/v2/runs/scheduler/core          1.948s
ok      github.com/flyteorg/flyte/v2/runs/service                12.511s
ok      github.com/flyteorg/flyte/v2/runs/test/api               12.527s
```

For a baseline I ran `./runs/repository/impl/...` on a clean checkout of `2ad38dca6` before touching anything: `ok ... 25.838s`. There were no pre-existing failures in this package to work around, so every red result quoted above came from the change itself.

### Labels

- **changed**: For changes in existing functionality.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly. No user-facing documentation covers this internal path; the reasoning lives in the code comments.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

### What was not tested

The 100,000-action benchmark from `flyteorg/benchmark` that produced the p95 numbers in the issue. I have no dev cluster to run `swarm.py` against, so the latency improvement is argued from the structure and from the concurrency test rather than re-measured end to end. If someone with a cluster reruns it, the number to watch is `rpc_server_duration_milliseconds` for `UpdateActionStatus`.

A real connection loss or failover. `TestRunNotifyLoop_RetriesUndeliveredPayloads` uses a nil connection with no database to reconnect to, which exercises the same branch, but it is not the same as pulling the plug on a live Postgres mid-drain.

The pending set still has no upper bound, which is what the issue proposes and I did not change. During a long outage it is bounded by the number of distinct actions being updated rather than by anything the process controls, whereas the old 256-slot buffer at least applied backpressure. At the issue's own figure of 65,000 live actions that is a few MB, so I left it alone, but if you would rather have a cap plus a dropped-notification counter I am happy to add it, and #7758 looks like the natural home for the counter.

I did not check whether `InternalRunService.UpdateActionStatus` is reachable by anything other than the in-cluster operator, so I cannot say whether the oversized-payload path above is only an operational footgun or something a caller could aim. The retry limit bounds the damage either way.

## Related PRs

- #7756 batch the pump's round trips, which composes with this
- #7758 instrument the pump
- #7643 counter for dropped subscriber updates, the other side of the notification path

---

_This change was developed with AI assistance from Claude. I reviewed and verified it before submitting._
