### PR TITLE
fix(spark): pass driver/executor pod specs through as the pod template

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -147,7 +147,7 @@ func serviceAccountName(metadata pluginsCore.TaskExecutionMetadata) string {
 	return name
 }
 
-func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, podSpec *v1.PodSpec, container *v1.Container) *sparkOp.SparkPodSpec {
+func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, podSpec, customPodSpec *v1.PodSpec, container *v1.Container) *sparkOp.SparkPodSpec {
 	annotations := utils.UnionMaps(config.GetK8sPluginConfig().DefaultAnnotations, utils.CopyMap(taskCtx.TaskExecutionMetadata().GetAnnotations()))
 	labels := utils.UnionMaps(config.GetK8sPluginConfig().DefaultLabels, utils.CopyMap(taskCtx.TaskExecutionMetadata().GetLabels()))
 
@@ -179,11 +179,17 @@ func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 
 	// The legacy fields above are always populated so the object stays valid on clusters whose
 	// CRD/operator predate pod-template support (unknown fields are pruned by the API server
-	// there). Where the CRD accepts it, additionally pass the full pod spec through as the pod
-	// template; the operator treats explicit fields as overrides of the template, and both are
-	// derived from the same pod spec.
+	// there). Where the CRD accepts it, additionally pass a pod spec through as the pod template;
+	// the operator treats explicit fields as overrides of the template. The user's driver/executor
+	// pod spec is passed through verbatim so the operator can patch it onto the container it
+	// generates (`spark-kubernetes-driver`/`spark-kubernetes-executor`); Flyte's own container
+	// names never match those, so merging it here would drop it on the floor.
 	if GetSparkConfig().EnablePodTemplate && podTemplateSupported(ctx) {
-		spec.Template = &v1.PodTemplateSpec{Spec: *podSpec.DeepCopy()}
+		templatePodSpec := customPodSpec
+		if templatePodSpec == nil {
+			templatePodSpec = podSpec
+		}
+		spec.Template = &v1.PodTemplateSpec{Spec: *templatePodSpec.DeepCopy()}
 		sa := serviceAccountName(taskCtx.TaskExecutionMetadata())
 		spec.ServiceAccount = &sa
 	}
@@ -203,24 +209,14 @@ func createDriverSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCont
 	}
 
 	driverPod := sparkJob.GetDriverPod()
