### PR TITLE
perf: drop notify hints when queues are full

### DIFF
--- a/runs/repository/impl/action.go
+++ b/runs/repository/impl/action.go
@@ -951,12 +951,7 @@ func (r *actionRepo) processNotifications() {
 // dedicated notify channel, avoiding connection pool contention.
 func (r *actionRepo) notifyRunUpdate(ctx context.Context, runID *common.RunIdentifier) {
 	payload := fmt.Sprintf("%s/%s/%s", runID.Project, runID.Domain, runID.Name)
-
-	select {
-	case r.runNotifyCh <- payload:
-	case <-ctx.Done():
-		logger.Warnf(ctx, "Run NOTIFY send cancelled for %s: %v", payload, ctx.Err())
-	}
+	r.enqueueNotify(ctx, "Run", payload, r.runNotifyCh)
 }
 
 // ListRootActions lists root actions (runs) matching scope and date filters.
@@ -1112,9 +1107,15 @@ func (r *actionRepo) notifyActionUpdate(ctx context.Context, actionID *common.Ac
 	payload := fmt.Sprintf("%s/%s/%s/%s",
 		actionID.Run.Project, actionID.Run.Domain, actionID.Run.Name, actionID.Name)
 
+	r.enqueueNotify(ctx, "Action", payload, r.actionNotifyCh)
+}
+
+func (r *actionRepo) enqueueNotify(ctx context.Context, kind, payload string, ch chan<- string) {
 	select {
-	case r.actionNotifyCh <- payload:
+	case ch <- payload:
 	case <-ctx.Done():
-		logger.Errorf(ctx, "Action NOTIFY send cancelled for %s: %v", payload, ctx.Err())
+		logger.Warnf(ctx, "%s NOTIFY send cancelled for %s: %v", kind, payload, ctx.Err())
+	default:
+		logger.Warnf(ctx, "%s NOTIFY queue full, dropping notification for %s", kind, payload)
 	}
 }

--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -851,6 +851,33 @@ func TestNotifyActionUpdate_PayloadWithSpecialChars(t *testing.T) {
 	}
 }
 
+func TestNotifyActionUpdate_DropsWhenQueueFull(t *testing.T) {
+	r := &actionRepo{
+		actionNotifyCh: make(chan string, 1),
+		runNotifyCh:    make(chan string, 1),
+	}
+	r.actionNotifyCh <- "already-queued"
+
+	actionID := &common.ActionIdentifier{
+		Run:  &common.RunIdentifier{Project: "proj", Domain: "domain", Name: "run"},
+		Name: "action",
+	}
+
+	done := make(chan struct{})
+	go func() {
+		r.notifyActionUpdate(context.Background(), actionID)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("notifyActionUpdate blocked on a full queue")
+	}
+
+	assert.Equal(t, "already-queued", <-r.actionNotifyCh)
+}
+
 func TestNotifyRunUpdate_PayloadWithSpecialChars(t *testing.T) {
 	r := &actionRepo{
 
@@ -876,6 +903,30 @@ func TestNotifyRunUpdate_PayloadWithSpecialChars(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("timed out waiting for payload on runNotifyCh")
 	}
+}
+
+func TestNotifyRunUpdate_DropsWhenQueueFull(t *testing.T) {
+	r := &actionRepo{
+		actionNotifyCh: make(chan string, 1),
+		runNotifyCh:    make(chan string, 1),
+	}
+	r.runNotifyCh <- "already-queued"
+
+	runID := &common.RunIdentifier{Project: "proj", Domain: "domain", Name: "run"}
+
+	done := make(chan struct{})
+	go func() {
+		r.notifyRunUpdate(context.Background(), runID)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("notifyRunUpdate blocked on a full queue")
+	}
+
+	assert.Equal(t, "already-queued", <-r.runNotifyCh)
 }
 
 func TestIsConnError(t *testing.T) {


### PR DESCRIPTION
## Summary
- make runs-service NOTIFY enqueue non-blocking for both action and run updates
- drop recoverable wakeup hints when the bounded queue is full instead of blocking write RPCs after the DB write has already succeeded
- keep ctx cancellation logging and add regression coverage for full queues

Fixes #7757.

## Testing
- GOCACHE=/private/tmp/flyte-go-cache GOMODCACHE=/private/tmp/flyte-go-mod-cache go test ./runs/repository/impl -run 'TestNotify(Action|Run)Update_(PayloadWithSpecialChars|DropsWhenQueueFull)$'