### PR TITLE
fix(executor): fail immediately on deterministic plugin errors

### DIFF
--- a/executor/pkg/controller/taskaction_controller.go
+++ b/executor/pkg/controller/taskaction_controller.go
@@ -45,8 +45,10 @@ import (
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
 	"github.com/flyteorg/flyte/v2/executor/pkg/plugin"
+	pluginserrors "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/errors"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/catalog"
 	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
+	stdErrors "github.com/flyteorg/flyte/v2/flytestdlib/errors"
 	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
@@ -178,9 +180,30 @@ func (r *TaskActionReconciler) resetPluginResource(
 	taskAction.Status.PluginStateVersion = 0
 }
 
+// nonRetryableErrorCodes are plugin error codes whose failures are deterministic:
+// the same input produces the same error, so retrying cannot change the outcome.
+// Note this only matches errors returned directly by a plugin; errors built from
+// a failure phase go through systemErrorFromPhaseInfo, which flattens the code
+// into the message text.
+var nonRetryableErrorCodes = []stdErrors.ErrorCode{
+	pluginserrors.BadTaskSpecification,
+	pluginserrors.MetadataTooLarge,
+}
+
+// nonRetryableCode reports the first non-retryable code found in err's cause chain.
+func nonRetryableCode(err error) (stdErrors.ErrorCode, bool) {
+	for _, code := range nonRetryableErrorCodes {
+		if stdErrors.IsCausedBy(err, code) {
+			return code, true
+		}
+	}
+	return "", false
+}
+
 // recordSystemError increments Status.SystemFailures and either requeues for
 // another attempt or, once the configured threshold is exceeded, converts the
-// TaskAction to a permanent failure. It does not touch the underlying plugin
+// TaskAction to a permanent failure. Errors carrying a non-retryable code skip
+// the counter entirely and fail immediately. It does not touch the underlying plugin
 // resource — callers that observed a failure phase should invoke
 // resetPluginResource first.
 func (r *TaskActionReconciler) recordSystemError(
@@ -191,6 +214,16 @@ func (r *TaskActionReconciler) recordSystemError(
 	handleErr error,
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+
+	if code, ok := nonRetryableCode(handleErr); ok {
+		logger.Error(handleErr, "non-retryable plugin error, failing TaskAction", "plugin", pluginID, "code", code)
+		return r.finalizePermanentFailure(ctx, taskAction, original, &core.ExecutionError{
+			Kind:    core.ExecutionError_USER,
+			Code:    code,
+			Message: handleErr.Error(),
+		})
+	}
+
 	logger.Error(handleErr, "system error from plugin", "plugin", pluginID)
 	if r.Recorder != nil {
 		r.Recorder.Eventf(taskAction, nil, corev1.EventTypeWarning, string(FailedPluginHandle), "HandlingPlugin",

--- a/executor/pkg/controller/taskaction_controller_test.go
+++ b/executor/pkg/controller/taskaction_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
+	pluginserrors "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/errors"
 	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
 	k8sPlugin "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
@@ -406,6 +407,33 @@ var _ = Describe("TaskAction Controller", func() {
 			Expect(ta.Status.ErrorState.Code).To(Equal(MaxSystemFailuresExceededCode))
 			Expect(ta.Status.ErrorState.Kind).To(Equal("SYSTEM"))
 			Expect(ta.Status.ErrorState.Message).To(ContainSubstring("admission webhook"))
+			Expect(isTerminal(ta)).To(BeTrue())
+		})
+
+		It("fails immediately on a non-retryable error without consuming any attempts", func() {
+			r := &TaskActionReconciler{
+				Client:            k8sClient,
+				Scheme:            k8sClient.Scheme(),
+				Recorder:          events.NewFakeRecorder(10),
+				eventsClient:      &fakeEventsClient{},
+				MaxSystemFailures: 3,
+			}
+			ta := &flyteorgv1.TaskAction{}
+			Expect(k8sClient.Get(ctx, nn, ta)).To(Succeed())
+			original := ta.DeepCopy()
+			startingAttempts := ta.Status.Attempts
+
+			handleErr := pluginserrors.Errorf(pluginserrors.BadTaskSpecification, "invalid ray submission mode %q", "HttpMode")
+
+			res, err := r.recordSystemError(ctx, ta, original, "ray", handleErr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.RequeueAfter).To(BeZero(), "terminal - should not requeue")
+			Expect(ta.Status.SystemFailures).To(BeZero(), "a deterministic failure must not consume system attempts")
+			Expect(ta.Status.Attempts).To(Equal(startingAttempts), "user retry budget must not be consumed")
+			Expect(ta.Status.ErrorState).NotTo(BeNil())
+			Expect(ta.Status.ErrorState.Code).To(Equal(pluginserrors.BadTaskSpecification))
+			Expect(ta.Status.ErrorState.Kind).To(Equal("USER"))
+			Expect(ta.Status.ErrorState.Message).To(ContainSubstring("invalid ray submission mode"))
 			Expect(isTerminal(ta)).To(BeTrue())
 		})
 	})

--- a/executor/pkg/plugin/k8s/plugin_manager.go
+++ b/executor/pkg/plugin/k8s/plugin_manager.go
@@ -220,7 +220,9 @@ func (pm *PluginManager) Handle(ctx context.Context, tCtx pluginsCore.TaskExecut
 	pluginState := PluginState{}
 	if v, err := tCtx.PluginStateReader().Get(&pluginState); err != nil {
 		if v != pluginStateVersion {
-			return pluginsCore.DoTransition(pluginsCore.PhaseInfoRetryableFailure(errors.CorruptedPluginState,
+			// Failing to read plugin state is deterministic, the stored bytes don't
+			// change between reconciles, so fail permanently instead of retrying.
+			return pluginsCore.DoTransition(pluginsCore.PhaseInfoSystemFailureWithCleanup(errors.CorruptedPluginState,
 				fmt.Sprintf("plugin state version mismatch expected [%d] got [%d]", pluginStateVersion, v), nil)), nil
 		}
 		return pluginsCore.UnknownTransition, errors.Wrapf(errors.CorruptedPluginState, err, "Failed to read unmarshal custom state")

--- a/executor/pkg/plugin/k8s/plugin_manager_test.go
+++ b/executor/pkg/plugin/k8s/plugin_manager_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,12 +19,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/errors"
 	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
 	pluginsCoreMock "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core/mocks"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/encoding"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s"
 	k8sMocks "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/k8s/mocks"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 )
 
 func TestAddObjectMetadata_GeneratedNameMaxLength(t *testing.T) {
@@ -161,4 +164,24 @@ func TestLaunchResource_InvalidCreateFastFails(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, pluginsCore.PhasePermanentFailure, transition.Info().Phase())
 	assert.Equal(t, "InvalidResource", transition.Info().Err().GetCode())
+}
+
+func TestHandle_CorruptedPluginStateFailsPermanently(t *testing.T) {
+	stateReader := &pluginsCoreMock.PluginStateReader{}
+	// (0, err) matches PluginStateManager's contract: the version is zeroed on decode failure.
+	stateReader.EXPECT().Get(mock.Anything).Return(uint8(0), fmt.Errorf("gob: decode failed"))
+
+	tCtx := &pluginsCoreMock.TaskExecutionContext{}
+	tCtx.EXPECT().PluginStateReader().Return(stateReader)
+
+	plugin := &k8sMocks.Plugin{}
+	plugin.EXPECT().GetProperties().Return(k8s.PluginProperties{})
+
+	pm := NewPluginManager("test", plugin, &pluginsCoreMock.KubeClient{})
+
+	transition, err := pm.Handle(context.Background(), tCtx)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhasePermanentFailure, transition.Info().Phase())
+	assert.Equal(t, string(errors.CorruptedPluginState), transition.Info().Err().GetCode())
+	assert.Equal(t, core.ExecutionError_SYSTEM, transition.Info().Err().GetKind())
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Plugin errors carrying a deterministic error code now fail the TaskAction immediately instead of consuming system-failure attempts.

```go
var nonRetryableErrorCodes = []stdErrors.ErrorCode{
	pluginserrors.BadTaskSpecification,
	pluginserrors.MetadataTooLarge,
}
```

`recordSystemError` checks the error's code before touching `Status.SystemFailures`, and routes a match straight to `finalizePermanentFailure` with `ExecutionError_USER` and the original code and message.

A few notes:

- **The check runs before the counter is incremented**, so a failure that is never retried doesn't leave a misleading `SystemFailures` count behind.
- **`Kind` is `USER`**, since both codes mean the task spec or the workload is at fault rather than the platform. Easy to change if you'd rather they were `SYSTEM`.
- **This only catches errors returned directly by a plugin.** Errors built from a failure phase go through `systemErrorFromPhaseInfo`, which flattens the code into the message text, so `IsCausedBy` can't see it. Noted in a comment where the codes are defined.
- **`MetadataTooLarge` is not produced anywhere in the codebase today**, so it's included defensively rather than tested against a real producer.
- **`CorruptedPluginState` is deliberately left out.** It looks recoverable rather than deterministic, and I'd like to handle it separately. Details in a comment below.

## Why are the changes needed?

Follow-up to #7799, where we noticed the v2 executor doesn't check plugin error codes: every plugin error goes through `recordSystemError` and is retried until `MaxSystemFailures` is exceeded, regardless of whether retrying could possibly help.

Concretely, a typo in the Ray plugin config (`submissionMode: HttpMode`) currently produces four attempts at 10-second intervals before failing, and reports as `MaxSystemFailuresExceeded` rather than naming the actual problem. With this change it fails in about a second, and the failure carries `BadTaskSpecification` and the original message, which points at the config.

## How was this patch tested?

- New spec in `taskaction_controller_test.go` asserting that a `BadTaskSpecification` error terminates immediately: no requeue, `SystemFailures` stays zero, the user's `Attempts` budget is untouched, and `Status.ErrorState` carries the code, `USER` kind, and the original message.
- Verified the spec catches regressions: swapping the code in `nonRetryableErrorCodes` for one the test doesn't use makes it fail.
- Existing `recordSystemError` specs still pass. They use a plain error with no typed code, so the new check correctly ignores them.