+	var customPodSpec *v1.PodSpec
 	if driverPod != nil {
 		if driverPod.GetPodSpec() != nil {
-			var customPodSpec *v1.PodSpec
-
 			err = utils.UnmarshalStructToObj(driverPod.GetPodSpec(), &customPodSpec) //nolint: staticcheck
 			if err != nil {
 				return nil, errors.Errorf(errors.BadTaskSpecification,
 					"Unable to unmarshal driver pod spec [%v], Err: [%v]", driverPod.GetPodSpec(), err.Error())
 			}
-
-			podSpec, err = flytek8s.MergeOverlayPodSpecOntoBase(podSpec, customPodSpec)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		if driverPod.GetPrimaryContainerName() != "" {
-			primaryContainerName = driverPod.GetPrimaryContainerName()
 		}
 	}
 
@@ -233,7 +229,7 @@ func createDriverSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCont
 	if err != nil {
 		return nil, err
 	}
-	sparkPodSpec := createSparkPodSpec(ctx, nonInterruptibleTaskCtx, podSpec, primaryContainer)
+	sparkPodSpec := createSparkPodSpec(ctx, nonInterruptibleTaskCtx, podSpec, customPodSpec, primaryContainer)
 	serviceAccountName := serviceAccountName(nonInterruptibleTaskCtx.TaskExecutionMetadata())
 	sparkPodSpec.ServiceAccount = &serviceAccountName
 	spec := driverSpec{
@@ -260,23 +256,14 @@ func createExecutorSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 	}
 
 	executorPod := sparkJob.GetExecutorPod()
+	var customPodSpec *v1.PodSpec
 	if executorPod != nil {
 		if executorPod.GetPodSpec() != nil {
-			var customPodSpec *v1.PodSpec
-
 			err = utils.UnmarshalStructToObj(executorPod.GetPodSpec(), &customPodSpec) //nolint: staticcheck
 			if err != nil {
 				return nil, errors.Errorf(errors.BadTaskSpecification,
 					"Unable to unmarshal executor pod spec [%v], Err: [%v]", executorPod.GetPodSpec(), err.Error())
 			}
-
-			podSpec, err = flytek8s.MergeOverlayPodSpecOntoBase(podSpec, customPodSpec)
-			if err != nil {
-				return nil, err
-			}
-		}
-		if executorPod.GetPrimaryContainerName() != "" {
-			primaryContainerName = executorPod.GetPrimaryContainerName()
 		}
 	}
 
@@ -289,7 +276,7 @@ func createExecutorSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 	if err != nil {
 		return nil, err
 	}
-	sparkPodSpec := createSparkPodSpec(ctx, taskCtx, podSpec, primaryContainer)
+	sparkPodSpec := createSparkPodSpec(ctx, taskCtx, podSpec, customPodSpec, primaryContainer)
 	spec := executorSpec{
 		primaryContainer,
 		&sparkOp.ExecutorSpec{

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -185,11 +185,15 @@ func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 	// generates (`spark-kubernetes-driver`/`spark-kubernetes-executor`); Flyte's own container
 	// names never match those, so merging it here would drop it on the floor.
 	if GetSparkConfig().EnablePodTemplate && podTemplateSupported(ctx) {
-		templatePodSpec := customPodSpec
-		if templatePodSpec == nil {
-			templatePodSpec = podSpec
+		templatePodSpec := podSpec.DeepCopy()
+		if customPodSpec != nil {
+			templatePodSpec = customPodSpec.DeepCopy()
+			// Preserve Flyte defaults when the user doesn't specify them in the custom pod spec.
+			if templatePodSpec.EnableServiceLinks == nil {
+				templatePodSpec.EnableServiceLinks = podSpec.EnableServiceLinks
+			}
 		}
-		spec.Template = &v1.PodTemplateSpec{Spec: *templatePodSpec.DeepCopy()}
+		spec.Template = &v1.PodTemplateSpec{Spec: *templatePodSpec}
 		sa := serviceAccountName(taskCtx.TaskExecutionMetadata())
 		spec.ServiceAccount = &sa
 	}

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1289,10 +1290,10 @@ func TestGetCompletionTime_WrongResourceType(t *testing.T) {
 
 // TestBuildResourceSparkExecutorAffinityDilution probes whether the non-interruptible
 // node-selector requirement (interruptible=false) survives on a Spark executor whose
-// custom executorPod carries its own node-affinity term. Spark merges the executor
-// overlay (spark.go createExecutorSpec) but re-applies no scheduling afterwards, so
-// this is the Spark analogue of the Ray OR-append dilution. If it fails, the appended
-// custom term lacks the non-interruptible requirement (bug); if it passes, no bug.
+// custom executorPod carries its own node-affinity term. The custom pod spec is handed
+// to the operator as the pod template rather than merged into the pod spec Flyte builds,
+// so it can no longer dilute the platform requirements on the explicit SparkPodSpec
+// fields — the operator treats those as overrides of the template.
 func TestBuildResourceSparkExecutorAffinityDilution(t *testing.T) {
 	sparkResourceHandler := sparkResourceHandler{}
 	defaultConfig := defaultPluginConfig()
@@ -1336,7 +1337,7 @@ func TestBuildResourceSparkExecutorAffinityDilution(t *testing.T) {
 	require.NotNil(t, sparkApp.Spec.Executor.Affinity)
 	require.NotNil(t, sparkApp.Spec.Executor.Affinity.NodeAffinity)
 	terms := sparkApp.Spec.Executor.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-	require.GreaterOrEqual(t, len(terms), 2, "expected the custom executor affinity term to be appended as a separate term")
+	require.NotEmpty(t, terms)
 	for i, term := range terms {
 		found := false
 		for _, e := range term.MatchExpressions {
@@ -1347,6 +1348,114 @@ func TestBuildResourceSparkExecutorAffinityDilution(t *testing.T) {
 		}
 		assert.Truef(t, found, "executor node selector term %d is missing the non-interruptible requirement", i)
 	}
+
+	// The custom term rides on the template instead, where the explicit fields above win.
+	require.NotNil(t, sparkApp.Spec.Executor.Template)
+	assert.Equal(t, executorPodSpec.Affinity, sparkApp.Spec.Executor.Template.Spec.Affinity)
+}
+
+// TestBuildResourceCustomPodSpecPassthrough covers the driver/executor pod specs reaching
+// the operator verbatim as the pod template. They used to be merged onto the pod spec Flyte
+// builds, which matches containers by name — and the container Flyte generates is named
+// after the task execution ID, so a container the user named anything else (the operator's
+// own `spark-kubernetes-{driver,executor}`, or `primary`) was silently dropped. Worse, a
+// `primary_container_name` that named such a container failed the task outright with
+// "invalid TaskSpecification, container [...] not defined".
+func TestBuildResourceCustomPodSpecPassthrough(t *testing.T) {
+	require.NoError(t, setSparkConfig(&Config{EnablePodTemplate: true}))
+	require.NoError(t, config.SetK8sPluginConfig(defaultPluginConfig()))
+	setPodTemplateSupportedForTest(true)
+
+	customPodSpec := func(containerName string) *corev1.PodSpec {
+		return &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: containerName,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceEphemeralStorage: resource.MustParse("9Gi")},
+				},
+			}},
+		}
+	}
+	driverPodSpec := customPodSpec("spark-kubernetes-driver")
+	executorPodSpec := customPodSpec("primary")
+
+	driverPodSpecPb, err := utils.MarshalObjToStruct(driverPodSpec)
+	require.NoError(t, err)
+	executorPodSpecPb, err := utils.MarshalObjToStruct(executorPodSpec)
+	require.NoError(t, err)
+
+	sparkJob := dummySparkCustomObj(dummySparkConf)
+	sparkJob.DriverPod = &core.K8SPod{PodSpec: driverPodSpecPb, PrimaryContainerName: "spark-kubernetes-driver"}
+	sparkJob.ExecutorPod = &core.K8SPod{PodSpec: executorPodSpecPb, PrimaryContainerName: "primary"}
+
+	sparkJobJSON, err := utils.MarshalToString(sparkJob)
+	require.NoError(t, err)
+	structObj := structpb.Struct{}
+	require.NoError(t, stdlibUtils.UnmarshalStringToPb(sparkJobJSON, &structObj))
+	taskTemplate := &core.TaskTemplate{
+		Id:     &core.Identifier{Name: "spark-custom-pod"},
+		Type:   "container",
+		Target: &core.TaskTemplate_Container{Container: &core.Container{Image: testImage, Args: testArgs, Env: dummyEnvVars}},
+		Custom: &structObj,
+	}
+
+	res, err := sparkResourceHandler{}.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, false))
+	require.NoError(t, err, "a primary_container_name that does not name a Flyte-generated container must not fail the task")
+	sparkApp, ok := res.(*sj.SparkApplication)
+	require.True(t, ok)
+
+	require.NotNil(t, sparkApp.Spec.Driver.Template)
+	assert.Equal(t, driverPodSpec.Containers, sparkApp.Spec.Driver.Template.Spec.Containers)
+	require.NotNil(t, sparkApp.Spec.Executor.Template)
+	assert.Equal(t, executorPodSpec.Containers, sparkApp.Spec.Executor.Template.Spec.Containers)
+
+	// The explicit fields still come from the pod spec Flyte builds, not from the template.
+	assert.Equal(t, testImage, *sparkApp.Spec.Driver.Image)
+	assert.Equal(t, testImage, *sparkApp.Spec.Executor.Image)
+}
+
+// TestBuildResourceCustomPodSpecDroppedWithoutTemplateSupport pins the accepted tradeoff:
+// the template is the only path a custom driver/executor pod spec travels, so on a cluster
+// whose SparkApplication CRD predates `spec.driver.template` it does not apply at all.
+func TestBuildResourceCustomPodSpecDroppedWithoutTemplateSupport(t *testing.T) {
+	require.NoError(t, setSparkConfig(&Config{EnablePodTemplate: true}))
+	require.NoError(t, config.SetK8sPluginConfig(defaultPluginConfig()))
+	setPodTemplateSupportedForTest(false)
+	defer setPodTemplateSupportedForTest(true)
+
+	executorPodSpec := &corev1.PodSpec{
+		NodeSelector: map[string]string{"custom": "true"},
+		Containers: []corev1.Container{{
+			Name: "primary",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceEphemeralStorage: resource.MustParse("9Gi")},
+			},
+		}},
+	}
+	podSpecPb, err := utils.MarshalObjToStruct(executorPodSpec)
+	require.NoError(t, err)
+
+	sparkJob := dummySparkCustomObj(dummySparkConf)
+	sparkJob.ExecutorPod = &core.K8SPod{PodSpec: podSpecPb, PrimaryContainerName: "primary"}
+
+	sparkJobJSON, err := utils.MarshalToString(sparkJob)
+	require.NoError(t, err)
+	structObj := structpb.Struct{}
+	require.NoError(t, stdlibUtils.UnmarshalStringToPb(sparkJobJSON, &structObj))
+	taskTemplate := &core.TaskTemplate{
+		Id:     &core.Identifier{Name: "spark-custom-pod-legacy-crd"},
+		Type:   "container",
+		Target: &core.TaskTemplate_Container{Container: &core.Container{Image: testImage, Args: testArgs, Env: dummyEnvVars}},
+		Custom: &structObj,
+	}
+
+	res, err := sparkResourceHandler{}.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, false))
+	require.NoError(t, err)
+	sparkApp, ok := res.(*sj.SparkApplication)
+	require.True(t, ok)
+
+	assert.Nil(t, sparkApp.Spec.Executor.Template)
+	assert.NotContains(t, sparkApp.Spec.Executor.NodeSelector, "custom")
 }
 
 // setPodTemplateSupportedForTest overrides the once-per-process CRD capability probe.


