### PR TITLE
fix(propeller): record events Admin already has in the dedup filter

### DIFF
--- a/flytepropeller/events/admin_eventsink.go
+++ b/flytepropeller/events/admin_eventsink.go
@@ -66,36 +66,41 @@ func (s *adminEventSink) Sink(ctx context.Context, message proto.Message) error 
 
 	// Validate submission with rate limiter and send admin event
 	if s.rateLimiter.Allow() {
+		var sendErr error
 		switch eventMessage := message.(type) {
 		case *event.WorkflowExecutionEvent:
 			request := &admin.WorkflowExecutionEventRequest{
 				Event: eventMessage,
 			}
 
-			_, err := s.adminClient.CreateWorkflowEvent(ctx, request)
-			if err != nil {
-				return errors.WrapError(err)
-			}
+			_, sendErr = s.adminClient.CreateWorkflowEvent(ctx, request)
 		case *event.NodeExecutionEvent:
 			request := &admin.NodeExecutionEventRequest{
 				Event: eventMessage,
 			}
 
-			_, err := s.adminClient.CreateNodeEvent(ctx, request)
-			if err != nil {
-				return errors.WrapError(err)
-			}
+			_, sendErr = s.adminClient.CreateNodeEvent(ctx, request)
 		case *event.TaskExecutionEvent:
 			request := &admin.TaskExecutionEventRequest{
 				Event: eventMessage,
 			}
 
-			_, err := s.adminClient.CreateTaskEvent(ctx, request)
-			if err != nil {
-				return errors.WrapError(err)
-			}
+			_, sendErr = s.adminClient.CreateTaskEvent(ctx, request)
 		default:
 			return fmt.Errorf("unknown event type [%s]", eventMessage.String())
+		}
+
+		if sendErr != nil {
+			wrapped := errors.WrapError(sendErr)
+			if errors.IsAlreadyExists(wrapped) {
+				// Admin already holds this event, so re-sending it can never succeed. Record the id
+				// so later re-emits are answered by the filter.Contains check above instead of
+				// spending rate limiter capacity that other executions need. The check returns this
+				// same error code, so callers see no change.
+				s.filter.Add(ctx, id)
+			}
+
+			return wrapped
 		}
 	} else {
 		return &errors.EventError{Code: errors.ResourceExhausted,

--- a/flytepropeller/events/eventsink_drain_repro_test.go
+++ b/flytepropeller/events/eventsink_drain_repro_test.go
@@ -1,0 +1,87 @@
+package events
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/flyteorg/flyte/flyteidl/clients/go/admin/mocks"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/event"
+	"github.com/flyteorg/flyte/flytestdlib/fastcheck"
+	"github.com/flyteorg/flyte/flytestdlib/promutils"
+)
+
+func taskEventFor(name string) *event.TaskExecutionEvent {
+	return &event.TaskExecutionEvent{
+		Phase:        core.TaskExecution_SUCCEEDED,
+		OccurredAt:   ptypes.TimestampNow(),
+		TaskId:       &core.Identifier{ResourceType: core.ResourceType_TASK, Name: "task-id"},
+		RetryAttempt: 1,
+		ParentNodeExecutionId: &core.NodeExecutionIdentifier{
+			NodeId: "node-id",
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    name,
+			},
+		},
+		Logs: []*core.TaskLog{{Uri: "logs.txt"}},
+	}
+}
+
+// A workflow that keeps re-emitting an event Admin has already durably recorded must not be able
+// to drain the process-wide event-sink rate limiter and starve other executions.
+//
+// The sink is built exactly as flytepropeller builds it in NewAdminEventSink: a real
+// OppoBloomFilter and a real token-bucket limiter. Only the Admin client is a stub, and it
+// answers exactly as a real Admin does for an event it already holds: codes.AlreadyExists.
+func TestAdminEventSink_AlreadyExistsDrainsRateLimiter(t *testing.T) {
+	ctx := context.Background()
+	scope := promutils.NewTestScope()
+
+	filter, err := fastcheck.NewOppoBloomFilter(50000, scope.NewSubScope("filter"))
+	assert.NoError(t, err)
+
+	// Capacity 10: a real deployment's shared budget, scaled down so the drain is observable.
+	adminClient := &mocks.AdminServiceClient{}
+	sink, err := NewAdminEventSink(ctx, adminClient, &Config{Rate: 1, Capacity: 10}, filter)
+	assert.NoError(t, err)
+
+	stuck := taskEventFor("stuck-execution")
+	healthy := taskEventFor("healthy-execution")
+
+	adminCalls := 0
+	adminClient.On("CreateTaskEvent", ctx,
+		mock.MatchedBy(func(req *admin.TaskExecutionEventRequest) bool {
+			return req.GetEvent().GetParentNodeExecutionId().GetExecutionId().GetName() == "stuck-execution"
+		}),
+	).Run(func(mock.Arguments) { adminCalls++ }).
+		Return(nil, status.Error(codes.AlreadyExists, "Grpc AlreadyExists error"))
+
+	adminClient.On("CreateTaskEvent", ctx,
+		mock.MatchedBy(func(req *admin.TaskExecutionEventRequest) bool {
+			return req.GetEvent().GetParentNodeExecutionId().GetExecutionId().GetName() == "healthy-execution"
+		}),
+	).Return(&admin.TaskExecutionEventResponse{}, nil)
+
+	// Admin already holds this event, so re-emitting it can never succeed. Every attempt should
+	// be answered from the local dedup filter, not by spending a token on a doomed round trip.
+	for i := 0; i < 10; i++ {
+		_ = sink.Sink(ctx, stuck)
+	}
+	t.Logf("re-emits of an already-recorded event that reached Admin: %d/10", adminCalls)
+	assert.Equal(t, 1, adminCalls,
+		"an already-recorded event should reach Admin once; afterwards the dedup filter should answer")
+
+	// The unrelated execution must still be able to record its event.
+	healthyErr := sink.Sink(ctx, healthy)
+	assert.NoError(t, healthyErr,
+		"a healthy execution was starved of rate-limiter capacity by an already-recorded event")
+}


