### PR TITLE
feat(monitoring): add TaskAction GC panels to the Flyte execution dashboard

### DIFF
--- a/monitoring/dashboards/flyte-execution.json
+++ b/monitoring/dashboards/flyte-execution.json
@@ -842,6 +842,136 @@
       ]
     },
     {
+      "id": 25,
+      "type": "timeseries",
+      "title": "GC deletions by outcome",
+      "description": "TaskAction GC delete attempts/sec by outcome. already_gone = removed by k8s cascade before the GC got to it; failed should stay at zero.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 33,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (outcome)(rate(taskaction_gc_deletions_total{service_name=\"executor\"}[5m]))",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 26,
+      "type": "timeseries",
+      "title": "GC sweep duration p50/p95/p99",
+      "description": "Duration of one GC sweep. Smallest histogram bucket is 100ms, so an idle-cluster p95 reads ~95ms even when sweeps take a few ms.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 33,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le)(rate(taskaction_gc_sweep_duration_milliseconds_bucket{service_name=\"executor\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le)(rate(taskaction_gc_sweep_duration_milliseconds_bucket{service_name=\"executor\"}[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le)(rate(taskaction_gc_sweep_duration_milliseconds_bucket{service_name=\"executor\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
       "id": 13,
       "type": "row",
       "title": "Pod resources (flyte2)",


### PR DESCRIPTION
## Tracking issue
Related to #7455

Follow-up to the review ask in #7550: test the GC metrics in the devbox and update the Grafana dashboard.

## Why are the changes needed?
#7550 added OTel metrics for the TaskAction garbage collector, but the dashboard doesn't chart them yet.

## What changes were proposed in this pull request?
Two panels in the "Task controller (executor)" row, next to the other executor panels:

- **GC deletions by outcome** — `sum by (outcome)(rate(taskaction_gc_deletions_total{service_name="executor"}[5m]))`, one line per outcome (`deleted` / `already_gone` / `failed`). `failed` should sit at zero on a healthy cluster.
- **GC sweep duration p50/p95/p99** — `histogram_quantile` over `taskaction_gc_sweep_duration_milliseconds_bucket`, same shape and style as the existing latency panels. The panel description notes that the smallest histogram bucket is 100ms, so an idle-cluster p95 reads ~95ms even when sweeps take a few milliseconds.

Purely additive: +130 lines, no existing panels touched.

Note: the `already_gone` and `failed` lines only appear once those outcomes first occur. Prometheus counters don't exist until their first increment. Those two paths are race/error conditions covered deterministically by the unit tests in #7550. The devbox run here verifies the pipeline end to end, which all three outcomes share (same counter, different `outcome` attribute).

## How was this patch tested?
End-to-end in the devbox:

1. `make devbox-build && make devbox-run && make devbox-monitoring`
2. Sped the GC up so deletions are observable in minutes: patched `flyte-binary-config` with `executor: {gc: {interval: 1m, maxTTL: 2m}}` and restarted the deployment (test-only override, not part of this PR)
3. Ran `hello.py` workflows against the devbox. Each run's 11 TaskActions were deleted by the GC and recorded as `taskaction_gc_deletions_total{outcome="deleted"}`, alongside the sweep histogram
4. The dashboard, provisioned from this file by `make devbox-monitoring`, rendered both panels against the live data

## Screenshots
<img width="1920" height="931" alt="image-1786493616824" src="https://github.com/user-attachments/assets/45d62013-e4ca-47ae-ae4b-c04abbd89473" />
