### PR TITLE
feat: add flyte-managed label to pods created by flyte and limit executor informer cache to the pods

### DIFF
--- a/executor/pkg/plugin/k8s/plugin_manager_test.go
+++ b/executor/pkg/plugin/k8s/plugin_manager_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
@@ -184,4 +186,62 @@ func TestHandle_CorruptedPluginStateFailsPermanently(t *testing.T) {
 	assert.Equal(t, pluginsCore.PhasePermanentFailure, transition.Info().Phase())
 	assert.Equal(t, string(errors.CorruptedPluginState), transition.Info().Err().GetCode())
 	assert.Equal(t, core.ExecutionError_SYSTEM, transition.Info().Err().GetKind())
+}
+
+// TestAddObjectMetadata_ManagedLabel verifies that the label the manager's Pod cache selects
+// on survives addObjectMetadata. NewTaskExecutionMetadata is the single injection point; this
+// asserts nothing here drops it, since a Pod without the label is invisible to the executor
+// that created it and checkResourcePhase would report it as deleted externally.
+func TestAddObjectMetadata_ManagedLabel(t *testing.T) {
+	newManager := func(t *testing.T) *PluginManager {
+		mockPlugin := k8sMocks.NewPlugin(t)
+		mockPlugin.EXPECT().GetProperties().Return(k8s.PluginProperties{})
+		return NewPluginManager("test-plugin", mockPlugin, nil)
+	}
+
+	// Mirrors what NewTaskExecutionMetadata injects into every task's labels.
+	managedLabels := map[string]string{
+		flytek8s.ManagedLabelKey: flytek8s.ManagedLabelValue,
+	}
+
+	newMeta := func(labels map[string]string) *pluginsCoreMock.TaskExecutionMetadata {
+		tID := &pluginsCoreMock.TaskExecutionID{}
+		tID.EXPECT().GetGeneratedName().Return("name").Maybe()
+		meta := &pluginsCoreMock.TaskExecutionMetadata{}
+		meta.EXPECT().GetTaskExecutionID().Return(tID).Maybe()
+		meta.EXPECT().GetNamespace().Return("ns")
+		meta.EXPECT().GetAnnotations().Return(nil)
+		meta.EXPECT().GetLabels().Return(labels)
+		meta.EXPECT().GetOwnerReference().Return(metav1.OwnerReference{})
+		return meta
+	}
+
+	t.Run("propagates to the object", func(t *testing.T) {
+		pod := &v1.Pod{}
+		newManager(t).addObjectMetadata(newMeta(managedLabels), pod, &config.K8sPluginConfig{})
+
+		assert.Equal(t, flytek8s.ManagedLabelValue, pod.GetLabels()[flytek8s.ManagedLabelKey])
+	})
+
+	t.Run("matches the selector the manager cache is configured with", func(t *testing.T) {
+		pod := &v1.Pod{}
+		newManager(t).addObjectMetadata(newMeta(managedLabels), pod, &config.K8sPluginConfig{})
+
+		selector := labels.SelectorFromSet(labels.Set{
+			flytek8s.ManagedLabelKey: flytek8s.ManagedLabelValue,
+		})
+		assert.True(t, selector.Matches(labels.Set(pod.GetLabels())))
+	})
+
+	t.Run("not dropped by platform defaults or labels already on the object", func(t *testing.T) {
+		pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{flytek8s.ManagedLabelKey: "object-value"},
+		}}
+		cfg := &config.K8sPluginConfig{
+			DefaultLabels: map[string]string{flytek8s.ManagedLabelKey: "default-value"},
+		}
+		newManager(t).addObjectMetadata(newMeta(managedLabels), pod, cfg)
+
+		assert.Equal(t, flytek8s.ManagedLabelValue, pod.GetLabels()[flytek8s.ManagedLabelKey])
+	})
 }

