### PR TITLE
[FIX] reference secrets with secretKeyRef instead of putting values in the pod spec

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go
@@ -137,13 +137,13 @@ func encodeSecretName(components *SecretNameComponents) string {
 	return EncodeSecretName(components.Org, components.Domain, components.Project, components.Name)
 }
 
-type resolvedSecret struct {
-	value               *SecretValue
-	secretID            string
-	imagePullSecretName string
+type resolvedUserSecret struct {
+	value       *SecretValue
+	secretID    string
+	isK8sSecret bool
 }
 
-func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, components *SecretNameComponents) (*resolvedSecret, error) {
+func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, components *SecretNameComponents) (*resolvedUserSecret, string, error) {
 	componentsCopy := *components // Create a copy to avoid modifying the original
 
 	// Compute encoded IDs for each scope in priority order.
@@ -167,6 +167,8 @@ func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, compon
 		{orgScopedSecret, orgScopedImagePullSecretName},
 	}
 
+	isK8sSecret := i.cfg.Type == config.EmbeddedSecretManagerTypeK8s
+
 	// Walk scopes in priority order (project+domain → domain → org). For each
 	// scope, check the cache first; on miss, fall through to the fetchers for
 	// that same scope. Only move to the next broader scope when the current
@@ -174,7 +176,13 @@ func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, compon
 	for _, scope := range scopes {
 		if cachedValue, err := i.secretCache.Get(ctx, scope.secretID); err == nil {
 			logger.Debugf(ctx, "Found secret [%s] in cache.", scope.secretID)
-			return &resolvedSecret{&cachedValue, scope.secretID, scope.imagePullSecretName}, nil
+			if isK8sSecret {
+				storedSecret := &corev1.Secret{}
+				err := i.k8sClient.Get(ctx, types.NamespacedName{Name: EncodeK8sSecretName(scope.secretID), Namespace: i.cfg.K8sConfig.Namespace}, storedSecret)
+				_, isK8sSecret = storedSecret.Data[scope.secretID]
+				isK8sSecret = isK8sSecret && err == nil
+			}
+			return &resolvedUserSecret{&cachedValue, scope.secretID, isK8sSecret}, scope.imagePullSecretName, nil
 		}
 
 		for _, secretFetcher := range i.secretFetchers {
@@ -183,17 +191,23 @@ func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, compon
 				if cacheErr := i.secretCache.Set(ctx, scope.secretID, *secretValue); cacheErr != nil {
 					logger.Warnf(ctx, "Failed to cache secret [%s]: %v", scope.secretID, cacheErr)
 				}
-				return &resolvedSecret{secretValue, scope.secretID, scope.imagePullSecretName}, nil
+				if isK8sSecret {
+					storedSecret := &corev1.Secret{}
+					err := i.k8sClient.Get(ctx, types.NamespacedName{Name: EncodeK8sSecretName(scope.secretID), Namespace: i.cfg.K8sConfig.Namespace}, storedSecret)
+					_, isK8sSecret = storedSecret.Data[scope.secretID]
+					isK8sSecret = isK8sSecret && err == nil
+				}
+				return &resolvedUserSecret{secretValue, scope.secretID, isK8sSecret}, scope.imagePullSecretName, nil
 			}
 			if !stdlibErrors.IsCausedBy(err, ErrCodeSecretNotFound) {
-				return nil, err
+				return nil, "", err
 			}
 			// NotFound from this fetcher — try the next fetcher at the same scope.
 		}
 		// All fetchers reported NotFound at this scope — fall through to the next broader scope.
 	}
 
-	return nil, stdlibErrors.Errorf(ErrCodeSecretNotFoundAcrossAllScopes, SecretSecretNotFoundAcrossAllScopes)
+	return nil, "", stdlibErrors.Errorf(ErrCodeSecretNotFoundAcrossAllScopes, SecretSecretNotFoundAcrossAllScopes)
 }
 
 // addImagePullSecretToPod adds an image pull secret to a pod if it doesn't already exist
@@ -302,7 +316,15 @@ func (i *EmbeddedSecretManagerInjector) Inject(
 		return pod, false, err
 	}
 
-	resolved, err := i.lookUpSecret(ctx, secretNameComponents)
+	// A SecretKeyRef can only reference a Secret in the same namespace as the pod, so the pod
+	// must be running in the same namespace the Kubernetes-native secret manager stores into.
+	if (secret.MountRequirement == core.Secret_ANY || secret.MountRequirement == core.Secret_ENV_VAR) && pod.GetNamespace() != i.cfg.K8sConfig.Namespace {
+		return pod, false, fmt.Errorf(
+			"cannot mount secret [%s]: pod namespace [%s] does not match the Kubernetes secret manager namespace [%s]",
+			secret.Key, pod.GetNamespace(), i.cfg.K8sConfig.Namespace)
+	}
+
+	resolved, imagePullSecretName, err := i.lookUpSecret(ctx, secretNameComponents)
 	if err != nil {
 		return pod, false, err
 	}
@@ -322,12 +344,16 @@ func (i *EmbeddedSecretManagerInjector) Inject(
 					"but has a binary value that is not a valid UTF-8 string; mount "+
 					"as a file instead", secret.Key)
 		}
