### PR TITLE
fix(plugins/ray): stop RayJobs sharing the plugin's start-params map

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"regexp"
 	"strconv"
 	"strings"
@@ -113,11 +114,14 @@ func (rayJobResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsC
 
 	cfg := GetConfig()
 
+	// Copy rather than alias: the resolved map is filled in below and handed to the RayJob CR, so
+	// aliasing would let one task's start params edit the shared plugin config and every other CR
+	// built from those defaults.
 	headNodeRayStartParams := make(map[string]string)
 	if rayJob.RayCluster.HeadGroupSpec != nil && rayJob.RayCluster.HeadGroupSpec.RayStartParams != nil {
-		headNodeRayStartParams = rayJob.RayCluster.HeadGroupSpec.RayStartParams
+		maps.Copy(headNodeRayStartParams, rayJob.RayCluster.HeadGroupSpec.RayStartParams)
 	} else if headNode := cfg.Defaults.HeadNode; len(headNode.StartParameters) > 0 {
-		headNodeRayStartParams = headNode.StartParameters
+		maps.Copy(headNodeRayStartParams, headNode.StartParameters)
 	}
 
 	if _, exist := headNodeRayStartParams[IncludeDashboard]; !exist {
@@ -284,9 +288,9 @@ func constructRayJob(ctx context.Context, taskCtx pluginsCore.TaskExecutionConte
 
 		workerNodeRayStartParams := make(map[string]string)
 		if spec.RayStartParams != nil {
-			workerNodeRayStartParams = spec.RayStartParams
+			maps.Copy(workerNodeRayStartParams, spec.RayStartParams)
 		} else if workerNode := cfg.Defaults.WorkerNode; len(workerNode.StartParameters) > 0 {
-			workerNodeRayStartParams = workerNode.StartParameters
+			maps.Copy(workerNodeRayStartParams, workerNode.StartParameters)
 		}
 
 		if _, exist := workerNodeRayStartParams[NodeIPAddress]; !exist {

--- a/flyteplugins/go/tasks/plugins/k8s/ray/sharedconfig_repro_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/sharedconfig_repro_test.go
@@ -1,0 +1,130 @@
+package ray
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/plugins"
+)
+
+// A RayJob that leaves RayStartParams unset — the common case, and the one that falls through to
+// the plugin's configured defaults.
+func rayJobWithoutStartParams() *plugins.RayJob {
+	return &plugins.RayJob{
+		RayCluster: &plugins.RayCluster{
+			HeadGroupSpec:   &plugins.HeadGroupSpec{},
+			WorkerGroupSpec: []*plugins.WorkerGroupSpec{{GroupName: workerGroupName, Replicas: 1, MinReplicas: 1, MaxReplicas: 1}},
+		},
+		ShutdownAfterJobFinishes: true,
+		TtlSecondsAfterFinished:  120,
+	}
+}
+
+// Other tests in this package replace the global config without restoring it, which can leave the
+// default start parameters empty and skip the branch under test. Pin a config with non-empty
+// defaults, and put the original back afterwards.
+func withDefaultStartParams(t *testing.T) {
+	origConfig := *GetConfig()
+	t.Cleanup(func() { assert.NoError(t, SetConfig(&origConfig)) })
+
+	assert.NoError(t, SetConfig(&Config{
+		Defaults: DefaultConfig{
+			HeadNode: NodeConfig{
+				StartParameters: map[string]string{DisableUsageStatsStartParameter: "true"},
+				IPAddress:       "$MY_POD_IP",
+			},
+			WorkerNode: NodeConfig{
+				StartParameters: map[string]string{DisableUsageStatsStartParameter: "true"},
+				IPAddress:       "$MY_POD_IP",
+			},
+		},
+	}))
+}
+
+// BuildResource must not write into the plugin's shared configuration.
+//
+// When a task leaves RayStartParams unset, the head/worker start params fall back to
+// cfg.Defaults.{Head,Worker}Node.StartParameters. Those maps belong to the process-wide plugin
+// config, so filling in include-dashboard / node-ip-address / dashboard-host mutates config that
+// every later task reads.
+func TestBuildResource_DoesNotMutateSharedConfig(t *testing.T) {
+	withDefaultStartParams(t)
+
+	cfg := GetConfig()
+	headDefaults := cfg.Defaults.HeadNode.StartParameters
+	workerDefaults := cfg.Defaults.WorkerNode.StartParameters
+
+	headBefore := maps.Clone(headDefaults)
+	workerBefore := maps.Clone(workerDefaults)
+
+	handler := rayJobResourceHandler{}
+	taskTemplate := dummyRayTaskTemplate("ray-id", rayJobWithoutStartParams())
+	taskCtx := dummyRayTaskContext(taskTemplate, resourceRequirements, nil, "", serviceAccount)
+
+	_, err := handler.BuildResource(context.TODO(), taskCtx)
+	assert.NoError(t, err)
+
+	assert.Equal(t, headBefore, cfg.Defaults.HeadNode.StartParameters,
+		"BuildResource mutated the shared head-node start parameters")
+	assert.Equal(t, workerBefore, cfg.Defaults.WorkerNode.StartParameters,
+		"BuildResource mutated the shared worker-node start parameters")
+}
+
+// Two RayJobs built independently must not share one RayStartParams map.
+//
+// constructRayJob assigns the resolved start params straight into the CR
+// (RayStartParams: headNodeRayStartParams). When they came from the shared defaults, every CR
+// built that way — and the plugin config itself — is the same map instance.
+func TestBuildResource_RayJobsDoNotShareStartParamsMap(t *testing.T) {
+	withDefaultStartParams(t)
+
+	handler := rayJobResourceHandler{}
+
+	build := func() *rayv1.RayJob {
+		taskTemplate := dummyRayTaskTemplate("ray-id", rayJobWithoutStartParams())
+		taskCtx := dummyRayTaskContext(taskTemplate, resourceRequirements, nil, "", serviceAccount)
+		obj, err := handler.BuildResource(context.TODO(), taskCtx)
+		assert.NoError(t, err)
+		return obj.(*rayv1.RayJob)
+	}
+
+	first := build()
+	second := build()
+
+	first.Spec.RayClusterSpec.HeadGroupSpec.RayStartParams["num-cpus"] = "tainted-by-first-rayjob"
+
+	assert.NotContains(t, second.Spec.RayClusterSpec.HeadGroupSpec.RayStartParams, "num-cpus",
+		"editing one RayJob's start params changed another RayJob's")
+	assert.NotContains(t, GetConfig().Defaults.HeadNode.StartParameters, "num-cpus",
+		"editing a RayJob's start params changed the shared plugin config")
+}
+
+// Start params a task supplies for itself reach the CR alongside the defaults the plugin injects.
+// Covers the head and worker branches that copy the task's own map rather than the config's.
+func TestBuildResource_KeepsTaskSuppliedStartParams(t *testing.T) {
+	withDefaultStartParams(t)
+
+	rayJob := rayJobWithoutStartParams()
+	rayJob.RayCluster.HeadGroupSpec.RayStartParams = map[string]string{"num-cpus": "1"}
+	rayJob.RayCluster.WorkerGroupSpec[0].RayStartParams = map[string]string{"num-cpus": "2"}
+
+	handler := rayJobResourceHandler{}
+	taskTemplate := dummyRayTaskTemplate("ray-id", rayJob)
+	taskCtx := dummyRayTaskContext(taskTemplate, resourceRequirements, nil, "", serviceAccount)
+
+	obj, err := handler.BuildResource(context.TODO(), taskCtx)
+	assert.NoError(t, err)
+	built := obj.(*rayv1.RayJob)
+
+	head := built.Spec.RayClusterSpec.HeadGroupSpec.RayStartParams
+	assert.Equal(t, "1", head["num-cpus"])
+	assert.Contains(t, head, NodeIPAddress)
+
+	worker := built.Spec.RayClusterSpec.WorkerGroupSpecs[0].RayStartParams
+	assert.Equal(t, "2", worker["num-cpus"])
+	assert.Contains(t, worker, NodeIPAddress)
+}


### PR DESCRIPTION
## Tracking issue

Related to https://github.com/flyteorg/flyte/pull/7851, the same fix on `master`. @pingsutw asked for the v2 plugin on `main` as well.

## Why are the changes needed?

A RayJob task that doesn't set `RayStartParams` falls back to the plugin's configured defaults. `BuildResource` doesn't copy them — it assigns `cfg.Defaults.HeadNode.StartParameters` to the local variable and then writes `include-dashboard`, `node-ip-address` and `dashboard-host` straight into it. That same map is what gets assigned to the CR.

So the plugin config and every RayJob built from the defaults are one map. The plugin rewrites its own configuration on the first build, and editing one RayJob's start params lands in every other RayJob and in the config:

```
editing one RayJob's start params changed another RayJob's
  map[... "num-cpus":"tainted-by-first-rayjob"]
```

Concurrent builds write that map unsynchronised, which is a data race on a plain Go map. The defaults ship non-empty (`disable-usage-stats`), so the `len(...) > 0` branch is taken on stock configuration. Worker groups take the same path.

## What changes were proposed in this pull request?

Copy the resolved start parameters into the map `BuildResource` already allocates, instead of reassigning the variable to the caller's or the config's map. Applies to the head group and to each worker group. The `make(map[string]string)` above was already being discarded by the reassignment, so this just uses it.

## How was this patch tested?

`sharedconfig_repro_test.go`, ported to the v2 API. The first two fail without the change:

- `TestBuildResource_DoesNotMutateSharedConfig` — builds once with no `RayStartParams` set, compares the config's head and worker start parameters against a snapshot taken beforehand.
- `TestBuildResource_RayJobsDoNotShareStartParamsMap` — builds two RayJobs, writes a key into the first one's head start params, checks the second RayJob and the plugin config are untouched.
- `TestBuildResource_KeepsTaskSuppliedStartParams` — a task supplying its own head and worker params still gets them through to the CR alongside the injected defaults.

Each test pins its own config, because other tests in the package call `SetConfig` without restoring it, which can empty the defaults and skip the branch under test.

To reproduce, check the file out at the base branch to drop the fix, then restore it:

```
git checkout upstream/main -- flyteplugins/go/tasks/plugins/k8s/ray/ray.go
go test ./flyteplugins/go/tasks/plugins/k8s/ray/ -count=1 -run TestBuildResource_ -v
git checkout HEAD -- flyteplugins/go/tasks/plugins/k8s/ray/ray.go
go test ./flyteplugins/go/tasks/plugins/k8s/ray/ -count=1 -run TestBuildResource_ -v
go test ./flyteplugins/go/tasks/plugins/k8s/... -count=1
```

<details><summary>Raw output</summary>

Without the fix:

```
    Error:      Not equal:
                expected: map[string]string{"disable-usage-stats":"true"}
                actual  : map[string]string{"dashboard-host":"", "disable-usage-stats":"true", "include-dashboard":"false", "node-ip-address":"$MY_POD_IP"}
    Messages:   BuildResource mutated the shared head-node start parameters
    Error:      Not equal:
                expected: map[string]string{"disable-usage-stats":"true"}
                actual  : map[string]string{"disable-usage-stats":"true", "node-ip-address":"$MY_POD_IP"}
    Messages:   BuildResource mutated the shared worker-node start parameters
--- FAIL: TestBuildResource_DoesNotMutateSharedConfig (0.00s)
    Error:      map[string]string{"dashboard-host":"", "disable-usage-stats":"true", "include-dashboard":"false", "node-ip-address":"$MY_POD_IP", "num-cpus":"tainted-by-first-rayjob"} should not contain "num-cpus"
    Messages:   editing one RayJob's start params changed another RayJob's
    Error:      map[string]string{"dashboard-host":"", "disable-usage-stats":"true", "include-dashboard":"false", "node-ip-address":"$MY_POD_IP", "num-cpus":"tainted-by-first-rayjob"} should not contain "num-cpus"
    Messages:   editing a RayJob's start params changed the shared plugin config
--- FAIL: TestBuildResource_RayJobsDoNotShareStartParamsMap (0.00s)
--- PASS: TestBuildResource_KeepsTaskSuppliedStartParams (0.00s)
FAIL
FAIL	github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/ray	0.994s
```

With the fix:

```
--- PASS: TestBuildResource_DoesNotMutateSharedConfig (0.00s)
--- PASS: TestBuildResource_RayJobsDoNotShareStartParamsMap (0.00s)
--- PASS: TestBuildResource_KeepsTaskSuppliedStartParams (0.00s)
PASS
ok  	github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/ray	0.842s
```

The wider run is green too:

```
ok  	github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/clustered	1.080s
ok  	github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/dask	1.738s
ok  	github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/kfoperators/common	2.439s
ok  	github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/kfoperators/mpi	3.769s
ok  	github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch	4.630s
ok  	github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow	5.245s
ok  	github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/pod	3.100s
ok  	github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/ray	6.714s
ok  	github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/plugins/k8s/spark	5.961s
```

</details>

`go vet` and `gofmt -l` are clean on the touched files.

### Labels

fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flyte/pull/7851