--- a/executor/pkg/plugin/task_exec_metadata.go
+++ b/executor/pkg/plugin/task_exec_metadata.go
@@ -82,6 +82,12 @@ func NewTaskExecutionMetadata(ta *flyteorgv1.TaskAction) (pluginsCore.TaskExecut
 		flytesecret.OrganizationLabel: flytesecret.DefaultOrganization,
 		flytesecret.ProjectLabel:      ta.Spec.Project,
 		flytesecret.DomainLabel:       ta.Spec.Domain,
+		// Marks every Pod this executor is responsible for, including the ones
+		// operators expand from the Pod templates embedded in a plugin's CRD.
+		// The manager cache selects on this label, so a Pod that does not carry
+		// it is invisible to the executor. Plugins merge these labels into the
+		// Pod templates they build, so setting it here covers all of them.
+		flytek8s.ManagedLabelKey: flytek8s.ManagedLabelValue,
 	}
 	if securityContext != nil && len(securityContext.Secrets) > 0 {
 		secretsMap, err = secrets.MarshalSecretsToMapStrings(securityContext.Secrets)

--- a/executor/pkg/plugin/task_exec_metadata_test.go
+++ b/executor/pkg/plugin/task_exec_metadata_test.go
@@ -1,12 +1,16 @@
 package plugin
 
 import (
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
+	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/encoding"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 )
@@ -135,5 +139,43 @@ func TestTaskExecutionID_GetGeneratedNameWith(t *testing.T) {
 		}
 		_, err := execID.GetGeneratedNameWith(0, 2)
 		require.Error(t, err)
+	})
+}
+
+func TestNewTaskExecutionMetadata_ManagedLabel(t *testing.T) {
+	// The manager cache selects on this label, so a Pod without it is invisible
+	// to the executor. Plugins merge these labels into the Pod templates they
+	// build, which is how operator-created Pods inherit it.
+	newMeta := func(labels map[string]string) pluginsCore.TaskExecutionMetadata {
+		meta, err := NewTaskExecutionMetadata(&flyteorgv1.TaskAction{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels},
+			Spec: flyteorgv1.TaskActionSpec{
+				Project:       "project",
+				Domain:        "development",
+				RunName:       "run-name",
+				ActionName:    "action-name",
+				RunOutputBase: "s3://bucket/run",
+			},
+		})
+		require.NoError(t, err)
+		return meta
+	}
+
+	t.Run("always set", func(t *testing.T) {
+		require.Equal(t, flytek8s.ManagedLabelValue,
+			newMeta(nil).GetLabels()[flytek8s.ManagedLabelKey])
+	})
+
+	t.Run("matches the cache selector", func(t *testing.T) {
+		selector := labels.SelectorFromSet(labels.Set{
+			flytek8s.ManagedLabelKey: flytek8s.ManagedLabelValue,
+		})
+		require.True(t, selector.Matches(labels.Set(newMeta(nil).GetLabels())))
+	})
+
+	t.Run("user labels cannot override it", func(t *testing.T) {
+		meta := newMeta(map[string]string{flytek8s.ManagedLabelKey: "false"})
+		require.Equal(t, flytek8s.ManagedLabelValue,
+			meta.GetLabels()[flytek8s.ManagedLabelKey])
 	})
 }

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -10,6 +10,8 @@ import (
 
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/informers"
@@ -17,6 +19,8 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	k8scache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -117,9 +121,29 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		metricsServerOptions.KeyName = cfg.MetricsCertKey
 	}
 
+	// controller-runtime caches every watched object across all namespaces, so the
+	// manager would otherwise hold every Pod in the cluster. On a large multi-tenant
+	// cluster that costs several GB of resident memory and OOMKills the executor.
+	//
+	// Restrict the cache to the Pods belonging to this executor. NewTaskExecutionMetadata
+	// puts the label on every task's execution labels, which each plugin merges into the
+	// object it builds, so both the Pods the executor creates directly and the ones an
+	// operator derives from a plugin's CRD (Ray head/worker, Kubeflow replicas, Dask
+	// scheduler/worker) carry it.
+	cacheOptions := cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Pod{}: {
+				Label: labels.SelectorFromSet(labels.Set{
+					flytek8s.ManagedLabelKey: flytek8s.ManagedLabelValue,
+				}),
+			},
+		},
+	}
+
 	mgr, err := ctrl.NewManager(sc.K8sConfig, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
+		Cache:                  cacheOptions,
 		WebhookServer:          webhook.NewServer(webhookServerOptions),
 		HealthProbeBindAddress: cfg.HealthProbeBindAddress,
 		LeaderElection:         cfg.LeaderElect,

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -53,6 +53,16 @@ const FlyteEnableVscode = "_F_E_VS"
 // to compute fractional GPU usage as slices/7.
 const GpuPartitionSlicesLabel = "platform.union.ai/gpu-partition-slices"
 
+// ManagedLabelKey and ManagedLabelValue mark the Pods the executor is responsible for.
+// The executor's informer cache selects on this label so it does not have to hold every
+// Pod in the cluster, so anything the executor needs to observe must carry it. It lives
+// here rather than in the executor because the plugins that build Pod templates have to
+// keep it intact.
+const (
+	ManagedLabelKey   = "flyte.org/managed"
+	ManagedLabelValue = "true"
+)
+
 var migPartitionRegexp = regexp.MustCompile(`^(\d+)g\.\d+gb$`)
 
 // parseMigSlices extracts the compute slice count from a MIG partition size string

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -511,7 +511,8 @@ func buildHeadPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodSpe
 		ObjectMeta: *objectMeta,
 	}
 	cfg := config.GetK8sPluginConfig()
