### PR TITLE
fix: render msgpack IO with non-string map keys instead of base64

### DIFF
--- a/dataproxy/converter/literal_json_converter.go
+++ b/dataproxy/converter/literal_json_converter.go
@@ -1,6 +1,7 @@
 package converter
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -642,7 +643,15 @@ func literalTypeToJsonSchema(ctx context.Context, literalType *core.LiteralType)
 				}
 				return metadataMap, nil
 			}
-			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("missing metadata for struct type"))
+			// A STRUCT carries no metadata when the SDK had no schema to attach,
+			// e.g. dict[int, int] — which is a STRUCT only because a LiteralMap
+			// can't hold non-string keys. Erroring here fails the whole
+			// conversion (the console then shows "Unable to load outputs"), so
+			// fall back to an open object instead.
+			return map[string]any{
+				"type":                 "object",
+				"additionalProperties": true,
+			}, nil
 		case core.SimpleType_ERROR:
 			return errorTypeToJsonSchema(), nil
 		case core.SimpleType_BINARY:
@@ -1047,6 +1056,63 @@ func findMatchingUnionVariant(ctx context.Context, value any, variants []*core.L
 	return nil, nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%s", errMsg))
 }
 
+// decodeMsgpackToJSON decodes msgpack bytes (the encoding the SDK uses for
+// STRUCT literals: dataclasses, pydantic models, and dicts that aren't
+// map[string, T]) into JSON-compatible values.
+//
+// The default msgpack.Unmarshal into `any` decodes maps as map[string]any and
+// therefore fails outright on non-string keys, e.g. a task returning
+// dict[int, int] — which is exactly why those outputs used to fall back to an
+// unreadable base64 blob. Decode maps untyped instead and stringify the keys,
+// since JSON objects only have string keys.
+func decodeMsgpackToJSON(data []byte) (any, error) {
+	dec := msgpack.NewDecoder(bytes.NewReader(data))
+	dec.SetMapDecoder(func(d *msgpack.Decoder) (any, error) { return d.DecodeUntypedMap() })
+	// Loose decoding yields int64/float64/string rather than sized types
+	// (int8, uint16, ...), which structpb doesn't accept.
+	dec.UseLooseInterfaceDecoding(true)
+
+	var decoded any
+	if err := dec.Decode(&decoded); err != nil {
+		return nil, err
+	}
+	return jsonSafeValue(decoded), nil
+}
+
+// jsonSafeValue rewrites the output of an untyped msgpack decode into values
+// structpb (and thus JSON) accepts: map keys become strings and raw bytes
+// become base64.
+func jsonSafeValue(v any) any {
+	switch t := v.(type) {
+	case map[any]any:
+		m := make(map[string]any, len(t))
+		for k, val := range t {
+			key, ok := k.(string)
+			if !ok {
+				key = fmt.Sprint(k)
+			}
+			m[key] = jsonSafeValue(val)
+		}
+		return m
+	case map[string]any:
+		m := make(map[string]any, len(t))
+		for k, val := range t {
+			m[k] = jsonSafeValue(val)
+		}
+		return m
+	case []any:
+		s := make([]any, len(t))
+		for i, val := range t {
+			s[i] = jsonSafeValue(val)
+		}
+		return s
+	case []byte:
+		return base64.StdEncoding.EncodeToString(t)
+	default:
+		return v
+	}
+}
+
 // literalToJsonValues converts a core.Literal to a JSON-compatible value.
 func literalToJsonValues(ctx context.Context, literal *core.Literal) (any, error) {
 	if literal == nil {
@@ -1085,8 +1151,7 @@ func literalToJsonValues(ctx context.Context, literal *core.Literal) (any, error
 		case *core.Scalar_Binary:
 			// Try to decode as msgpack, fallback to base64 encoded string
 			if s.Binary != nil && len(s.Binary.GetValue()) > 0 {
-				var decoded any
-				err := msgpack.Unmarshal(s.Binary.GetValue(), &decoded)
+				decoded, err := decodeMsgpackToJSON(s.Binary.GetValue())
 				if err == nil {
 					return decoded, nil
 				}

--- a/dataproxy/converter/literal_json_converter_test.go
+++ b/dataproxy/converter/literal_json_converter_test.go
@@ -2,11 +2,13 @@ package converter
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -625,4 +627,53 @@ func createSimpleDataclassLiteralSingleType() ([]*task.NamedLiteral, *core.Varia
 	})
 
 	return literals, variableMap
+}
+
+func TestMsgpackBinaryLiteralToJson(t *testing.T) {
+	// STRUCT is what the SDK uses for dicts it can't express as a LiteralMap
+	// (non-string keys) as well as for dataclasses/pydantic models.
+	structVariableMap := makeVariableMap(map[string]*core.Variable{
+		"o0": {Type: &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRUCT}}},
+	})
+
+	binaryLiteral := func(value []byte) []*task.NamedLiteral {
+		return []*task.NamedLiteral{
+			{Name: "o0", Value: &core.Literal{Value: &core.Literal_Scalar{Scalar: &core.Scalar{
+				Value: &core.Scalar_Binary{Binary: &core.Binary{Value: value, Tag: "msgpack"}},
+			}}}},
+		}
+	}
+
+	defaultValue := func(t *testing.T, literals []*task.NamedLiteral) any {
+		t.Helper()
+		result, err := LiteralsToLaunchFormJson(context.Background(), literals, structVariableMap)
+		require.NoError(t, err)
+		properties := result.AsMap()["properties"].(map[string]any)
+		return properties["o0"].(map[string]any)["default"]
+	}
+
+	t.Run("int-keyed map decodes instead of falling back to base64", func(t *testing.T) {
+		// dict[int, int] returned by a real task; keys are stringified for JSON
+		// and numbers land as float64 once through structpb.
+		raw, err := base64.StdEncoding.DecodeString("hQNuBGMBcwVRAl8=")
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string]any{
+			"1": float64(115), "2": float64(95), "3": float64(110), "4": float64(99), "5": float64(81),
+		}, defaultValue(t, binaryLiteral(raw)))
+	})
+
+	t.Run("string-keyed map still decodes", func(t *testing.T) {
+		raw, err := msgpack.Marshal(map[string]any{"a": 1, "nested": map[string]any{"b": true}})
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string]any{
+			"a": float64(1), "nested": map[string]any{"b": true},
+		}, defaultValue(t, binaryLiteral(raw)))
+	})
+
+	t.Run("non-msgpack bytes still fall back to base64", func(t *testing.T) {
+		raw := []byte{0xc1, 0xc1, 0xc1}
+		assert.Equal(t, base64.StdEncoding.EncodeToString(raw), defaultValue(t, binaryLiteral(raw)))
+	})
 }


