### PR TITLE
ci: cache devbox image layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ENV CGO_ENABLED=0
 
 WORKDIR /flyteorg/build
 
+COPY go.mod go.sum ./
+RUN mkdir flyteidl2 flyteplugins flytestdlib && go mod download
+
 COPY dataproxy dataproxy
 COPY executor executor
 COPY flytecopilot flytecopilot
@@ -23,12 +26,10 @@ COPY runs runs
 COPY cache_service cache_service
 COPY secret secret
 
-COPY go.mod go.sum ./
-RUN go mod download
 COPY manager manager
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg/mod \
+RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -v -o dist/flyte ./manager/cmd/
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg/mod \
+RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -v -o dist/flyte-copilot ./flytecopilot
 
 

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,14 @@ build: verify ## Build all Go service binaries
 # Devbox Commands
 # =============================================================================
 
+# Local builds keep refreshing floating preloaded images such as flyteconsole:latest.
+# CI leaves CACHEBUST empty so buildx can restore that image layer from cache.
+DEVBOX_CACHEBUST ?= $(if $(GITHUB_ACTIONS),,$(shell date +%s))
+DEVBOX_CACHEBUST_FLAG := $(if $(DEVBOX_CACHEBUST),CACHEBUST=$(DEVBOX_CACHEBUST))
+
 .PHONY: devbox-build
-devbox-build: ## Build the flyte devbox image (docker/devbox-bundled), always re-pulling the latest UI image
-	$(MAKE) -C docker/devbox-bundled build CACHEBUST=$(shell date +%s)
+devbox-build: ## Build the flyte devbox image (docker/devbox-bundled), re-pulling the latest UI image outside CI
+	$(MAKE) -C docker/devbox-bundled build $(DEVBOX_CACHEBUST_FLAG)
 
 # Run in dev mode with extra arg FLYTE_DEV=True
 .PHONY: devbox-run

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build: verify ## Build all Go service binaries
 # =============================================================================
 
 # Local builds keep refreshing floating preloaded images such as flyteconsole:latest.
-# CI leaves CACHEBUST empty so buildx can restore that image layer from cache.
+# In CI we omit CACHEBUST (Dockerfile defaults it to 0) so buildx can restore the preload layer from cache.
 DEVBOX_CACHEBUST ?= $(if $(GITHUB_ACTIONS),,$(shell date +%s))
 DEVBOX_CACHEBUST_FLAG := $(if $(DEVBOX_CACHEBUST),CACHEBUST=$(DEVBOX_CACHEBUST))
 

--- a/docker/devbox-bundled/Dockerfile
+++ b/docker/devbox-bundled/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /flyteorg/build
 COPY bootstrap/go.mod bootstrap/go.sum ./
 RUN go mod download
 COPY bootstrap/ ./
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg/mod \
+RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -o dist/flyte-devbox-bootstrap cmd/bootstrap/main.go && \
     go build -o dist/embedded-postgres cmd/embedded-postgres/main.go
 


### PR DESCRIPTION
## Summary

- Stop passing a timestamp `CACHEBUST` to the devbox image build in GitHub Actions so the preloaded image layer can restore from buildx cache.
- Keep local `make devbox-build` behavior unchanged by continuing to refresh floating preloaded images outside CI.
- Move the flyte binary image `go mod download` layer before source copies and remove ineffective module cache mounts.

## Root Cause

The devbox workflow already configures buildx `type=gha` cache, but the top-level `devbox-build` target always passed `CACHEBUST=$(date +%s)`. That invalidated the `RUN ./preload manifest.txt` layer on every CI run, forcing the bundled image preload work to repeat.

The binary image also ran `go mod download` after copying source directories, so source changes invalidated dependency download reuse.

## Validation

- `git diff --check`
- `GITHUB_ACTIONS=true make -n devbox-build FLYTE_ARCHES=amd64` shows GHA cache flags and no `--build-arg CACHEBUST=...`.
- `make -n devbox-build FLYTE_ARCHES=amd64` still shows `CACHEBUST=...` and `--build-arg CACHEBUST=...` locally.
- Targeted preload-stage cache test: first local run `43s`, second local run `3s`; second run showed `RUN echo "cachebust=0" && ./preload manifest.txt` as `CACHED`.
- `docker buildx build --builder flyte-devbox --platform linux/amd64 --target flytebuilder --progress=plain --output=type=cacheonly .` succeeded.