-		secretRef, err := i.envVarSecretRef(ctx, secretNameComponents, resolved.secretID, pod.GetNamespace())
-		if err != nil {
-			logger.Errorf(ctx, "Failed to inject secret [%v] as an environment variable: %v", secret.Key, err)
-			return pod, false, err
+		if !resolved.isK8sSecret {
+			return pod, false, fmt.Errorf(
+				"secret %q cannot be mounted as an environment variable: "+
+					"it is not stored in a Kubernetes secret", secret.Key)
 		}
-		i.injectAsEnvVar(secret, secretRef, pod)
+
+		i.injectAsEnvVar(secret, &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: EncodeK8sSecretName(resolved.secretID)},
+			Key:                  resolved.secretID,
+		}, pod)
 	case core.Secret_FILE:
 		secretBytes := secretValue.BinaryValue
 		if len(secretValue.StringValue) > 0 {
@@ -341,7 +367,7 @@ func (i *EmbeddedSecretManagerInjector) Inject(
 	}
 
 	if i.cfg.ImagePullSecrets.Enabled {
-		pod, err = i.findAndAddImagePullSecret(ctx, resolved.imagePullSecretName, pod)
+		pod, err = i.findAndAddImagePullSecret(ctx, imagePullSecretName, pod)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to add image pull secret [%s]: %v", secretNameComponents.Name, err)
 			return pod, false, err
@@ -370,38 +396,6 @@ func (i *EmbeddedSecretManagerInjector) injectAsEnvVar(secret *core.Secret, secr
 	}
 	pod.Spec.InitContainers = AppendEnvVars(pod.Spec.InitContainers, envVars...)
 	pod.Spec.Containers = AppendEnvVars(pod.Spec.Containers, envVars...)
-}
-
-func (i *EmbeddedSecretManagerInjector) envVarSecretRef(
-	ctx context.Context,
-	components *SecretNameComponents,
-	secretID string,
-	namespace string,
-) (*corev1.SecretKeySelector, error) {
-	name := EncodeK8sSecretName(secretID)
-
-	if namespace == "" {
-		return nil, fmt.Errorf("cannot mount secret [%s]: pod has no namespace, so Kubernetes secret [%s] was not looked up", components.Name, name)
-	}
-
-	storedSecret := &corev1.Secret{}
-	if err := i.k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, storedSecret); err != nil {
-		if k8sError.IsNotFound(err) {
-			return nil, fmt.Errorf("cannot mount secret [%s]: it is not stored in a Kubernetes secret %s/%s", components.Name, namespace, name)
-		}
-
-		return nil, fmt.Errorf("failed to look up secret %s/%s: %w", namespace, name, err)
-	}
-
-	if _, found := storedSecret.Data[secretID]; !found {
-		return nil, fmt.Errorf("cannot mount secret [%s]: secret %s/%s has no key %s", components.Name, namespace, name, secretID)
-	}
-
-	logger.Debugf(ctx, "Referencing secret %s/%s for %s", namespace, name, components)
-	return &corev1.SecretKeySelector{
-		LocalObjectReference: corev1.LocalObjectReference{Name: name},
-		Key:                  secretID,
-	}, nil
 }
 
 func (i *EmbeddedSecretManagerInjector) injectAsFile(secret *core.Secret, secretValue []byte, pod *corev1.Pod) {

--- a/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go
@@ -137,7 +137,13 @@ func encodeSecretName(components *SecretNameComponents) string {
 	return EncodeSecretName(components.Org, components.Domain, components.Project, components.Name)
 }
 
-func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, components *SecretNameComponents) (*SecretValue, string, error) {
+type resolvedSecret struct {
+	value               *SecretValue
+	secretID            string
+	imagePullSecretName string
+}
+
+func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, components *SecretNameComponents) (*resolvedSecret, error) {
 	componentsCopy := *components // Create a copy to avoid modifying the original
 
 	// Compute encoded IDs for each scope in priority order.
@@ -168,7 +174,7 @@ func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, compon
 	for _, scope := range scopes {
 		if cachedValue, err := i.secretCache.Get(ctx, scope.secretID); err == nil {
 			logger.Debugf(ctx, "Found secret [%s] in cache.", scope.secretID)
-			return &cachedValue, scope.imagePullSecretName, nil
+			return &resolvedSecret{&cachedValue, scope.secretID, scope.imagePullSecretName}, nil
 		}
 
 		for _, secretFetcher := range i.secretFetchers {
@@ -177,17 +183,17 @@ func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, compon
 				if cacheErr := i.secretCache.Set(ctx, scope.secretID, *secretValue); cacheErr != nil {
 					logger.Warnf(ctx, "Failed to cache secret [%s]: %v", scope.secretID, cacheErr)
 				}
-				return secretValue, scope.imagePullSecretName, nil
+				return &resolvedSecret{secretValue, scope.secretID, scope.imagePullSecretName}, nil
 			}
 			if !stdlibErrors.IsCausedBy(err, ErrCodeSecretNotFound) {
-				return nil, "", err
+				return nil, err
 			}
 			// NotFound from this fetcher — try the next fetcher at the same scope.
 		}
 		// All fetchers reported NotFound at this scope — fall through to the next broader scope.
 	}
 
-	return nil, "", stdlibErrors.Errorf(ErrCodeSecretNotFoundAcrossAllScopes, SecretSecretNotFoundAcrossAllScopes)
+	return nil, stdlibErrors.Errorf(ErrCodeSecretNotFoundAcrossAllScopes, SecretSecretNotFoundAcrossAllScopes)
 }
 
 // addImagePullSecretToPod adds an image pull secret to a pod if it doesn't already exist
@@ -296,32 +302,32 @@ func (i *EmbeddedSecretManagerInjector) Inject(
 		return pod, false, err
 	}
 
-	secretValue, k8sImagePullSecretName, err := i.lookUpSecret(ctx, secretNameComponents)
+	resolved, err := i.lookUpSecret(ctx, secretNameComponents)
 	if err != nil {
 		return pod, false, err
 	}
