### PR TITLE
Stamp 1-based FLYTE_ATTEMPT env var alongside FLYTE_ATTEMPT_NUMBER

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/container_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/container_helper_test.go
@@ -655,7 +655,7 @@ func TestAddFlyteCustomizationsToContainer(t *testing.T) {
 	assert.EqualValues(t, container.Command, []string{"s3://input/path"})
 	assert.Len(t, container.Resources.Limits, 3)
 	assert.Len(t, container.Resources.Requests, 3)
-	assert.Len(t, container.Env, 13)
+	assert.Len(t, container.Env, 14)
 }
 
 func TestAddFlyteCustomizationsToContainer_Resources(t *testing.T) {

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go
@@ -74,6 +74,13 @@ func GetExecutionEnvVars(id pluginsCore.TaskExecutionID, consoleURL string) []v1
 			Name:  "FLYTE_ATTEMPT_NUMBER",
 			Value: attemptNumber,
 		},
+		{
+			// 1-based attempt ordinal, matching the wire/API convention
+			// (ActionAttemptIdentifier, console). FLYTE_ATTEMPT_NUMBER above is the
+			// 0-based retry index and is kept for existing SDK/user-code readers.
+			Name:  "FLYTE_ATTEMPT",
+			Value: strconv.Itoa(int(id.GetID().RetryAttempt) + 1),
+		},
 	}
 
 	if len(consoleURL) > 0 {

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds_test.go
@@ -27,13 +27,13 @@ func TestGetExecutionEnvVars(t *testing.T) {
 	}{
 		{
 			"no-console-url",
-			13,
+			14,
 			"",
 			nil,
 		},
 		{
 			"with-console-url",
-			14,
+			15,
 			"scheme://host/path",
 			&v12.EnvVar{
 				Name:  "FLYTE_EXECUTION_URL",
@@ -42,7 +42,7 @@ func TestGetExecutionEnvVars(t *testing.T) {
 		},
 		{
 			"with-console-url-ending-in-single-slash",
-			14,
+			15,
 			"scheme://host/path/",
 			&v12.EnvVar{
 				Name:  "FLYTE_EXECUTION_URL",
@@ -51,7 +51,7 @@ func TestGetExecutionEnvVars(t *testing.T) {
 		},
 		{
 			"with-console-url-ending-in-multiple-slashes",
-			14,
+			15,
 			"scheme://host/path////",
 			&v12.EnvVar{
 				Name:  "FLYTE_EXECUTION_URL",
@@ -63,7 +63,7 @@ func TestGetExecutionEnvVars(t *testing.T) {
 		envVars := GetExecutionEnvVars(mock, tt.consoleURL)
 		assert.Len(t, envVars, tt.expectedEnvVars)
 		if tt.expectedEnvVar != nil {
-			assert.Equal(t, tt.expectedEnvVar, &envVars[5])
+			assert.Equal(t, tt.expectedEnvVar, &envVars[6])
 		}
 	}
 }


### PR DESCRIPTION
## Why are the changes needed?

Attempt numbering today is split across two conventions: the v2 wire/API (`ActionAttemptIdentifier`, console, action events) is 1-based, while the execution layer's `TaskExecutionIdentifier.retry_attempt` — and the `FLYTE_ATTEMPT_NUMBER` env var derived from it — is a 0-based retry index inherited from v1. User code inside a task therefore sees `0` for the same attempt the console displays as "Attempt 1".

This adds a 1-based `FLYTE_ATTEMPT` env var so SDKs can expose an attempt number consistent with the UI, without touching any existing consumer.

## What changes were proposed in this pull request?

`GetExecutionEnvVars` stamps `FLYTE_ATTEMPT` (value `RetryAttempt + 1`) alongside the unchanged `FLYTE_ATTEMPT_NUMBER`. Purely additive: old SDKs keep reading the old var; new SDKs read `FLYTE_ATTEMPT` and fall back to `FLYTE_ATTEMPT_NUMBER + 1` on backends without this change, so every old/new backend × old/new SDK combination behaves identically (companion SDK PR adds `TaskContext.attempt` with that fallback).

## How was this patch tested?

Updated `TestGetExecutionEnvVars` and `TestAddFlyteCustomizationsToContainer` env-var count/index expectations; suite passes.

### Labels

- **added**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199AnC2fWkbhANzJtAKEV61