### PR TITLE
fix(pytorch): propagate pod metadata to the PyTorchJob CR

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
@@ -136,12 +136,22 @@ func (pytorchOperatorResourceHandler) BuildResource(ctx context.Context, taskCtx
 		delete(jobSpec.PyTorchReplicaSpecs, kubeflowv1.PyTorchJobReplicaTypeMaster)
 	}
 
+	// Propagate the task's pod metadata (k8s_pod / pod_template labels and annotations) onto the CR
+	// itself, as the ray and dask plugins do. The replica pod templates already receive this metadata
+	// via common.ToReplicaSpec; without this the CR only gets the execution-level labels that the
+	// plugin manager stamps on every resource.
+	_, objectMeta, _, err := flytek8s.ToK8sPodSpec(ctx, taskCtx)
+	if err != nil {
+		return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "Unable to create pod spec: [%v]", err.Error())
+	}
+
 	job := &kubeflowv1.PyTorchJob{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       kubeflowv1.PyTorchJobKind,
 			APIVersion: kubeflowv1.SchemeGroupVersion.String(),
 		},
-		Spec: jobSpec,
+		ObjectMeta: *objectMeta,
+		Spec:       jobSpec,
 	}
 
 	return job, nil

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
@@ -466,6 +466,52 @@ func TestBuildResourcePytorch(t *testing.T) {
 	}
 }
 
+func TestBuildResourcePytorchPodTemplateMetadataOnCR(t *testing.T) {
+	const crPodTemplateName = "pytorch-cr-pod-template"
+	crPodTemplateLabels := map[string]string{"pod-template-label": "pod-template-label-value"}
+	crPodTemplateAnnotations := map[string]string{"pod-template-annotation": "pod-template-annotation-value"}
+
+	crPodTemplate := &corev1.PodTemplate{
+		ObjectMeta: v1.ObjectMeta{
+			Name: crPodTemplateName,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: v1.ObjectMeta{
+				Labels:      crPodTemplateLabels,
+				Annotations: crPodTemplateAnnotations,
+			},
+		},
+	}
+	flytek8s.DefaultPodTemplateStore.Store(crPodTemplate)
+	defer flytek8s.DefaultPodTemplateStore.Delete(crPodTemplate)
+
+	pytorchResourceHandler := pytorchOperatorResourceHandler{}
+
+	taskTemplate := dummyPytorchTaskTemplate("job-pod-template", dummyPytorchCustomObj(100))
+	taskTemplate.Metadata = &core.TaskMetadata{PodTemplateName: crPodTemplateName}
+
+	res, err := pytorchResourceHandler.BuildResource(context.TODO(), dummyPytorchTaskContext(taskTemplate, resourceRequirements, nil, ""))
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+
+	pytorchJob, ok := res.(*kubeflowv1.PyTorchJob)
+	assert.True(t, ok)
+
+	// The pod metadata must land on the CR itself, not only on the replica pod templates.
+	for k, v := range crPodTemplateLabels {
+		assert.Equal(t, v, pytorchJob.Labels[k])
+	}
+	for k, v := range crPodTemplateAnnotations {
+		assert.Equal(t, v, pytorchJob.Annotations[k])
+	}
+
+	for _, replicaSpec := range pytorchJob.Spec.PyTorchReplicaSpecs {
+		for k, v := range crPodTemplateLabels {
+			assert.Equal(t, v, replicaSpec.Template.Labels[k])
+		}
+	}
+}
+
 func TestBuildResourcePytorchContainerImage(t *testing.T) {
 	assert.NoError(t, flytek8sConfig.SetK8sPluginConfig(&flytek8sConfig.K8sPluginConfig{}))
 


### PR DESCRIPTION
BuildResource returned the PyTorchJob without an ObjectMeta, so pod-level metadata (pod_template / k8s_pod labels and annotations) only reached the replica pod templates via common.ToReplicaSpec and never the CR itself. Execution-level labels were unaffected -- the plugin manager stamps those on every resource in addObjectMetadata.

Set ObjectMeta from a fresh flytek8s.ToK8sPodSpec call, matching what the ray and dask plugins already do. Deriving it from a replica spec would be wrong: ToReplicaSpecWithOverrides builds a per-replica-group task context, so group-specific labels would leak onto the CR.

## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
