### PR TITLE
fix: honor cron trigger timezone when scheduling runs

### DIFF
--- a/runs/schedule/cron.go
+++ b/runs/schedule/cron.go
@@ -1,0 +1,35 @@
+package schedule
+
+import (
+	"fmt"
+
+	"github.com/robfig/cron/v3"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
+)
+
+// ParseCron parses either form of cron schedule, including its timezone.
+func ParseCron(schedule *task.Schedule) (cron.Schedule, error) {
+	if schedule == nil {
+		return nil, nil
+	}
+
+	var expression string
+	switch value := schedule.GetExpression().(type) {
+	case *task.Schedule_CronExpression:
+		expression = value.CronExpression
+	case *task.Schedule_Cron:
+		expression = value.Cron.GetExpression()
+		if timezone := value.Cron.GetTimezone(); timezone != "" {
+			expression = fmt.Sprintf("CRON_TZ=%s %s", timezone, expression)
+		}
+	default:
+		return nil, nil
+	}
+
+	parsed, err := cron.ParseStandard(expression)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cron expression %q: %w", expression, err)
+	}
+	return parsed, nil
+}

--- a/runs/scheduler/core/schedule_time.go
+++ b/runs/scheduler/core/schedule_time.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
 	"github.com/flyteorg/flyte/v2/runs/repository/models"
+	"github.com/flyteorg/flyte/v2/runs/schedule"
 )
 
 // ParseSchedule returns a cron.Schedule for the trigger's automation spec.
@@ -30,7 +31,7 @@ func ParseSchedule(t *models.Trigger) (cron.Schedule, error) {
 		return nil, nil
 	}
 
-	if parsed, err := ParseCronSchedule(sched); err != nil || parsed != nil {
+	if parsed, err := schedule.ParseCron(sched); err != nil || parsed != nil {
 		return parsed, err
 	}
 
@@ -44,30 +45,6 @@ func ParseSchedule(t *models.Trigger) (cron.Schedule, error) {
 	}
 
 	return nil, nil
-}
-
-// ParseCronSchedule parses either form of cron schedule, including its timezone.
-func ParseCronSchedule(sched *task.Schedule) (cron.Schedule, error) {
-	if sched == nil {
-		return nil, nil
-	}
-
-	expr := sched.GetCronExpression() //nolint:staticcheck // legacy field
-	if c := sched.GetCron(); c != nil {
-		expr = c.GetExpression()
-		if tz := c.GetTimezone(); tz != "" {
-			expr = fmt.Sprintf("CRON_TZ=%s %s", tz, expr)
-		}
-	}
-	if expr == "" {
-		return nil, nil
-	}
-
-	parsed, err := cron.ParseStandard(expr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid cron expression %q: %w", expr, err)
-	}
-	return parsed, nil
 }
 
 // fixedRateDuration converts a FixedRate proto to a time.Duration.

--- a/runs/scheduler/core/schedule_time.go
+++ b/runs/scheduler/core/schedule_time.go
@@ -30,21 +30,8 @@ func ParseSchedule(t *models.Trigger) (cron.Schedule, error) {
 		return nil, nil
 	}
 
-	// Prefer the structured Cron object; fall back to legacy CronExpression string.
-	if c := sched.GetCron(); c != nil && c.GetExpression() != "" {
-		expr := c.GetExpression()
-		parsed, err := cron.ParseStandard(expr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid cron expression %q: %w", expr, err)
-		}
-		return parsed, nil
-	}
-	if expr := sched.GetCronExpression(); expr != "" { //nolint:staticcheck // legacy field
-		parsed, err := cron.ParseStandard(expr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid cron expression %q: %w", expr, err)
-		}
-		return parsed, nil
+	if parsed, err := ParseCronSchedule(sched); err != nil || parsed != nil {
+		return parsed, err
 	}
 
 	// Fixed-rate schedule.
@@ -57,6 +44,30 @@ func ParseSchedule(t *models.Trigger) (cron.Schedule, error) {
 	}
 
 	return nil, nil
+}
+
+// ParseCronSchedule parses either form of cron schedule, including its timezone.
+func ParseCronSchedule(sched *task.Schedule) (cron.Schedule, error) {
+	if sched == nil {
+		return nil, nil
+	}
+
+	expr := sched.GetCronExpression() //nolint:staticcheck // legacy field
+	if c := sched.GetCron(); c != nil {
+		expr = c.GetExpression()
+		if tz := c.GetTimezone(); tz != "" {
+			expr = fmt.Sprintf("CRON_TZ=%s %s", tz, expr)
+		}
+	}
+	if expr == "" {
+		return nil, nil
+	}
+
+	parsed, err := cron.ParseStandard(expr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cron expression %q: %w", expr, err)
+	}
+	return parsed, nil
 }
 
 // fixedRateDuration converts a FixedRate proto to a time.Duration.