### PR DESCRIPTION
## Why are the changes needed?

A Spark task that customizes its driver or executor pod cannot do so today, and in the
common case it fails outright:

```python
flyte.TaskEnvironment(
    name="spark_exec_disk",
    plugin_config=Spark(
        spark_conf=base_conf,
        executor_pod=flyte.PodTemplate(
            primary_container_name="primary",
            pod_spec=V1PodSpec(containers=[V1Container(
                name="primary",
                resources=V1ResourceRequirements(requests={"ephemeral-storage": "9Gi"}),
            )]),
        ),
    ),
)
```

```
[BadTaskSpecification] invalid TaskSpecification, container [primary] not defined
```

`createDriverSpec`/`createExecutorSpec` merged the custom pod spec onto the pod spec Flyte
builds with `MergeOverlayPodSpecOntoBase`. That merge matches containers **by name**, and
iterates the base containers only — the container Flyte generates is named after the task
execution ID (`<TaskAction name>-<attempt>` in v2, `container_helper.go` `BuildRawContainer`),
which no user can predict. So:

1. any container in the custom pod spec is silently dropped (the `ephemeral-storage` request
   above never reaches the pod), and
2. `primary_container_name` then overrode the primary container name, and the following
   `GetContainer(podSpec, primaryContainerName)` failed the task.