-	podTemplateSpec.SetLabels(utils.UnionMaps(cfg.DefaultLabels, podTemplateSpec.GetLabels(), utils.CopyMap(taskCtx.TaskExecutionMetadata().GetLabels()), spec.GetK8SPod().GetMetadata().GetLabels()))
+	podTemplateSpec.SetLabels(utils.UnionMaps(cfg.DefaultLabels, podTemplateSpec.GetLabels(), utils.CopyMap(taskCtx.TaskExecutionMetadata().GetLabels()), spec.GetK8SPod().GetMetadata().GetLabels(),
+		map[string]string{flytek8s.ManagedLabelKey: flytek8s.ManagedLabelValue}))
 	podTemplateSpec.SetAnnotations(utils.UnionMaps(cfg.DefaultAnnotations, podTemplateSpec.GetAnnotations(), utils.CopyMap(taskCtx.TaskExecutionMetadata().GetAnnotations()), spec.GetK8SPod().GetMetadata().GetAnnotations()))
 
 	return podTemplateSpec, nil
@@ -675,7 +676,8 @@ func buildWorkerPodTemplate(primaryContainer *v1.Container, basePodSpec *v1.PodS
 		ObjectMeta: *objectMetadata,
 	}
 	cfg := config.GetK8sPluginConfig()
-	podTemplateSpec.SetLabels(utils.UnionMaps(cfg.DefaultLabels, podTemplateSpec.GetLabels(), utils.CopyMap(taskCtx.TaskExecutionMetadata().GetLabels()), spec.GetK8SPod().GetMetadata().GetLabels()))
+	podTemplateSpec.SetLabels(utils.UnionMaps(cfg.DefaultLabels, podTemplateSpec.GetLabels(), utils.CopyMap(taskCtx.TaskExecutionMetadata().GetLabels()), spec.GetK8SPod().GetMetadata().GetLabels(),
+		map[string]string{flytek8s.ManagedLabelKey: flytek8s.ManagedLabelValue}))
 	podTemplateSpec.SetAnnotations(utils.UnionMaps(cfg.DefaultAnnotations, podTemplateSpec.GetAnnotations(), utils.CopyMap(taskCtx.TaskExecutionMetadata().GetAnnotations()), spec.GetK8SPod().GetMetadata().GetAnnotations()))
 	return podTemplateSpec, nil
 }

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -209,7 +209,7 @@ func TestBuildResourceRay(t *testing.T) {
 			"node-ip-address": "$MY_POD_IP", "num-cpus": "1",
 		})
 	assert.Equal(t, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Annotations, map[string]string{"annotation-1": "val1"})
-	assert.Equal(t, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Labels, map[string]string{"label-1": "val1"})
+	assert.Equal(t, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Labels, map[string]string{"label-1": "val1", flytek8s.ManagedLabelKey: flytek8s.ManagedLabelValue})
 	assert.Equal(t, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Tolerations, toleration)
 
 	workerReplica := int32(3)
@@ -220,7 +220,7 @@ func TestBuildResourceRay(t *testing.T) {
 	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.ServiceAccountName, serviceAccount)
 	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].RayStartParams, map[string]string{"disable-usage-stats": "true", "node-ip-address": "$MY_POD_IP"})
 	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Annotations, map[string]string{"annotation-1": "val1"})
-	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Labels, map[string]string{"label-1": "val1"})
+	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Labels, map[string]string{"label-1": "val1", flytek8s.ManagedLabelKey: flytek8s.ManagedLabelValue})
 	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Tolerations, toleration)
 
 	// Make sure the default service account is being used if SA is not provided in the task context
@@ -1279,7 +1279,7 @@ func TestDefaultStartParameters(t *testing.T) {
 			"node-ip-address": "$MY_POD_IP",
 		})
 	assert.Equal(t, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Annotations, map[string]string{"annotation-1": "val1"})
-	assert.Equal(t, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Labels, map[string]string{"label-1": "val1"})
+	assert.Equal(t, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Labels, map[string]string{"label-1": "val1", flytek8s.ManagedLabelKey: flytek8s.ManagedLabelValue})
 	assert.Equal(t, ray.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Tolerations, toleration)
 
 	workerReplica := int32(3)
