### PR TITLE
Make api and well known ingresses have configurable hosts

### DIFF
--- a/charts/flyte-binary/README.md
+++ b/charts/flyte-binary/README.md
@@ -145,6 +145,7 @@ Chart for basic single Flyte executable deployment
 | fullnameOverride | string | `""` |  |
 | ingress.apiJwtIngress.annotations | object | `{}` |  |
 | ingress.apiJwtIngress.enabled | bool | `false` |  |
+| ingress.apiJwtIngress.host | string | `""` |  |
 | ingress.apiJwtIngress.ingressClassName | string | `""` |  |
 | ingress.apiJwtIngress.tls | list | `[]` |  |
 | ingress.commonAnnotations | object | `{}` |  |
@@ -160,6 +161,7 @@ Chart for basic single Flyte executable deployment
 | ingress.tls | list | `[]` |  |
 | ingress.wellknownIngress.annotations | object | `{}` |  |
 | ingress.wellknownIngress.enabled | bool | `false` |  |
+| ingress.wellknownIngress.host | string | `""` |  |
 | ingress.wellknownIngress.ingressClassName | string | `""` |  |
 | ingress.wellknownIngress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |
@@ -183,4 +185,3 @@ Chart for basic single Flyte executable deployment
 | serviceAccount.imagePullSecrets | list | `[]` |  |
 | serviceAccount.labels | object | `{}` |  |
 | serviceAccount.name | string | `""` |  |
-

--- a/charts/flyte-binary/README.md
+++ b/charts/flyte-binary/README.md
@@ -185,3 +185,4 @@ Chart for basic single Flyte executable deployment
 | serviceAccount.imagePullSecrets | list | `[]` |  |
 | serviceAccount.labels | object | `{}` |  |
 | serviceAccount.name | string | `""` |  |
+

--- a/charts/flyte-binary/templates/ingress/api-jwt.yaml
+++ b/charts/flyte-binary/templates/ingress/api-jwt.yaml
@@ -52,7 +52,9 @@ spec:
             servicePort: {{ include "flyte-binary.service.http.port" $ }}
             {{- end }}
       {{- end }}
-    {{- if .Values.ingress.host }}
+    {{- if .Values.ingress.apiJwtIngress.host }}
+    host: {{ tpl .Values.ingress.apiJwtIngress.host . | quote }}
+    {{- else if .Values.ingress.host }}
     host: {{ tpl .Values.ingress.host . | quote }}
     {{- end }}
 {{- end }}

--- a/charts/flyte-binary/templates/ingress/wellknown.yaml
+++ b/charts/flyte-binary/templates/ingress/wellknown.yaml
@@ -52,7 +52,9 @@ spec:
             servicePort: {{ include "flyte-binary.service.http.port" $ }}
             {{- end }}
       {{- end }}
-    {{- if .Values.ingress.host }}
+    {{- if .Values.ingress.wellknownIngress.host }}
+    host: {{ tpl .Values.ingress.wellknownIngress.host . | quote }}
+    {{- else if .Values.ingress.host }}
     host: {{ tpl .Values.ingress.host . | quote }}
     {{- end }}
 {{- end }}

--- a/charts/flyte-binary/values.yaml
+++ b/charts/flyte-binary/values.yaml
@@ -402,6 +402,8 @@ ingress:
   apiJwtIngress:
     # enabled Create the JWT (Bearer) API ingress
     enabled: false
+    # host Hostname for the JWT API ingress. Overrides `ingress.host`
+    host: ""
     # annotations Annotations for the JWT API ingress (controller/JWT config)
     annotations: {}
     # ingressClassName Ingress class for the JWT API ingress. Overrides `ingressClassName`
@@ -416,6 +418,8 @@ ingress:
   wellknownIngress:
     # enabled Create the unauthenticated auth-discovery ingress
     enabled: false
+    # host Hostname for the auth-discovery ingress. Overrides `ingress.host`
+    host: ""
     # annotations Annotations for the auth-discovery ingress (controller config)
     annotations: {}
     # ingressClassName Ingress class for the auth-discovery ingress. Overrides `ingressClassName`


### PR DESCRIPTION
## Why are the changes needed?

With `ingress-nginx` you cannot have multiple ingresses with the same hosts and the same routes. The http ingress and the api-jwt conflict in that regard.

ie. 

```
one or more synchronization tasks completed unsuccessfully, reason: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "<redacted>" and path "/flyteidl2.workflow.RunService" is already defined in ingress flyte-v2/flyte-v2-flyte-binary-http
```

Additionally, it may be nice to have ingresses on different hosts (ie. api.flyte2.internal.com, flyte2.internal.com, oauth.flyte2.internal.com)

## What changes were proposed in this pull request?

This pull request allows each ingress to have a configurable host such that you can run them on different sub domains (ie. different hosts).

Empty strings are falsy in helm so this change is completely backwards compatible and does not change the default behavior.

## How was this patch tested?

Untested but pretty straightforward...

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