Naming the container after the operator's `spark-kubernetes-driver` /
`spark-kubernetes-executor` — the names the Spark operator itself documents for pod
templates — hits exactly the same wall.

## What changes were proposed in this pull request?

Hand the custom pod spec to the Spark operator verbatim as
`spec.{driver,executor}.template` instead of merging it into Flyte's pod spec, and drop the
`primary_container_name` override. The operator patches the template onto the container it
generates, which is the container users are naming in the first place.

- `createSparkPodSpec` now takes the custom pod spec separately and uses it for
  `spec.Template`, falling back to the pod spec Flyte builds when the task sets no custom
  driver/executor pod (unchanged behavior for the vast majority of tasks).
- The explicit `SparkPodSpec` fields (affinity, tolerations, node selector, image, env, …)
  are still derived from the pod spec Flyte builds, so platform scheduling constraints stay
  intact — the operator treats explicit fields as overrides of the template, so a custom
  affinity in the template can no longer dilute the non-interruptible node-selector
  requirement.

**Tradeoff, called out explicitly:** the template is now the only path a custom
driver/executor pod spec travels. On a cluster whose `SparkApplication` CRD predates
`spec.driver.template` (or with the `enable-pod-template: false` kill switch), the custom
pod spec no longer applies at all, where previously its pod-level fields were merged into
the legacy `SparkPodSpec` fields. Container-level fields never worked on that path anyway.
`TestBuildResourceCustomPodSpecDroppedWithoutTemplateSupport` pins this behavior.

## How was this patch tested?

`go test ./go/tasks/plugins/k8s/spark/` — green. Tests added/updated:

- `TestBuildResourceCustomPodSpecPassthrough` — driver pod named `spark-kubernetes-driver`
  and executor pod named `primary`, both with an `ephemeral-storage` request and a matching
  `primary_container_name`. Asserts the build succeeds and both containers reach
  `spec.{driver,executor}.template` verbatim, while image/env still come from Flyte's pod
  spec. Fails on `main` with `invalid TaskSpecification, container [spark-kubernetes-driver]
  not defined` (verified).
- `TestBuildResourceCustomPodSpecDroppedWithoutTemplateSupport` — documents the tradeoff
  above on a legacy CRD.
- `TestBuildResourceSparkExecutorAffinityDilution` — updated: the custom affinity now lands
  on the template, and every node selector term on the explicit `Affinity` field still
  carries the non-interruptible requirement.
- `TestBuildResourcePodTemplateGating` (existing) covers the no-custom-pod-spec fallback.

### Labels

fixed

## Check all the applicable boxes

- [x] I updated the documentation accordingly. (n/a — no user-facing config change)
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

https://claude.ai/code/session_01SAATDRHXajHapuojwQ4SMR