--- a/runs/scheduler/core/scheduler_test.go
+++ b/runs/scheduler/core/scheduler_test.go
@@ -36,13 +36,13 @@ func (r *recordingExecutor) count() int {
 // newCronTrigger builds a schedule trigger whose scheduling baseline (UpdatedAt)
 // is `baseline`. A baseline in the past is exactly the deploy-time situation that
 // used to make the job fire immediately on registration.
-func newCronTrigger(t *testing.T, name, expr string, baseline time.Time) *models.Trigger {
+func newCronTrigger(t *testing.T, name, expr, timezone string, baseline time.Time) *models.Trigger {
 	t.Helper()
 	spec := &task.TriggerAutomationSpec{
 		Type: task.TriggerAutomationSpecType_TYPE_SCHEDULE,
 		Automation: &task.TriggerAutomationSpec_Schedule{
 			Schedule: &task.Schedule{
-				Expression: &task.Schedule_Cron{Cron: &task.Cron{Expression: expr}},
+				Expression: &task.Schedule_Cron{Cron: &task.Cron{Expression: expr, Timezone: timezone}},
 			},
 		},
 	}
@@ -60,6 +60,59 @@ func newCronTrigger(t *testing.T, name, expr string, baseline time.Time) *models
 	}
 }
 
+func TestCronScheduleTimezone(t *testing.T) {
+	tests := []struct {
+		name     string
+		timezone string
+		baseline time.Time
+		want     []time.Time
+	}{
+		{
+			name:     "UTC",
+			timezone: "UTC",
+			baseline: time.Date(2026, 7, 1, 8, 59, 0, 0, time.UTC),
+			want: []time.Time{
+				time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 7, 2, 9, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name:     "non-UTC",
+			timezone: "America/Los_Angeles",
+			baseline: time.Date(2026, 7, 1, 15, 59, 0, 0, time.UTC),
+			want: []time.Time{
+				time.Date(2026, 7, 1, 16, 0, 0, 0, time.UTC),
+				time.Date(2026, 7, 2, 16, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name:     "DST boundary",
+			timezone: "America/Los_Angeles",
+			baseline: time.Date(2026, 3, 7, 16, 59, 0, 0, time.UTC),
+			want: []time.Time{
+				time.Date(2026, 3, 7, 17, 0, 0, 0, time.UTC),
+				time.Date(2026, 3, 8, 16, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trig := newCronTrigger(t, tt.name, "0 9 * * *", tt.timezone, tt.baseline)
+			schedule, err := ParseSchedule(trig)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want[0], schedule.Next(tt.baseline).UTC())
+
+			catchUp, err := GetCatchUpTimes(trig, tt.want[1].Add(time.Minute))
+			require.NoError(t, err)
+			require.Len(t, catchUp, len(tt.want))
+			for i := range catchUp {
+				assert.Equal(t, tt.want[i], catchUp[i].UTC())
+			}
+		})
+	}
+}
+
 // TestUpdateSchedules_NoImmediateFireForPastBaseline locks in that registering a
 // trigger does not schedule its first fire in the past. StartTime returns the
 // deploy/last-exec baseline (in the past); the cron loop fires any entry whose
@@ -70,7 +123,7 @@ func TestUpdateSchedules_NoImmediateFireForPastBaseline(t *testing.T) {
 	s := NewGoCronScheduler(exec)
 
 	// Hourly cron, baseline 10 minutes in the past.
-	trig := newCronTrigger(t, "k1", "0 * * * *", time.Now().Add(-10*time.Minute))
+	trig := newCronTrigger(t, "k1", "0 * * * *", "", time.Now().Add(-10*time.Minute))
 	s.UpdateSchedules(context.Background(), []*models.Trigger{trig})
 
 	require.Len(t, s.jobs, 1)
@@ -94,7 +147,7 @@ func TestUpdateSchedules_RunningSchedulerDoesNotFireImmediately(t *testing.T) {
 	s.Start()
 	defer s.Stop()
 
-	trig := newCronTrigger(t, "k1", "0 * * * *", time.Now().Add(-10*time.Minute))
+	trig := newCronTrigger(t, "k1", "0 * * * *", "", time.Now().Add(-10*time.Minute))
 	s.UpdateSchedules(context.Background(), []*models.Trigger{trig})
 
 	// Give the run loop time to process the newly added entry. With the past

--- a/runs/service/task_service_test.go
+++ b/runs/service/task_service_test.go
@@ -31,6 +31,68 @@ func cronAutomation(kickoffArg string) *task.TriggerAutomationSpec {
 	}
 }
 
+func TestValidateCronExpression(t *testing.T) {
+	tests := []struct {
+		name     string
+		schedule *task.Schedule
+		wantErr  bool
+	}{
+		{
+			name: "structured cron with timezone",
+			schedule: &task.Schedule{
+				Expression: &task.Schedule_Cron{Cron: &task.Cron{
+					Expression: "0 9 * * *",
+					Timezone:   "America/Los_Angeles",
+				}},
+			},
+		},
+		{
+			name: "invalid structured cron",
+			schedule: &task.Schedule{
+				Expression: &task.Schedule_Cron{Cron: &task.Cron{Expression: "invalid"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "legacy cron",
+			schedule: &task.Schedule{
+				Expression: &task.Schedule_CronExpression{CronExpression: "0 9 * * *"},
+			},
+		},
+		{
+			name: "invalid legacy cron",
+			schedule: &task.Schedule{
+				Expression: &task.Schedule_CronExpression{CronExpression: "invalid"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty structured cron",
+			schedule: &task.Schedule{
+				Expression: &task.Schedule_Cron{Cron: &task.Cron{}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &task.TriggerAutomationSpec{
+				Automation: &task.TriggerAutomationSpec_Schedule{
+					Schedule: tt.schedule,
+				},
+			}
+			err := validateCronExpression("trigger", spec)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 // buildTriggerModels maps an offloaded embedded trigger's inputs into the TriggerSpec input_wrapper.
 func TestBuildTriggerModels_OffloadedInputs(t *testing.T) {
 	taskId := &task.TaskIdentifier{Project: "p", Domain: "d", Name: "t", Version: "v1"}

--- a/runs/service/trigger_service.go
+++ b/runs/service/trigger_service.go
@@ -17,7 +17,7 @@ import (
 	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
 	"github.com/flyteorg/flyte/v2/runs/repository/models"
 	"github.com/flyteorg/flyte/v2/runs/repository/transformers"
-	schedulercore "github.com/flyteorg/flyte/v2/runs/scheduler/core"
+	"github.com/flyteorg/flyte/v2/runs/schedule"
 )
 
 type triggerService struct {
@@ -205,7 +205,7 @@ func (s *triggerService) DeleteTriggers(
 
 // validateCronExpression validates the cron expression in a TriggerAutomationSpec, if present.
 func validateCronExpression(triggerName string, spec *taskpb.TriggerAutomationSpec) error {
-	if _, err := schedulercore.ParseCronSchedule(spec.GetSchedule()); err != nil {
+	if _, err := schedule.ParseCron(spec.GetSchedule()); err != nil {
 		return connect.NewError(connect.CodeInvalidArgument,
 			fmt.Errorf("trigger %q has invalid cron expression: %w", triggerName, err))
 	}

--- a/runs/service/trigger_service.go
+++ b/runs/service/trigger_service.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/robfig/cron/v3"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	commonpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
@@ -18,6 +17,7 @@ import (
 	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
 	"github.com/flyteorg/flyte/v2/runs/repository/models"
 	"github.com/flyteorg/flyte/v2/runs/repository/transformers"
+	schedulercore "github.com/flyteorg/flyte/v2/runs/scheduler/core"
 )
 
 type triggerService struct {
@@ -205,15 +205,7 @@ func (s *triggerService) DeleteTriggers(
 
 // validateCronExpression validates the cron expression in a TriggerAutomationSpec, if present.
 func validateCronExpression(triggerName string, spec *taskpb.TriggerAutomationSpec) error {
-	cronSchedule := spec.GetSchedule().GetCron()
-	if cronSchedule == nil {
-		return nil
-	}
-	expr := cronSchedule.GetExpression()
-	if tz := cronSchedule.GetTimezone(); tz != "" {
-		expr = fmt.Sprintf("CRON_TZ=%s %s", tz, expr)
-	}
-	if _, err := cron.ParseStandard(expr); err != nil {
+	if _, err := schedulercore.ParseCronSchedule(spec.GetSchedule()); err != nil {
 		return connect.NewError(connect.CodeInvalidArgument,
 			fmt.Errorf("trigger %q has invalid cron expression: %w", triggerName, err))
 	}


### PR DESCRIPTION
## Why are the changes needed?

The structured `Cron` schedule carries a `timezone`, and trigger validation already prepends `CRON_TZ=` before parsing it. The scheduler does not: `ParseSchedule` passes only `Cron.expression` to `cron.ParseStandard`, and the cron runner defaults to UTC. Every accepted non-UTC trigger therefore executes in UTC.

Concretely, a trigger deployed as `0 9 * * *` with timezone `America/Los_Angeles` passes validation but fires at 09:00 UTC instead of 09:00 Pacific. Users get runs several hours early or late, the offset shifts again across daylight-saving transitions, and catch-up time calculations inherit the same error. `CRON_TZ` is the per-schedule timezone override documented by robfig/cron, so the information is available, it is just dropped on the runtime path.

## What changes were proposed in this pull request?

- Add a shared `ParseCron` helper that handles both schedule forms: the structured `Cron` message (applying `CRON_TZ=<timezone>` when a timezone is set) and the legacy `cron_expression` string.
- Use it in `ParseSchedule` so live scheduling and catch-up calculations respect the declared timezone.
- Use it in `validateCronExpression` so deploy-time validation and runtime parsing can no longer disagree about what a schedule means.

One behavior change worth calling out: because validation now goes through the same parser, an invalid legacy `cron_expression` is rejected at registration. Previously only the structured `Cron` form was validated, and a bad legacy expression was accepted and then failed later inside the scheduler.

## How was this patch tested?

New table tests in the scheduler core cover UTC, a non-UTC zone, and a DST boundary (7-8 March 2026 in `America/Los_Angeles`), asserting both the next fire time and the catch-up times. New validation tests cover structured cron with a timezone, legacy cron, and invalid expressions in both forms.

```
go test ./runs/service ./runs/scheduler/core
```

## Check all the applicable boxes

- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

None.

## Docs link

None.