+	secretValue := resolved.value
 
 	switch secret.MountRequirement {
 	case core.Secret_ANY:
 		fallthrough
 	case core.Secret_ENV_VAR:
-		var stringValue string
-		if secretValue.StringValue != "" {
-			stringValue = secretValue.StringValue
-		} else {
-			// GCP secrets store values as binary only. This means a secret could be
-			// defined as a file, but mounted as an environment variable.
-			// We could fail this path for AWS, but for consistent behaviour between
-			// AWS and GCP we will allow this path for AWS as well.
-			if !utf8.Valid(secretValue.BinaryValue) {
-				return pod, false, fmt.Errorf(
-					"secret %q is attempted to be mounted as an environment variable, "+
-						"but has a binary value that is not a valid UTF-8 string; mount "+
-						"as a file instead", secret.Key)
-			}
-			stringValue = string(secretValue.BinaryValue)
+		// GCP secrets store values as binary only. This means a secret could be
+		// defined as a file, but mounted as an environment variable.
+		// We could fail this path for AWS, but for consistent behaviour between
+		// AWS and GCP we will allow this path for AWS as well.
+		if secretValue.StringValue == "" && !utf8.Valid(secretValue.BinaryValue) {
+			return pod, false, fmt.Errorf(
+				"secret %q is attempted to be mounted as an environment variable, "+
+					"but has a binary value that is not a valid UTF-8 string; mount "+
+					"as a file instead", secret.Key)
 		}
-		i.injectAsEnvVar(secret, stringValue, pod)
+		secretRef, err := i.envVarSecretRef(ctx, secretNameComponents, resolved.secretID, pod.GetNamespace())
+		if err != nil {
+			logger.Errorf(ctx, "Failed to inject secret [%v] as an environment variable: %v", secret.Key, err)
+			return pod, false, err
+		}
+		i.injectAsEnvVar(secret, secretRef, pod)
 	case core.Secret_FILE:
 		secretBytes := secretValue.BinaryValue
 		if len(secretValue.StringValue) > 0 {
@@ -335,7 +341,7 @@ func (i *EmbeddedSecretManagerInjector) Inject(
 	}
 
 	if i.cfg.ImagePullSecrets.Enabled {
-		pod, err = i.findAndAddImagePullSecret(ctx, k8sImagePullSecretName, pod)
+		pod, err = i.findAndAddImagePullSecret(ctx, resolved.imagePullSecretName, pod)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to add image pull secret [%s]: %v", secretNameComponents.Name, err)
 			return pod, false, err
@@ -345,7 +351,7 @@ func (i *EmbeddedSecretManagerInjector) Inject(
 	return pod, true, nil
 }
 
-func (i *EmbeddedSecretManagerInjector) injectAsEnvVar(secret *core.Secret, secretValue string, pod *corev1.Pod) {
+func (i *EmbeddedSecretManagerInjector) injectAsEnvVar(secret *core.Secret, secretRef *corev1.SecretKeySelector, pod *corev1.Pod) {
 	valueEnvVarName := i.parentCfg.SecretEnvVarPrefix + strings.ToUpper(secret.GetKey())
 	if secret.GetEnvVar() != "" {
 		valueEnvVarName = secret.EnvVar
@@ -356,12 +362,46 @@ func (i *EmbeddedSecretManagerInjector) injectAsEnvVar(secret *core.Secret, secr
 			Value: i.parentCfg.SecretEnvVarPrefix,
 		},
 		{
-			Name:  valueEnvVarName,
-			Value: secretValue,
+			Name: valueEnvVarName,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: secretRef,
+			},
 		},
 	}
 	pod.Spec.InitContainers = AppendEnvVars(pod.Spec.InitContainers, envVars...)
 	pod.Spec.Containers = AppendEnvVars(pod.Spec.Containers, envVars...)
+}
+
+func (i *EmbeddedSecretManagerInjector) envVarSecretRef(
+	ctx context.Context,
+	components *SecretNameComponents,
+	secretID string,
+	namespace string,
+) (*corev1.SecretKeySelector, error) {
+	name := EncodeK8sSecretName(secretID)
+
+	if namespace == "" {
+		return nil, fmt.Errorf("cannot mount secret [%s]: pod has no namespace, so Kubernetes secret [%s] was not looked up", components.Name, name)
+	}
+
+	storedSecret := &corev1.Secret{}
+	if err := i.k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, storedSecret); err != nil {
+		if k8sError.IsNotFound(err) {
+			return nil, fmt.Errorf("cannot mount secret [%s]: it is not stored in a Kubernetes secret %s/%s", components.Name, namespace, name)
+		}
+
+		return nil, fmt.Errorf("failed to look up secret %s/%s: %w", namespace, name, err)
+	}
+
+	if _, found := storedSecret.Data[secretID]; !found {
+		return nil, fmt.Errorf("cannot mount secret [%s]: secret %s/%s has no key %s", components.Name, namespace, name, secretID)
+	}
+
+	logger.Debugf(ctx, "Referencing secret %s/%s for %s", namespace, name, components)
+	return &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{Name: name},
+		Key:                  secretID,
+	}, nil
 }
 
 func (i *EmbeddedSecretManagerInjector) injectAsFile(secret *core.Secret, secretValue []byte, pod *corev1.Pod) {

--- a/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager_test.go
@@ -26,7 +26,29 @@ import (
 
 const (
 	testReferenceNamespace = "test-reference-namespace"
+	testPodNamespace       = "test-pod-namespace"
 )
+
+func expectStoredSecret(
+	mockClient *mocks.MockableControllerRuntimeClient,
+	secretID string,
+	namespace string,
+) string {
+	name := EncodeK8sSecretName(secretID)
+	stored := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data:       map[string][]byte{secretID: []byte("stored value")},
+	}
+
+	mockClient.
+		On("Get", mock.Anything, types.NamespacedName{Name: name, Namespace: namespace}, &corev1.Secret{}).
+		Run(func(args mock.Arguments) {
+			*args.Get(2).(*corev1.Secret) = *stored
+		}).
+		Return(nil).Maybe()
+
+	return name
+}
 
 func newAlwaysMissCache(t *testing.T) *cacheMocks.CacheInterface[SecretValue] {
 	t.Helper()
@@ -156,6 +178,7 @@ func TestEmbeddedSecretManagerInjector_Inject(t *testing.T) {
 			name: "all labels",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testPodNamespace,
 					Labels: map[string]string{
 						OrganizationLabel: OrganizationLabel,
 						ProjectLabel:      ProjectLabel,
@@ -170,6 +193,7 @@ func TestEmbeddedSecretManagerInjector_Inject(t *testing.T) {
 			},
 			expectedPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testPodNamespace,
 					Labels: map[string]string{
 						OrganizationLabel: OrganizationLabel,
 						ProjectLabel:      ProjectLabel,
@@ -181,8 +205,15 @@ func TestEmbeddedSecretManagerInjector_Inject(t *testing.T) {
 						{
 							Env: []corev1.EnvVar{
 								{
-									Name:  "_UNION_SECRETID",
-									Value: secretValue,
+									Name: "_UNION_SECRETID",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: EncodeK8sSecretName(orgSecretID),
+											},
+											Key: orgSecretID,
+										},
+									},
 								},
 								{
 									Name:  SecretEnvVarPrefix,
@@ -212,6 +243,7 @@ func TestEmbeddedSecretManagerInjector_Inject(t *testing.T) {
 				mockClient.
 					On("Get", ctx, types.NamespacedName{Name: tt.expectedK8sSecretName, Namespace: testReferenceNamespace}, &corev1.Secret{}).
 					Return(k8sError.NewNotFound(corev1.Resource("secret"), tt.expectedK8sSecretName))
+				expectStoredSecret(mockClient, orgSecretID, tt.pod.GetNamespace())
 			}
 
 			secretCache := newAlwaysMissCache(t)
@@ -343,6 +375,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToOrganization(t *testi
 					},
 				},
 				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testPodNamespace,
 					Labels: map[string]string{
 						"organization": "o-apple",
 						"domain":       "d-cherry",
@@ -351,6 +384,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToOrganization(t *testi
 				},
 			}
 
+			orgSecretID := "u__org__o-apple__domain____project____key__secret1"
 			mockClient := &mocks.MockableControllerRuntimeClient{}
 			kubernetesSecretName := ToImagePullK8sName(SecretNameComponents{
 				Org:     "o-apple",
@@ -361,13 +395,14 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToOrganization(t *testi
 			mockClient.
 				On("Get", ctx, types.NamespacedName{Name: kubernetesSecretName, Namespace: testReferenceNamespace}, &corev1.Secret{}).
 				Return(k8sError.NewNotFound(corev1.Resource("secret"), kubernetesSecretName))
+			expectStoredSecret(mockClient, orgSecretID, testPodNamespace)
 
 			secretCache := newAlwaysMissCache(t)
 			injector := NewEmbeddedSecretManagerInjector(
 				config.EmbeddedSecretManagerConfig{},
 				[]SecretFetcher{secretFetcherMock{
 					Secrets: map[string]SecretValue{
-						"u__org__o-apple__domain____project____key__secret1": {
+						orgSecretID: {
 							StringValue: "fruits",
 						},
 					},
@@ -376,8 +411,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToOrganization(t *testi
 			pod, injected, err := injector.Inject(ctx, tt.secret, pod)
 			assert.NoError(t, err)
 			assert.True(t, injected)
-			assert.True(t, podHasSecretInjected(pod, "secret1", "fruits", tt.secret.GetEnvVar()))
-
+			assert.True(t, podHasSecretInjected(pod, "secret1", orgSecretID, tt.secret.GetEnvVar()))
 		})
 	}
 }
@@ -392,6 +426,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToDomain(t *testing.T) 
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testPodNamespace,
 			Labels: map[string]string{
 				"organization": "o-apple",
 				"domain":       "d-cherry",
@@ -413,12 +448,14 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToDomain(t *testing.T) 
 		Project: "",
 		Name:    "secret1",
 	})
+	domainSecretID := "u__org__o-apple__domain__d-cherry__project____key__secret1"
 	mockClient.
 		On("Get", ctx, types.NamespacedName{Name: kubernetesSecretName1, Namespace: testReferenceNamespace}, &corev1.Secret{}).
 		Return(k8sError.NewNotFound(corev1.Resource("secret"), kubernetesSecretName1))
 	mockClient.
 		On("Get", ctx, types.NamespacedName{Name: kubernetesSecretName2, Namespace: testReferenceNamespace}, &corev1.Secret{}).
 		Return(k8sError.NewNotFound(corev1.Resource("secret"), kubernetesSecretName2))
+	expectStoredSecret(mockClient, domainSecretID, testPodNamespace)
 
 	secretCache := newAlwaysMissCache(t)
 	injector := NewEmbeddedSecretManagerInjector(
@@ -428,7 +465,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToDomain(t *testing.T) 
 				"u__org__o-apple__domain____project____key__secret1": {
 					StringValue: "fruits @ org",
 				},
-				"u__org__o-apple__domain__d-cherry__project____key__secret1": {
+				domainSecretID: {
 					StringValue: "fruits @ domain",
 				},
 			},
@@ -437,7 +474,8 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToDomain(t *testing.T) 
 	pod, injected, err := injector.Inject(ctx, secret, pod)
 	assert.NoError(t, err)
 	assert.True(t, injected)
-	assert.True(t, podHasSecretInjected(pod, "secret1", "fruits @ domain", ""))
+	// The domain-scoped secret shadows the org-scoped one, so the env var points at its object.
+	assert.True(t, podHasSecretInjected(pod, "secret1", domainSecretID, ""))
 }
 
 func TestEmbeddedSecretManagerInjector_InjectSecretScopedToProject(t *testing.T) {
@@ -450,6 +488,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToProject(t *testing.T)
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testPodNamespace,
 			Labels: map[string]string{
 				"organization": "o-apple",
 				"domain":       "d-cherry",
@@ -477,6 +516,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToProject(t *testing.T)
 		Project: "p-banana",
 		Name:    "secret1",
 	})
+	projectSecretID := "u__org__o-apple__domain__d-cherry__project__p-banana__key__secret1"
 	mockClient.
 		On("Get", ctx, types.NamespacedName{Name: kubernetesSecretName1, Namespace: testReferenceNamespace}, &corev1.Secret{}).
 		Return(k8sError.NewNotFound(corev1.Resource("secret"), kubernetesSecretName1))
@@ -486,6 +526,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToProject(t *testing.T)
 	mockClient.
 		On("Get", ctx, types.NamespacedName{Name: kubernetesSecretName3, Namespace: testReferenceNamespace}, &corev1.Secret{}).
 		Return(k8sError.NewNotFound(corev1.Resource("secret"), kubernetesSecretName3))
+	expectStoredSecret(mockClient, projectSecretID, testPodNamespace)
 
 	secretCache := newAlwaysMissCache(t)
 	injector := NewEmbeddedSecretManagerInjector(
@@ -498,7 +539,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToProject(t *testing.T)
 				"u__org__o-apple__domain__d-cherry__project____key__secret1": {
 					StringValue: "fruits @ domain",
 				},
-				"u__org__o-apple__domain__d-cherry__project__p-banana__key__secret1": {
+				projectSecretID: {
 					StringValue: "fruits @ project",
 				},
 			},
@@ -507,7 +548,8 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToProject(t *testing.T)
 	pod, injected, err := injector.Inject(ctx, secret, pod)
 	assert.NoError(t, err)
 	assert.True(t, injected)
-	assert.True(t, podHasSecretInjected(pod, "secret1", "fruits @ project", ""))
+	// The project-scoped secret wins over the broader scopes, so the env var points at its object.
+	assert.True(t, podHasSecretInjected(pod, "secret1", projectSecretID, ""))
 }
 
 // TestEmbeddedSecretManagerInjector_LookUpSecret_StaleOrgCacheDoesNotMaskProjectScope
@@ -522,6 +564,7 @@ func TestEmbeddedSecretManagerInjector_LookUpSecret_StaleOrgCacheDoesNotMaskProj
 	pod := &corev1.Pod{
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{}}},
 		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testPodNamespace,
 			Labels: map[string]string{
 				"organization": "o-apple",
 				"domain":       "d-cherry",
@@ -548,6 +591,7 @@ func TestEmbeddedSecretManagerInjector_LookUpSecret_StaleOrgCacheDoesNotMaskProj
 	mockClient.
 		On("Get", ctx, types.NamespacedName{Name: orgImagePullName, Namespace: testReferenceNamespace}, &corev1.Secret{}).
 		Return(k8sError.NewNotFound(corev1.Resource("secret"), orgImagePullName)).Maybe()
+	expectStoredSecret(mockClient, projectDomainID, testPodNamespace)
 
 	injector := NewEmbeddedSecretManagerInjector(
 		config.EmbeddedSecretManagerConfig{},
@@ -565,7 +609,124 @@ func TestEmbeddedSecretManagerInjector_LookUpSecret_StaleOrgCacheDoesNotMaskProj
 	assert.NoError(t, err)
 	assert.True(t, injected)
 	// Must pick up the newly-created project+domain value, not the stale cached org value.
-	assert.True(t, podHasSecretInjected(pod, "secret1", "fresh project value", ""))
+	assert.True(t, podHasSecretInjected(pod, "secret1", projectDomainID, ""))
+}
+
+// Verifies which Kubernetes Secret an env var mount is pointed at, and that a secret the pod
+// cannot reference fails injection.
+func TestEmbeddedSecretManagerInjector_InjectAsEnvVar_ReferencesStoredSecret(t *testing.T) {
+	ctx := context.Background()
+	secretID := "u__org__o-apple__domain__d-cherry__project__p-banana__key__secret1" //nolint:gosec
+	storedSecretName := EncodeK8sSecretName(secretID)
+
+	newPod := func() *corev1.Pod {
+		return &corev1.Pod{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{}}},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testPodNamespace,
+				Labels: map[string]string{
+					"organization": "o-apple",
+					"domain":       "d-cherry",
+					"project":      "p-banana",
+				},
+			},
+		}
+	}
+
+	newInjector := func(t *testing.T, mockClient *mocks.MockableControllerRuntimeClient) SecretsInjector {
+		return NewEmbeddedSecretManagerInjector(
+			config.EmbeddedSecretManagerConfig{},
+			[]SecretFetcher{secretFetcherMock{
+				Secrets: map[string]SecretValue{secretID: {StringValue: "fruits"}},
+			}},
+			mockClient, testReferenceNamespace, newAlwaysMissCache(t),
+			&config.Config{SecretEnvVarPrefix: config.DefaultSecretEnvVarPrefix},
+		)
+	}
+
+	t.Run("stored in the pod's namespace", func(t *testing.T) {
+		mockClient := &mocks.MockableControllerRuntimeClient{}
+		expectStoredSecret(mockClient, secretID, testPodNamespace)
+
+		pod, injected, err := newInjector(t, mockClient).Inject(ctx, &core.Secret{Key: "secret1"}, newPod())
+		assert.NoError(t, err)
+		assert.True(t, injected)
+
+		env, found := lo.Find(pod.Spec.Containers[0].Env, func(env corev1.EnvVar) bool {
+			return env.Name == config.DefaultSecretEnvVarPrefix+"SECRET1"
+		})
+		assert.True(t, found)
+		assert.Empty(t, env.Value)
+		assert.Equal(t, storedSecretName, env.ValueFrom.SecretKeyRef.Name)
+		assert.Equal(t, secretID, env.ValueFrom.SecretKeyRef.Key)
+
+		mockClient.AssertNotCalled(t, "Create", mock.Anything, mock.Anything)
+		mockClient.AssertNotCalled(t, "Update", mock.Anything, mock.Anything)
+	})
+
+	t.Run("not stored in the pod's namespace", func(t *testing.T) {
+		mockClient := &mocks.MockableControllerRuntimeClient{}
+		mockClient.
+			On("Get", ctx, types.NamespacedName{Name: storedSecretName, Namespace: testPodNamespace}, &corev1.Secret{}).
+			Return(k8sError.NewNotFound(corev1.Resource("secret"), storedSecretName))
+
+		pod, injected, err := newInjector(t, mockClient).Inject(ctx, &core.Secret{Key: "secret1"}, newPod())
+		assert.ErrorContains(t, err, "it is not stored in a Kubernetes secret")
+		assert.False(t, injected)
+		assert.Empty(t, pod.Spec.Containers[0].Env)
+
+		mockClient.AssertNotCalled(t, "Create", mock.Anything, mock.Anything)
+	})
+
+	t.Run("stored under a different key", func(t *testing.T) {
+		mockClient := &mocks.MockableControllerRuntimeClient{}
+		mockClient.
+			On("Get", ctx, types.NamespacedName{Name: storedSecretName, Namespace: testPodNamespace}, &corev1.Secret{}).
+			Run(func(args mock.Arguments) {
+				*args.Get(2).(*corev1.Secret) = corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: storedSecretName, Namespace: testPodNamespace},
+					Data:       map[string][]byte{"some-other-key": []byte("fruits")},
+				}
+			}).
+			Return(nil)
+
+		pod, injected, err := newInjector(t, mockClient).Inject(ctx, &core.Secret{Key: "secret1"}, newPod())
+		assert.ErrorContains(t, err, "has no key")
+		assert.False(t, injected)
+		assert.Empty(t, pod.Spec.Containers[0].Env)
+	})
+}
+
+// A pod without a namespace has no Secret the env var could reference.
+func TestEmbeddedSecretManagerInjector_InjectAsEnvVar_FailsWithoutNamespace(t *testing.T) {
+	ctx := context.Background()
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{}}},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"organization": "o-apple",
+				"domain":       "d-cherry",
+				"project":      "p-banana",
+			},
+		},
+	}
+
+	mockClient := &mocks.MockableControllerRuntimeClient{}
+	injector := NewEmbeddedSecretManagerInjector(
+		config.EmbeddedSecretManagerConfig{},
+		[]SecretFetcher{secretFetcherMock{
+			Secrets: map[string]SecretValue{
+				"u__org__o-apple__domain__d-cherry__project__p-banana__key__secret1": {StringValue: "fruits"},
+			},
+		}},
+		mockClient, testReferenceNamespace, newAlwaysMissCache(t),
+		&config.Config{SecretEnvVarPrefix: config.DefaultSecretEnvVarPrefix},
+	)
+
+	pod, injected, err := injector.Inject(ctx, &core.Secret{Key: "secret1"}, pod)
+	assert.ErrorContains(t, err, "pod has no namespace")
+	assert.False(t, injected)
+	assert.Empty(t, pod.Spec.Containers[0].Env)
 }
 
 func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
