### PR TITLE
feat(sentry): count deploy_task, deploy_app and deploy_trigger server-side

### DIFF
--- a/app/setup.go
+++ b/app/setup.go
@@ -52,12 +52,9 @@ func Setup(ctx context.Context, sc *stdlibapp.SetupContext) error {
 		return fmt.Errorf("creating otel interceptor: %w", err)
 	}
 
-	// Sentry is on by default with the hardcoded DSN; FLYTE_DISABLE_SENTRY=true opts out.
 	interceptors := []connect.Interceptor{otelInterceptor}
 	if sentryutils.Init(ctx, otelServiceName) {
 		interceptors = append(interceptors, sentryutils.Interceptor(sentryOperations))
-		// Sentry sends async; flush buffered events/metrics on shutdown so they
-		// aren't lost when the pod stops.
 		sc.AddWorker("app-sentry-flush", func(ctx context.Context) error {
 			<-ctx.Done()
 			sentryutils.Flush()

--- a/app/setup.go
+++ b/app/setup.go
@@ -10,6 +10,7 @@ import (
 	stdlibapp "github.com/flyteorg/flyte/v2/flytestdlib/app"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/otelutils"
+	"github.com/flyteorg/flyte/v2/flytestdlib/sentryutils"
 
 	appconfig "github.com/flyteorg/flyte/v2/app/config"
 	appinternal "github.com/flyteorg/flyte/v2/app/internal"
@@ -18,6 +19,12 @@ import (
 )
 
 const otelServiceName = "app-service"
+
+// sentryOperations names the procedures worth counting, so an OSS count can be
+// compared against the same operation counted by the SDK.
+var sentryOperations = map[string]string{
+	appconnect.AppServiceCreateProcedure: "deploy_app",
+}
 
 // SetupInternal registers the data plane InternalAppService on the SetupContext mux.
 // It must be called before Setup so the proxy can reach /internal/... on the same mux.
@@ -45,6 +52,19 @@ func Setup(ctx context.Context, sc *stdlibapp.SetupContext) error {
 		return fmt.Errorf("creating otel interceptor: %w", err)
 	}
 
+	// Sentry is on by default with the hardcoded DSN; FLYTE_DISABLE_SENTRY=true opts out.
+	interceptors := []connect.Interceptor{otelInterceptor}
+	if sentryutils.Init(ctx, otelServiceName) {
+		interceptors = append(interceptors, sentryutils.Interceptor(sentryOperations))
+		// Sentry sends async; flush buffered events/metrics on shutdown so they
+		// aren't lost when the pod stops.
+		sc.AddWorker("app-sentry-flush", func(ctx context.Context) error {
+			<-ctx.Done()
+			sentryutils.Flush()
+			return nil
+		})
+	}
+
 	internalAppURL := cfg.InternalAppServiceURL
 	if sc.BaseURL != "" {
 		internalAppURL = sc.BaseURL
@@ -58,7 +78,7 @@ func Setup(ctx context.Context, sc *stdlibapp.SetupContext) error {
 
 	appSvc := service.NewAppService(internalClient, cfg.CacheTTL)
 
-	path, handler := appconnect.NewAppServiceHandler(appSvc, connect.WithInterceptors(otelInterceptor))
+	path, handler := appconnect.NewAppServiceHandler(appSvc, connect.WithInterceptors(interceptors...))
 	sc.Mux.Handle(path, handler)
 	logger.Infof(ctx, "Mounted AppService at %s", path)
 

--- a/app/setup.go
+++ b/app/setup.go
@@ -20,8 +20,6 @@ import (
 
 const otelServiceName = "app-service"
 
-// sentryOperations names the procedures worth counting, so an OSS count can be
-// compared against the same operation counted by the SDK.
 var sentryOperations = map[string]string{
 	appconnect.AppServiceCreateProcedure: "deploy_app",
 }

--- a/flytestdlib/sentryutils/sentryutils.go
+++ b/flytestdlib/sentryutils/sentryutils.go
@@ -20,9 +20,7 @@ import (
 // dsn is hardcoded and is not user configuration
 const dsn = "https://d0e3f0a470b8e1333411eff583cf4004@o4507249423810560.ingest.us.sentry.io/4511135180128256"
 
-// operationMetric is the counter every instrumented operation increments. The
-// SDK emits the same metric name and "operation" attribute values, so an OSS
-// count subtracted from an SDK count gives the non-OSS share of that operation.
+// operationMetric is the counter every instrumented operation increments.
 const operationMetric = "flyte.operation"
 
 var (

--- a/flytestdlib/sentryutils/sentryutils.go
+++ b/flytestdlib/sentryutils/sentryutils.go
@@ -37,8 +37,7 @@ func Disabled() bool {
 }
 
 // Init initializes the process-wide Sentry client and reports whether
-// reporting is on. Several services call it while setting up; the client is
-// global, so the first caller wins and names the environment.
+// reporting is on.
 func Init(ctx context.Context, environment string) bool {
 	initOnce.Do(func() {
 		if Disabled() {

--- a/flytestdlib/sentryutils/sentryutils.go
+++ b/flytestdlib/sentryutils/sentryutils.go
@@ -1,0 +1,102 @@
+// Package sentryutils reports Flyte operation counts and server-side failures
+// to Sentry. The DSN is hardcoded and is not user configuration;
+// FLYTE_DISABLE_SENTRY=true opts out.
+package sentryutils
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/attribute"
+
+	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
+)
+
+// dsn is hardcoded and is not user configuration
+const dsn = "https://d0e3f0a470b8e1333411eff583cf4004@o4507249423810560.ingest.us.sentry.io/4511135180128256"
+
+// operationMetric is the counter every instrumented operation increments. The
+// SDK emits the same metric name and "operation" attribute values, so an OSS
+// count subtracted from an SDK count gives the non-OSS share of that operation.
+const operationMetric = "flyte.operation"
+
+var (
+	initOnce sync.Once
+	enabled  bool
+)
+
+// Disabled honors FLYTE_DISABLE_SENTRY, unset or unparsable means enabled.
+func Disabled() bool {
+	disabled, _ := strconv.ParseBool(os.Getenv("FLYTE_DISABLE_SENTRY"))
+	return disabled
+}
+
+// Init initializes the process-wide Sentry client and reports whether
+// reporting is on. Several services call it while setting up; the client is
+// global, so the first caller wins and names the environment.
+func Init(ctx context.Context, environment string) bool {
+	initOnce.Do(func() {
+		if Disabled() {
+			return
+		}
+		if err := sentry.Init(sentry.ClientOptions{Dsn: dsn, Environment: environment}); err != nil {
+			logger.Errorf(ctx, "failed to initialize sentry, continuing without it: %v", err)
+			return
+		}
+		enabled = true
+		logger.Infof(ctx, "Sentry error reporting enabled")
+	})
+	return enabled
+}
+
+// Flush drains buffered events and metrics. Sentry sends async, so a service
+// shutting down has to wait or lose whatever is still queued.
+func Flush() {
+	sentry.Flush(2 * time.Second)
+}
+
+// Count records n successful occurrences of operation.
+func Count(ctx context.Context, operation string, n int64) {
+	sentry.NewMeter(ctx).Count(operationMetric, n, sentry.WithAttributes(
+		attribute.String("operation", operation),
+		attribute.String("status", "success"),
+	))
+}
+
+// Interceptor counts one operation per call for each procedure in operations
+// (keyed by procedure, valued by operation name) and reports server-side
+// failures as exceptions. Client-caused errors (invalid argument, not found,
+// ...) are intentionally not reported as exceptions.
+func Interceptor(operations map[string]string) connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			resp, err := next(ctx, req)
+			operation, ok := operations[req.Spec().Procedure]
+			if !ok {
+				return resp, err
+			}
+			attrs := []attribute.Builder{attribute.String("operation", operation)}
+			if err != nil {
+				attrs = append(attrs,
+					attribute.String("status", "error"),
+					attribute.String("error_code", connect.CodeOf(err).String()),
+				)
+				switch connect.CodeOf(err) {
+				case connect.CodeInternal, connect.CodeUnknown, connect.CodeDataLoss:
+					hub := sentry.CurrentHub().Clone()
+					hub.Scope().SetTag("procedure", req.Spec().Procedure)
+					hub.CaptureException(err)
+				}
+			} else {
+				attrs = append(attrs, attribute.String("status", "success"))
+			}
+			sentry.NewMeter(ctx).Count(operationMetric, 1, sentry.WithAttributes(attrs...))
+			return resp, err
+		}
+	}
+}

--- a/runs/setup.go
+++ b/runs/setup.go
@@ -34,8 +34,6 @@ import (
 
 const otelServiceName = "runs-service"
 
-// sentryOperations names the procedures worth counting, so an OSS count can be
-// compared against the same operation counted by the SDK.
 var sentryOperations = map[string]string{
 	workflowconnect.RunServiceCreateRunProcedure:        "create_run",
 	taskconnect.TaskServiceDeployTaskProcedure:          "deploy_task",
@@ -82,12 +80,9 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 		return fmt.Errorf("creating otel interceptor: %w", err)
 	}
 
-	// Sentry is on by default with the hardcoded DSN; FLYTE_DISABLE_SENTRY=true opts out.
 	interceptors := []connect.Interceptor{otelInterceptor}
 	if sentryutils.Init(ctx, otelServiceName) {
 		interceptors = append(interceptors, sentryutils.Interceptor(sentryOperations), deployTriggerInterceptor())
-		// Sentry sends async; flush buffered events/metrics on shutdown so they
-		// aren't lost when the pod stops.
 		sc.AddWorker("sentry-flush", func(ctx context.Context) error {
 			<-ctx.Done()
 			sentryutils.Flush()

--- a/runs/setup.go
+++ b/runs/setup.go
@@ -5,22 +5,20 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
-	"strconv"
 	"time"
 
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
-	"github.com/getsentry/sentry-go"
-	"github.com/getsentry/sentry-go/attribute"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/app"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/otelutils"
+	"github.com/flyteorg/flyte/v2/flytestdlib/sentryutils"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/actions/actionsconnect"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/auth/authconnect"
 	projectpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/project"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/project/projectconnect"
+	taskpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task/taskconnect"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/trigger/triggerconnect"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow/workflowconnect"
@@ -36,40 +34,27 @@ import (
 
 const otelServiceName = "runs-service"
 
-// sentryDSN is hardcoded and is not user configuration
-const sentryDSN = "https://d0e3f0a470b8e1333411eff583cf4004@o4507249423810560.ingest.us.sentry.io/4511135180128256"
-
-// sentryDisabled honors FLYTE_DISABLE_SENTRY, unset or unparsable means enabled.
-func sentryDisabled() bool {
-	disabled, _ := strconv.ParseBool(os.Getenv("FLYTE_DISABLE_SENTRY"))
-	return disabled
+// sentryOperations names the procedures worth counting, so an OSS count can be
+// compared against the same operation counted by the SDK.
+var sentryOperations = map[string]string{
+	workflowconnect.RunServiceCreateRunProcedure:        "create_run",
+	taskconnect.TaskServiceDeployTaskProcedure:          "deploy_task",
+	triggerconnect.TriggerServiceDeployTriggerProcedure: "deploy_trigger",
 }
 
-// sentryInterceptor reports server-side CreateRun failures to Sentry and emits
-// a "flyte.operation" counter per CreateRun call. Client-caused errors
-// (invalid argument, not found, ...) are intentionally not reported as
-// exceptions.
-func sentryInterceptor() connect.UnaryInterceptorFunc {
+// deployTriggerInterceptor counts the triggers that ride along inside a
+// DeployTask request. TriggerService.DeployTrigger only ever sees standalone
+// trigger deploys, so without this the deploy_trigger count misses every
+// trigger declared on a task.
+func deployTriggerInterceptor() connect.UnaryInterceptorFunc {
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			resp, err := next(ctx, req)
-			if req.Spec().Procedure == workflowconnect.RunServiceCreateRunProcedure {
-				attrs := []attribute.Builder{attribute.String("operation", "create_run")}
-				if err != nil {
-					attrs = append(attrs,
-						attribute.String("status", "error"),
-						attribute.String("error_code", connect.CodeOf(err).String()),
-					)
-					switch connect.CodeOf(err) {
-					case connect.CodeInternal, connect.CodeUnknown, connect.CodeDataLoss:
-						hub := sentry.CurrentHub().Clone()
-						hub.Scope().SetTag("procedure", req.Spec().Procedure)
-						hub.CaptureException(err)
-					}
-				} else {
-					attrs = append(attrs, attribute.String("status", "success"))
-				}
-				sentry.NewMeter(ctx).Count("flyte.operation", 1, sentry.WithAttributes(attrs...))
+			if err != nil || req.Spec().Procedure != taskconnect.TaskServiceDeployTaskProcedure {
+				return resp, err
+			}
+			if deployReq, ok := req.Any().(*taskpb.DeployTaskRequest); ok && len(deployReq.Triggers) > 0 {
+				sentryutils.Count(ctx, "deploy_trigger", int64(len(deployReq.Triggers)))
 			}
 			return resp, err
 		}
@@ -98,24 +83,16 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	}
 
 	// Sentry is on by default with the hardcoded DSN; FLYTE_DISABLE_SENTRY=true opts out.
-	runsInterceptors := []connect.Interceptor{otelInterceptor}
-	if !sentryDisabled() {
-		if err := sentry.Init(sentry.ClientOptions{
-			Dsn:         sentryDSN,
-			Environment: otelServiceName,
-		}); err != nil {
-			logger.Errorf(ctx, "failed to initialize sentry, continuing without it: %v", err)
-		} else {
-			runsInterceptors = append(runsInterceptors, sentryInterceptor())
-			// Sentry sends async; flush buffered events/metrics on shutdown so they
-			// aren't lost when the pod stops.
-			sc.AddWorker("sentry-flush", func(ctx context.Context) error {
-				<-ctx.Done()
-				sentry.Flush(2 * time.Second)
-				return nil
-			})
-			logger.Infof(ctx, "Sentry error reporting enabled")
-		}
+	interceptors := []connect.Interceptor{otelInterceptor}
+	if sentryutils.Init(ctx, otelServiceName) {
+		interceptors = append(interceptors, sentryutils.Interceptor(sentryOperations), deployTriggerInterceptor())
+		// Sentry sends async; flush buffered events/metrics on shutdown so they
+		// aren't lost when the pod stops.
+		sc.AddWorker("sentry-flush", func(ctx context.Context) error {
+			<-ctx.Done()
+			sentryutils.Flush()
+			return nil
+		})
 	}
 
 	repo, err := repository.NewRepository(sc.DB, cfg.Database)
@@ -157,7 +134,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	runsSvc := service.NewRunService(repo, actionsClient, projectClient, cfg.StoragePrefix, sc.DataStore, abortReconciler, cfg.AuthMetadata.ExternalAuthServerBaseURL, cfg.TrustForwardedIdentityHeaders, cfg.IdentityHeaders)
 	taskSvc := service.NewTaskService(repo, projectClient)
 
-	runsPath, runsHandler := workflowconnect.NewRunServiceHandler(runsSvc, connect.WithInterceptors(runsInterceptors...))
+	runsPath, runsHandler := workflowconnect.NewRunServiceHandler(runsSvc, connect.WithInterceptors(interceptors...))
 	sc.Mux.Handle(runsPath, runsHandler)
 	logger.Infof(ctx, "Mounted RunService at %s", runsPath)
 
@@ -165,7 +142,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	sc.Mux.Handle(internalRunsPath, internalRunsHandler)
 	logger.Infof(ctx, "Mounted InternalRunService at %s", internalRunsPath)
 
-	taskPath, taskHandler := taskconnect.NewTaskServiceHandler(taskSvc, connect.WithInterceptors(otelInterceptor))
+	taskPath, taskHandler := taskconnect.NewTaskServiceHandler(taskSvc, connect.WithInterceptors(interceptors...))
 	sc.Mux.Handle(taskPath, taskHandler)
 	logger.Infof(ctx, "Mounted TaskService at %s", taskPath)
 
@@ -187,7 +164,7 @@ func Setup(ctx context.Context, sc *app.SetupContext) error {
 	logger.Infof(ctx, "Mounted OAuth2 metadata at /.well-known/oauth-authorization-server")
 
 	triggerSvc := service.NewTriggerService(repo)
-	triggerPath, triggerHandler := triggerconnect.NewTriggerServiceHandler(triggerSvc, connect.WithInterceptors(otelInterceptor))
+	triggerPath, triggerHandler := triggerconnect.NewTriggerServiceHandler(triggerSvc, connect.WithInterceptors(interceptors...))
 	sc.Mux.Handle(triggerPath, triggerHandler)
 	logger.Infof(ctx, "Mounted TriggerService at %s", triggerPath)
 

--- a/runs/setup_test.go
+++ b/runs/setup_test.go
@@ -1,0 +1,106 @@
+package runs
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/getsentry/sentry-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flyteorg/flyte/v2/flytestdlib/sentryutils"
+	taskpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task/taskconnect"
+)
+
+type stubTaskService struct {
+	taskconnect.UnimplementedTaskServiceHandler
+	err error
+}
+
+func (s *stubTaskService) DeployTask(context.Context, *connect.Request[taskpb.DeployTaskRequest]) (*connect.Response[taskpb.DeployTaskResponse], error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return connect.NewResponse(&taskpb.DeployTaskResponse{}), nil
+}
+
+// newTestClient serves svc behind the same interceptor chain Setup installs.
+func newTestClient(t *testing.T, svc taskconnect.TaskServiceHandler) taskconnect.TaskServiceClient {
+	t.Helper()
+	mux := http.NewServeMux()
+	path, handler := taskconnect.NewTaskServiceHandler(svc, connect.WithInterceptors(
+		sentryutils.Interceptor(sentryOperations),
+		deployTriggerInterceptor(),
+	))
+	mux.Handle(path, handler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return taskconnect.NewTaskServiceClient(srv.Client(), srv.URL)
+}
+
+// bindMockTransport swaps in a Sentry client whose events the test can read.
+func bindMockTransport(t *testing.T) *sentry.MockTransport {
+	t.Helper()
+	transport := &sentry.MockTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://key@example.invalid/1",
+		Transport: transport,
+	})
+	require.NoError(t, err)
+	hub := sentry.CurrentHub()
+	previous := hub.Client()
+	hub.BindClient(client)
+	t.Cleanup(func() { hub.BindClient(previous) })
+	return transport
+}
+
+// The interceptors must never change what the caller sees.
+func TestDeployTaskInterceptorsArePassThrough(t *testing.T) {
+	bindMockTransport(t)
+	client := newTestClient(t, &stubTaskService{})
+
+	resp, err := client.DeployTask(context.Background(), connect.NewRequest(&taskpb.DeployTaskRequest{
+		Triggers: []*taskpb.TaskTrigger{{Name: "nightly"}, {Name: "on-merge"}},
+	}))
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+// A server-side failure is worth an exception; a client-caused one is not.
+func TestDeployTaskReportsOnlyServerSideFailures(t *testing.T) {
+	for name, tc := range map[string]struct {
+		code       connect.Code
+		wantEvents int
+	}{
+		"internal":         {connect.CodeInternal, 1},
+		"unknown":          {connect.CodeUnknown, 1},
+		"invalid argument": {connect.CodeInvalidArgument, 0},
+		"not found":        {connect.CodeNotFound, 0},
+	} {
+		t.Run(name, func(t *testing.T) {
+			transport := bindMockTransport(t)
+			client := newTestClient(t, &stubTaskService{
+				err: connect.NewError(tc.code, errors.New("boom")),
+			})
+
+			_, err := client.DeployTask(context.Background(), connect.NewRequest(&taskpb.DeployTaskRequest{}))
+			require.Error(t, err)
+			assert.Len(t, transport.Events(), tc.wantEvents)
+		})
+	}
+}
+
+// The operation names have to match the ones flyte-sdk emits, or an OSS count
+// cannot be subtracted from an SDK count.
+func TestSentryOperationNamesMatchSDK(t *testing.T) {
+	assert.Equal(t, map[string]string{
+		"/flyteidl2.workflow.RunService/CreateRun":        "create_run",
+		"/flyteidl2.task.TaskService/DeployTask":          "deploy_task",
+		"/flyteidl2.trigger.TriggerService/DeployTrigger": "deploy_trigger",
+	}, sentryOperations)
+}

--- a/runs/setup_test.go
+++ b/runs/setup_test.go
@@ -95,8 +95,8 @@ func TestDeployTaskReportsOnlyServerSideFailures(t *testing.T) {
 	}
 }
 
-// The operation names have to match the ones flyte-sdk emits, or an OSS count
-// cannot be subtracted from an SDK count.
+// The operation names have to match the ones flyte-sdk emits, or the two
+// sides of the same counter do not line up.
 func TestSentryOperationNamesMatchSDK(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		"/flyteidl2.workflow.RunService/CreateRun":        "create_run",


### PR DESCRIPTION
## Why are the changes needed?

`flyte.operation` is emitted from two places: this repo's Connect interceptor, and flyte-sdk. The SDK counts `create_run`, `deploy_task`, `deploy_app` and `deploy_trigger`; the server only counted `create_run`. So the metric can tell us how many runs are created and nothing about deploys, and the two sides can't be compared for any operation but runs.

Counting the same four operations server-side closes that gap.

There is a second gap. Triggers declared on a task ride along **inside** `DeployTaskRequest` — `TriggerService.DeployTrigger` is only reached by a standalone `flyte.remote.Trigger.create()` call, which nothing in the SDK does on its own. So a counter attached to `DeployTrigger` alone reports close to zero regardless of how many triggers are deployed. (Confirmed on the Sentry side: 0 `deploy_trigger` events in 90 days against 83K `deploy_task`.) The triggers carried by `DeployTask` have to be counted too.

## What changes were proposed in this pull request?

- **New `flytestdlib/sentryutils`** — the Sentry wiring that was inline in `runs/setup.go`, extracted so `app` can share it. Behavior is unchanged: same hardcoded DSN, same `FLYTE_DISABLE_SENTRY` opt-out, same policy of reporting only `Internal`/`Unknown`/`DataLoss` as exceptions. `Init` is a `sync.Once` because the Sentry client is process-global and more than one service now initializes it.
- **`Interceptor` takes a procedure → operation map** instead of hardcoding `CreateRun`.
- **`runs/setup.go`** — the map now covers `RunService.CreateRun`, `TaskService.DeployTask` and `TriggerService.DeployTrigger`, and the interceptor is attached to the Task and Trigger handlers (previously otel-only).
- **`deployTriggerInterceptor`** counts `len(req.Triggers)` on a successful `DeployTask`, closing the gap described above.
- **`app/setup.go`** — `AppService.Create` → `deploy_app`.

No behavior change for callers: the interceptors only observe, and every failure path in `sentryutils` is already non-fatal.

## How was this patch tested?

New `runs/setup_test.go` drives `DeployTask` through the real interceptor chain over an `httptest` server:

- `TestDeployTaskInterceptorsArePassThrough` — a request carrying triggers returns the handler's response unchanged.
- `TestDeployTaskReportsOnlyServerSideFailures` — table over `Internal`/`Unknown` (1 Sentry event) vs `InvalidArgument`/`NotFound` (0), read off a `sentry.MockTransport`.
- `TestSentryOperationNamesMatchSDK` — pins the operation strings. They have to match the ones flyte-sdk emits for the two sides to line up, and nothing else would catch a rename.

```
go build ./...                # clean
go test ./runs/ ./app/...     # ok
```

### Labels

**added**

## Related PRs

- flyteorg/flyte-sdk#1436 — the matching SDK-side fix for the `deploy_trigger` undercount. `deploy_trigger` counts only line up between the SDK and this repo once both land.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
