### PR TITLE
Only mount API paths once when using multiple ingresses

### DIFF
--- a/charts/flyte-binary/templates/ingress/http.yaml
+++ b/charts/flyte-binary/templates/ingress/http.yaml
@@ -52,6 +52,7 @@ spec:
               number: {{ .Values.console.service.port }}
         path: {{ .Values.console.basePath }}/*
         pathType: ImplementationSpecific
+      {{- if not .Values.ingress.apiJwtIngress.enabled }}
       {{- $paths := (include "flyte-binary.ingress.apiPaths" .) | fromYamlArray }}
       {{- range $path := $paths }}
       - path: {{ $path }}
@@ -68,6 +69,7 @@ spec:
           serviceName: {{ include "flyte-binary.service.http.name" $ }}
           servicePort: {{ include "flyte-binary.service.http.port" $ }}
           {{- end }}
+      {{- end }}
       {{- end }}
       {{- if .Values.ingress.httpExtraPaths.append }}
       {{- tpl ( .Values.ingress.httpExtraPaths.append | toYaml ) . | nindent 6 }}


### PR DESCRIPTION
## Why are the changes needed?
I recently setup Flyte OSS using ingress-nginx. The Flyte binary helm chart has an ingress for console (or all)  traffic, one for API / CLI traffic, and another for OIDC metadata. One of the issues we encountered is that the API paths are mounted on both the console ingress as well as the API ingress. This doesn't cause issues for some ingress implementations but ingress-nginx get upset when the same API paths are mounted on several ingresses bound to the same host/domain since the choice is ambiguous. 

## What changes were proposed in this pull request?

This pull request only renders the API paths into the console ingress when it is configured as the all in one ingress. Otherwise when the API ingress is rendered it will omit the API paths from the console ingress.

## How was this patch tested?

Tested in our environment

### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
