### PR TITLE
feat: limit executor informer cache to one namespace, opt-in

### DIFF
--- a/executor/pkg/config/config.go
+++ b/executor/pkg/config/config.go
@@ -26,6 +26,7 @@ var (
 		Cluster:                 "",
 		MaxSystemFailures:       3,
 		MaxConcurrentReconciles: 512,
+		LimitCacheToNamespace:   false,
 		RequeueDuration:         stdconfig.Duration{Duration: 10 * time.Second},
 		GC: GCConfig{
 			Interval: stdconfig.Duration{Duration: 30 * time.Minute},
@@ -99,6 +100,20 @@ type Config struct {
 	// more reconciles and more load on the plugin backends. 0 or unset means the
 	// built-in default of 10s.
 	RequeueDuration stdconfig.Duration `json:"requeueDuration" pflag:",How long to wait before reconciling a running TaskAction again. 0 means the default of 10s"`
+
+	// LimitCacheToNamespace scopes the controller-runtime informer cache to the single
+	// namespace the executor operates in, instead of watching every namespace in the
+	// cluster.
+	//
+	// Defaults to false, which preserves the cluster-wide behaviour. On a large
+	// multi-tenant cluster the cluster-wide cache holds every Pod in the cluster and
+	// can require several GB of memory, so operators running the executor in a single
+	// namespace will usually want this enabled.
+	//
+	// Only enable this when every task pod runs in the executor's own namespace. The
+	// PodTemplate informer is unaffected and still watches every namespace, so
+	// per-namespace PodTemplate overrides keep working.
+	LimitCacheToNamespace bool `json:"limitCacheToNamespace" pflag:",Scope the informer cache to the executor's own namespace instead of the whole cluster"`
 
 	// GC configures the garbage collector for terminal TaskActions.
 	GC GCConfig `json:"gc" pflag:",Garbage collector configuration for terminal TaskActions"`

--- a/executor/pkg/config/config_flags.go
+++ b/executor/pkg/config/config_flags.go
@@ -67,6 +67,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultK8sServiceAccount"), defaultConfig.DefaultK8sServiceAccount, "Default Kubernetes service account for task pods when the task does not set one")
 	cmdFlags.Int32(fmt.Sprintf("%v%v", prefix, "maxSystemFailures"), defaultConfig.MaxSystemFailures, "Max consecutive system-level failures before forcing permanent failure")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "requeueDuration"), defaultConfig.RequeueDuration.String(), "How long to wait before reconciling a running TaskAction again. 0 means the default of 10s")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "limitCacheToNamespace"), defaultConfig.LimitCacheToNamespace, "Scope the informer cache to the executor's own namespace instead of the whole cluster")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.interval"), defaultConfig.GC.Interval.String(), "How often the garbage collector runs. 0 disables GC.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gc.maxTTL"), defaultConfig.GC.MaxTTL.String(), "Time-to-live for terminal TaskActions before deletion.")
 	return cmdFlags

--- a/executor/pkg/config/config_flags_test.go
+++ b/executor/pkg/config/config_flags_test.go
@@ -337,6 +337,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_limitCacheToNamespace", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("limitCacheToNamespace", testValue)
+			if vBool, err := cmdFlags.GetBool("limitCacheToNamespace"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vBool), &actual.LimitCacheToNamespace)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_gc.interval", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/executor/pkg/controller/metrics.go
+++ b/executor/pkg/controller/metrics.go
@@ -10,6 +10,7 @@ import (
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	toolscache "k8s.io/client-go/tools/cache"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
 )
