### PR TITLE
fix: repair missing action rows on status update

### DIFF
--- a/actions/k8s/client.go
+++ b/actions/k8s/client.go
@@ -735,6 +735,58 @@ func (c *ActionsClient) notifySubscribers(ctx context.Context, update *ActionUpd
 // notifyRunService forwards a watch event to the internal run service.
 // On ADDED events it calls RecordAction to create the DB record.
 // On all events it calls UpdateActionStatus (when phase is meaningful) to update the actions table.
+func buildRecordActionRequest(ctx context.Context, taskAction *executorv1.TaskAction, update *ActionUpdate) *workflow.RecordActionRequest {
+	recordReq := &workflow.RecordActionRequest{
+		ActionId: update.ActionID,
+		Parent:   update.ParentActionName,
+		InputUri: taskAction.Spec.InputURI,
+		Group:    taskAction.Spec.Group,
+	}
+	if taskAction.Spec.ActionType == executorv1.ActionTypeCondition {
+		condSpec := &workflow.ConditionAction{}
+		if err := proto.Unmarshal(taskAction.Spec.ConditionSpec, condSpec); err != nil {
+			logger.Warnf(ctx, "Failed to unmarshal condition spec for %s: %v", update.ActionID.Name, err)
+		} else {
+			recordReq.Spec = &workflow.RecordActionRequest_Condition{Condition: condSpec}
+		}
+	} else if taskAction.Spec.TaskType != "" {
+		ta := &workflow.TaskAction{
+			Id: &task.TaskIdentifier{
+				Project: taskAction.Spec.Project,
+				Domain:  taskAction.Spec.Domain,
+			},
+		}
+		// Deserialize TaskTemplate to build TaskSpec
+		if len(taskAction.Spec.TaskTemplate) > 0 {
+			var tmpl core.TaskTemplate
+			if err := proto.Unmarshal(taskAction.Spec.TaskTemplate, &tmpl); err == nil {
+				if tmplID := tmpl.GetId(); tmplID != nil {
+					ta.Id.Name = tmplID.GetName()
+					ta.Id.Version = tmplID.GetVersion()
+				}
+				ta.Spec = &task.TaskSpec{
+					TaskTemplate: &tmpl,
+					ShortName:    taskAction.Spec.ShortName,
+				}
+			}
+		}
+		recordReq.Spec = &workflow.RecordActionRequest_Task{
+			Task: ta,
+		}
+	}
+	return recordReq
+}
+
+func (c *ActionsClient) recordActionInRunService(ctx context.Context, taskAction *executorv1.TaskAction, update *ActionUpdate, actionKey []byte) bool {
+	recordReq := buildRecordActionRequest(ctx, taskAction, update)
+	if _, err := c.runClient.RecordAction(ctx, connect.NewRequest(recordReq)); err != nil {
+		logger.Warnf(ctx, "Failed to record action in run service for %s: %v", update.ActionID.Name, err)
+		return false
+	}
+	c.recordedFilter.Add(ctx, actionKey)
+	return true
+}
+
 func (c *ActionsClient) notifyRunService(ctx context.Context, taskAction *executorv1.TaskAction, update *ActionUpdate, eventType watch.EventType) {
 	if c.runClient == nil {
 		return
@@ -744,49 +796,7 @@ func (c *ActionsClient) notifyRunService(ctx context.Context, taskAction *execut
 	if isDuplicate {
 		logger.Debugf(ctx, "Skipping duplicate RecordAction for %s", update.ActionID.Name)
 	} else {
-		recordReq := &workflow.RecordActionRequest{
-			ActionId: update.ActionID,
-			Parent:   update.ParentActionName,
-			InputUri: taskAction.Spec.InputURI,
-			Group:    taskAction.Spec.Group,
-		}
-		if taskAction.Spec.ActionType == executorv1.ActionTypeCondition {
-			condSpec := &workflow.ConditionAction{}
-			if err := proto.Unmarshal(taskAction.Spec.ConditionSpec, condSpec); err != nil {
-				logger.Warnf(ctx, "Failed to unmarshal condition spec for %s: %v", update.ActionID.Name, err)
-			} else {
-				recordReq.Spec = &workflow.RecordActionRequest_Condition{Condition: condSpec}
-			}
-		} else if taskAction.Spec.TaskType != "" {
-			ta := &workflow.TaskAction{
-				Id: &task.TaskIdentifier{
-					Project: taskAction.Spec.Project,
-					Domain:  taskAction.Spec.Domain,
-				},
-			}
-			// Deserialize TaskTemplate to build TaskSpec
-			if len(taskAction.Spec.TaskTemplate) > 0 {
-				var tmpl core.TaskTemplate
-				if err := proto.Unmarshal(taskAction.Spec.TaskTemplate, &tmpl); err == nil {
-					if tmplID := tmpl.GetId(); tmplID != nil {
-						ta.Id.Name = tmplID.GetName()
-						ta.Id.Version = tmplID.GetVersion()
-					}
-					ta.Spec = &task.TaskSpec{
-						TaskTemplate: &tmpl,
-						ShortName:    taskAction.Spec.ShortName,
-					}
-				}
-			}
-			recordReq.Spec = &workflow.RecordActionRequest_Task{
-				Task: ta,
-			}
-		}
-		if _, err := c.runClient.RecordAction(ctx, connect.NewRequest(recordReq)); err != nil {
-			logger.Warnf(ctx, "Failed to record action in run service for %s: %v", update.ActionID.Name, err)
-		} else {
-			c.recordedFilter.Add(ctx, actionKey)
-		}
+		c.recordActionInRunService(ctx, taskAction, update, actionKey)
 	}
 
 	// When a child action first appears, the parent must already be running (it
@@ -837,9 +847,28 @@ func (c *ActionsClient) notifyRunService(ctx context.Context, taskAction *execut
 				}
 			}
 		}
-		if _, err := c.runClient.UpdateActionStatus(ctx, connect.NewRequest(statusReq)); err != nil {
+		resp, err := c.runClient.UpdateActionStatus(ctx, connect.NewRequest(statusReq))
+		if err != nil {
 			logger.Warnf(ctx, "Failed to update action status in run service for %s: %v", update.ActionID.Name, err)
-		} else if isTerminalPhase(update.Phase) && !update.IsDeleted {
+			return
+		}
+		if connect.Code(resp.Msg.GetStatus().GetCode()) == connect.CodeNotFound {
+			logger.Warnf(ctx, "Action %s missing in run service during status update; recording and retrying", update.ActionID.Name)
+			if !c.recordActionInRunService(ctx, taskAction, update, actionKey) {
+				return
+			}
+			resp, err = c.runClient.UpdateActionStatus(ctx, connect.NewRequest(statusReq))
+			if err != nil {
+				logger.Warnf(ctx, "Failed to retry action status update in run service for %s: %v", update.ActionID.Name, err)
+				return
+			}
+		}
+		if code := connect.Code(resp.Msg.GetStatus().GetCode()); code != 0 {
+			logger.Warnf(ctx, "Run service returned %s while updating action status for %s: %s",
+				code.String(), update.ActionID.Name, resp.Msg.GetStatus().GetMessage())
+			return
+		}
+		if isTerminalPhase(update.Phase) && !update.IsDeleted {
 			// Skip label patching for deleted CRs — the patch would always fail
 			// with "not found" since the object is already gone.
 			if err := c.markTerminalStatusRecorded(ctx, taskAction); err != nil {

--- a/actions/k8s/client_test.go
+++ b/actions/k8s/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	grpcstatus "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -143,6 +144,44 @@ func TestNotifyRunService_UpdateActionStatusIncludesAttemptsAndCacheStatus(t *te
 	c.notifyRunService(ctx, ta, update, watch.Modified)
 
 	mockClient.AssertNumberOfCalls(t, "UpdateActionStatus", 1)
+}
+
+func TestNotifyRunService_RecordAndRetryWhenStatusUpdateReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := runmocks.NewInternalRunServiceClient(t)
+	filter, err := fastcheck.NewOppoBloomFilter(128, promutils.NewTestScope())
+	require.NoError(t, err)
+
+	c := &ActionsClient{
+		runClient:      mockClient,
+		recordedFilter: filter,
+		subscribers:    make(map[string]map[chan *ActionUpdate]struct{}),
+	}
+
+	ta, update := newTestActionUpdate("action-missing-row")
+	update.Phase = common.ActionPhase_ACTION_PHASE_RUNNING
+	actionKey := []byte(buildTaskActionName(update.ActionID))
+	c.recordedFilter.Add(ctx, actionKey)
+
+	mockClient.On("UpdateActionStatus", mock.Anything, mock.Anything).
+		Return(&connect.Response[workflow.UpdateActionStatusResponse]{
+			Msg: &workflow.UpdateActionStatusResponse{
+				Status: &grpcstatus.Status{
+					Code:    int32(connect.CodeNotFound),
+					Message: "action not found",
+				},
+			},
+		}, nil).Once()
+	mockClient.On("RecordAction", mock.Anything, mock.Anything).
+		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Once()
+	mockClient.On("UpdateActionStatus", mock.Anything, mock.Anything).
+		Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil).Once()
+
+	c.notifyRunService(ctx, ta, update, watch.Modified)
+
+	mockClient.AssertNumberOfCalls(t, "RecordAction", 1)
+	mockClient.AssertNumberOfCalls(t, "UpdateActionStatus", 2)
 }
 
 func TestBuildTaskActionName(t *testing.T) {

--- a/runs/repository/impl/action.go
+++ b/runs/repository/impl/action.go
@@ -482,6 +482,10 @@ func (r *actionRepo) UpdateActionPhase(
 	}
 	if rowsAffected > 0 {
 		r.notifyActionUpdate(ctx, actionID)
+	} else if _, err := r.GetAction(ctx, actionID); err != nil {
+		return fmt.Errorf("%w: %s/%s/%s/%s",
+			interfaces.ErrActionNotFound,
+			actionID.Run.Project, actionID.Run.Domain, actionID.Run.Name, actionID.Name)
 	}
 
 	// If this is the root action (the run itself), also notify run subscribers

--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -183,6 +183,24 @@ func TestUpdateActionPhase_NilStartTimeUsesCreatedAt(t *testing.T) {
 	assert.Less(t, action.DurationMs.Int64, int64(5000), "without a start time, duration is created_at-based")
 }
 
+func TestUpdateActionPhase_MissingActionReturnsNotFound(t *testing.T) {
+	db := setupActionDB(t)
+	defer func() { db.Exec("DELETE FROM actions") }()
+	actionRepo, err := NewActionRepo(db, testDbConfig)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	actionID := &common.ActionIdentifier{
+		Run:  &common.RunIdentifier{Org: "org1", Project: "proj1", Domain: "domain1", Name: "missing-run"},
+		Name: "missing-action",
+	}
+
+	err = actionRepo.UpdateActionPhase(ctx, actionID, common.ActionPhase_ACTION_PHASE_RUNNING,
+		1, core.CatalogCacheStatus_CACHE_DISABLED, nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, interfaces.ErrActionNotFound)
+}
+
 func TestWatchActionUpdates_OnlyStreamsTargetAction(t *testing.T) {
 	db := setupActionDB(t)
 	defer func() { db.Exec("DELETE FROM actions") }()

--- a/runs/repository/interfaces/action.go
+++ b/runs/repository/interfaces/action.go
@@ -2,12 +2,15 @@ package interfaces
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 	"github.com/flyteorg/flyte/v2/runs/repository/models"
 )
+
+var ErrActionNotFound = errors.New("action not found")
 
 // ActionRepo defines the interface for actions/runs data access
 type ActionRepo interface {

--- a/runs/service/condition_test.go
+++ b/runs/service/condition_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -16,6 +17,7 @@ import (
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow"
+	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
 	"github.com/flyteorg/flyte/v2/runs/repository/models"
 )
 
@@ -118,6 +120,21 @@ func TestUpdateActionStatus_NoOutputSkipsRunInfoWrite(t *testing.T) {
 		Status:   &workflow.ActionStatus{Phase: common.ActionPhase_ACTION_PHASE_RUNNING},
 	}))
 	require.NoError(t, err)
+}
+
+func TestUpdateActionStatus_MissingActionReturnsNotFoundStatus(t *testing.T) {
+	actionRepo, _, svc := newTestServiceWithTaskRepo(t)
+
+	actionRepo.On("UpdateActionPhase", mock.Anything, testActionID,
+		common.ActionPhase_ACTION_PHASE_RUNNING, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(fmt.Errorf("%w: missing", interfaces.ErrActionNotFound))
+
+	resp, err := svc.UpdateActionStatus(context.Background(), connect.NewRequest(&workflow.UpdateActionStatusRequest{
+		ActionId: testActionID,
+		Status:   &workflow.ActionStatus{Phase: common.ActionPhase_ACTION_PHASE_RUNNING},
+	}))
+	require.NoError(t, err)
+	assert.EqualValues(t, connect.CodeNotFound, resp.Msg.GetStatus().GetCode())
 }
 
 func TestSignalEvent(t *testing.T) {

--- a/runs/service/internal_run_service.go
+++ b/runs/service/internal_run_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow/workflowconnect"
+	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
 	"github.com/flyteorg/flyte/v2/runs/repository/models"
 )
 
@@ -266,6 +267,9 @@ func (s *RunService) updateSingleActionStatus(ctx context.Context, req *workflow
 		startTime,
 	); err != nil {
 		logger.Warnf(ctx, "UpdateActionStatus: failed to update action %s: %v", req.GetActionId().GetName(), err)
+		if errors.Is(err, interfaces.ErrActionNotFound) {
+			return connect.NewError(connect.CodeNotFound, err)
+		}
 		return connect.NewError(connect.CodeInternal, err)
 	}
 


### PR DESCRIPTION
## Summary
- return a repository-level ErrActionNotFound when UpdateActionPhase matches no row and the action truly does not exist
- map that sentinel to a NotFound status in InternalRunService.UpdateActionStatus
- make the actions watcher re-record the TaskAction and retry UpdateActionStatus when the run service reports NotFound
- preserve stale/backward phase no-op behavior by checking row existence before returning NotFound

Fixes #7257.

## Testing
- GOCACHE=/private/tmp/flyte-go-cache GOMODCACHE=/private/tmp/flyte-go-mod-cache go test ./actions/k8s -run 'TestNotifyRunService_RecordAndRetryWhenStatusUpdateReturnsNotFound$'\n- GOCACHE=/private/tmp/flyte-go-cache GOMODCACHE=/private/tmp/flyte-go-mod-cache go test ./runs/service -run 'TestUpdateActionStatus_MissingActionReturnsNotFoundStatus$'\n- GOCACHE=/private/tmp/flyte-go-cache GOMODCACHE=/private/tmp/flyte-go-mod-cache go test ./runs/repository/impl -run 'TestUpdateActionPhase_(MissingActionReturnsNotFound|BlocksBackwardFromSucceeded)$'