### PR TITLE
feat(executor): stamp run, action, attempt and task-name labels on task pods

### DIFF
--- a/executor/pkg/plugin/k8s/plugin_manager_test.go
+++ b/executor/pkg/plugin/k8s/plugin_manager_test.go
@@ -245,3 +245,44 @@ func TestAddObjectMetadata_ManagedLabel(t *testing.T) {
 		assert.Equal(t, flytek8s.ManagedLabelValue, pod.GetLabels()[flytek8s.ManagedLabelKey])
 	})
 }
+
+func TestAddObjectMetadata_StampsTaskLabelsOnPod(t *testing.T) {
+	taskExecID := pluginsCoreMock.NewTaskExecutionID(t)
+	taskExecID.EXPECT().GetGeneratedName().Return("run-name-action-name-0")
+
+	taskMeta := pluginsCoreMock.NewTaskExecutionMetadata(t)
+	taskMeta.EXPECT().GetNamespace().Return("project-development")
+	taskMeta.EXPECT().GetAnnotations().Return(map[string]string{"flyte/annotation": "value"})
+	taskMeta.EXPECT().GetLabels().Return(map[string]string{
+		"project":   "project",
+		"domain":    "development",
+		"run":       "run-name",
+		"action":    "action-name",
+		"attempt":   "2",
+		"task-name": "my_module.my_task",
+	})
+	taskMeta.EXPECT().GetTaskExecutionID().Return(taskExecID)
+	taskMeta.EXPECT().GetOwnerReference().Return(metav1.OwnerReference{Name: "owner"})
+
+	plugin := k8sMocks.NewPlugin(t)
+	plugin.EXPECT().GetProperties().Return(k8s.PluginProperties{})
+
+	pm := NewPluginManager("test", plugin, nil)
+
+	pod := &v1.Pod{}
+	pm.addObjectMetadata(taskMeta, pod, &config.K8sPluginConfig{
+		DefaultLabels: map[string]string{"cluster": "default"},
+	})
+
+	assert.Equal(t, map[string]string{
+		"cluster":   "default",
+		"project":   "project",
+		"domain":    "development",
+		"run":       "run-name",
+		"action":    "action-name",
+		"attempt":   "2",
+		"task-name": "my_module.my_task",
+	}, pod.GetLabels())
+	assert.Equal(t, "project-development", pod.GetNamespace())
+	assert.Equal(t, "run-name-action-name-0", pod.GetName())
+}

--- a/executor/pkg/plugin/task_exec_metadata.go
+++ b/executor/pkg/plugin/task_exec_metadata.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"fmt"
+	"strconv"
 
 	"google.golang.org/protobuf/proto"
 	v1 "k8s.io/api/core/v1"