@@ -112,6 +113,9 @@ func countByPhase(items []*flyteorgv1.TaskAction) map[string]int64 {
 // this is what keeps the active gauge cheap when many TaskActions exist. The indexer
 // is resolved lazily on first call, because the cache is not yet started when the
 // reconciler is constructed.
+//
+// A namespace-scoped cache (the executor's limitCacheToNamespace option) exposes no
+// indexer, so this falls back to the cache's List rather than dropping the gauge.
 func cachedPhaseCounter(c ctrlcache.Cache) func(context.Context) map[string]int64 {
 	var indexer toolscache.Indexer
 	return func(ctx context.Context) map[string]int64 {
@@ -127,7 +131,7 @@ func cachedPhaseCounter(c ctrlcache.Cache) func(context.Context) map[string]int6
 			}
 			sii, ok := informer.(toolscache.SharedIndexInformer)
 			if !ok {
-				return nil
+				return listPhaseCounts(ctx, c)
 			}
 			indexer = sii.GetIndexer()
 		}
@@ -140,6 +144,26 @@ func cachedPhaseCounter(c ctrlcache.Cache) func(context.Context) map[string]int6
 		}
 		return countByPhase(items)
 	}
+}
+
+// listPhaseCounts tallies TaskActions by phase through the cache's List, for caches
+// that do not expose an indexer.
+//
+// UnsafeDisableDeepCopy keeps this as cheap as the indexer path: a cache List otherwise
+// deep-copies every TaskAction on every collection cycle, which is the allocation churn
+// the indexer path exists to avoid, on the memory-constrained deployments that enable
+// namespace scoping in the first place. Safe here because the objects are only read for
+// their phase and never mutated or retained.
+func listPhaseCounts(ctx context.Context, c ctrlcache.Cache) map[string]int64 {
+	var list flyteorgv1.TaskActionList
+	if err := c.List(ctx, &list, client.UnsafeDisableDeepCopy); err != nil {
+		return nil
+	}
+	items := make([]*flyteorgv1.TaskAction, 0, len(list.Items))
+	for i := range list.Items {
+		items = append(items, &list.Items[i])
+	}
+	return countByPhase(items)
 }
 
 // observeCRDSize records the serialized size of a TaskAction CRD. No-op when

--- a/executor/pkg/controller/metrics_test.go
+++ b/executor/pkg/controller/metrics_test.go
@@ -14,6 +14,9 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
 )
 
@@ -137,4 +140,65 @@ func TestRecordK8sOp(t *testing.T) {
 	assert.NotPanics(t, func() {
 		nilMetrics.recordK8sOp(context.Background(), opGet, time.Now(), nil)
 	})
+}
+
+// stubInformer embeds the cache.Informer interface, so it deliberately does NOT
+// implement toolscache.SharedIndexInformer -- matching controller-runtime's
+// multiNamespaceInformer, which a namespace-scoped cache returns and which exposes
+// no indexer.
+type stubInformer struct {
+	ctrlcache.Informer
+}
+
+// stubNoIndexerCache mimics a namespace-scoped controller-runtime cache: its
+// informer has no indexer, so callers must fall back to List.
+type stubNoIndexerCache struct {
+	ctrlcache.Cache
+	items     []flyteorgv1.TaskAction
+	listCalls int
+	listOpts  []client.ListOption
+}
+
+func (c *stubNoIndexerCache) GetInformer(_ context.Context, _ client.Object, _ ...ctrlcache.InformerGetOption) (ctrlcache.Informer, error) {
+	return stubInformer{}, nil
+}
+
+func (c *stubNoIndexerCache) List(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	tal, ok := list.(*flyteorgv1.TaskActionList)
+	if !ok {
+		return errors.New("unexpected list type")
+	}
+	c.listCalls++
+	c.listOpts = opts
+	tal.Items = c.items
+	return nil
+}
+
+// TestCachedPhaseCounterFallsBackWithoutIndexer covers the namespace-scoped cache
+// path: controller-runtime returns an informer with no indexer, so the counter must
+// list through the cache rather than silently reporting nothing.
+func TestCachedPhaseCounterFallsBackWithoutIndexer(t *testing.T) {
+	c := &stubNoIndexerCache{items: []flyteorgv1.TaskAction{
+		{ObjectMeta: metav1.ObjectMeta{Name: "ta-1"}, Status: flyteorgv1.TaskActionStatus{PluginPhase: "Executing"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ta-2"}, Status: flyteorgv1.TaskActionStatus{PluginPhase: "Executing"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ta-3"}},
+	}}
+
+	counter := cachedPhaseCounter(c)
+	assert.Equal(t, map[string]int64{"Executing": 2, "Unknown": 1}, counter(context.Background()))
+
+	// The gauge is observed once per export, so the informer lookup is repeated rather
+	// than cached; what matters is that every cycle keeps reporting.
+	assert.Equal(t, map[string]int64{"Executing": 2, "Unknown": 1}, counter(context.Background()))
+	assert.Equal(t, 2, c.listCalls)
+
+	// Deep copying every TaskAction each cycle would reintroduce the allocation churn
+	// namespace scoping is meant to remove, so the List must opt out of it.
+	assert.Equal(t, []client.ListOption{client.UnsafeDisableDeepCopy}, c.listOpts)
+}
+
+// TestCachedPhaseCounterNilCache guards the no-cache path used when metrics are
+// registered without a manager cache.
+func TestCachedPhaseCounterNilCache(t *testing.T) {
+	assert.Nil(t, cachedPhaseCounter(nil)(context.Background()))
 }

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -17,6 +17,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	k8scache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -117,9 +118,19 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		metricsServerOptions.KeyName = cfg.MetricsCertKey
 	}
 