### PR DESCRIPTION
## Tracking issue

Remove this section if not applicable

## Why are the changes needed?

A task whose output can't be expressed as a `LiteralMap` — anything with non-string keys, e.g. `-> dict[int, int]` — is serialized by the SDK as a msgpack `Binary` scalar under a `STRUCT` type. Rendering one in the UI hits two problems in the translator:

1. `msgpack.Unmarshal` into `any` decodes maps as `map[string]any`, so it errors on the first int key (`msgpack: invalid code=3 decoding string/bytes length`) and falls back to base64. The console then shows an opaque blob:

   ```
   o0: hQNuBGMBcwVRAl8=
   ```

2. `literalTypeToJsonSchema` hard-errors with `missing metadata for struct type` for a `STRUCT` that carries no metadata — which is exactly what the SDK emits for such a dict, since there's no dataclass schema to attach. That fails the entire conversion, so the panel shows "Unable to load outputs" rather than just an ugly value.

## What changes were proposed in this pull request?

- `decodeMsgpackToJSON` decodes maps untyped (`DecodeUntypedMap`) and stringifies the keys — JSON objects only have string keys — so the output above renders as `{"1": 115, "2": 95, "3": 110, "4": 99, "5": 81}`. Loose interface decoding is enabled so numbers come back as `int64`/`float64` rather than sized types (`int8`, `uint16`, …) that `structpb` rejects. `jsonSafeValue` also base64s any raw `[]byte`, the only sensible JSON representation for embedded binary.
- A `STRUCT` with no metadata now falls back to an open object schema instead of erroring.

Non-msgpack bytes keep the existing base64 fallback, and metadata-carrying STRUCTs (dataclasses, pydantic models) are unaffected.

## How was this patch tested?

New `TestMsgpackBinaryLiteralToJson` in `dataproxy/converter/literal_json_converter_test.go`, driving the full `LiteralsToLaunchFormJson` path with a metadata-less `STRUCT` variable (so it covers the schema fallback too):

- the actual base64 payload from a real run (`hQNuBGMBcwVRAl8=`) decodes to `{"1": 115, ...}` instead of falling back to base64
- string-keyed and nested maps still decode as before
- non-msgpack bytes still fall back to base64

```
$ go test ./dataproxy/...
ok  	github.com/flyteorg/flyte/v2/dataproxy	2.431s
ok  	github.com/flyteorg/flyte/v2/dataproxy/config	1.138s
ok  	github.com/flyteorg/flyte/v2/dataproxy/converter	0.797s
ok  	github.com/flyteorg/flyte/v2/dataproxy/logs	1.389s
ok  	github.com/flyteorg/flyte/v2/dataproxy/service	2.551s
```

### Labels

fixed

### Setup process

### Screenshots

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

## Docs link

https://claude.ai/code/session_01Sbi3ptp7Siz8FR73SNFUzP
