### PR TITLE
feat(runs): settings persistence layer (RFC #7775, 1/2)

### DIFF
--- a/runs/migrations/sql/20260812100000_add_settings_table.sql
+++ b/runs/migrations/sql/20260812100000_add_settings_table.sql
@@ -1,0 +1,12 @@
+-- Settings: one row per settings scope (instance, domain, or project).
+-- data holds the Settings proto as protojson; version implements
+-- optimistic locking. See the Settings Service RFC (#7775).
+
+CREATE TABLE IF NOT EXISTS settings (
+    id         BIGSERIAL   PRIMARY KEY,
+    key        TEXT        NOT NULL UNIQUE,
+    data       JSONB       NOT NULL DEFAULT '{}',
+    version    BIGINT      NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/runs/repository/impl/settings.go
+++ b/runs/repository/impl/settings.go
@@ -25,6 +25,10 @@ func NewSettingsRepo(db *sqlx.DB) interfaces.SettingsRepo {
 }
 
 func (r *settingsRepo) CreateSettings(ctx context.Context, settings *models.Settings) error {
+	if len(settings.Data) == 0 {
+		return fmt.Errorf("settings data is required: %s", settings.Key)
+	}
+
 	now := time.Now().UTC()
 	settings.CreatedAt = now
 	settings.UpdatedAt = now

--- a/runs/repository/impl/settings.go
+++ b/runs/repository/impl/settings.go
@@ -1,0 +1,99 @@
+package impl
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+
+	"github.com/flyteorg/flyte/v2/flytestdlib/database"
+	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
+	"github.com/flyteorg/flyte/v2/runs/repository/models"
+)
+
+type settingsRepo struct {
+	db *sqlx.DB
+}
+
+// NewSettingsRepo returns a SettingsRepo backed by Postgres.
+func NewSettingsRepo(db *sqlx.DB) interfaces.SettingsRepo {
+	return &settingsRepo{db: db}
+}
+
+func (r *settingsRepo) CreateSettings(ctx context.Context, settings *models.Settings) error {
+	now := time.Now().UTC()
+	settings.CreatedAt = now
+	settings.UpdatedAt = now
+	settings.Version = 1
+
+	result, err := r.db.ExecContext(ctx,
+		`INSERT INTO settings (key, data, version, created_at, updated_at)
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (key) DO NOTHING`,
+		settings.Key, settings.Data, settings.Version, settings.CreatedAt, settings.UpdatedAt)
+	if err != nil {
+		if database.IsPgErrorWithCode(err, database.PgDuplicatedKey) {
+			return fmt.Errorf("%w: %s", interfaces.ErrSettingsAlreadyExists, settings.Key)
+		}
+		return fmt.Errorf("failed to create settings %s: %w", settings.Key, err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("%w: %s", interfaces.ErrSettingsAlreadyExists, settings.Key)
+	}
+	return nil
+}
+
+func (r *settingsRepo) GetSettings(ctx context.Context, key string) (*models.Settings, error) {
+	var settings models.Settings
+	err := sqlx.GetContext(ctx, r.db, &settings, "SELECT * FROM settings WHERE key = $1", key)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", interfaces.ErrSettingsNotFound, key)
+		}
+		return nil, fmt.Errorf("failed to get settings %s: %w", key, err)
+	}
+	return &settings, nil
+}
+
+func (r *settingsRepo) GetSettingsByKeys(ctx context.Context, keys []string) ([]*models.Settings, error) {
+	var settings []*models.Settings
+	if err := sqlx.SelectContext(ctx, r.db, &settings, "SELECT * FROM settings WHERE key = ANY($1)", pq.Array(keys)); err != nil {
+		return nil, fmt.Errorf("failed to get settings by keys: %w", err)
+	}
+	return settings, nil
+}
+
+func (r *settingsRepo) UpdateSettings(ctx context.Context, settings *models.Settings) error {
+	now := time.Now().UTC()
+
+	result, err := r.db.ExecContext(ctx,
+		`UPDATE settings SET data = $1, version = version + 1, updated_at = $2 WHERE key = $3 AND version = $4`,
+		settings.Data, now, settings.Key, settings.Version)
+	if err != nil {
+		return fmt.Errorf("failed to update settings %s: %w", settings.Key, err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	// Zero rows: the caller's version is stale (or the row is gone);
+	// either way the caller must re-read, so report it as a conflict.
+	if rowsAffected == 0 {
+		return fmt.Errorf("%w: %s", interfaces.ErrSettingsVersionConflict, settings.Key)
+	}
+
+	// Keep the caller's struct matching the row the DB now holds.
+	settings.Version++
+	settings.UpdatedAt = now
+	return nil
+}

--- a/runs/repository/impl/settings.go
+++ b/runs/repository/impl/settings.go
@@ -90,9 +90,12 @@ func (r *settingsRepo) UpdateSettings(ctx context.Context, settings *models.Sett
 	if err != nil {
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
-	// Zero rows: the caller's version is stale (or the row is gone);
-	// either way the caller must re-read, so report it as a conflict.
+	// Zero rows means the version was stale or the row does not exist.
+	// We distinguish it, so callers know whether to retry or to create.
 	if rowsAffected == 0 {
+		if _, getErr := r.GetSettings(ctx, settings.Key); getErr != nil {
+			return getErr
+		}
 		return fmt.Errorf("%w: %s", interfaces.ErrSettingsVersionConflict, settings.Key)
 	}
 

--- a/runs/repository/impl/settings.go
+++ b/runs/repository/impl/settings.go
@@ -77,6 +77,10 @@ func (r *settingsRepo) GetSettingsByKeys(ctx context.Context, keys []string) ([]
 }
 
 func (r *settingsRepo) UpdateSettings(ctx context.Context, settings *models.Settings) error {
+	if len(settings.Data) == 0 {
+		return fmt.Errorf("settings data is required: %s", settings.Key)
+	}
+
 	now := time.Now().UTC()
 
 	result, err := r.db.ExecContext(ctx,

--- a/runs/repository/impl/settings_test.go
+++ b/runs/repository/impl/settings_test.go
@@ -120,3 +120,15 @@ func TestUpdateSettings_VersionConflict(t *testing.T) {
 	require.JSONEq(t, string(writer.Data), string(got.Data))
 	require.True(t, got.UpdatedAt.After(got.CreatedAt))
 }
+
+func TestUpdateSettings_NotFound(t *testing.T) {
+	repo := setupSettingTest(t)
+	ctx := context.Background()
+
+	stale := &models.Settings{
+		Key:     models.EncodeSettingsKey("", "nowhere", ""),
+		Data:    []byte(`{}`),
+		Version: 1,
+	}
+	require.ErrorIs(t, repo.UpdateSettings(ctx, stale), interfaces.ErrSettingsNotFound)
+}

--- a/runs/repository/impl/settings_test.go
+++ b/runs/repository/impl/settings_test.go
@@ -1,0 +1,122 @@
+package impl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
+	"github.com/flyteorg/flyte/v2/runs/repository/models"
+)
+
+func setupSettingTest(t *testing.T) interfaces.SettingsRepo {
+	db := setupDB(t)
+	t.Cleanup(func() { db.Exec("DELETE FROM settings") })
+	return NewSettingsRepo(db)
+}
+
+func TestCreateAndGetSettings_RoundTrip(t *testing.T) {
+	repo := setupSettingTest(t)
+	ctx := context.Background()
+
+	key := models.EncodeSettingsKey("", "development", "")
+	created := &models.Settings{
+		Key:  key,
+		Data: []byte(`{"environmentVariables":{"state":"VALUE", "values":{"LOG_LEVEL": "debug"}}}`),
+	}
+	require.NoError(t, repo.CreateSettings(ctx, created))
+	require.Equal(t, uint64(1), created.Version)
+
+	got, err := repo.GetSettings(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, key, got.Key)
+	require.Equal(t, uint64(1), got.Version)
+	require.JSONEq(t, string(created.Data), string(got.Data))
+	require.False(t, got.CreatedAt.IsZero())
+}
+
+func TestCreateSettings_AlreadyExists(t *testing.T) {
+	repo := setupSettingTest(t)
+	ctx := context.Background()
+
+	key := models.EncodeSettingsKey("", "development", "recsys")
+	first := &models.Settings{Key: key, Data: []byte(`{}`)}
+	require.NoError(t, repo.CreateSettings(ctx, first))
+
+	dup := &models.Settings{Key: key, Data: []byte(`{"labels": {}}`)}
+	err := repo.CreateSettings(ctx, dup)
+	require.ErrorIs(t, err, interfaces.ErrSettingsAlreadyExists)
+
+	got, err := repo.GetSettings(ctx, key)
+	require.NoError(t, err)
+	require.JSONEq(t, `{}`, string(got.Data))
+}
+
+func TestGetSettings_NotFound(t *testing.T) {
+	repo := setupSettingTest(t)
+	ctx := context.Background()
+
+	got, err := repo.GetSettings(ctx, models.EncodeSettingsKey("", "nowhere", ""))
+	require.ErrorIs(t, err, interfaces.ErrSettingsNotFound)
+	require.Nil(t, got)
+}
+
+func TestGetSettingsByKeys_MissingRowsAreNotErrors(t *testing.T) {
+	repo := setupSettingTest(t)
+	ctx := context.Background()
+
+	instanceKey := models.EncodeSettingsKey("", "", "")
+	domainKey := models.EncodeSettingsKey("", "development", "")
+	projectKey := models.EncodeSettingsKey("", "development", "recsys")
+
+	require.NoError(t, repo.CreateSettings(ctx, &models.Settings{Key: instanceKey, Data: []byte(`{}`)}))
+	require.NoError(t, repo.CreateSettings(ctx, &models.Settings{Key: domainKey, Data: []byte(`{}`)}))
+	// deliberately no row for projectKey
+
+	rows, err := repo.GetSettingsByKeys(ctx, []string{instanceKey, domainKey, projectKey})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	foundKeys := make(map[string]bool)
+	for _, row := range rows {
+		foundKeys[row.Key] = true
+	}
+	require.True(t, foundKeys[instanceKey])
+	require.True(t, foundKeys[domainKey])
+	require.False(t, foundKeys[projectKey])
+}
+
+func TestUpdateSettings_VersionConflict(t *testing.T) {
+	repo := setupSettingTest(t)
+	ctx := context.Background()
+
+	key := models.EncodeSettingsKey("", "development", "recsys")
+
+	// The row is born at version 1.
+	writer := &models.Settings{Key: key, Data: []byte(`{"run":{"defaultQueue":{"state":"VALUE","stringValue":"cpu-pool"}}}`)}
+	require.NoError(t, repo.CreateSettings(ctx, writer))
+
+	// A second caller reads the rwo while it's still at version 1.
+	staleWriter, err := repo.GetSettings(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), staleWriter.Version)
+
+	// First update wins, the writer's struct syncs to version 2.
+	writer.Data = []byte(`{"run":{"defaultQueue":{"state":"VALUE","stringValue":"gpu-pool"}}}`)
+	require.NoError(t, repo.UpdateSettings(ctx, writer))
+	require.Equal(t, uint64(2), writer.Version)
+
+	// The stale writer saves against a version that no longer exists.
+	staleWriter.Data = []byte(`{"run":{"maxActionConcurrency":{"state":"VALUE","intValue":"64"}}}`)
+	err = repo.UpdateSettings(ctx, staleWriter)
+	require.ErrorIs(t, err, interfaces.ErrSettingsVersionConflict)
+	require.Equal(t, uint64(1), staleWriter.Version)
+
+	// The table keeps the winner's write, the stale write never landed.
+	got, err := repo.GetSettings(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), got.Version)
+	require.JSONEq(t, string(writer.Data), string(got.Data))
+	require.True(t, got.UpdatedAt.After(got.CreatedAt))
+}

--- a/runs/repository/interfaces/settings.go
+++ b/runs/repository/interfaces/settings.go
@@ -20,6 +20,7 @@ type SettingsRepo interface {
 	// no stored row are simply absent from the result; missing rows are not an error.
 	GetSettingsByKeys(ctx context.Context, keys []string) ([]*models.Settings, error)
 	// UpdateSettings persists settings for its key only if the row still has
-	// settings.Version; returns ErrSettingsVersionConflict when it doesn't.
+	// settings.Version; returns ErrSettingsVersionConflict when the stored version differs,
+	// and ErrSettingsNotFound when no row exists for the key.
 	UpdateSettings(ctx context.Context, settings *models.Settings) error
 }

--- a/runs/repository/interfaces/settings.go
+++ b/runs/repository/interfaces/settings.go
@@ -1,0 +1,25 @@
+package interfaces
+
+import (
+	"context"
+	"errors"
+
+	"github.com/flyteorg/flyte/v2/runs/repository/models"
+)
+
+var (
+	ErrSettingsNotFound        = errors.New("settings not found")
+	ErrSettingsVersionConflict = errors.New("settings version conflict")
+	ErrSettingsAlreadyExists   = errors.New("settings already exists")
+)
+
+type SettingsRepo interface {
+	CreateSettings(ctx context.Context, settings *models.Settings) error
+	GetSettings(ctx context.Context, key string) (*models.Settings, error)
+	// GetSettingsByKeys returns the settings rows for the given keys. Keys with
+	// no stored row are simply absent from the result; missing rows are not an error.
+	GetSettingsByKeys(ctx context.Context, keys []string) ([]*models.Settings, error)
+	// UpdateSettings persists settings for its key only if the row still has
+	// settings.Version; returns ErrSettingsVersionConflict when it doesn't.
+	UpdateSettings(ctx context.Context, settings *models.Settings) error
+}

--- a/runs/repository/models/settings.go
+++ b/runs/repository/models/settings.go
@@ -1,0 +1,35 @@
+package models
+
+import (
+	"fmt"
+	"time"
+)
+
+// Settings is one row per settings scope (instance, domain, or project).
+type Settings struct {
+	ID        uint      `db:"id"`
+	Key       string    `db:"key"`
+	Data      []byte    `db:"data"`
+	Version   uint64    `db:"version"`
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+}
+
+// DefaultOrg mirrors secret.DefaultOrganization; duplicated so runs/ doesn't
+// take a flyteplugins import for one constant.
+const DefaultOrg = "flyte"
+
+// NormalizeOrg returns DefaultOrg for an empty org, otherwise org unchanged.
+func NormalizeOrg(org string) string {
+	if org == "" {
+		return DefaultOrg
+	}
+	return org
+}
+
+// EncodeSettingsKey encodes a settings scope as "v1:{org}:{domain}:{project}".
+// Empty org is normalized to DefaultOrg; empty domain/project segments are
+// kept, so an instance-level key looks like "v1:flyte::".
+func EncodeSettingsKey(org, domain, project string) string {
+	return fmt.Sprintf("v1:%s:%s:%s", NormalizeOrg(org), domain, project)
+}

--- a/runs/repository/models/settings_test.go
+++ b/runs/repository/models/settings_test.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeSettingsKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		org     string
+		domain  string
+		project string
+		want    string
+	}{
+		{name: "all segments set", org: "acme", domain: "dev", project: "recsys", want: "v1:acme:dev:recsys"},
+		{name: "domain level, empty org normalized", org: "", domain: "dev", project: "", want: "v1:flyte:dev:"},
+		{name: "instance level, all empty", org: "", domain: "", project: "", want: "v1:flyte::"},
+		{name: "empty org with domain and project", org: "", domain: "dev", project: "recsys", want: "v1:flyte:dev:recsys"},
+		{name: "org flyte passes through unchanged", org: "flyte", domain: "dev", project: "", want: "v1:flyte:dev:"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, EncodeSettingsKey(tc.org, tc.domain, tc.project))
+		})
+	}
+}


### PR DESCRIPTION
## Tracking issue

Related to #7775 (Settings Service RFC, first implementation PR)

## Why are the changes needed?

The Settings API in `flyteidl2/settings/` is fully defined, but no server implements it: there is currently no way to store or read settings at all. #7775 lays out the implementation plan. This PR is the first piece of it, the persistence layer: the `settings` table and the repository that owns all SQL against it, so the CRUD service handlers (next PR) have something to build on.

This is built as a vertical slice rather than strictly phase-by-phase: this PR covers tasks 1.1-1.4, and the follow-up adds minimal versions of 2.4-2.6 (Connect handlers and `runs/setup.go` wiring) so the service is callable end to end.

## What changes were proposed in this pull request?

- Migration for the `settings` table: one row per scope (instance / domain / project), with a `version` column for optimistic locking
- Go model and key encoder (`"v1:{org}:{domain}:{project}"`, empty org normalized to `flyte`, matching the existing secret/app-service convention)
- Repository interface (`Create/Get/GetByKeys/Update`) with sentinel errors, and the sqlx implementation; optimistic locking follows the trigger repository's pattern

Settings are stored as the raw protojson of the `Settings` message. Sparse storage (prune/hydrate) and value validation are deferred to tasks 2.1/2.3, which fit naturally with the merge-engine work.

Not included (follow-ups): CRUD handlers and registration (next PR), merge/inheritance resolution, applying settings to runs.

## How was this patch tested?

Embedded-Postgres tests (real PostgreSQL via the existing `RunTestMain` harness, all migrations applied):

- create then get round-trip (struct/row consistency, JSONB round-trip)
- duplicate create returns `ErrSettingsAlreadyExists`, original row unharmed
- get of a missing key returns `ErrSettingsNotFound`
- multi-key ancestor fetch: missing rows are absent from results, not errors
- optimistic-locking race: the stale writer gets `ErrSettingsVersionConflict`,
  the winner's write survives, and the struct version syncs only on success

The whole `impl` package passes (new tests plus all existing ones), and the key encoder has its own table test in `models`. `gofmt` and `go vet` are clean.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

Follow-up: CRUD service handlers + wiring, to be opened on top of this branch.