+	// By default controller-runtime caches watched objects across every namespace.
+	// When the executor only ever operates in a single namespace, that cache holds
+	// every Pod in the cluster, which on a large multi-tenant cluster costs several
+	// GB of memory. LimitCacheToNamespace scopes it to sc.Namespace instead.
+	cacheOptions := cache.Options{}
+	if cfg.LimitCacheToNamespace {
+		cacheOptions.DefaultNamespaces = map[string]cache.Config{sc.Namespace: {}}
+	}
+
 	mgr, err := ctrl.NewManager(sc.K8sConfig, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
+		Cache:                  cacheOptions,
 		WebhookServer:          webhook.NewServer(webhookServerOptions),
 		HealthProbeBindAddress: cfg.HealthProbeBindAddress,
 		LeaderElection:         cfg.LeaderElect,


### PR DESCRIPTION
## Tracking issue

Closes #7831

## Why are the changes needed?

The executor's manager is created without a Cache option, so the informer cache watches **every namespace** and caches every Pod in the cluster. On a large multi-tenant cluster this stops the executor starting at all: with tens of thousands of pods across thousands of namespaces, the cache fill needs several GB and the executor is OOMKilled in a loop at 4 GiB. Raising the limit is not a fix: memory scales with the cluster's size, not the executor's workload. There is no way to configure the scope today.

## What changes were proposed in this pull request?

A new executor option, limitCacheToNamespace, **defaulting to false** so it is a no-op for existing deployments. When enabled:

1. **Manager cache** — scoped to the executor namespace. This is the actual fix; both cache consumers already scope every read to that namespace.

2. **The PodTemplate informer is deliberately left alone**, so per-namespace PodTemplate overrides keep working. An earlier revision scoped it too; I dropped that. It saves almost nothing and is the only part that removes a capability — the store resolves a task's own namespace before falling back, so the cluster-wide watch is what makes overrides work. Its one real benefit is namespace-scoped RBAC, which also needs a Role the chart does not ship, so it belongs in its own PR.

3. **A regression fix in the active-TaskAction gauge**, which reaches the cache's indexer via a type assertion that holds today. A namespace-scoped cache returns an informer with no indexer, so the gauge would silently stop reporting, with no log or error, exactly while an operator validates a memory change. It now falls back to a List.

## How was this patch tested?

- A new test covers the gauge fallback, and was confirmed to fail against the unfixed code.
- Full suite as CI runs it, with envtest and race: all pass. Build, vet, gofmt clean; go mod tidy no diff.
- **Verified on a real cluster**: the executor went from an OOMKill loop to steady state — memory 3468Mi → 37Mi, CPU 1414m → 2m, restarts 5+ → 0 — and a workflow ran 11/11.

Generated flags files were mirrored by hand; the pflags generator panics on current Go for me. A boolean rather than a namespace list, since it reuses the namespace the executor already knows.

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
- [x] Local code review completed