@@ -22,6 +23,24 @@ import (
 
 var _ pluginsCore.TaskExecutionMetadata = &taskExecutionMetadata{}
 var _ pluginsCore.TaskExecutionID = &taskExecutionID{}
+
+const (
+	// Labels stamped on task pods so external per-pod metrics (DCGM, cAdvisor,
+	// kube-state-metrics) can be joined back to Flyte semantics. They are bare
+	// names, matching the project/domain/organization labels already injected,
+	// which kube-state-metrics surfaces as `label_run`, `label_action`,
+	// `label_attempt` and `label_task_name`.
+
+	// RunLabel carries the name of the run that owns the action.
+	RunLabel = "run"
+	// ActionLabel carries the name of the action the pod is executing.
+	ActionLabel = "action"
+	// AttemptLabel carries the 1-based attempt number, so the pod of a retried
+	// action can be told apart from the pods of its earlier attempts.
+	AttemptLabel = "attempt"
+	// TaskNameLabel carries the registered task name from the task template.
+	TaskNameLabel = "task-name"
+)
 
 type taskExecutionID struct {
 	generatedName string
@@ -114,6 +133,13 @@ func NewTaskExecutionMetadata(ta *flyteorgv1.TaskAction) (pluginsCore.TaskExecut
 	maxAttempts := maxAttemptsFromTaskTemplate(ta.Spec.TaskTemplate)
 	taskID := taskIDFromTaskTemplate(ta.Spec.TaskTemplate)
 
+	// Identify the pod in Flyte terms so per-pod metric series can be joined back to
+	// the run, action and attempt that produced them.
+	setSanitizedLabel(injectLabels, RunLabel, ta.Spec.RunName)
+	setSanitizedLabel(injectLabels, ActionLabel, ta.Spec.ActionName)
+	injectLabels[AttemptLabel] = strconv.FormatUint(uint64(retryAttempt)+1, 10)
+	setSanitizedLabel(injectLabels, TaskNameLabel, taskID.GetName())
+
 	return &taskExecutionMetadata{
 		ownerID: types.NamespacedName{
 			Name:      ta.Name,
@@ -151,6 +177,14 @@ func NewTaskExecutionMetadata(ta *flyteorgv1.TaskAction) (pluginsCore.TaskExecut
 		securityContext: securityContext,
 		serviceAccount:  resolveServiceAccount(securityContext, executorconfig.GetConfig().DefaultK8sServiceAccount),
 	}, nil
+}
+
+// setSanitizedLabel stamps a label only when the value survives sanitization, so pods
+// never carry an empty label that would look like a real, blank value to a metrics query.
+func setSanitizedLabel(labels map[string]string, key, value string) {
+	if sanitized := pluginsUtils.SanitizeLabelValue(value); sanitized != "" {
+		labels[key] = sanitized
+	}
 }
 
 func buildGeneratedName(ta *flyteorgv1.TaskAction) string {

--- a/executor/pkg/plugin/task_exec_metadata_test.go
+++ b/executor/pkg/plugin/task_exec_metadata_test.go
@@ -1,17 +1,20 @@
 package plugin
 
 import (
-	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
 	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/encoding"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s"
+	flytesecret "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/secret"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
 )
 
@@ -178,4 +181,90 @@ func TestNewTaskExecutionMetadata_ManagedLabel(t *testing.T) {
 		require.Equal(t, flytek8s.ManagedLabelValue,
 			meta.GetLabels()[flytek8s.ManagedLabelKey])
 	})
+}
+
+func TestNewTaskExecutionMetadata_StampsIdentifyingLabels(t *testing.T) {
+	taskTemplate, err := proto.Marshal(&core.TaskTemplate{
+		Id: &core.Identifier{Name: "my_module.my_task"},
+	})
+	require.NoError(t, err)
+
+	taskAction := &flyteorgv1.TaskAction{
+		Spec: flyteorgv1.TaskActionSpec{
+			Project:       "project",
+			Domain:        "development",
+			RunName:       "run-name",
+			ActionName:    "action-name",
+			RunOutputBase: "s3://bucket/run",
+			TaskTemplate:  taskTemplate,
+		},
+		Status: flyteorgv1.TaskActionStatus{Attempts: 3},
+	}
+
+	meta, err := NewTaskExecutionMetadata(taskAction)
+	require.NoError(t, err)
+
+	labels := meta.GetLabels()
+	require.Equal(t, "run-name", labels[RunLabel])
+	require.Equal(t, "action-name", labels[ActionLabel])
+	// Attempts are 1-based, and the third attempt is the second retry.
+	require.Equal(t, "3", labels[AttemptLabel])
+	require.Equal(t, "my_module.my_task", labels[TaskNameLabel])
+
+	// The labels injected for secret scoping are still there.
+	require.Equal(t, "project", labels[flytesecret.ProjectLabel])
+	require.Equal(t, "development", labels[flytesecret.DomainLabel])
+}
+
+func TestNewTaskExecutionMetadata_LabelsAreSanitizedAndOptional(t *testing.T) {
+	longName := strings.Repeat("a", 70)
+	taskTemplate, err := proto.Marshal(&core.TaskTemplate{
+		Id: &core.Identifier{Name: longName},
+	})
+	require.NoError(t, err)
+
+	taskAction := &flyteorgv1.TaskAction{
+		Spec: flyteorgv1.TaskActionSpec{
+			Project:      "project",
+			Domain:       "development",
+			RunName:      "run/name:with bad chars",
+			TaskTemplate: taskTemplate,
+		},
+	}
+
+	meta, err := NewTaskExecutionMetadata(taskAction)
+	require.NoError(t, err)
+
+	labels := meta.GetLabels()
+	require.Equal(t, "run-name-with-bad-chars", labels[RunLabel])
+	require.Len(t, labels[TaskNameLabel], 63)
+	// A first attempt that has not been recorded yet still reads as attempt 1.
+	require.Equal(t, "1", labels[AttemptLabel])
+	// An empty action name is left unstamped rather than stamped blank.
+	require.NotContains(t, labels, ActionLabel)
+
+	for key, value := range labels {
+		require.Empty(t, validation.IsValidLabelValue(value), "label %s has invalid value %q", key, value)
+	}
+}
+
+func TestNewTaskExecutionMetadata_CRDLabelsDoNotClobberIdentifyingLabels(t *testing.T) {
+	taskAction := &flyteorgv1.TaskAction{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{RunLabel: "spoofed", "team": "data"},
+		},
+		Spec: flyteorgv1.TaskActionSpec{
+			Project:    "project",
+			Domain:     "development",
+			RunName:    "run-name",
+			ActionName: "action-name",
+		},
+	}
+
+	meta, err := NewTaskExecutionMetadata(taskAction)
+	require.NoError(t, err)
+
+	labels := meta.GetLabels()
+	require.Equal(t, "run-name", labels[RunLabel])
+	require.Equal(t, "data", labels["team"])
 }

--- a/flyteplugins/go/tasks/pluginmachinery/utils/labels.go
+++ b/flyteplugins/go/tasks/pluginmachinery/utils/labels.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"regexp"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+var labelInvalidCharsRegex = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+var labelInvalidLeadingRegex = regexp.MustCompile(`^[^a-zA-Z0-9]`)
+var labelInvalidTrailingRegex = regexp.MustCompile(`[^a-zA-Z0-9]$`)
+
+// SanitizeLabelValue coerces an arbitrary string into a valid Kubernetes label value:
+// at most 63 characters, made up of alphanumerics, dots, dashes and underscores, and
+// beginning and ending with an alphanumeric character. An empty input stays empty so
+// callers can decide whether to stamp the label at all.
+func SanitizeLabelValue(value string) string {
+	if value == "" {
+		return ""
+	}
+
+	sanitized := labelInvalidCharsRegex.ReplaceAllString(value, "-")
+	if len(sanitized) > validation.LabelValueMaxLength {
+		sanitized = sanitized[:validation.LabelValueMaxLength]
+	}
+	if labelInvalidLeadingRegex.MatchString(sanitized) {
+		sanitized = "x" + sanitized[1:]
+	}
+	if labelInvalidTrailingRegex.MatchString(sanitized) {
+		sanitized = sanitized[:len(sanitized)-1] + "x"
+	}
+	return sanitized
+}

--- a/flyteplugins/go/tasks/pluginmachinery/utils/labels_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/utils/labels_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestSanitizeLabelValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"empty stays empty", "", ""},
+		{"already valid", "my-run.name_1", "my-run.name_1"},
+		{"invalid characters", "my_module.my task/v2", "my_module.my-task-v2"},
+		{"leading non alphanumeric", "-leading", "xleading"},
+		{"trailing non alphanumeric", "trailing-", "trailingx"},
+		{"unicode", "täsk", "t-sk"},
+		{"truncated to 63", strings.Repeat("a", 70), strings.Repeat("a", 63)},
+		{"truncation cannot leave a trailing dash", strings.Repeat("a", 62) + "-b", strings.Repeat("a", 62) + "x"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := SanitizeLabelValue(test.value)
+			assert.Equal(t, test.expected, got)
+			if got != "" {
+				assert.Empty(t, validation.IsValidLabelValue(got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why are the changes needed?

The v2 executor stamps only `organization`, `project`, and `domain` on task pods. Flyte v1 also stamped `execution-id`, `task-name`, `node-id`, which is what every metrics-to-task join depends on: kube-state-metrics turns pod labels into `kube_pod_labels{label_*}` series that DCGM/cAdvisor metrics can be joined against to attribute utilization to a run, action, and attempt.

Without these labels, any per-run resource or GPU metrics query has to fall back to pod-name regexes, which breaks down for multi-pod tasks (Ray workers, JobSet replicas). This is also groundwork for GPU health/observability: per-GPU DCGM series need to be attributable to a run/action/attempt.

## What changes were proposed in this pull request?

- `executor/pkg/plugin/task_exec_metadata.go`: inject `run`, `action`, `attempt` (1-based, matching the `attempt-N` pod-name suffix) and `task-name` into the labels applied to every task pod. Empty values are skipped so a pod never carries a blank label that would read as a real value in PromQL. CRD-supplied labels cannot override these keys.
- `flyteplugins/go/tasks/pluginmachinery/utils/labels.go` (new): exported `SanitizeLabelValue` — truncates to 63 chars, replaces disallowed characters, and fixes leading/trailing characters after truncation so a cut can't leave a dangling `-`. The repo had two unexported copies (`clustered/util.go`, `secret/imagepull_kubernetes_utils.go`), neither reachable from the executor.

Label keys are bare (unprefixed) to match the existing `project`/`domain`/`organization` labels, so they surface as `label_run`/`label_action`/`label_attempt`/`label_task_name` in kube-state-metrics.

## How was this patch tested?

- New unit tests: labels stamped on the metadata; sanitization/truncation with every value asserted against `k8s.io/apimachinery/pkg/util/validation.IsValidLabelValue`; CRD labels cannot spoof `run`; `addObjectMetadata` lands all labels on a real `v1.Pod` alongside `cfg.DefaultLabels`; sanitizer edge cases.
- `go build ./...`, `go vet`, `gofmt` clean. `go test ./executor/pkg/plugin/... ./flyteplugins/go/tasks/pluginmachinery/utils/...` pass. (`executor/pkg/controller` `TestControllers` fails identically on `main` due to a missing local envtest binary — unrelated.)

### Labels

- **added**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)