@@ -578,12 +739,13 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 	testNamespace := "test-pod-namespace"
 
 	secretName := "u__org__test-organization__domain__test-domain__project__test-project__key__test-secret" //nolint:gosec
-	kubernetesSecretName := ToImagePullK8sName(SecretNameComponents{
+	secretNameComponents := SecretNameComponents{
 		Org:     testOrganization,
 		Domain:  testDomain,
 		Project: testProject,
 		Name:    testSecretName,
-	})
+	}
+	kubernetesSecretName := ToImagePullK8sName(secretNameComponents)
 
 	referenceImagePullSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -640,6 +802,7 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 				*secret = *existingMirrorImagePullSecret
 			}).
 			Return(nil)
+		expectStoredSecret(mockClient, secretName, testNamespace)
 
 		secretCache := newAlwaysMissCache(t)
 		injector := NewEmbeddedSecretManagerInjector(
@@ -677,6 +840,7 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 		mockClient.
 			On("Create", ctx, existingMirrorImagePullSecret).
 			Return(nil)
+		expectStoredSecret(mockClient, secretName, testNamespace)
 
 		secretCache := newAlwaysMissCache(t)
 		injector := NewEmbeddedSecretManagerInjector(
@@ -699,6 +863,7 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 		testPod := pod.DeepCopy()
 
 		mockClient := &mocks.MockableControllerRuntimeClient{}
+		expectStoredSecret(mockClient, secretName, testNamespace)
 
 		secretCache := newAlwaysMissCache(t)
 		injector := NewEmbeddedSecretManagerInjector(
@@ -716,8 +881,8 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 		assert.True(t, injected)
 		assert.Nil(t, resultPod.Spec.ImagePullSecrets)
 
-		mockClient.AssertNotCalled(t, "Get", mock.Anything, mock.Anything, mock.Anything)
-		mockClient.AssertNotCalled(t, "Create", mock.Anything, mock.Anything)
+		mockClient.AssertNotCalled(t, "Get", mock.Anything, types.NamespacedName{Name: kubernetesSecretName, Namespace: testReferenceNamespace}, mock.Anything)
+		mockClient.AssertNotCalled(t, "Create", mock.Anything, existingMirrorImagePullSecret)
 	})
 
 	t.Run("image pull secret is not scoped to project or domain", func(t *testing.T) {
@@ -750,6 +915,7 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 				*secret = *orgBasedExistingMirrorSecret
 			}).
 			Return(nil)
+		expectStoredSecret(mockClient, orgBasedSecretName, testNamespace)
 
 		secretCache := newAlwaysMissCache(t)
 		injector := NewEmbeddedSecretManagerInjector(
@@ -769,7 +935,7 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 	})
 }
 