@@ -1290,7 +1290,7 @@ func TestDefaultStartParameters(t *testing.T) {
 	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.ServiceAccountName, serviceAccount)
 	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].RayStartParams, map[string]string{"disable-usage-stats": "true", "node-ip-address": "$MY_POD_IP"})
 	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Annotations, map[string]string{"annotation-1": "val1"})
-	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Labels, map[string]string{"label-1": "val1"})
+	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Labels, map[string]string{"label-1": "val1", flytek8s.ManagedLabelKey: flytek8s.ManagedLabelValue})
 	assert.Equal(t, ray.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Tolerations, toleration)
 }
 
@@ -2420,4 +2420,34 @@ func TestGetCompletionTime_WrongResourceType(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, result.IsZero())
 	assert.Contains(t, err.Error(), "unexpected resource type")
+}
+
+// TestBuildResourceRayManagedLabelNotOverridable verifies that a task cannot drop the label
+// the executor's Pod cache selects on by setting it in its own k8s_pod metadata. A head or
+// worker Pod without the label is invisible to the executor that created it.
+func TestBuildResourceRayManagedLabelNotOverridable(t *testing.T) {
+	assert.NoError(t, config.SetK8sPluginConfig(&config.K8sPluginConfig{}))
+
+	rayJobObj := dummyRayCustomObj()
+	overrides := &core.K8SPod{
+		Metadata: &core.K8SObjectMetadata{
+			Labels: map[string]string{flytek8s.ManagedLabelKey: "false"},
+		},
+	}
+	rayJobObj.RayCluster.HeadGroupSpec.K8SPod = overrides
+	rayJobObj.RayCluster.WorkerGroupSpec[0].K8SPod = overrides
+
+	taskTemplate := dummyRayTaskTemplate("ray-id", rayJobObj)
+	rayCtx := dummyRayTaskContext(taskTemplate, resourceRequirements, nil, "", serviceAccount)
+
+	resource, err := rayJobResourceHandler{}.BuildResource(context.TODO(), rayCtx)
+	assert.NoError(t, err)
+	rayJob, ok := resource.(*rayv1.RayJob)
+	assert.True(t, ok)
+
+	headLabels := rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.GetLabels()
+	assert.Equal(t, flytek8s.ManagedLabelValue, headLabels[flytek8s.ManagedLabelKey])
+
+	workerLabels := rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.GetLabels()
+	assert.Equal(t, flytek8s.ManagedLabelValue, workerLabels[flytek8s.ManagedLabelKey])
 }


### PR DESCRIPTION
## Tracking issue

Closes #7831

Supersedes #7832 — same idea, but reduced after review to only the manager cache (a PodTemplate half was dropped) and rebased on current main.

## Why are the changes needed?

The executor's manager is created without a `Cache` option, so controller-runtime defaults to caching watched objects across every namespace. The TaskAction controller watches Pods, so on a large multi-tenant cluster the executor caches every Pod in the cluster.

On a cluster with ~88k pods across ~11.7k namespaces this made the executor OOMKill in a loop about 16s after start, against a 4Gi limit. A full pod list is ~1.7GB serialized and the in-memory objects are several times that; memory was observed at 3468Mi and still climbing at the moment of the kill.

This is not an RBAC problem. The informer succeeds, and that is exactly the problem.

There is no way to configure this today: the namespace settings that exist govern where objects are written, not what the informer watches.

## What changes were proposed in this pull request?

Adds `limitCacheToNamespace`, default `false`. When enabled, the manager cache is scoped to the executor's own namespace using controller-runtime's existing `cache.Options.DefaultNamespaces`. No new machinery.

Measured on the cluster above: memory 3468Mi to 37Mi, CPU 1414m to 2m, with the workflow still completing.

Two things worth a reviewer's attention:

1. Default `false` makes this a strict no-op unless an operator opts in.

2. Scoping the cache makes controller-runtime return a `multiNamespaceInformer`, which exposes no indexer. `cachedPhaseCounter` reaches the indexer through a type assertion and returned nil when that failed, so the `taskaction.active` gauge would have silently stopped reporting for precisely the operators enabling this to watch memory. It now falls back to the cache's List, with a regression test that fails against the unfixed code.

The PodTemplate informer is deliberately left cluster-wide so per-namespace PodTemplate overrides keep working.

## How was this patch tested?

`go test -race -count=1 ./executor/...` passes for every package including `executor/test/integration` (envtest installed), plus the before/after deployment measurement above.

### Labels

added
