### PR TITLE
fix: drop the task entrypoint from the spark driver/executor pod template

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -193,6 +193,24 @@ func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 				templatePodSpec.EnableServiceLinks = podSpec.EnableServiceLinks
 			}
 		}
+		// Spark adopts one container from the template as the driver/executor and writes its
+		// own args onto it (`driver --properties-file ... --class ...`), but leaves `command`
+		// alone because it expects the image entrypoint to consume those args. Flyte's
+		// container carries the task entrypoint in `command`, so leaving it in place makes
+		// the kubelet run `a0 <task args> driver --properties-file ...` and the task CLI
+		// rejects Spark's flags. Drop it: on this container the entrypoint belongs to Spark.
+		// Indexed rather than via flytek8s.GetContainer, which returns a pointer to the range
+		// copy: writes through it are discarded. Nothing matches when the user supplied their
+		// own driver/executor pod spec, whose containers are named for what the operator
+		// generates rather than for the task.
+		for i := range templatePodSpec.Containers {
+			if templatePodSpec.Containers[i].Name == container.Name {
+				templatePodSpec.Containers[i].Command = nil
+				templatePodSpec.Containers[i].Args = nil
+				break
+			}
+		}
+
 		spec.Template = &v1.PodTemplateSpec{Spec: *templatePodSpec}
 		sa := serviceAccountName(taskCtx.TaskExecutionMetadata())
 		spec.ServiceAccount = &sa

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -154,7 +154,10 @@ func serviceAccountName(metadata pluginsCore.TaskExecutionMetadata) string {
 
 // sparkContainerName is the name the operator and Spark expect for the role's container:
 // defaultDriverPrimaryContainerName or defaultExecutorPrimaryContainerName.
-func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, podSpec, customPodSpec *v1.PodSpec, container *v1.Container, sparkContainerName string) *sparkOp.SparkPodSpec {
+//
+// The second return value is the template container Spark should adopt, empty when the plugin
+// cannot say -- see the podTemplateContainerName note below.
+func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, podSpec, customPodSpec *v1.PodSpec, container *v1.Container, sparkContainerName string) (*sparkOp.SparkPodSpec, string) {
 	annotations := utils.UnionMaps(config.GetK8sPluginConfig().DefaultAnnotations, utils.CopyMap(taskCtx.TaskExecutionMetadata().GetAnnotations()))
 	labels := utils.UnionMaps(config.GetK8sPluginConfig().DefaultLabels, utils.CopyMap(taskCtx.TaskExecutionMetadata().GetLabels()))
 
@@ -191,6 +194,7 @@ func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 	// pod spec is passed through verbatim so the operator can patch it onto the container it
 	// generates (`spark-kubernetes-driver`/`spark-kubernetes-executor`); Flyte's own container
 	// names never match those, so merging it here would drop it on the floor.
+	var templateContainerName string
 	if GetSparkConfig().EnablePodTemplate && podTemplateSupported(ctx) {
 		templatePodSpec := podSpec.DeepCopy()
 		if customPodSpec != nil {
@@ -232,8 +236,12 @@ func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 		spec.Template = &v1.PodTemplateSpec{Spec: *templatePodSpec}
 		sa := serviceAccountName(taskCtx.TaskExecutionMetadata())
 		spec.ServiceAccount = &sa
+
+		if customPodSpec == nil {
+			templateContainerName = sparkContainerName
+		}
 	}
-	return &spec
+	return &spec, templateContainerName
 }
 
 type driverSpec struct {
@@ -269,7 +277,14 @@ func createDriverSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCont
 	if err != nil {
 		return nil, err
 	}
-	sparkPodSpec := createSparkPodSpec(ctx, nonInterruptibleTaskCtx, podSpec, customPodSpec, primaryContainer, defaultDriverPrimaryContainerName)
+	sparkPodSpec, templateContainerName := createSparkPodSpec(ctx, nonInterruptibleTaskCtx, podSpec, customPodSpec, primaryContainer, defaultDriverPrimaryContainerName)
+	// Spark adopts the container named here, falling back to the first one in the template.
+	// Without this a pod template that orders a sidecar ahead of the task container has Spark
+	// run the sidecar as the driver. Left unset for a custom pod spec, whose primary container
+	// this plugin does not choose.
+	if templateContainerName != "" {
+		sparkConfig[sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName] = templateContainerName
+	}
 	serviceAccountName := serviceAccountName(nonInterruptibleTaskCtx.TaskExecutionMetadata())
 	sparkPodSpec.ServiceAccount = &serviceAccountName
 	spec := driverSpec{
@@ -316,7 +331,10 @@ func createExecutorSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 	if err != nil {
 		return nil, err
 	}
-	sparkPodSpec := createSparkPodSpec(ctx, taskCtx, podSpec, customPodSpec, primaryContainer, defaultExecutorPrimaryContainerName)
+	sparkPodSpec, templateContainerName := createSparkPodSpec(ctx, taskCtx, podSpec, customPodSpec, primaryContainer, defaultExecutorPrimaryContainerName)
+	if templateContainerName != "" {
+		sparkConfig[sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName] = templateContainerName
+	}
 	spec := executorSpec{
 		primaryContainer,
 		&sparkOp.ExecutorSpec{

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -29,13 +29,9 @@ import (
 )
 
 const (
-	KindSparkApplication = "SparkApplication"
-	sparkDriverUI        = "sparkDriverUI"
-	sparkHistoryUI       = "sparkHistoryUI"
-	// The names the operator's mutating webhook looks for (findContainer in
-	// internal/webhook/sparkpod_defaulter.go), which are also the names Spark gives the
-	// containers it builds. The driver name is what the log links and pod demystification
-	// below expect to find in the pod.
+	KindSparkApplication                = "SparkApplication"
+	sparkDriverUI                       = "sparkDriverUI"
+	sparkHistoryUI                      = "sparkHistoryUI"
 	defaultDriverPrimaryContainerName   = sparkOpCommon.SparkDriverContainerName
 	defaultExecutorPrimaryContainerName = sparkOpCommon.Spark3DefaultExecutorContainerName
 )
@@ -154,10 +150,12 @@ func serviceAccountName(metadata pluginsCore.TaskExecutionMetadata) string {
 
 // sparkContainerName is the name the operator and Spark expect for the role's container:
 // defaultDriverPrimaryContainerName or defaultExecutorPrimaryContainerName.
+// customPrimaryContainerName is the primary container the user declared on their own
+// driver/executor pod spec, if any.
 //
-// The second return value is the template container Spark should adopt, empty when the plugin
-// cannot say -- see the podTemplateContainerName note below.
-func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, podSpec, customPodSpec *v1.PodSpec, container *v1.Container, sparkContainerName string) (*sparkOp.SparkPodSpec, string) {
+// The second return value is the template container Spark should adopt, empty when no template
+// is attached or when a custom pod spec named no primary container.
+func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, podSpec, customPodSpec *v1.PodSpec, container *v1.Container, sparkContainerName, customPrimaryContainerName string) (*sparkOp.SparkPodSpec, string) {
 	annotations := utils.UnionMaps(config.GetK8sPluginConfig().DefaultAnnotations, utils.CopyMap(taskCtx.TaskExecutionMetadata().GetAnnotations()))
 	labels := utils.UnionMaps(config.GetK8sPluginConfig().DefaultLabels, utils.CopyMap(taskCtx.TaskExecutionMetadata().GetLabels()))
 
@@ -237,7 +235,11 @@ func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 		sa := serviceAccountName(taskCtx.TaskExecutionMetadata())
 		spec.ServiceAccount = &sa
 
-		if customPodSpec == nil {
+		if customPodSpec != nil {
+			// The user names their own primary container; an empty or absent one leaves the
+			// conf unset, which is Spark's first-container default either way.
+			templateContainerName = customPrimaryContainerName
+		} else {
 			templateContainerName = sparkContainerName
 		}
 	}
@@ -277,11 +279,10 @@ func createDriverSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCont
 	if err != nil {
 		return nil, err
 	}
-	sparkPodSpec, templateContainerName := createSparkPodSpec(ctx, nonInterruptibleTaskCtx, podSpec, customPodSpec, primaryContainer, defaultDriverPrimaryContainerName)
+	sparkPodSpec, templateContainerName := createSparkPodSpec(ctx, nonInterruptibleTaskCtx, podSpec, customPodSpec, primaryContainer, defaultDriverPrimaryContainerName, driverPod.GetPrimaryContainerName())
 	// Spark adopts the container named here, falling back to the first one in the template.
 	// Without this a pod template that orders a sidecar ahead of the task container has Spark
-	// run the sidecar as the driver. Left unset for a custom pod spec, whose primary container
-	// this plugin does not choose.
+	// run the sidecar as the driver.
 	if templateContainerName != "" {
 		sparkConfig[sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName] = templateContainerName
 	}
@@ -331,7 +332,7 @@ func createExecutorSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 	if err != nil {
 		return nil, err
 	}
-	sparkPodSpec, templateContainerName := createSparkPodSpec(ctx, taskCtx, podSpec, customPodSpec, primaryContainer, defaultExecutorPrimaryContainerName)
+	sparkPodSpec, templateContainerName := createSparkPodSpec(ctx, taskCtx, podSpec, customPodSpec, primaryContainer, defaultExecutorPrimaryContainerName, executorPod.GetPrimaryContainerName())
 	if templateContainerName != "" {
 		sparkConfig[sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName] = templateContainerName
 	}

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -29,10 +29,15 @@ import (
 )
 
 const (
-	KindSparkApplication              = "SparkApplication"
-	sparkDriverUI                     = "sparkDriverUI"
-	sparkHistoryUI                    = "sparkHistoryUI"
-	defaultDriverPrimaryContainerName = "spark-kubernetes-driver"
+	KindSparkApplication = "SparkApplication"
+	sparkDriverUI        = "sparkDriverUI"
+	sparkHistoryUI       = "sparkHistoryUI"
+	// The names the operator's mutating webhook looks for (findContainer in
+	// internal/webhook/sparkpod_defaulter.go), which are also the names Spark gives the
+	// containers it builds. The driver name is what the log links and pod demystification
+	// below expect to find in the pod.
+	defaultDriverPrimaryContainerName   = sparkOpCommon.SparkDriverContainerName
+	defaultExecutorPrimaryContainerName = sparkOpCommon.Spark3DefaultExecutorContainerName
 )
 
 var featureRegex = regexp.MustCompile(`^spark.((flyteorg)|(flyte)).(.+).enabled$`)
@@ -147,7 +152,9 @@ func serviceAccountName(metadata pluginsCore.TaskExecutionMetadata) string {
 	return name
 }
 
-func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, podSpec, customPodSpec *v1.PodSpec, container *v1.Container) *sparkOp.SparkPodSpec {
+// sparkContainerName is the name the operator and Spark expect for the role's container:
+// defaultDriverPrimaryContainerName or defaultExecutorPrimaryContainerName.
+func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, podSpec, customPodSpec *v1.PodSpec, container *v1.Container, sparkContainerName string) *sparkOp.SparkPodSpec {
 	annotations := utils.UnionMaps(config.GetK8sPluginConfig().DefaultAnnotations, utils.CopyMap(taskCtx.TaskExecutionMetadata().GetAnnotations()))
 	labels := utils.UnionMaps(config.GetK8sPluginConfig().DefaultLabels, utils.CopyMap(taskCtx.TaskExecutionMetadata().GetLabels()))
 
@@ -192,19 +199,30 @@ func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 			if templatePodSpec.EnableServiceLinks == nil {
 				templatePodSpec.EnableServiceLinks = podSpec.EnableServiceLinks
 			}
-		}
-		// Spark adopts one container from the template as the driver/executor and writes its
-		// own args onto it (`driver --properties-file ... --class ...`), but leaves `command`
-		// alone because it expects the image entrypoint to consume those args. Flyte's
-		// container carries the task entrypoint in `command`, so leaving it in place makes
-		// the kubelet run `a0 <task args> driver --properties-file ...` and the task CLI
-		// rejects Spark's flags. Drop it: on this container the entrypoint belongs to Spark.
-		// Indexed rather than via flytek8s.GetContainer, which returns a pointer to the range
-		// copy: writes through it are discarded. Nothing matches when the user supplied their
-		// own driver/executor pod spec, whose containers are named for what the operator
-		// generates rather than for the task.
-		for i := range templatePodSpec.Containers {
-			if templatePodSpec.Containers[i].Name == container.Name {
+		} else {
+			// Only Flyte's own pod spec is adjusted here. A custom driver/executor pod spec is
+			// passed through verbatim: it is written against what the operator generates, so
+			// its containers already carry the name below and never the task entrypoint.
+			//
+			// Indexed rather than via flytek8s.GetContainer, which returns a pointer to the
+			// range copy, so writes through it are discarded.
+			for i := range templatePodSpec.Containers {
+				if templatePodSpec.Containers[i].Name != container.Name {
+					continue
+				}
+				// The operator's mutating webhook patches the container it finds by name --
+				// spark-kubernetes-driver, or executor/spark-kubernetes-executor -- and leaves
+				// the pod alone when none matches (findContainer in
+				// internal/webhook/sparkpod_defaulter.go). Under the task's own container name
+				// every volume, mount and env the operator manages would be dropped.
+				templatePodSpec.Containers[i].Name = sparkContainerName
+
+				// Spark writes its own arguments onto this container (`driver
+				// --properties-file ... --class ...`) but leaves command alone, expecting the
+				// image entrypoint to consume them. Leaving the task entrypoint in place makes
+				// the kubelet run `a0 <task args> driver --properties-file ...`, which the task
+				// CLI rejects. The task arguments still reach the application through
+				// spec.arguments.
 				templatePodSpec.Containers[i].Command = nil
 				templatePodSpec.Containers[i].Args = nil
 				break
@@ -251,7 +269,7 @@ func createDriverSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCont
 	if err != nil {
 		return nil, err
 	}
-	sparkPodSpec := createSparkPodSpec(ctx, nonInterruptibleTaskCtx, podSpec, customPodSpec, primaryContainer)
+	sparkPodSpec := createSparkPodSpec(ctx, nonInterruptibleTaskCtx, podSpec, customPodSpec, primaryContainer, defaultDriverPrimaryContainerName)
 	serviceAccountName := serviceAccountName(nonInterruptibleTaskCtx.TaskExecutionMetadata())
 	sparkPodSpec.ServiceAccount = &serviceAccountName
 	spec := driverSpec{
@@ -298,7 +316,7 @@ func createExecutorSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 	if err != nil {
 		return nil, err
 	}
-	sparkPodSpec := createSparkPodSpec(ctx, taskCtx, podSpec, customPodSpec, primaryContainer)
+	sparkPodSpec := createSparkPodSpec(ctx, taskCtx, podSpec, customPodSpec, primaryContainer, defaultExecutorPrimaryContainerName)
 	spec := executorSpec{
 		primaryContainer,
 		&sparkOp.ExecutorSpec{

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -149,13 +149,9 @@ func serviceAccountName(metadata pluginsCore.TaskExecutionMetadata) string {
 }
 
 // sparkContainerName is the name the operator and Spark expect for the role's container:
-// defaultDriverPrimaryContainerName or defaultExecutorPrimaryContainerName.
-// customPrimaryContainerName is the primary container the user declared on their own
-// driver/executor pod spec, if any.
-//
-// The second return value is the template container Spark should adopt, empty when no template
-// is attached or when a custom pod spec named no primary container.
-func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, podSpec, customPodSpec *v1.PodSpec, container *v1.Container, sparkContainerName, customPrimaryContainerName string) (*sparkOp.SparkPodSpec, string) {
+// defaultDriverPrimaryContainerName or defaultExecutorPrimaryContainerName. A custom
+// driver/executor pod spec is expected to name its own container that way already.
+func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, podSpec, customPodSpec *v1.PodSpec, container *v1.Container, sparkContainerName string) *sparkOp.SparkPodSpec {
 	annotations := utils.UnionMaps(config.GetK8sPluginConfig().DefaultAnnotations, utils.CopyMap(taskCtx.TaskExecutionMetadata().GetAnnotations()))
 	labels := utils.UnionMaps(config.GetK8sPluginConfig().DefaultLabels, utils.CopyMap(taskCtx.TaskExecutionMetadata().GetLabels()))
 
@@ -188,11 +184,15 @@ func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 	// The legacy fields above are always populated so the object stays valid on clusters whose
 	// CRD/operator predate pod-template support (unknown fields are pruned by the API server
 	// there). Where the CRD accepts it, additionally pass a pod spec through as the pod template;
-	// the operator treats explicit fields as overrides of the template. The user's driver/executor
-	// pod spec is passed through verbatim so the operator can patch it onto the container it
-	// generates (`spark-kubernetes-driver`/`spark-kubernetes-executor`); Flyte's own container
-	// names never match those, so merging it here would drop it on the floor.
-	var templateContainerName string
+	// the operator treats explicit fields as overrides of the template.
+	//
+	// Either way the role's container ends up named `spark-kubernetes-driver` /
+	// `spark-kubernetes-executor`: Flyte's own container is renamed below, and a custom
+	// driver/executor pod spec is expected to use those names already, so it is passed through
+	// verbatim. Spark keeps whatever name the template gives the container it adopts
+	// (BasicDriverFeatureStep: `.withName(Option(pod.container.getName).getOrElse(...))`), and
+	// the operator's webhook only patches a container it finds by those names, as do this
+	// plugin's log links.
 	if GetSparkConfig().EnablePodTemplate && podTemplateSupported(ctx) {
 		templatePodSpec := podSpec.DeepCopy()
 		if customPodSpec != nil {
@@ -202,29 +202,14 @@ func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 				templatePodSpec.EnableServiceLinks = podSpec.EnableServiceLinks
 			}
 		} else {
-			// Only Flyte's own pod spec is adjusted here. A custom driver/executor pod spec is
-			// passed through verbatim: it is written against what the operator generates, so
-			// its containers already carry the name below and never the task entrypoint.
-			//
-			// Indexed rather than via flytek8s.GetContainer, which returns a pointer to the
-			// range copy, so writes through it are discarded.
 			for i := range templatePodSpec.Containers {
 				if templatePodSpec.Containers[i].Name != container.Name {
 					continue
 				}
 				// The operator's mutating webhook patches the container it finds by name --
-				// spark-kubernetes-driver, or executor/spark-kubernetes-executor -- and leaves
-				// the pod alone when none matches (findContainer in
-				// internal/webhook/sparkpod_defaulter.go). Under the task's own container name
-				// every volume, mount and env the operator manages would be dropped.
+				// spark-kubernetes-driver, or executor/spark-kubernetes-executor.
 				templatePodSpec.Containers[i].Name = sparkContainerName
-
-				// Spark writes its own arguments onto this container (`driver
-				// --properties-file ... --class ...`) but leaves command alone, expecting the
-				// image entrypoint to consume them. Leaving the task entrypoint in place makes
-				// the kubelet run `a0 <task args> driver --properties-file ...`, which the task
-				// CLI rejects. The task arguments still reach the application through
-				// spec.arguments.
+				// SparkApplication already set the command and args, so we don't need to set it in the primary pod again
 				templatePodSpec.Containers[i].Command = nil
 				templatePodSpec.Containers[i].Args = nil
 				break
@@ -234,16 +219,8 @@ func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 		spec.Template = &v1.PodTemplateSpec{Spec: *templatePodSpec}
 		sa := serviceAccountName(taskCtx.TaskExecutionMetadata())
 		spec.ServiceAccount = &sa
-
-		if customPodSpec != nil {
-			// The user names their own primary container; an empty or absent one leaves the
-			// conf unset, which is Spark's first-container default either way.
-			templateContainerName = customPrimaryContainerName
-		} else {
-			templateContainerName = sparkContainerName
-		}
 	}
-	return &spec, templateContainerName
+	return &spec
 }
 
 type driverSpec struct {
@@ -279,12 +256,12 @@ func createDriverSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCont
 	if err != nil {
 		return nil, err
 	}
-	sparkPodSpec, templateContainerName := createSparkPodSpec(ctx, nonInterruptibleTaskCtx, podSpec, customPodSpec, primaryContainer, defaultDriverPrimaryContainerName, driverPod.GetPrimaryContainerName())
+	sparkPodSpec := createSparkPodSpec(ctx, nonInterruptibleTaskCtx, podSpec, customPodSpec, primaryContainer, defaultDriverPrimaryContainerName)
 	// Spark adopts the container named here, falling back to the first one in the template.
-	// Without this a pod template that orders a sidecar ahead of the task container has Spark
+	// Without this a pod template that orders a sidecar ahead of the driver container has Spark
 	// run the sidecar as the driver.
-	if templateContainerName != "" {
-		sparkConfig[sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName] = templateContainerName
+	if sparkPodSpec.Template != nil {
+		sparkConfig[sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName] = defaultDriverPrimaryContainerName
 	}
 	serviceAccountName := serviceAccountName(nonInterruptibleTaskCtx.TaskExecutionMetadata())
 	sparkPodSpec.ServiceAccount = &serviceAccountName
@@ -332,9 +309,9 @@ func createExecutorSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 	if err != nil {
 		return nil, err
 	}
-	sparkPodSpec, templateContainerName := createSparkPodSpec(ctx, taskCtx, podSpec, customPodSpec, primaryContainer, defaultExecutorPrimaryContainerName, executorPod.GetPrimaryContainerName())
-	if templateContainerName != "" {
-		sparkConfig[sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName] = templateContainerName
+	sparkPodSpec := createSparkPodSpec(ctx, taskCtx, podSpec, customPodSpec, primaryContainer, defaultExecutorPrimaryContainerName)
+	if sparkPodSpec.Template != nil {
+		sparkConfig[sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName] = defaultExecutorPrimaryContainerName
 	}
 	spec := executorSpec{
 		primaryContainer,

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark.go
@@ -148,9 +148,6 @@ func serviceAccountName(metadata pluginsCore.TaskExecutionMetadata) string {
 	return name
 }
 
-// sparkContainerName is the name the operator and Spark expect for the role's container:
-// defaultDriverPrimaryContainerName or defaultExecutorPrimaryContainerName. A custom
-// driver/executor pod spec is expected to name its own container that way already.
 func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionContext, podSpec, customPodSpec *v1.PodSpec, container *v1.Container, sparkContainerName string) *sparkOp.SparkPodSpec {
 	annotations := utils.UnionMaps(config.GetK8sPluginConfig().DefaultAnnotations, utils.CopyMap(taskCtx.TaskExecutionMetadata().GetAnnotations()))
 	labels := utils.UnionMaps(config.GetK8sPluginConfig().DefaultLabels, utils.CopyMap(taskCtx.TaskExecutionMetadata().GetLabels()))
@@ -184,15 +181,10 @@ func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 	// The legacy fields above are always populated so the object stays valid on clusters whose
 	// CRD/operator predate pod-template support (unknown fields are pruned by the API server
 	// there). Where the CRD accepts it, additionally pass a pod spec through as the pod template;
-	// the operator treats explicit fields as overrides of the template.
-	//
-	// Either way the role's container ends up named `spark-kubernetes-driver` /
-	// `spark-kubernetes-executor`: Flyte's own container is renamed below, and a custom
-	// driver/executor pod spec is expected to use those names already, so it is passed through
-	// verbatim. Spark keeps whatever name the template gives the container it adopts
-	// (BasicDriverFeatureStep: `.withName(Option(pod.container.getName).getOrElse(...))`), and
-	// the operator's webhook only patches a container it finds by those names, as do this
-	// plugin's log links.
+	// the operator treats explicit fields as overrides of the template. The user's driver/executor
+	// pod spec is passed through verbatim so the operator can patch it onto the container it
+	// generates (`spark-kubernetes-driver`/`spark-kubernetes-executor`); Flyte's own container
+	// names never match those, so merging it here would drop it on the floor.
 	if GetSparkConfig().EnablePodTemplate && podTemplateSupported(ctx) {
 		templatePodSpec := podSpec.DeepCopy()
 		if customPodSpec != nil {
@@ -209,7 +201,7 @@ func createSparkPodSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCo
 				// The operator's mutating webhook patches the container it finds by name --
 				// spark-kubernetes-driver, or executor/spark-kubernetes-executor.
 				templatePodSpec.Containers[i].Name = sparkContainerName
-				// SparkApplication already set the command and args, so we don't need to set it in the primary pod again
+				// SparkApplication already set the command and args, so we don't need to set it in the primary pod again.
 				templatePodSpec.Containers[i].Command = nil
 				templatePodSpec.Containers[i].Args = nil
 				break
@@ -257,9 +249,6 @@ func createDriverSpec(ctx context.Context, taskCtx pluginsCore.TaskExecutionCont
 		return nil, err
 	}
 	sparkPodSpec := createSparkPodSpec(ctx, nonInterruptibleTaskCtx, podSpec, customPodSpec, primaryContainer, defaultDriverPrimaryContainerName)
-	// Spark adopts the container named here, falling back to the first one in the template.
-	// Without this a pod template that orders a sidecar ahead of the driver container has Spark
-	// run the sidecar as the driver.
 	if sparkPodSpec.Template != nil {
 		sparkConfig[sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName] = defaultDriverPrimaryContainerName
 	}

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
@@ -1605,13 +1605,9 @@ func TestBuildResourcePodTemplateRenamesTaskContainer(t *testing.T) {
 }
 
 // TestBuildResourcePodTemplateCustomPodSpec pins the other half of the contract: a
-// user-supplied driver/executor pod spec is written against what the operator generates, so it
-// already carries the operator's container names and never the task entrypoint. It is passed
-// through verbatim -- the rename and entrypoint strip apply only to Flyte's own pod spec.
-//
-// Spark still has to be told which container to adopt, and for a custom spec the user is the one
-// who says which is primary (core.K8SPod.primary_container_name). When they don't, the conf is
-// left unset, which is Spark's first-container default either way.
+// user-supplied driver/executor pod spec is expected to name its container the way the operator
+// and Spark do, so it is passed through verbatim -- the rename and entrypoint strip apply only
+// to Flyte's own pod spec.
 func TestBuildResourcePodTemplateCustomPodSpec(t *testing.T) {
 	assert.NoError(t, setSparkConfig(&Config{EnablePodTemplate: true}))
 	assert.NoError(t, config.SetK8sPluginConfig(defaultPluginConfig()))
@@ -1625,71 +1621,52 @@ func TestBuildResourcePodTemplateCustomPodSpec(t *testing.T) {
 			Args:    []string{"--user-flag"},
 		}}}
 	}
+	driverPodSpec := customPodSpec(defaultDriverPrimaryContainerName)
+	executorPodSpec := customPodSpec(defaultExecutorPrimaryContainerName)
 
-	build := func(t *testing.T, driverPrimary, executorPrimary string) (*sj.SparkApplication, *corev1.PodSpec, *corev1.PodSpec) {
-		t.Helper()
-		driverPodSpec := customPodSpec(defaultDriverPrimaryContainerName)
-		executorPodSpec := customPodSpec(defaultExecutorPrimaryContainerName)
+	driverPodSpecPb, err := utils.MarshalObjToStruct(driverPodSpec)
+	require.NoError(t, err)
+	executorPodSpecPb, err := utils.MarshalObjToStruct(executorPodSpec)
+	require.NoError(t, err)
 
-		driverPodSpecPb, err := utils.MarshalObjToStruct(driverPodSpec)
-		require.NoError(t, err)
-		executorPodSpecPb, err := utils.MarshalObjToStruct(executorPodSpec)
-		require.NoError(t, err)
+	sparkJob := dummySparkCustomObj(dummySparkConf)
+	sparkJob.DriverPod = &core.K8SPod{PodSpec: driverPodSpecPb, PrimaryContainerName: defaultDriverPrimaryContainerName}
+	sparkJob.ExecutorPod = &core.K8SPod{PodSpec: executorPodSpecPb, PrimaryContainerName: defaultExecutorPrimaryContainerName}
 
-		sparkJob := dummySparkCustomObj(dummySparkConf)
-		sparkJob.DriverPod = &core.K8SPod{PodSpec: driverPodSpecPb, PrimaryContainerName: driverPrimary}
-		sparkJob.ExecutorPod = &core.K8SPod{PodSpec: executorPodSpecPb, PrimaryContainerName: executorPrimary}
-
-		sparkJobJSON, err := utils.MarshalToString(sparkJob)
-		require.NoError(t, err)
-		structObj := structpb.Struct{}
-		require.NoError(t, stdlibUtils.UnmarshalStringToPb(sparkJobJSON, &structObj))
-		taskTemplate := &core.TaskTemplate{
-			Id:     &core.Identifier{Name: "spark-custom-pod-template"},
-			Type:   "container",
-			Target: &core.TaskTemplate_Container{Container: &core.Container{Image: testImage, Args: testArgs, Env: dummyEnvVars}},
-			Custom: &structObj,
-		}
-
-		resource, err := sparkResourceHandler{}.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, false))
-		require.NoError(t, err)
-		return resource.(*sj.SparkApplication), driverPodSpec, executorPodSpec
+	sparkJobJSON, err := utils.MarshalToString(sparkJob)
+	require.NoError(t, err)
+	structObj := structpb.Struct{}
+	require.NoError(t, stdlibUtils.UnmarshalStringToPb(sparkJobJSON, &structObj))
+	taskTemplate := &core.TaskTemplate{
+		Id:     &core.Identifier{Name: "spark-custom-pod-template"},
+		Type:   "container",
+		Target: &core.TaskTemplate_Container{Container: &core.Container{Image: testImage, Args: testArgs, Env: dummyEnvVars}},
+		Custom: &structObj,
 	}
 
-	t.Run("passed through verbatim", func(t *testing.T) {
-		sparkApp, driverPodSpec, executorPodSpec := build(t, defaultDriverPrimaryContainerName, defaultExecutorPrimaryContainerName)
+	resource, err := sparkResourceHandler{}.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, false))
+	require.NoError(t, err)
+	sparkApp := resource.(*sj.SparkApplication)
 
-		for _, tc := range []struct {
-			role     string
-			expected *corev1.PodSpec
-			template *corev1.PodTemplateSpec
-		}{
-			{"driver", driverPodSpec, sparkApp.Spec.Driver.Template},
-			{"executor", executorPodSpec, sparkApp.Spec.Executor.Template},
-		} {
-			require.NotNil(t, tc.template, "%s template missing", tc.role)
-			require.Len(t, tc.template.Spec.Containers, 1, "%s template was rewritten", tc.role)
-			assert.Equal(t, tc.expected.Containers[0].Name, tc.template.Spec.Containers[0].Name)
-			assert.Equal(t, tc.expected.Containers[0].Command, tc.template.Spec.Containers[0].Command,
-				"%s custom pod spec must be passed through verbatim", tc.role)
-			assert.Equal(t, tc.expected.Containers[0].Args, tc.template.Spec.Containers[0].Args)
-		}
-	})
+	for _, tc := range []struct {
+		role     string
+		expected *corev1.PodSpec
+		template *corev1.PodTemplateSpec
+	}{
+		{"driver", driverPodSpec, sparkApp.Spec.Driver.Template},
+		{"executor", executorPodSpec, sparkApp.Spec.Executor.Template},
+	} {
+		require.NotNil(t, tc.template, "%s template missing", tc.role)
+		require.Len(t, tc.template.Spec.Containers, 1, "%s template was rewritten", tc.role)
+		assert.Equal(t, tc.expected.Containers[0].Name, tc.template.Spec.Containers[0].Name)
+		assert.Equal(t, tc.expected.Containers[0].Command, tc.template.Spec.Containers[0].Command,
+			"%s custom pod spec must be passed through verbatim", tc.role)
+		assert.Equal(t, tc.expected.Containers[0].Args, tc.template.Spec.Containers[0].Args)
+	}
 
-	t.Run("declared primary container names the one Spark adopts", func(t *testing.T) {
-		sparkApp, _, _ := build(t, defaultDriverPrimaryContainerName, defaultExecutorPrimaryContainerName)
-
-		assert.Equal(t, defaultDriverPrimaryContainerName,
-			sparkApp.Spec.SparkConf[sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName])
-		assert.Equal(t, defaultExecutorPrimaryContainerName,
-			sparkApp.Spec.SparkConf[sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName])
-	})
-
-	t.Run("no declared primary container leaves the conf unset", func(t *testing.T) {
-		sparkApp, _, _ := build(t, "", "")
-
-		// Spark's own first-container default applies, exactly as before this plugin set the conf.
-		assert.NotContains(t, sparkApp.Spec.SparkConf, sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName)
-		assert.NotContains(t, sparkApp.Spec.SparkConf, sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName)
-	})
+	// The container Spark adopts is named the same way whoever wrote the template.
+	assert.Equal(t, defaultDriverPrimaryContainerName,
+		sparkApp.Spec.SparkConf[sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName])
+	assert.Equal(t, defaultExecutorPrimaryContainerName,
+		sparkApp.Spec.SparkConf[sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName])
 }

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
@@ -1531,3 +1531,49 @@ func TestDefaultSparkVersionSatisfiesOperator(t *testing.T) {
 	assert.Less(t, sparkOpUtil.CompareSemanticVersion("", "3.0.0"), 0,
 		"an unset spark-version is expected to lose the comparison; the default exists to avoid it")
 }
+
+// TestBuildResourcePodTemplateDropsTaskEntrypoint covers the driver failing with
+// "No such option '--properties-file'". Spark adopts a container from the template and writes
+// its own driver arguments onto it, but leaves command alone -- it expects the image entrypoint
+// to consume them. With the task entrypoint still in command the kubelet runs
+// `a0 <task args> driver --properties-file ...` and the task CLI rejects Spark's flags.
+//
+// The task arguments must survive on spec.arguments, which is how spark-submit passes them to
+// the application; only the container-level copy goes away.
+func TestBuildResourcePodTemplateDropsTaskEntrypoint(t *testing.T) {
+	assert.NoError(t, setSparkConfig(&Config{EnablePodTemplate: true}))
+	assert.NoError(t, config.SetK8sPluginConfig(defaultPluginConfig()))
+	setPodTemplateSupportedForTest(true)
+
+	podSpec := dummyPodSpec()
+	primary := &podSpec.Containers[0] // "primary"; dummyPodSpec's "init" is an init container
+	primary.Command = []string{"a0"}
+	require.NotEmpty(t, primary.Args, "fixture must carry args for this test to mean anything")
+
+	taskTemplate := dummySparkTaskTemplatePod("entrypoint", dummySparkConf, podSpec)
+	taskCtx := dummySparkTaskContext(taskTemplate, false)
+	resource, err := sparkResourceHandler{}.BuildResource(context.TODO(), taskCtx)
+	require.NoError(t, err)
+	sparkApp := resource.(*sj.SparkApplication)
+
+	for _, tc := range []struct {
+		role     string
+		template *corev1.PodTemplateSpec
+	}{
+		{"driver", sparkApp.Spec.Driver.Template},
+		{"executor", sparkApp.Spec.Executor.Template},
+	} {
+		require.NotNil(t, tc.template, "%s template missing", tc.role)
+		templateContainer, err := flytek8s.GetContainer(&tc.template.Spec, primary.Name)
+		require.NoError(t, err, "%s template lost the primary container", tc.role)
+		assert.Nil(t, templateContainer.Command, "%s template must not carry the task entrypoint", tc.role)
+		assert.Nil(t, templateContainer.Args, "%s template must not carry the task args", tc.role)
+
+		// Sidecars keep theirs: Spark leaves every other container in the template alone.
+		sidecar, err := flytek8s.GetContainer(&tc.template.Spec, "secondary")
+		require.NoError(t, err)
+		assert.NotEmpty(t, sidecar.Args, "%s template dropped a sidecar's args", tc.role)
+	}
+
+	assert.Equal(t, testArgs, sparkApp.Spec.Arguments, "task args must still reach spark-submit")
+}

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
@@ -11,6 +11,7 @@ import (
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	sj "github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	sparkOp "github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	sparkOpCommon "github.com/kubeflow/spark-operator/v2/pkg/common"
 	sparkOpUtil "github.com/kubeflow/spark-operator/v2/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1517,6 +1518,14 @@ func TestBuildResourcePodTemplateGating(t *testing.T) {
 	expected := withoutTemplate.DeepCopy()
 	delete(normalized.Spec.SparkConf, "spark.kubernetes.driverEnv.FLYTE_START_TIME")
 	delete(expected.Spec.SparkConf, "spark.kubernetes.driverEnv.FLYTE_START_TIME")
+	// Template-only: they name the container Spark should adopt from the template.
+	assert.Equal(t, defaultDriverPrimaryContainerName,
+		normalized.Spec.SparkConf[sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName])
+	assert.Equal(t, defaultExecutorPrimaryContainerName,
+		normalized.Spec.SparkConf[sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName])
+	assert.NotContains(t, expected.Spec.SparkConf, sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName)
+	delete(normalized.Spec.SparkConf, sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName)
+	delete(normalized.Spec.SparkConf, sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName)
 	assert.Equal(t, expected, normalized)
 }
 
@@ -1586,6 +1595,13 @@ func TestBuildResourcePodTemplateRenamesTaskContainer(t *testing.T) {
 	}
 
 	assert.Equal(t, testArgs, sparkApp.Spec.Arguments, "task args must still reach spark-submit")
+
+	// Spark picks the first container in the template unless told which one to adopt, so a pod
+	// template that orders a sidecar first would otherwise have it run as the driver.
+	assert.Equal(t, defaultDriverPrimaryContainerName,
+		sparkApp.Spec.SparkConf[sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName])
+	assert.Equal(t, defaultExecutorPrimaryContainerName,
+		sparkApp.Spec.SparkConf[sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName])
 }
 
 // TestBuildResourcePodTemplateCustomPodSpecUntouched pins the other half of the contract: a
@@ -1648,4 +1664,9 @@ func TestBuildResourcePodTemplateCustomPodSpecUntouched(t *testing.T) {
 			"%s custom pod spec must be passed through verbatim", tc.role)
 		assert.Equal(t, tc.expected.Containers[0].Args, tc.template.Spec.Containers[0].Args)
 	}
+
+	// The plugin does not choose a custom pod spec's primary container, so it does not tell
+	// Spark which one to adopt either -- that stays Spark's own first-container default.
+	assert.NotContains(t, sparkApp.Spec.SparkConf, sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName)
+	assert.NotContains(t, sparkApp.Spec.SparkConf, sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName)
 }

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
@@ -1604,11 +1604,15 @@ func TestBuildResourcePodTemplateRenamesTaskContainer(t *testing.T) {
 		sparkApp.Spec.SparkConf[sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName])
 }
 
-// TestBuildResourcePodTemplateCustomPodSpecUntouched pins the other half of the contract: a
+// TestBuildResourcePodTemplateCustomPodSpec pins the other half of the contract: a
 // user-supplied driver/executor pod spec is written against what the operator generates, so it
 // already carries the operator's container names and never the task entrypoint. It is passed
-// through verbatim -- the rewrite above applies only to Flyte's own pod spec.
-func TestBuildResourcePodTemplateCustomPodSpecUntouched(t *testing.T) {
+// through verbatim -- the rename and entrypoint strip apply only to Flyte's own pod spec.
+//
+// Spark still has to be told which container to adopt, and for a custom spec the user is the one
+// who says which is primary (core.K8SPod.primary_container_name). When they don't, the conf is
+// left unset, which is Spark's first-container default either way.
+func TestBuildResourcePodTemplateCustomPodSpec(t *testing.T) {
 	assert.NoError(t, setSparkConfig(&Config{EnablePodTemplate: true}))
 	assert.NoError(t, config.SetK8sPluginConfig(defaultPluginConfig()))
 	setPodTemplateSupportedForTest(true)
@@ -1621,52 +1625,71 @@ func TestBuildResourcePodTemplateCustomPodSpecUntouched(t *testing.T) {
 			Args:    []string{"--user-flag"},
 		}}}
 	}
-	driverPodSpec := customPodSpec(defaultDriverPrimaryContainerName)
-	executorPodSpec := customPodSpec(defaultExecutorPrimaryContainerName)
 
-	driverPodSpecPb, err := utils.MarshalObjToStruct(driverPodSpec)
-	require.NoError(t, err)
-	executorPodSpecPb, err := utils.MarshalObjToStruct(executorPodSpec)
-	require.NoError(t, err)
+	build := func(t *testing.T, driverPrimary, executorPrimary string) (*sj.SparkApplication, *corev1.PodSpec, *corev1.PodSpec) {
+		t.Helper()
+		driverPodSpec := customPodSpec(defaultDriverPrimaryContainerName)
+		executorPodSpec := customPodSpec(defaultExecutorPrimaryContainerName)
 
-	sparkJob := dummySparkCustomObj(dummySparkConf)
-	sparkJob.DriverPod = &core.K8SPod{PodSpec: driverPodSpecPb, PrimaryContainerName: defaultDriverPrimaryContainerName}
-	sparkJob.ExecutorPod = &core.K8SPod{PodSpec: executorPodSpecPb, PrimaryContainerName: defaultExecutorPrimaryContainerName}
+		driverPodSpecPb, err := utils.MarshalObjToStruct(driverPodSpec)
+		require.NoError(t, err)
+		executorPodSpecPb, err := utils.MarshalObjToStruct(executorPodSpec)
+		require.NoError(t, err)
 
-	sparkJobJSON, err := utils.MarshalToString(sparkJob)
-	require.NoError(t, err)
-	structObj := structpb.Struct{}
-	require.NoError(t, stdlibUtils.UnmarshalStringToPb(sparkJobJSON, &structObj))
-	taskTemplate := &core.TaskTemplate{
-		Id:     &core.Identifier{Name: "spark-custom-pod-untouched"},
-		Type:   "container",
-		Target: &core.TaskTemplate_Container{Container: &core.Container{Image: testImage, Args: testArgs, Env: dummyEnvVars}},
-		Custom: &structObj,
+		sparkJob := dummySparkCustomObj(dummySparkConf)
+		sparkJob.DriverPod = &core.K8SPod{PodSpec: driverPodSpecPb, PrimaryContainerName: driverPrimary}
+		sparkJob.ExecutorPod = &core.K8SPod{PodSpec: executorPodSpecPb, PrimaryContainerName: executorPrimary}
+
+		sparkJobJSON, err := utils.MarshalToString(sparkJob)
+		require.NoError(t, err)
+		structObj := structpb.Struct{}
+		require.NoError(t, stdlibUtils.UnmarshalStringToPb(sparkJobJSON, &structObj))
+		taskTemplate := &core.TaskTemplate{
+			Id:     &core.Identifier{Name: "spark-custom-pod-template"},
+			Type:   "container",
+			Target: &core.TaskTemplate_Container{Container: &core.Container{Image: testImage, Args: testArgs, Env: dummyEnvVars}},
+			Custom: &structObj,
+		}
+
+		resource, err := sparkResourceHandler{}.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, false))
+		require.NoError(t, err)
+		return resource.(*sj.SparkApplication), driverPodSpec, executorPodSpec
 	}
 
-	taskCtx := dummySparkTaskContext(taskTemplate, false)
-	resource, err := sparkResourceHandler{}.BuildResource(context.TODO(), taskCtx)
-	require.NoError(t, err)
-	sparkApp := resource.(*sj.SparkApplication)
+	t.Run("passed through verbatim", func(t *testing.T) {
+		sparkApp, driverPodSpec, executorPodSpec := build(t, defaultDriverPrimaryContainerName, defaultExecutorPrimaryContainerName)
 
-	for _, tc := range []struct {
-		role     string
-		expected *corev1.PodSpec
-		template *corev1.PodTemplateSpec
-	}{
-		{"driver", driverPodSpec, sparkApp.Spec.Driver.Template},
-		{"executor", executorPodSpec, sparkApp.Spec.Executor.Template},
-	} {
-		require.NotNil(t, tc.template, "%s template missing", tc.role)
-		require.Len(t, tc.template.Spec.Containers, 1, "%s template was rewritten", tc.role)
-		assert.Equal(t, tc.expected.Containers[0].Name, tc.template.Spec.Containers[0].Name)
-		assert.Equal(t, tc.expected.Containers[0].Command, tc.template.Spec.Containers[0].Command,
-			"%s custom pod spec must be passed through verbatim", tc.role)
-		assert.Equal(t, tc.expected.Containers[0].Args, tc.template.Spec.Containers[0].Args)
-	}
+		for _, tc := range []struct {
+			role     string
+			expected *corev1.PodSpec
+			template *corev1.PodTemplateSpec
+		}{
+			{"driver", driverPodSpec, sparkApp.Spec.Driver.Template},
+			{"executor", executorPodSpec, sparkApp.Spec.Executor.Template},
+		} {
+			require.NotNil(t, tc.template, "%s template missing", tc.role)
+			require.Len(t, tc.template.Spec.Containers, 1, "%s template was rewritten", tc.role)
+			assert.Equal(t, tc.expected.Containers[0].Name, tc.template.Spec.Containers[0].Name)
+			assert.Equal(t, tc.expected.Containers[0].Command, tc.template.Spec.Containers[0].Command,
+				"%s custom pod spec must be passed through verbatim", tc.role)
+			assert.Equal(t, tc.expected.Containers[0].Args, tc.template.Spec.Containers[0].Args)
+		}
+	})
 
-	// The plugin does not choose a custom pod spec's primary container, so it does not tell
-	// Spark which one to adopt either -- that stays Spark's own first-container default.
-	assert.NotContains(t, sparkApp.Spec.SparkConf, sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName)
-	assert.NotContains(t, sparkApp.Spec.SparkConf, sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName)
+	t.Run("declared primary container names the one Spark adopts", func(t *testing.T) {
+		sparkApp, _, _ := build(t, defaultDriverPrimaryContainerName, defaultExecutorPrimaryContainerName)
+
+		assert.Equal(t, defaultDriverPrimaryContainerName,
+			sparkApp.Spec.SparkConf[sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName])
+		assert.Equal(t, defaultExecutorPrimaryContainerName,
+			sparkApp.Spec.SparkConf[sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName])
+	})
+
+	t.Run("no declared primary container leaves the conf unset", func(t *testing.T) {
+		sparkApp, _, _ := build(t, "", "")
+
+		// Spark's own first-container default applies, exactly as before this plugin set the conf.
+		assert.NotContains(t, sparkApp.Spec.SparkConf, sparkOpCommon.SparkKubernetesDriverPodTemplateContainerName)
+		assert.NotContains(t, sparkApp.Spec.SparkConf, sparkOpCommon.SparkKubernetesExecutorPodTemplateContainerName)
+	})
 }

--- a/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/spark/spark_test.go
@@ -1532,15 +1532,20 @@ func TestDefaultSparkVersionSatisfiesOperator(t *testing.T) {
 		"an unset spark-version is expected to lose the comparison; the default exists to avoid it")
 }
 
-// TestBuildResourcePodTemplateDropsTaskEntrypoint covers the driver failing with
-// "No such option '--properties-file'". Spark adopts a container from the template and writes
-// its own driver arguments onto it, but leaves command alone -- it expects the image entrypoint
-// to consume them. With the task entrypoint still in command the kubelet runs
-// `a0 <task args> driver --properties-file ...` and the task CLI rejects Spark's flags.
+// TestBuildResourcePodTemplateRenamesTaskContainer covers two things the operator and Spark
+// require of the template's task container.
 //
-// The task arguments must survive on spec.arguments, which is how spark-submit passes them to
-// the application; only the container-level copy goes away.
-func TestBuildResourcePodTemplateDropsTaskEntrypoint(t *testing.T) {
+// The name: the operator's mutating webhook patches the container it finds by name and leaves
+// the pod alone when none matches (findContainer in internal/webhook/sparkpod_defaulter.go), and
+// the plugin's own log links and pod demystification look for the same driver name. Under the
+// task's container name all of that misses.
+//
+// The entrypoint: Spark writes its own arguments onto this container but leaves command alone,
+// expecting the image entrypoint to consume them. With the task entrypoint still there the
+// kubelet runs `a0 <task args> driver --properties-file ...` and the task CLI fails with
+// "No such option '--properties-file'". The task arguments must survive on spec.arguments,
+// which is how spark-submit passes them to the application.
+func TestBuildResourcePodTemplateRenamesTaskContainer(t *testing.T) {
 	assert.NoError(t, setSparkConfig(&Config{EnablePodTemplate: true}))
 	assert.NoError(t, config.SetK8sPluginConfig(defaultPluginConfig()))
 	setPodTemplateSupportedForTest(true)
@@ -1558,22 +1563,89 @@ func TestBuildResourcePodTemplateDropsTaskEntrypoint(t *testing.T) {
 
 	for _, tc := range []struct {
 		role     string
+		expected string
 		template *corev1.PodTemplateSpec
 	}{
-		{"driver", sparkApp.Spec.Driver.Template},
-		{"executor", sparkApp.Spec.Executor.Template},
+		{"driver", defaultDriverPrimaryContainerName, sparkApp.Spec.Driver.Template},
+		{"executor", defaultExecutorPrimaryContainerName, sparkApp.Spec.Executor.Template},
 	} {
 		require.NotNil(t, tc.template, "%s template missing", tc.role)
-		templateContainer, err := flytek8s.GetContainer(&tc.template.Spec, primary.Name)
-		require.NoError(t, err, "%s template lost the primary container", tc.role)
-		assert.Nil(t, templateContainer.Command, "%s template must not carry the task entrypoint", tc.role)
-		assert.Nil(t, templateContainer.Args, "%s template must not carry the task args", tc.role)
 
-		// Sidecars keep theirs: Spark leaves every other container in the template alone.
+		taskContainer, err := flytek8s.GetContainer(&tc.template.Spec, tc.expected)
+		require.NoErrorf(t, err, "%s template has no %q container", tc.role, tc.expected)
+		assert.Nil(t, taskContainer.Command, "%s template must not carry the task entrypoint", tc.role)
+		assert.Nil(t, taskContainer.Args, "%s template must not carry the task args", tc.role)
+
+		_, err = flytek8s.GetContainer(&tc.template.Spec, primary.Name)
+		assert.Errorf(t, err, "%s template still carries the task container name", tc.role)
+
+		// Sidecars are left alone: only the container Spark adopts is rewritten.
 		sidecar, err := flytek8s.GetContainer(&tc.template.Spec, "secondary")
 		require.NoError(t, err)
 		assert.NotEmpty(t, sidecar.Args, "%s template dropped a sidecar's args", tc.role)
 	}
 
 	assert.Equal(t, testArgs, sparkApp.Spec.Arguments, "task args must still reach spark-submit")
+}
+
+// TestBuildResourcePodTemplateCustomPodSpecUntouched pins the other half of the contract: a
+// user-supplied driver/executor pod spec is written against what the operator generates, so it
+// already carries the operator's container names and never the task entrypoint. It is passed
+// through verbatim -- the rewrite above applies only to Flyte's own pod spec.
+func TestBuildResourcePodTemplateCustomPodSpecUntouched(t *testing.T) {
+	assert.NoError(t, setSparkConfig(&Config{EnablePodTemplate: true}))
+	assert.NoError(t, config.SetK8sPluginConfig(defaultPluginConfig()))
+	setPodTemplateSupportedForTest(true)
+
+	customPodSpec := func(name string) *corev1.PodSpec {
+		return &corev1.PodSpec{Containers: []corev1.Container{{
+			Name:    name,
+			Image:   testImage,
+			Command: []string{"user-entrypoint"},
+			Args:    []string{"--user-flag"},
+		}}}
+	}
+	driverPodSpec := customPodSpec(defaultDriverPrimaryContainerName)
+	executorPodSpec := customPodSpec(defaultExecutorPrimaryContainerName)
+
+	driverPodSpecPb, err := utils.MarshalObjToStruct(driverPodSpec)
+	require.NoError(t, err)
+	executorPodSpecPb, err := utils.MarshalObjToStruct(executorPodSpec)
+	require.NoError(t, err)
+
+	sparkJob := dummySparkCustomObj(dummySparkConf)
+	sparkJob.DriverPod = &core.K8SPod{PodSpec: driverPodSpecPb, PrimaryContainerName: defaultDriverPrimaryContainerName}
+	sparkJob.ExecutorPod = &core.K8SPod{PodSpec: executorPodSpecPb, PrimaryContainerName: defaultExecutorPrimaryContainerName}
+
+	sparkJobJSON, err := utils.MarshalToString(sparkJob)
+	require.NoError(t, err)
+	structObj := structpb.Struct{}
+	require.NoError(t, stdlibUtils.UnmarshalStringToPb(sparkJobJSON, &structObj))
+	taskTemplate := &core.TaskTemplate{
+		Id:     &core.Identifier{Name: "spark-custom-pod-untouched"},
+		Type:   "container",
+		Target: &core.TaskTemplate_Container{Container: &core.Container{Image: testImage, Args: testArgs, Env: dummyEnvVars}},
+		Custom: &structObj,
+	}
+
+	taskCtx := dummySparkTaskContext(taskTemplate, false)
+	resource, err := sparkResourceHandler{}.BuildResource(context.TODO(), taskCtx)
+	require.NoError(t, err)
+	sparkApp := resource.(*sj.SparkApplication)
+
+	for _, tc := range []struct {
+		role     string
+		expected *corev1.PodSpec
+		template *corev1.PodTemplateSpec
+	}{
+		{"driver", driverPodSpec, sparkApp.Spec.Driver.Template},
+		{"executor", executorPodSpec, sparkApp.Spec.Executor.Template},
+	} {
+		require.NotNil(t, tc.template, "%s template missing", tc.role)
+		require.Len(t, tc.template.Spec.Containers, 1, "%s template was rewritten", tc.role)
+		assert.Equal(t, tc.expected.Containers[0].Name, tc.template.Spec.Containers[0].Name)
+		assert.Equal(t, tc.expected.Containers[0].Command, tc.template.Spec.Containers[0].Command,
+			"%s custom pod spec must be passed through verbatim", tc.role)
+		assert.Equal(t, tc.expected.Containers[0].Args, tc.template.Spec.Containers[0].Args)
+	}
 }


### PR DESCRIPTION
## Tracking issue

Related to #7822, #7850

## Why are the changes needed?

Every Spark task fails in the driver on clusters where the pod template path is active. Observed on the demo cluster:

```
Non-spark-on-k8s command provided, proceeding in pass-through mode...
+ exec /usr/bin/tini -s -- a0 --inputs s3://.../inputs.pb --outputs-path s3://... \
    ... mod spark_example instance hello_spark_nested \
    driver --properties-file /opt/spark/conf/spark.properties \
    --class org.apache.spark.deploy.PythonRunner local:///opt/venv/bin/runtime.py a0 --inputs ...

Usage: a0 [OPTIONS] [RESOLVER_ARGS]...
Error: No such option '--properties-file'
```

Read the exec'd line in two halves:

| segment | origin |
|---|---|
| `a0 <task args>` | container **command**, from the pod template Flyte sends |
| `driver --properties-file … --class …PythonRunner … a0 <task args>` | container **args**, written by Spark (trailing part is `spec.arguments`) |

Spark adopts one container from the template as the driver/executor and overwrites its `args`, but deliberately leaves `command` alone — it expects the image's ENTRYPOINT to consume `driver …`. Flyte's container carries the task entrypoint in `command`, so the kubelet runs `command + args` and hands Spark's flags to the task CLI. The image entrypoint says the same thing in its first line: it saw `a0` where it expected `driver`/`executor`, so it passed everything through.

The legacy field path never hit this, because `SparkPodSpec` has no command/args fields at all — the entrypoint only became reachable when #7822 started sending the full pod spec as a template.

## What changes were proposed in this pull request?

In `createSparkPodSpec`, rewrite the task container of the template Flyte builds — and only that one:

1. **Rename it** to `spark-kubernetes-driver` / `spark-kubernetes-executor`. The operator's mutating webhook patches the container it finds by name and leaves the pod alone when none matches (`findContainer`, `internal/webhook/sparkpod_defaulter.go:743-757`), so under the task's own container name every volume, mount and env the operator manages is silently dropped. The plugin already assumed the driver name elsewhere — `getDriverPodLogContext` and `DemystifyFailedOrPendingPod` both look for `defaultDriverPrimaryContainerName` (`spark.go:487,489,599`) — and nothing was producing a container by that name.
2. **Clear `Command`/`Args`.** On this container the entrypoint belongs to Spark.
3. **Name it in `spark.kubernetes.{driver,executor}.podTemplateContainerName`.** Spark keeps whatever name the template gives the container it adopts — `BasicDriverFeatureStep.scala:104` is `.withName(Option(pod.container.getName).getOrElse(DEFAULT_DRIVER_CONTAINER_NAME))`, so the default only applies to an unnamed container. The rename settles the operator's webhook, but Spark's own selection is separate: with that conf unset it adopts the *first* container in the template and treats the rest as sidecars, so a pod template ordering a sidecar ahead of the task container has Spark run the sidecar as the driver.

All three are scoped to Flyte's own pod spec. A custom driver/executor pod spec is written against what the operator generates, so it already carries these names and never the task entrypoint — it is passed through verbatim, now structurally (an `else` branch) rather than relying on the name lookup happening to miss. Those specs are expected to name their container the way the operator and Spark do, so the container Spark adopts is `spark-kubernetes-driver` / `spark-kubernetes-executor` either way — which is why `podTemplateContainerName` is simply that constant rather than something plumbed back out of the pod-spec builder.

The names now come from the operator's own constants rather than a repeated literal, so the rename, the log links and the webhook cannot drift apart:

```go
defaultDriverPrimaryContainerName   = sparkOpCommon.SparkDriverContainerName
defaultExecutorPrimaryContainerName = sparkOpCommon.Spark3DefaultExecutorContainerName
```

Task arguments are unaffected where they matter: they still reach the application via `spec.arguments`, which is how spark-submit has always passed them. Only the container-level copy goes away, and sidecars are untouched.

One implementation note for reviewers: the loop is indexed rather than using `flytek8s.GetContainer`, which returns `&container` from a `for _, container := range` — a pointer to the range copy, so writes through it are discarded. My first cut used it and the new test caught it; that helper is read-only in practice and is arguably worth fixing separately.

## How was this patch tested?

Two new tests:

- `TestBuildResourcePodTemplateRenamesTaskContainer` — builds a task with a command, args and a sidecar, then asserts on both driver and executor templates that the container is renamed to the operator's name, has no `command`/`args`, that the task's container name is gone, that the sidecar kept its args, and that `spec.arguments` still carries the task args.
- `TestBuildResourcePodTemplateCustomPodSpec` — a user-supplied driver/executor pod spec keeps its container name, command and args, and the `podTemplateContainerName` confs still name the operator's containers.

Both also assert the `podTemplateContainerName` confs, and `TestBuildResourcePodTemplateGating` now checks they appear only on the template path.

```
$ go test ./flyteplugins/go/tasks/plugins/k8s/spark/... -count=1
ok  	github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/spark	0.651s
$ go test ./flyteplugins/... -count=1     # no failures
```

Both fail without the fix — the entrypoint half reports the shipped symptom, and dropping just the rename reports:

```
Messages: driver template has no "spark-kubernetes-driver" container
```

### Labels

fixed

## Check all the applicable boxes

- [x] I updated the documentation accordingly. *(n/a)*
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

- #7822 — pass driver/executor pod specs through as the pod template (introduced the path this fixes)
- #7850 — declare spec.sparkVersion on SparkApplications that carry a pod template

https://claude.ai/code/session_01UCd3Y6KWUMQRu7bRF5RMZU