-func podHasSecretInjected(pod *corev1.Pod, secretKey string, secretValue string, envVar string) bool {
+func podHasSecretInjected(pod *corev1.Pod, secretKey string, secretID string, envVar string) bool {
 	// When Secret.EnvVar is set the injector emits a single value env var with
 	// that name; otherwise it emits the auto-generated <prefix><KEY> name.
 	expectedName := config.DefaultSecretEnvVarPrefix + strings.ToUpper(secretKey)
@@ -778,7 +944,12 @@ func podHasSecretInjected(pod *corev1.Pod, secretKey string, secretValue string,
 	}
 	return lo.EveryBy(pod.Spec.Containers, func(container corev1.Container) bool {
 		hasValueEnvVar := lo.ContainsBy(container.Env, func(env corev1.EnvVar) bool {
-			return env.Name == expectedName && env.Value == secretValue
+			return env.Name == expectedName &&
+				env.Value == "" &&
+				env.ValueFrom != nil &&
+				env.ValueFrom.SecretKeyRef != nil &&
+				env.ValueFrom.SecretKeyRef.Name == EncodeK8sSecretName(secretID) &&
+				env.ValueFrom.SecretKeyRef.Key == secretID
 		})
 		hasPrefixEnvVar := lo.ContainsBy(container.Env, func(env corev1.EnvVar) bool {
 			return env.Name == SecretEnvVarPrefix && env.Value == config.DefaultSecretEnvVarPrefix

--- a/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager_test.go
@@ -248,7 +248,7 @@ func TestEmbeddedSecretManagerInjector_Inject(t *testing.T) {
 
 			secretCache := newAlwaysMissCache(t)
 			parentCfg := &config.Config{SecretEnvVarPrefix: config.DefaultSecretEnvVarPrefix}
-			injector := NewEmbeddedSecretManagerInjector(config.EmbeddedSecretManagerConfig{}, []SecretFetcher{gcpSecretsFetcher}, mockClient, testReferenceNamespace, secretCache, parentCfg)
+			injector := NewEmbeddedSecretManagerInjector(config.EmbeddedSecretManagerConfig{Type: config.EmbeddedSecretManagerTypeK8s, K8sConfig: config.K8sConfig{Namespace: testPodNamespace}}, []SecretFetcher{gcpSecretsFetcher}, mockClient, testReferenceNamespace, secretCache, parentCfg)
 
 			actualP, injected, err := injector.Inject(ctx, inputSecret, tt.pod)
 			assert.Equal(t, tt.expectedInjected, injected)
@@ -399,7 +399,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToOrganization(t *testi
 
 			secretCache := newAlwaysMissCache(t)
 			injector := NewEmbeddedSecretManagerInjector(
-				config.EmbeddedSecretManagerConfig{},
+				config.EmbeddedSecretManagerConfig{Type: config.EmbeddedSecretManagerTypeK8s, K8sConfig: config.K8sConfig{Namespace: testPodNamespace}},
 				[]SecretFetcher{secretFetcherMock{
 					Secrets: map[string]SecretValue{
 						orgSecretID: {
@@ -459,7 +459,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToDomain(t *testing.T) 
 
 	secretCache := newAlwaysMissCache(t)
 	injector := NewEmbeddedSecretManagerInjector(
-		config.EmbeddedSecretManagerConfig{},
+		config.EmbeddedSecretManagerConfig{Type: config.EmbeddedSecretManagerTypeK8s, K8sConfig: config.K8sConfig{Namespace: testPodNamespace}},
 		[]SecretFetcher{secretFetcherMock{
 			Secrets: map[string]SecretValue{
 				"u__org__o-apple__domain____project____key__secret1": {
@@ -530,7 +530,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToProject(t *testing.T)
 
 	secretCache := newAlwaysMissCache(t)
 	injector := NewEmbeddedSecretManagerInjector(
-		config.EmbeddedSecretManagerConfig{},
+		config.EmbeddedSecretManagerConfig{Type: config.EmbeddedSecretManagerTypeK8s, K8sConfig: config.K8sConfig{Namespace: testPodNamespace}},
 		[]SecretFetcher{secretFetcherMock{
 			Secrets: map[string]SecretValue{
 				"u__org__o-apple__domain____project____key__secret1": {
@@ -594,7 +594,7 @@ func TestEmbeddedSecretManagerInjector_LookUpSecret_StaleOrgCacheDoesNotMaskProj
 	expectStoredSecret(mockClient, projectDomainID, testPodNamespace)
 
 	injector := NewEmbeddedSecretManagerInjector(
-		config.EmbeddedSecretManagerConfig{},
+		config.EmbeddedSecretManagerConfig{Type: config.EmbeddedSecretManagerTypeK8s, K8sConfig: config.K8sConfig{Namespace: testPodNamespace}},
 		[]SecretFetcher{secretFetcherMock{
 			Secrets: map[string]SecretValue{
 				projectDomainID: {StringValue: "fresh project value"},
@@ -635,7 +635,7 @@ func TestEmbeddedSecretManagerInjector_InjectAsEnvVar_ReferencesStoredSecret(t *
 
 	newInjector := func(t *testing.T, mockClient *mocks.MockableControllerRuntimeClient) SecretsInjector {
 		return NewEmbeddedSecretManagerInjector(
-			config.EmbeddedSecretManagerConfig{},
+			config.EmbeddedSecretManagerConfig{Type: config.EmbeddedSecretManagerTypeK8s, K8sConfig: config.K8sConfig{Namespace: testPodNamespace}},
 			[]SecretFetcher{secretFetcherMock{
 				Secrets: map[string]SecretValue{secretID: {StringValue: "fruits"}},
 			}},
@@ -691,7 +691,7 @@ func TestEmbeddedSecretManagerInjector_InjectAsEnvVar_ReferencesStoredSecret(t *
 			Return(nil)
 
 		pod, injected, err := newInjector(t, mockClient).Inject(ctx, &core.Secret{Key: "secret1"}, newPod())
-		assert.ErrorContains(t, err, "has no key")
+		assert.ErrorContains(t, err, "it is not stored in a Kubernetes secret")
 		assert.False(t, injected)
 		assert.Empty(t, pod.Spec.Containers[0].Env)
 	})
@@ -713,7 +713,7 @@ func TestEmbeddedSecretManagerInjector_InjectAsEnvVar_FailsWithoutNamespace(t *t
 
 	mockClient := &mocks.MockableControllerRuntimeClient{}
 	injector := NewEmbeddedSecretManagerInjector(
-		config.EmbeddedSecretManagerConfig{},
+		config.EmbeddedSecretManagerConfig{Type: config.EmbeddedSecretManagerTypeK8s, K8sConfig: config.K8sConfig{Namespace: testPodNamespace}},
 		[]SecretFetcher{secretFetcherMock{
 			Secrets: map[string]SecretValue{
 				"u__org__o-apple__domain__d-cherry__project__p-banana__key__secret1": {StringValue: "fruits"},
@@ -724,7 +724,7 @@ func TestEmbeddedSecretManagerInjector_InjectAsEnvVar_FailsWithoutNamespace(t *t
 	)
 
 	pod, injected, err := injector.Inject(ctx, &core.Secret{Key: "secret1"}, pod)
-	assert.ErrorContains(t, err, "pod has no namespace")
+	assert.ErrorContains(t, err, "pod namespace [] does not match the Kubernetes secret manager namespace")
 	assert.False(t, injected)
 	assert.Empty(t, pod.Spec.Containers[0].Env)
 }
@@ -778,6 +778,8 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 	}
 
 	enabledConfig := config.EmbeddedSecretManagerConfig{
+		Type:      config.EmbeddedSecretManagerTypeK8s,
+		K8sConfig: config.K8sConfig{Namespace: testNamespace},
 		ImagePullSecrets: config.ImagePullSecretsConfig{
 			Enabled: true,
 		},
@@ -867,7 +869,7 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 
 		secretCache := newAlwaysMissCache(t)
 		injector := NewEmbeddedSecretManagerInjector(
-			config.EmbeddedSecretManagerConfig{},
+			config.EmbeddedSecretManagerConfig{Type: config.EmbeddedSecretManagerTypeK8s, K8sConfig: config.K8sConfig{Namespace: testPodNamespace}},
 			[]SecretFetcher{secretFetcherMock{
 				Secrets: map[string]SecretValue{
 					secretName: {


### PR DESCRIPTION
## Tracking issue
Close #7824 

## Why are the changes needed?
`flyte.Secret(key="my_secret", as_env_var="MY_SECRET_KEY")` will trigger that the backend injects the plain value from secret to the pod.
That's meaning who use `kubectl describe <pod>` command to able to know the actual secret value.
  
```python
env = flyte.TaskEnvironment(
    name="hello_world",
    resources=flyte.Resources(cpu=1, memory="1Gi"),
    image=image,
    secrets=[
        flyte.Secret(key="my_secret", as_env_var="MY_SECRET_KEY"),
    ]
)
```

## What changes were proposed in this pull request?
1. After the existing cascade lookup resolves which scope the secret lives at, check that it is actually stored in a Kubernetes Secret in the pod's namespace (envVarSecretRef: object EncodeK8sSecretName(secretID), data key secretID).
2. If it is, point the env var at it with an EnvVarSource/secretKeyRef instead of the plain value; if it is not, return an error instead of falling back to the value.

## How was this patch tested?
1. Unit tests commands 
```bash
make test_unit
```

2. quickstart.py is following, run the commands in the `setup section` to check the results.
```python
import os
import flyte

env = flyte.TaskEnvironment(
    name="my_env",
    resources=flyte.Resources(memory="250Mi"),
    image=(
        flyte.Image.from_debian_base(
            name="my-image",
            python_version=(3, 13),
            registry="localhost:30000",  # the devbox registry, so the cluster can pull the build
        )
        .with_apt_packages("libopenblas-dev")
        .with_pip_packages("numpy")
        .with_env_vars({"OMP_NUM_THREADS": "4"})
    ),
    secrets=[
        flyte.Secret(key="MY_SECRET_KEY", as_env_var="MY_SECRET_KEY"),
    ],
)

@env.task
def fn(x: int) -> int:
    print(f"MY_SECRET_KEY={os.environ.get('MY_SECRET_KEY')!r}", flush=True)
    slope, intercept = 2, 5
    return slope * x + intercept

@env.task
def main(x_list: list[int] = [1, 2, 3]) -> float:
    print(f"MY_SECRET_KEY={os.environ.get('MY_SECRET_KEY')!r}", flush=True)
    y_list = list(flyte.map(fn, x_list))
    return sum(y_list) / len(y_list)

if __name__ == "__main__":
    flyte.init_from_config()
    run = flyte.run(main)
    print(run.name)
    print(run.url)
```

### Labels
- **fix**:

### Setup process
```bash
make devbox-build
make devbox-start

# Use kubectl or k9s to view the pod spec, secret resources and action logs.
# Case 1：org scope，--value
flyte create secret MY_SECRET_KEY --value my_secret_value
flyte run -p flytesnacks -d development quickstart.py main

# Case 2：org scope，--from-file
flyte delete secret MY_SECRET_KEY
flyte create secret MY_SECRET_KEY --from-file ./my_secret_file
flyte run -p flytesnacks -d development quickstart.py main

# Case 3：project scope
flyte create project --name my_project  --id my_project
flyte create secret MY_SECRET_KEY --value my_secret_value --project my_project --domain development
flyte run -p flytesnacks -d development quickstart.py main

```

### Screenshots
<img width="1458" height="842" alt="Screenshot 2026-08-12 at 6 28 01 AM" src="https://github.com/user-attachments/assets/f1a0a464-808d-41ca-92bf-e6ebc923a7b9" />


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
