### PR TITLE
feat: allow immediate TaskAction GC

### DIFF
--- a/executor/pkg/config/config.go
+++ b/executor/pkg/config/config.go
@@ -110,7 +110,8 @@ type GCConfig struct {
 	Interval stdconfig.Duration `json:"interval" pflag:",How often the garbage collector runs. 0 disables GC."`
 
 	// MaxTTL is the time-to-live for terminal TaskActions before deletion.
-	MaxTTL stdconfig.Duration `json:"maxTTL" pflag:",Time-to-live for terminal TaskActions before deletion."`
+	// A value <= 0 deletes terminal TaskActions on the next GC cycle.
+	MaxTTL stdconfig.Duration `json:"maxTTL" pflag:",Time-to-live for terminal TaskActions before deletion. <= 0 deletes terminal TaskActions immediately."`
 }
 
 // GetConfig returns the parsed executor configuration

--- a/executor/pkg/config/config_flags.go
+++ b/executor/pkg/config/config_flags.go
@@ -68,6 +68,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.Int32(fmt.Sprintf("%v%v", prefix, "maxSystemFailures"), defaultConfig.MaxSystemFailures, "Max consecutive system-level failures before forcing permanent failure")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "requeueDuration"), defaultConfig.RequeueDuration.String(), "How long to wait before reconciling a running TaskAction again. 0 means the default of 10s")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.interval"), defaultConfig.GC.Interval.String(), "How often the garbage collector runs. 0 disables GC.")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.maxTTL"), defaultConfig.GC.MaxTTL.String(), "Time-to-live for terminal TaskActions before deletion.")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.maxTTL"), defaultConfig.GC.MaxTTL.String(), "Time-to-live for terminal TaskActions before deletion. <= 0 deletes terminal TaskActions immediately.")
 	return cmdFlags
 }

--- a/executor/pkg/controller/garbage_collector.go
+++ b/executor/pkg/controller/garbage_collector.go
@@ -76,13 +76,27 @@ func (gc *GarbageCollector) Start(ctx context.Context) error {
 // it to exercise the Continue pagination path without creating 500 objects.
 var gcPageSize = 500
 
+func shouldDeleteTerminalTaskAction(completedTime string, maxTTL time.Duration, now time.Time) bool {
+	if completedTime == "" {
+		return false
+	}
+	if maxTTL <= 0 {
+		return true
+	}
+
+	// The minute-precision format is lexicographically ordered, so string comparison works.
+	cutoff := now.UTC().Add(-maxTTL).Format(labelTimeFormat)
+	return completedTime < cutoff
+}
+
 // collect lists all terminated TaskActions (paginated) and deletes those whose completed-time has expired.
+// A non-positive maxTTL means terminal TaskActions are deleted on the next GC cycle.
 func (gc *GarbageCollector) collect(ctx context.Context) (err error) {
 	start := time.Now()
 	defer func() { gc.metrics.recordSweep(ctx, start, err) }()
 	logger := log.FromContext(ctx).WithName("gc")
 
-	cutoff := time.Now().UTC().Add(-gc.maxTTL).Format(labelTimeFormat)
+	now := time.Now().UTC()
 	deleted := 0
 	total := 0
 	continueToken := ""
@@ -111,8 +125,7 @@ func (gc *GarbageCollector) collect(ctx context.Context) (err error) {
 				continue
 			}
 
-			// The minute-precision format is lexicographically ordered, so string comparison works.
-			if completedTime < cutoff {
+			if shouldDeleteTerminalTaskAction(completedTime, gc.maxTTL, now) {
 				if err := gc.client.Delete(ctx, ta); err != nil {
 					// Already gone is the desired state: a child TaskAction is
 					// often cascade-deleted (via OwnerReferences) when its parent

--- a/executor/pkg/controller/garbage_collector_test.go
+++ b/executor/pkg/controller/garbage_collector_test.go
@@ -92,6 +92,21 @@ var _ = Describe("GarbageCollector", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("should delete terminal TaskActions immediately when maxTTL is zero", func() {
+		recentTime := time.Now().UTC().Format(labelTimeFormat)
+		createTaskAction(ctx, "gc-immediate", map[string]string{
+			LabelTerminationStatus: LabelValueTerminated,
+			LabelCompletedTime:     recentTime,
+		})
+
+		gc := NewGarbageCollector(k8sClient, k8sClient, 1*time.Minute, 0, metricnoop.NewMeterProvider())
+		Expect(gc.collect(ctx)).To(Succeed())
+
+		ta := &flyteorgv1.TaskAction{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: "gc-immediate", Namespace: "default"}, ta)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
 	It("should retain non-terminated TaskActions", func() {
 		createTaskAction(ctx, "gc-active", nil)
 

--- a/executor/pkg/controller/garbage_collector_unit_test.go
+++ b/executor/pkg/controller/garbage_collector_unit_test.go
@@ -1,0 +1,57 @@
+package controller
+
+import (
+	"testing"
+	"time"
+)
+
+func TestShouldDeleteTerminalTaskAction(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name          string
+		completedTime string
+		maxTTL        time.Duration
+		want          bool
+	}{
+		{
+			name:          "expired positive ttl",
+			completedTime: now.Add(-2 * time.Hour).Format(labelTimeFormat),
+			maxTTL:        time.Hour,
+			want:          true,
+		},
+		{
+			name:          "recent positive ttl",
+			completedTime: now.Format(labelTimeFormat),
+			maxTTL:        time.Hour,
+			want:          false,
+		},
+		{
+			name:          "zero ttl deletes immediately",
+			completedTime: now.Format(labelTimeFormat),
+			maxTTL:        0,
+			want:          true,
+		},
+		{
+			name:          "negative ttl deletes immediately",
+			completedTime: now.Format(labelTimeFormat),
+			maxTTL:        -time.Second,
+			want:          true,
+		},
+		{
+			name:          "missing completed time is retained",
+			completedTime: "",
+			maxTTL:        0,
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldDeleteTerminalTaskAction(tt.completedTime, tt.maxTTL, now)
+			if got != tt.want {
+				t.Fatalf("shouldDeleteTerminalTaskAction() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -269,9 +269,6 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	}
 
 	if cfg.GC.Interval.Duration > 0 {
-		if cfg.GC.MaxTTL.Duration <= 0 {
-			return fmt.Errorf("executor: gc.maxTTL must be positive when gc is enabled, got %v", cfg.GC.MaxTTL.Duration)
-		}
 		gc := controller.NewGarbageCollector(mgr.GetClient(), mgr.GetAPIReader(), cfg.GC.Interval.Duration, cfg.GC.MaxTTL.Duration, otelutils.GetMeterProvider(otelServiceName))
 		if err := mgr.Add(gc); err != nil {
 			return fmt.Errorf("executor: failed to add garbage collector: %w", err)


### PR DESCRIPTION
## Summary
- allow executor GC to treat gc.maxTTL <= 0 as immediate deletion of terminal TaskActions on the next GC cycle
- remove the setup-time validation that rejected maxTTL <= 0 when GC is enabled
- update config/help text and add both envtest coverage and a pure unit test for the TTL decision table

Fixes #7008.

## Testing
- GOCACHE=/private/tmp/flyte-go-cache GOMODCACHE=/private/tmp/flyte-go-mod-cache go test ./executor/pkg/controller -run TestShouldDeleteTerminalTaskAction

Note: full `go test ./executor/pkg/controller` could not run locally because this machine is missing envtest binaries (`/usr/local/kubebuilder/bin/etcd`). The focused pure unit test above passed; the added Ginkgo spec should run in CI where envtest is available.