### PR DESCRIPTION
## Why are the changes needed?

`adminEventSink.Sink` keeps a dedup filter so an event that has already been recorded doesn't go back to Admin. The id is only added to that filter after a clean send:

```go
	s.filter.Add(ctx, id)
	return nil
```

When Admin answers `AlreadyExists`, the sink returns the wrapped error and the id is never recorded. Every later re-emit of that event passes `filter.Contains`, takes a token from the sink's rate limiter, and makes a round trip that cannot succeed.

The limiter is shared by every execution the propeller is running. One execution re-emitting a recorded event can drain it, and the executions that needed those tokens get `ResourceExhausted`:

```
re-emits of an already-recorded event that reached Admin: 10/10
Error:      Received unexpected error:
            ResourceExhausted: Resource Exhausted, caused by [Admin EventSink throttling admin traffic]
Messages:   a healthy execution was starved of rate-limiter capacity by an already-recorded event
```

## What changes were proposed in this pull request?

Add the id to the dedup filter when Admin reports it already has the event, so later re-emits are answered by the `filter.Contains` check instead of spending limiter capacity.

The error is still returned, and `filter.Contains` returns that same code for a locally known duplicate, so callers see no change either way.

Only `AlreadyExists` is filtered. `EventAlreadyInTerminalState` is deliberately left out: callers act on it — `nodeerrors.IllegalStateError` in `node_exec_context.go`, a forced transition to `WorkflowPhaseFailed` in `workflow/executor.go` — and folding it into the filter would replay it as `AlreadyExists`, which those same callers map to nil.

## How was this patch tested?

`TestAdminEventSink_AlreadyExistsDrainsRateLimiter` builds the sink the way `NewAdminEventSink` does in production — a real `OppoBloomFilter` and a real token-bucket limiter, with only the Admin client stubbed, answering `codes.AlreadyExists` as a real Admin does for an event it already holds. It re-emits that event ten times against a limiter with ten tokens, then checks an unrelated execution can still record its own event.

```
cd flytepropeller
git checkout upstream/master -- events/admin_eventsink.go   # drop the fix
go test ./events/ -run TestAdminEventSink_AlreadyExistsDrainsRateLimiter -count=1
git checkout HEAD -- events/admin_eventsink.go              # restore it
go test ./events/ -run TestAdminEventSink_AlreadyExistsDrainsRateLimiter -count=1 -v
go test ./events/... -count=1
```

<details><summary>Raw output</summary>

Without the fix:

```
--- FAIL: TestAdminEventSink_AlreadyExistsDrainsRateLimiter (0.00s)
    eventsink_drain_repro_test.go:79: re-emits of an already-recorded event that reached Admin: 10/10
    eventsink_drain_repro_test.go:80:
        	Error:      	Not equal:
        	            	expected: 1
        	            	actual  : 10
        	Messages:   	an already-recorded event should reach Admin once; afterwards the dedup filter should answer
    eventsink_drain_repro_test.go:85:
        	Error:      	Received unexpected error:
        	            	ResourceExhausted: Resource Exhausted, caused by [Admin EventSink throttling admin traffic]
        	Messages:   	a healthy execution was starved of rate-limiter capacity by an already-recorded event
FAIL
FAIL	github.com/flyteorg/flyte/flytepropeller/events	0.850s
```

With the fix:

```
=== RUN   TestAdminEventSink_AlreadyExistsDrainsRateLimiter
    eventsink_drain_repro_test.go:79: re-emits of an already-recorded event that reached Admin: 1/10
--- PASS: TestAdminEventSink_AlreadyExistsDrainsRateLimiter (0.00s)
PASS
ok  	github.com/flyteorg/flyte/flytepropeller/events	0.739s
```

The rest of the package, including `TestAdminAlreadyExistsError` which pins the returned error:

```
ok  	github.com/flyteorg/flyte/flytepropeller/events	0.983s
ok  	github.com/flyteorg/flyte/flytepropeller/events/errors	0.305s
```

</details>

### Labels

fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
