### PR TITLE
Fix event batcher flush span race

### DIFF
--- a/executor/pkg/controller/event_batcher.go
+++ b/executor/pkg/controller/event_batcher.go
@@ -126,7 +126,6 @@ func (b *eventBatcher) flush(batch []*eventReq) {
 	ctx, span := b.tracer.Start(ctx, "eventBatcher.flush",
 		trace.WithLinks(links...),
 		trace.WithAttributes(attribute.Int("events.batch_size", len(batch))))
-	defer span.End()
 	_, err := b.client.Record(ctx, connect.NewRequest(&workflow.RecordRequest{
 		Events: events,
 	}))
@@ -134,6 +133,7 @@ func (b *eventBatcher) flush(batch []*eventReq) {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, err.Error())
 	}
+	span.End()
 	for _, r := range batch {
 		r.done <- err
 	}


### PR DESCRIPTION
## Summary

Fixes a timing race in `eventBatcher.flush` telemetry recording. The flush span was ended via `defer`, after callers were released through their `done` channel, so `Record` could return before the span recorder observed the ended `eventBatcher.flush` span.

This makes the span end explicit before notifying callers, keeping the synchronous `Record` contract aligned with the test expectation.

## Root cause

`TestEventBatcher_FlushSpanLinksCallers` inspects ended spans immediately after `Record` returns. Because `span.End()` ran in a deferred call after writing to `done`, scheduler timing could let the test resume before the span was ended, producing zero flush spans.

## Validation

- `go test ./executor/pkg/controller -run TestEventBatcher_FlushSpanLinksCallers -count=100`
- `go test -race -coverprofile=coverage.out -covermode=atomic ./executor/pkg/controller`
- `go test -race -coverprofile=coverage.out -covermode=atomic ./executor/...`
- `go test ./executor/pkg/controller -run TestEventBatcher_FlushSpanLinksCallers -count=20`