### PR TITLE
Document user_metadata filters on artifact list requests

### DIFF
--- a/flyteidl2/artifact/artifact_service.proto
+++ b/flyteidl2/artifact/artifact_service.proto
@@ -67,7 +67,11 @@ message GetArtifactResponse {
 message ListArtifactsRequest {
   // Common list request parameters (limit, token, filters).
   // Supported filters: field "name" with CONTAINS,
-  // field "created_at" with GREATER_THAN (RFC3339 timestamp value).
+  // field "created_at" with GREATER_THAN (RFC3339 timestamp value),
+  // and field "user_metadata.<key>" targeting one key of the artifact's
+  // user_metadata map, with EQUAL, NOT_EQUAL, VALUE_IN, VALUE_NOT_IN,
+  // EXISTS or NOT_EXISTS. Values for one key are ORed; separate keys are
+  // ANDed.
   common.ListRequest request = 1;
 
   // Project scope for the listing. organization is stamped by the server.
@@ -89,7 +93,10 @@ message ListArtifactsResponse {
 // request message for listing distinct artifact names.
 message ListArtifactNamesRequest {
   // Common list request parameters (limit, token, filters).
-  // Supported filters: field "name" with CONTAINS.
+  // Supported filters: field "name" with CONTAINS, and field
+  // "user_metadata.<key>" as described on ListArtifactsRequest. A name is
+  // listed when any of its versions matches, represented by the newest
+  // matching version.
   common.ListRequest request = 1;
 
   // Project scope for the listing. organization is stamped by the server.


### PR DESCRIPTION
## Why are the changes needed?

The comments on `ListArtifactsRequest` and `ListArtifactNamesRequest` enumerate which filters the service supports. unionai/cloud is adding `user_metadata` filtering, so leaving it out makes those comments **wrong** rather than merely incomplete — a caller reading them would conclude the filter doesn't exist.

## What changes were proposed in this pull request?

Comment-only. **No new field is needed:** `common.ListRequest.filters` already carries this, keyed by a `user_metadata.<key>` field name — the same mechanism the runs service uses for `labels.<key>` label filtering, which likewise has no label-specific IDL.

Documents the supported functions (`EQUAL`, `NOT_EQUAL`, `VALUE_IN`, `VALUE_NOT_IN`, `EXISTS`, `NOT_EXISTS`), and that values for one key are ORed while separate keys are ANDed.

For `ListArtifactNamesRequest` it also states the grouping semantic, which is the non-obvious part: a name is listed when **any** of its versions matches, represented by the newest matching version.

## How was this patch tested?

Comment-only — no generated code changes, no behavior change. The filtering itself is implemented and tested in unionai/cloud.

### Labels

- **changed** — documentation of existing filter support.

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.