### PR TITLE
feat: count dropped action subscriber updates

### DIFF
--- a/actions/k8s/client.go
+++ b/actions/k8s/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -69,10 +70,10 @@ type ActionsClient struct {
 	mu sync.RWMutex
 	// Map parent action name to subscriber channels.
 	// Multiple callers may watch the same parent action concurrently.
-	// TODO: add a prometheus counter for dropped updates when metrics are wired up
-	subscribers map[string]map[chan *ActionUpdate]struct{}
-	stopCh      chan struct{}
-	watching    bool
+	subscribers              map[string]map[chan *ActionUpdate]struct{}
+	droppedSubscriberUpdates prometheus.Counter
+	stopCh                   chan struct{}
+	watching                 bool
 
 	// Worker pool: numWorkers goroutines each own one channel.
 	// Events are sharded by the TaskAction name, so per-resource ordering is preserved.
@@ -111,6 +112,10 @@ func NewActionsClient(k8sClient client.WithWatch, sharedCache ctrlcache.Cache, n
 		runClient:   runClient,
 		subscribers: make(map[string]map[chan *ActionUpdate]struct{}),
 	}
+	c.droppedSubscriberUpdates = scope.MustNewCounter(
+		"dropped_subscriber_updates",
+		"Number of action updates dropped because a subscriber channel was full.",
+	)
 
 	// The dedup filter is mandatory: notifyRunService records on every event type
 	// and relies on the filter to keep RecordAction idempotent.
@@ -727,6 +732,9 @@ func (c *ActionsClient) notifySubscribers(ctx context.Context, update *ActionUpd
 		select {
 		case ch <- update:
 		default:
+			if c.droppedSubscriberUpdates != nil {
+				c.droppedSubscriberUpdates.Inc()
+			}
 			logger.Warnf(ctx, "subscriber channel full, dropping update for parent action: %s", update.ParentActionName)
 		}
 	}

--- a/actions/k8s/client_subscribe_test.go
+++ b/actions/k8s/client_subscribe_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
@@ -16,6 +18,10 @@ func newSubscribeTestClient() *ActionsClient {
 		recordedFilter: testFilter(),
 		bufferSize:     10,
 		subscribers:    make(map[string]map[chan *ActionUpdate]struct{}),
+		droppedSubscriberUpdates: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "test_dropped_subscriber_updates",
+			Help: "test counter",
+		}),
 	}
 }
 
@@ -70,4 +76,17 @@ func TestUnsubscribeScopedByRun(t *testing.T) {
 
 	// Notifying after unsubscribe must not panic or deliver.
 	c.notifySubscribers(context.Background(), childUpdate("runA", "child1", "a0"))
+}
+
+func TestNotifySubscribersCountsDroppedUpdates(t *testing.T) {
+	c := newSubscribeTestClient()
+	c.bufferSize = 1
+
+	ch := c.Subscribe("runA", "a0")
+	ch <- childUpdate("runA", "existing", "a0")
+
+	c.notifySubscribers(context.Background(), childUpdate("runA", "dropped", "a0"))
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(c.droppedSubscriberUpdates))
+	assert.Equal(t, "existing", (<-ch).ActionID.GetName())
 }


### PR DESCRIPTION
## Summary
- add a Prometheus counter for action subscriber updates dropped because a subscriber channel is full
- initialize the counter from the ActionsClient metrics scope
- keep direct test fixtures nil-safe and add regression coverage for the drop path

Fixes #7641.

## Testing
- GOCACHE=/private/tmp/flyte-go-cache GOMODCACHE=/private/tmp/flyte-go-mod-cache go test ./actions/k8s -run 'Test(SubscribeIsScopedByRun|UnsubscribeScopedByRun|NotifySubscribersCountsDroppedUpdates|NewActionsClient_RequiresPositiveRecordFilterSize)$'