### PR TITLE
fix: reference embedded env secrets from pod specs

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -356,37 +357,82 @@ func (i *EmbeddedSecretManagerInjector) upsertEnvVarSecret(
 	pod *corev1.Pod,
 ) (string, error) {
 	k8sSecretName := ToEnvVarK8sName(components)
+	desiredSecret := newEnvVarSecret(k8sSecretName, pod.GetNamespace(), components, secretValue)
+	if err := i.k8sClient.Create(ctx, desiredSecret); err == nil {
+		return k8sSecretName, nil
+	} else if !k8sError.IsAlreadyExists(err) {
+		return "", fmt.Errorf("failed to create env var secret [%s] in namespace [%s]: %w", k8sSecretName, pod.GetNamespace(), err)
+	}
+
 	namespacedName := types.NamespacedName{Name: k8sSecretName, Namespace: pod.GetNamespace()}
 	k8sSecret := &corev1.Secret{}
 	err := i.k8sClient.Get(ctx, namespacedName, k8sSecret)
-	if err != nil && k8sError.IsNotFound(err) {
-		newSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      k8sSecretName,
-				Namespace: pod.GetNamespace(),
-				Labels:    ToEnvVarK8sLabels(components),
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: map[string][]byte{
-				EmbeddedSecretsEnvVarKey: secretValue,
-			},
-		}
-		if err := i.k8sClient.Create(ctx, newSecret); err != nil {
-			return "", fmt.Errorf("failed to create env var secret [%s] in namespace [%s]: %w", k8sSecretName, pod.GetNamespace(), err)
-		}
+	if k8sError.IsNotFound(err) {
+		// Another admission path may have just created the Secret through the API
+		// server while this process's informer cache has not observed it yet. The
+		// pod can safely reference the Secret name in that case.
 		return k8sSecretName, nil
 	} else if err != nil {
-		return "", fmt.Errorf("failed to check for env var secret [%s] in namespace [%s]: %w", k8sSecretName, pod.GetNamespace(), err)
+		return "", fmt.Errorf("failed to get env var secret [%s] in namespace [%s]: %w", k8sSecretName, pod.GetNamespace(), err)
 	}
 
+	if !envVarSecretNeedsPatch(k8sSecret, components, secretValue) {
+		return k8sSecretName, nil
+	}
+
+	originalSecret := k8sSecret.DeepCopy()
+	if k8sSecret.Labels == nil {
+		k8sSecret.Labels = map[string]string{}
+	}
+	for key, value := range ToEnvVarK8sLabels(components) {
+		k8sSecret.Labels[key] = value
+	}
 	if k8sSecret.Data == nil {
 		k8sSecret.Data = map[string][]byte{}
 	}
 	k8sSecret.Data[EmbeddedSecretsEnvVarKey] = secretValue
-	if err := i.k8sClient.Update(ctx, k8sSecret); err != nil {
-		return "", fmt.Errorf("failed to update env var secret [%s] in namespace [%s]: %w", k8sSecretName, pod.GetNamespace(), err)
+	if err := i.k8sClient.Patch(ctx, k8sSecret, client.MergeFrom(originalSecret)); err != nil {
+		return "", fmt.Errorf("failed to patch env var secret [%s] in namespace [%s]: %w", k8sSecretName, pod.GetNamespace(), err)
 	}
 	return k8sSecretName, nil
+}
+
+func newEnvVarSecret(
+	name string,
+	namespace string,
+	components SecretNameComponents,
+	secretValue []byte,
+) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    ToEnvVarK8sLabels(components),
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			EmbeddedSecretsEnvVarKey: secretValue,
+		},
+	}
+}
+
+func envVarSecretNeedsPatch(
+	k8sSecret *corev1.Secret,
+	components SecretNameComponents,
+	secretValue []byte,
+) bool {
+	if k8sSecret.Type != corev1.SecretTypeOpaque {
+		return true
+	}
+	if !bytes.Equal(k8sSecret.Data[EmbeddedSecretsEnvVarKey], secretValue) {
+		return true
+	}
+	for key, value := range ToEnvVarK8sLabels(components) {
+		if k8sSecret.Labels[key] != value {
+			return true
+		}
+	}
+	return false
 }
 
 func (i *EmbeddedSecretManagerInjector) injectAsEnvVar(

--- a/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager.go
@@ -58,6 +58,7 @@ const (
 	SecretNilErrorFormat                                        = "secret %v read as empty from the secret manager"                          // #nosec G101
 	SecretRequirementsErrorFormat                               = "secret read requirements not met due to empty %v field in the pod labels" // #nosec G101
 	SecretSecretNotFoundAcrossAllScopes                         = "secret not found across all scopes"                                       // #nosec G101
+	EmbeddedSecretsEnvVarKey                                    = "value"                                                                    // #nosec G101
 	ErrCodeSecretRequirementsError       stdlibErrors.ErrorCode = "SecretRequirementsError"                                                  // #nosec G101
 	ErrCodeSecretNotFound                stdlibErrors.ErrorCode = "SecretNotFound"                                                           // #nosec G101
 	ErrCodeSecretNotFoundAcrossAllScopes stdlibErrors.ErrorCode = "SecretNotFoundAcrossAllScopes"                                            // #nosec G101
@@ -137,28 +138,28 @@ func encodeSecretName(components *SecretNameComponents) string {
 	return EncodeSecretName(components.Org, components.Domain, components.Project, components.Name)
 }
 
-func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, components *SecretNameComponents) (*SecretValue, string, error) {
+func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, components *SecretNameComponents) (*SecretValue, SecretNameComponents, error) {
 	componentsCopy := *components // Create a copy to avoid modifying the original
 
 	// Compute encoded IDs for each scope in priority order.
 	projectDomainScopedSecret := encodeSecretName(&componentsCopy)
-	projectDomainScopedImagePullSecretName := ToImagePullK8sName(componentsCopy)
+	projectDomainScopedComponents := componentsCopy
 
 	componentsCopy.Project = EmptySecretScope
 	domainScopedSecret := encodeSecretName(&componentsCopy)
-	domainScopedImagePullSecretName := ToImagePullK8sName(componentsCopy)
+	domainScopedComponents := componentsCopy
 
 	componentsCopy.Domain = EmptySecretScope
 	orgScopedSecret := encodeSecretName(&componentsCopy)
-	orgScopedImagePullSecretName := ToImagePullK8sName(componentsCopy)
+	orgScopedComponents := componentsCopy
 
 	scopes := []struct {
-		secretID            string
-		imagePullSecretName string
+		secretID   string
+		components SecretNameComponents
 	}{
-		{projectDomainScopedSecret, projectDomainScopedImagePullSecretName},
-		{domainScopedSecret, domainScopedImagePullSecretName},
-		{orgScopedSecret, orgScopedImagePullSecretName},
+		{projectDomainScopedSecret, projectDomainScopedComponents},
+		{domainScopedSecret, domainScopedComponents},
+		{orgScopedSecret, orgScopedComponents},
 	}
 
 	// Walk scopes in priority order (project+domain → domain → org). For each
@@ -168,7 +169,7 @@ func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, compon
 	for _, scope := range scopes {
 		if cachedValue, err := i.secretCache.Get(ctx, scope.secretID); err == nil {
 			logger.Debugf(ctx, "Found secret [%s] in cache.", scope.secretID)
-			return &cachedValue, scope.imagePullSecretName, nil
+			return &cachedValue, scope.components, nil
 		}
 
 		for _, secretFetcher := range i.secretFetchers {
@@ -177,17 +178,17 @@ func (i *EmbeddedSecretManagerInjector) lookUpSecret(ctx context.Context, compon
 				if cacheErr := i.secretCache.Set(ctx, scope.secretID, *secretValue); cacheErr != nil {
 					logger.Warnf(ctx, "Failed to cache secret [%s]: %v", scope.secretID, cacheErr)
 				}
-				return secretValue, scope.imagePullSecretName, nil
+				return secretValue, scope.components, nil
 			}
 			if !stdlibErrors.IsCausedBy(err, ErrCodeSecretNotFound) {
-				return nil, "", err
+				return nil, SecretNameComponents{}, err
 			}
 			// NotFound from this fetcher — try the next fetcher at the same scope.
 		}
 		// All fetchers reported NotFound at this scope — fall through to the next broader scope.
 	}
 
-	return nil, "", stdlibErrors.Errorf(ErrCodeSecretNotFoundAcrossAllScopes, SecretSecretNotFoundAcrossAllScopes)
+	return nil, SecretNameComponents{}, stdlibErrors.Errorf(ErrCodeSecretNotFoundAcrossAllScopes, SecretSecretNotFoundAcrossAllScopes)
 }
 
 // addImagePullSecretToPod adds an image pull secret to a pod if it doesn't already exist
@@ -296,7 +297,7 @@ func (i *EmbeddedSecretManagerInjector) Inject(
 		return pod, false, err
 	}
 
-	secretValue, k8sImagePullSecretName, err := i.lookUpSecret(ctx, secretNameComponents)
+	secretValue, resolvedSecretNameComponents, err := i.lookUpSecret(ctx, secretNameComponents)
 	if err != nil {
 		return pod, false, err
 	}
@@ -321,7 +322,9 @@ func (i *EmbeddedSecretManagerInjector) Inject(
 			}
 			stringValue = string(secretValue.BinaryValue)
 		}
-		i.injectAsEnvVar(secret, stringValue, pod)
+		if err := i.injectAsEnvVar(ctx, secret, resolvedSecretNameComponents, []byte(stringValue), pod); err != nil {
+			return pod, false, err
+		}
 	case core.Secret_FILE:
 		secretBytes := secretValue.BinaryValue
 		if len(secretValue.StringValue) > 0 {
@@ -335,6 +338,7 @@ func (i *EmbeddedSecretManagerInjector) Inject(
 	}
 
 	if i.cfg.ImagePullSecrets.Enabled {
+		k8sImagePullSecretName := ToImagePullK8sName(resolvedSecretNameComponents)
 		pod, err = i.findAndAddImagePullSecret(ctx, k8sImagePullSecretName, pod)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to add image pull secret [%s]: %v", secretNameComponents.Name, err)
@@ -345,23 +349,84 @@ func (i *EmbeddedSecretManagerInjector) Inject(
 	return pod, true, nil
 }
 
-func (i *EmbeddedSecretManagerInjector) injectAsEnvVar(secret *core.Secret, secretValue string, pod *corev1.Pod) {
+func (i *EmbeddedSecretManagerInjector) upsertEnvVarSecret(
+	ctx context.Context,
+	components SecretNameComponents,
+	secretValue []byte,
+	pod *corev1.Pod,
+) (string, error) {
+	k8sSecretName := ToEnvVarK8sName(components)
+	namespacedName := types.NamespacedName{Name: k8sSecretName, Namespace: pod.GetNamespace()}
+	k8sSecret := &corev1.Secret{}
+	err := i.k8sClient.Get(ctx, namespacedName, k8sSecret)
+	if err != nil && k8sError.IsNotFound(err) {
+		newSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      k8sSecretName,
+				Namespace: pod.GetNamespace(),
+				Labels:    ToEnvVarK8sLabels(components),
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				EmbeddedSecretsEnvVarKey: secretValue,
+			},
+		}
+		if err := i.k8sClient.Create(ctx, newSecret); err != nil {
+			return "", fmt.Errorf("failed to create env var secret [%s] in namespace [%s]: %w", k8sSecretName, pod.GetNamespace(), err)
+		}
+		return k8sSecretName, nil
+	} else if err != nil {
+		return "", fmt.Errorf("failed to check for env var secret [%s] in namespace [%s]: %w", k8sSecretName, pod.GetNamespace(), err)
+	}
+
+	if k8sSecret.Data == nil {
+		k8sSecret.Data = map[string][]byte{}
+	}
+	k8sSecret.Data[EmbeddedSecretsEnvVarKey] = secretValue
+	if err := i.k8sClient.Update(ctx, k8sSecret); err != nil {
+		return "", fmt.Errorf("failed to update env var secret [%s] in namespace [%s]: %w", k8sSecretName, pod.GetNamespace(), err)
+	}
+	return k8sSecretName, nil
+}
+
+func (i *EmbeddedSecretManagerInjector) injectAsEnvVar(
+	ctx context.Context,
+	secret *core.Secret,
+	components SecretNameComponents,
+	secretValue []byte,
+	pod *corev1.Pod,
+) error {
+	k8sSecretName, err := i.upsertEnvVarSecret(ctx, components, secretValue, pod)
+	if err != nil {
+		return err
+	}
+
 	valueEnvVarName := i.parentCfg.SecretEnvVarPrefix + strings.ToUpper(secret.GetKey())
 	if secret.GetEnvVar() != "" {
 		valueEnvVarName = secret.EnvVar
 	}
+	optional := false
 	envVars := []corev1.EnvVar{
 		{
 			Name:  SecretEnvVarPrefix,
 			Value: i.parentCfg.SecretEnvVarPrefix,
 		},
 		{
-			Name:  valueEnvVarName,
-			Value: secretValue,
+			Name: valueEnvVarName,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: k8sSecretName,
+					},
+					Key:      EmbeddedSecretsEnvVarKey,
+					Optional: &optional,
+				},
+			},
 		},
 	}
 	pod.Spec.InitContainers = AppendEnvVars(pod.Spec.InitContainers, envVars...)
 	pod.Spec.Containers = AppendEnvVars(pod.Spec.Containers, envVars...)
+	return nil
 }
 
 func (i *EmbeddedSecretManagerInjector) injectAsFile(secret *core.Secret, secretValue []byte, pod *corev1.Pod) {

--- a/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager_test.go
@@ -40,6 +40,35 @@ func newAlwaysMissCache(t *testing.T) *cacheMocks.CacheInterface[SecretValue] {
 	return m
 }
 
+func expectEnvVarSecretCreate(
+	t *testing.T,
+	mockClient *mocks.MockableControllerRuntimeClient,
+	ctx context.Context,
+	namespace string,
+	components SecretNameComponents,
+	secretValue []byte,
+) string {
+	t.Helper()
+	k8sSecretName := ToEnvVarK8sName(components)
+	mockClient.
+		On("Get", ctx, types.NamespacedName{Name: k8sSecretName, Namespace: namespace}, &corev1.Secret{}).
+		Return(k8sError.NewNotFound(corev1.Resource("secret"), k8sSecretName))
+	mockClient.
+		On("Create", ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      k8sSecretName,
+				Namespace: namespace,
+				Labels:    ToEnvVarK8sLabels(components),
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				EmbeddedSecretsEnvVarKey: secretValue,
+			},
+		}).
+		Return(nil)
+	return k8sSecretName
+}
+
 func TestEmbeddedSecretManagerInjector_Inject(t *testing.T) {
 	ctx = context.Background()
 	gcpClient = &mocks.GCPSecretManagerClient{}
@@ -181,8 +210,21 @@ func TestEmbeddedSecretManagerInjector_Inject(t *testing.T) {
 						{
 							Env: []corev1.EnvVar{
 								{
-									Name:  "_UNION_SECRETID",
-									Value: secretValue,
+									Name: "_UNION_SECRETID",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: ToEnvVarK8sName(SecretNameComponents{
+													Org:     OrganizationLabel,
+													Domain:  "",
+													Project: "",
+													Name:    secretIDKey,
+												}),
+											},
+											Key:      EmbeddedSecretsEnvVarKey,
+											Optional: lo.ToPtr(false),
+										},
+									},
 								},
 								{
 									Name:  SecretEnvVarPrefix,
@@ -209,6 +251,12 @@ func TestEmbeddedSecretManagerInjector_Inject(t *testing.T) {
 			mockClient := &mocks.MockableControllerRuntimeClient{}
 
 			if tt.expectedInjected {
+				expectEnvVarSecretCreate(t, mockClient, ctx, "", SecretNameComponents{
+					Org:     OrganizationLabel,
+					Domain:  "",
+					Project: "",
+					Name:    secretIDKey,
+				}, []byte(secretValue))
 				mockClient.
 					On("Get", ctx, types.NamespacedName{Name: tt.expectedK8sSecretName, Namespace: testReferenceNamespace}, &corev1.Secret{}).
 					Return(k8sError.NewNotFound(corev1.Resource("secret"), tt.expectedK8sSecretName))
@@ -352,6 +400,12 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToOrganization(t *testi
 			}
 
 			mockClient := &mocks.MockableControllerRuntimeClient{}
+			envVarSecretName := expectEnvVarSecretCreate(t, mockClient, ctx, "", SecretNameComponents{
+				Org:     "o-apple",
+				Domain:  "",
+				Project: "",
+				Name:    "secret1",
+			}, []byte("fruits"))
 			kubernetesSecretName := ToImagePullK8sName(SecretNameComponents{
 				Org:     "o-apple",
 				Domain:  "",
@@ -376,7 +430,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToOrganization(t *testi
 			pod, injected, err := injector.Inject(ctx, tt.secret, pod)
 			assert.NoError(t, err)
 			assert.True(t, injected)
-			assert.True(t, podHasSecretInjected(pod, "secret1", "fruits", tt.secret.GetEnvVar()))
+			assert.True(t, podHasSecretInjected(pod, "secret1", envVarSecretName, tt.secret.GetEnvVar()))
 
 		})
 	}
@@ -401,6 +455,12 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToDomain(t *testing.T) 
 	}
 
 	mockClient := &mocks.MockableControllerRuntimeClient{}
+	envVarSecretName := expectEnvVarSecretCreate(t, mockClient, ctx, "", SecretNameComponents{
+		Org:     "o-apple",
+		Domain:  "d-cherry",
+		Project: "",
+		Name:    "secret1",
+	}, []byte("fruits @ domain"))
 	kubernetesSecretName1 := ToImagePullK8sName(SecretNameComponents{
 		Org:     "o-apple",
 		Domain:  "",
@@ -437,7 +497,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToDomain(t *testing.T) 
 	pod, injected, err := injector.Inject(ctx, secret, pod)
 	assert.NoError(t, err)
 	assert.True(t, injected)
-	assert.True(t, podHasSecretInjected(pod, "secret1", "fruits @ domain", ""))
+	assert.True(t, podHasSecretInjected(pod, "secret1", envVarSecretName, ""))
 }
 
 func TestEmbeddedSecretManagerInjector_InjectSecretScopedToProject(t *testing.T) {
@@ -459,6 +519,12 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToProject(t *testing.T)
 	}
 
 	mockClient := &mocks.MockableControllerRuntimeClient{}
+	envVarSecretName := expectEnvVarSecretCreate(t, mockClient, ctx, "", SecretNameComponents{
+		Org:     "o-apple",
+		Domain:  "d-cherry",
+		Project: "p-banana",
+		Name:    "secret1",
+	}, []byte("fruits @ project"))
 	kubernetesSecretName1 := ToImagePullK8sName(SecretNameComponents{
 		Org:     "o-apple",
 		Domain:  "",
@@ -507,7 +573,7 @@ func TestEmbeddedSecretManagerInjector_InjectSecretScopedToProject(t *testing.T)
 	pod, injected, err := injector.Inject(ctx, secret, pod)
 	assert.NoError(t, err)
 	assert.True(t, injected)
-	assert.True(t, podHasSecretInjected(pod, "secret1", "fruits @ project", ""))
+	assert.True(t, podHasSecretInjected(pod, "secret1", envVarSecretName, ""))
 }
 
 // TestEmbeddedSecretManagerInjector_LookUpSecret_StaleOrgCacheDoesNotMaskProjectScope
@@ -544,6 +610,12 @@ func TestEmbeddedSecretManagerInjector_LookUpSecret_StaleOrgCacheDoesNotMaskProj
 	// image pull mirroring path calls Get on the controller-runtime client for
 	// the org-scoped image-pull Secret; return NotFound so the happy path runs.
 	mockClient := &mocks.MockableControllerRuntimeClient{}
+	envVarSecretName := expectEnvVarSecretCreate(t, mockClient, ctx, "", SecretNameComponents{
+		Org:     "o-apple",
+		Domain:  "d-cherry",
+		Project: "p-banana",
+		Name:    "secret1",
+	}, []byte("fresh project value"))
 	orgImagePullName := ToImagePullK8sName(SecretNameComponents{Org: "o-apple", Name: "secret1"})
 	mockClient.
 		On("Get", ctx, types.NamespacedName{Name: orgImagePullName, Namespace: testReferenceNamespace}, &corev1.Secret{}).
@@ -565,7 +637,7 @@ func TestEmbeddedSecretManagerInjector_LookUpSecret_StaleOrgCacheDoesNotMaskProj
 	assert.NoError(t, err)
 	assert.True(t, injected)
 	// Must pick up the newly-created project+domain value, not the stale cached org value.
-	assert.True(t, podHasSecretInjected(pod, "secret1", "fresh project value", ""))
+	assert.True(t, podHasSecretInjected(pod, "secret1", envVarSecretName, ""))
 }
 
 func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
@@ -625,6 +697,12 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 		testPod := pod.DeepCopy()
 
 		mockClient := &mocks.MockableControllerRuntimeClient{}
+		expectEnvVarSecretCreate(t, mockClient, ctx, testNamespace, SecretNameComponents{
+			Org:     testOrganization,
+			Domain:  testDomain,
+			Project: testProject,
+			Name:    testSecretName,
+		}, []byte("test-credentials"))
 		mockClient.
 			On("Get", ctx, types.NamespacedName{Name: kubernetesSecretName, Namespace: testReferenceNamespace}, &corev1.Secret{}).
 			Run(func(args mock.Arguments) {
@@ -662,6 +740,12 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 		testPod := pod.DeepCopy()
 
 		mockClient := &mocks.MockableControllerRuntimeClient{}
+		expectEnvVarSecretCreate(t, mockClient, ctx, testNamespace, SecretNameComponents{
+			Org:     testOrganization,
+			Domain:  testDomain,
+			Project: testProject,
+			Name:    testSecretName,
+		}, []byte("test-credentials"))
 		mockClient.
 			On("Get", ctx, types.NamespacedName{Name: kubernetesSecretName, Namespace: testReferenceNamespace}, &corev1.Secret{}).
 			Run(func(args mock.Arguments) {
@@ -699,6 +783,12 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 		testPod := pod.DeepCopy()
 
 		mockClient := &mocks.MockableControllerRuntimeClient{}
+		expectEnvVarSecretCreate(t, mockClient, ctx, testNamespace, SecretNameComponents{
+			Org:     testOrganization,
+			Domain:  testDomain,
+			Project: testProject,
+			Name:    testSecretName,
+		}, []byte("test-credentials"))
 
 		secretCache := newAlwaysMissCache(t)
 		injector := NewEmbeddedSecretManagerInjector(
@@ -715,9 +805,6 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, injected)
 		assert.Nil(t, resultPod.Spec.ImagePullSecrets)
-
-		mockClient.AssertNotCalled(t, "Get", mock.Anything, mock.Anything, mock.Anything)
-		mockClient.AssertNotCalled(t, "Create", mock.Anything, mock.Anything)
 	})
 
 	t.Run("image pull secret is not scoped to project or domain", func(t *testing.T) {
@@ -733,6 +820,12 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 		orgBasedReferenceImagePullSecret := referenceImagePullSecret.DeepCopy()
 		orgBasedReferenceImagePullSecret.SetName(orgBasedKubernetesSecretName)
 		mockClient := &mocks.MockableControllerRuntimeClient{}
+		expectEnvVarSecretCreate(t, mockClient, ctx, testNamespace, SecretNameComponents{
+			Org:     testOrganization,
+			Domain:  "",
+			Project: "",
+			Name:    testSecretName,
+		}, []byte("test-credentials"))
 		mockClient.
 			On("Get", ctx, types.NamespacedName{Name: orgBasedKubernetesSecretName, Namespace: testReferenceNamespace}, &corev1.Secret{}).
 			Run(func(args mock.Arguments) {
@@ -769,7 +862,7 @@ func TestEmbeddedSecretManagerInjector_InjectImagePullSecret(t *testing.T) {
 	})
 }
 
-func podHasSecretInjected(pod *corev1.Pod, secretKey string, secretValue string, envVar string) bool {
+func podHasSecretInjected(pod *corev1.Pod, secretKey string, k8sSecretName string, envVar string) bool {
 	// When Secret.EnvVar is set the injector emits a single value env var with
 	// that name; otherwise it emits the auto-generated <prefix><KEY> name.
 	expectedName := config.DefaultSecretEnvVarPrefix + strings.ToUpper(secretKey)
@@ -778,7 +871,12 @@ func podHasSecretInjected(pod *corev1.Pod, secretKey string, secretValue string,
 	}
 	return lo.EveryBy(pod.Spec.Containers, func(container corev1.Container) bool {
 		hasValueEnvVar := lo.ContainsBy(container.Env, func(env corev1.EnvVar) bool {
-			return env.Name == expectedName && env.Value == secretValue
+			return env.Name == expectedName &&
+				env.Value == "" &&
+				env.ValueFrom != nil &&
+				env.ValueFrom.SecretKeyRef != nil &&
+				env.ValueFrom.SecretKeyRef.Name == k8sSecretName &&
+				env.ValueFrom.SecretKeyRef.Key == EmbeddedSecretsEnvVarKey
 		})
 		hasPrefixEnvVar := lo.ContainsBy(container.Env, func(env corev1.EnvVar) bool {
 			return env.Name == SecretEnvVarPrefix && env.Value == config.DefaultSecretEnvVarPrefix

--- a/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/embedded_secret_manager_test.go
@@ -51,9 +51,6 @@ func expectEnvVarSecretCreate(
 	t.Helper()
 	k8sSecretName := ToEnvVarK8sName(components)
 	mockClient.
-		On("Get", ctx, types.NamespacedName{Name: k8sSecretName, Namespace: namespace}, &corev1.Secret{}).
-		Return(k8sError.NewNotFound(corev1.Resource("secret"), k8sSecretName))
-	mockClient.
 		On("Create", ctx, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      k8sSecretName,
@@ -67,6 +64,88 @@ func expectEnvVarSecretCreate(
 		}).
 		Return(nil)
 	return k8sSecretName
+}
+
+func TestEmbeddedSecretManagerInjector_UpsertEnvVarSecretAlreadyExistsWithStaleCache(t *testing.T) {
+	ctx := context.Background()
+	components := SecretNameComponents{Org: "org", Domain: "domain", Project: "project", Name: "secret"}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "pod-namespace"}}
+	k8sSecretName := ToEnvVarK8sName(components)
+
+	mockClient := &mocks.MockableControllerRuntimeClient{}
+	mockClient.
+		On("Create", ctx, newEnvVarSecret(k8sSecretName, pod.GetNamespace(), components, []byte("secret-value"))).
+		Return(k8sError.NewAlreadyExists(corev1.Resource("secret"), k8sSecretName))
+	mockClient.
+		On("Get", ctx, types.NamespacedName{Name: k8sSecretName, Namespace: pod.GetNamespace()}, &corev1.Secret{}).
+		Return(k8sError.NewNotFound(corev1.Resource("secret"), k8sSecretName))
+
+	injector := &EmbeddedSecretManagerInjector{k8sClient: mockClient}
+	gotName, err := injector.upsertEnvVarSecret(ctx, components, []byte("secret-value"), pod)
+
+	assert.NoError(t, err)
+	assert.Equal(t, k8sSecretName, gotName)
+	mockClient.AssertNotCalled(t, "Patch", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestEmbeddedSecretManagerInjector_UpsertEnvVarSecretSkipsUnchangedExistingSecret(t *testing.T) {
+	ctx := context.Background()
+	components := SecretNameComponents{Org: "org", Domain: "domain", Project: "project", Name: "secret"}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "pod-namespace"}}
+	secretValue := []byte("secret-value")
+	k8sSecretName := ToEnvVarK8sName(components)
+
+	mockClient := &mocks.MockableControllerRuntimeClient{}
+	mockClient.
+		On("Create", ctx, newEnvVarSecret(k8sSecretName, pod.GetNamespace(), components, secretValue)).
+		Return(k8sError.NewAlreadyExists(corev1.Resource("secret"), k8sSecretName))
+	mockClient.
+		On("Get", ctx, types.NamespacedName{Name: k8sSecretName, Namespace: pod.GetNamespace()}, &corev1.Secret{}).
+		Run(func(args mock.Arguments) {
+			secret := args.Get(2).(*corev1.Secret)
+			*secret = *newEnvVarSecret(k8sSecretName, pod.GetNamespace(), components, secretValue)
+		}).
+		Return(nil)
+
+	injector := &EmbeddedSecretManagerInjector{k8sClient: mockClient}
+	gotName, err := injector.upsertEnvVarSecret(ctx, components, secretValue, pod)
+
+	assert.NoError(t, err)
+	assert.Equal(t, k8sSecretName, gotName)
+	mockClient.AssertNotCalled(t, "Patch", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestEmbeddedSecretManagerInjector_UpsertEnvVarSecretPatchesChangedExistingSecret(t *testing.T) {
+	ctx := context.Background()
+	components := SecretNameComponents{Org: "org", Domain: "domain", Project: "project", Name: "secret"}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "pod-namespace"}}
+	k8sSecretName := ToEnvVarK8sName(components)
+
+	mockClient := &mocks.MockableControllerRuntimeClient{}
+	mockClient.
+		On("Create", ctx, newEnvVarSecret(k8sSecretName, pod.GetNamespace(), components, []byte("new-value"))).
+		Return(k8sError.NewAlreadyExists(corev1.Resource("secret"), k8sSecretName))
+	mockClient.
+		On("Get", ctx, types.NamespacedName{Name: k8sSecretName, Namespace: pod.GetNamespace()}, &corev1.Secret{}).
+		Run(func(args mock.Arguments) {
+			secret := args.Get(2).(*corev1.Secret)
+			*secret = *newEnvVarSecret(k8sSecretName, pod.GetNamespace(), components, []byte("old-value"))
+		}).
+		Return(nil)
+	mockClient.
+		On("Patch", ctx, mock.AnythingOfType("*v1.Secret"), mock.Anything).
+		Run(func(args mock.Arguments) {
+			secret := args.Get(1).(*corev1.Secret)
+			assert.Equal(t, []byte("new-value"), secret.Data[EmbeddedSecretsEnvVarKey])
+			assert.Equal(t, ToEnvVarK8sLabels(components), secret.Labels)
+		}).
+		Return(nil)
+
+	injector := &EmbeddedSecretManagerInjector{k8sClient: mockClient}
+	gotName, err := injector.upsertEnvVarSecret(ctx, components, []byte("new-value"), pod)
+
+	assert.NoError(t, err)
+	assert.Equal(t, k8sSecretName, gotName)
 }
 
 func TestEmbeddedSecretManagerInjector_Inject(t *testing.T) {

--- a/flyteplugins/go/tasks/pluginmachinery/secret/imagepull_kubernetes_utils.go
+++ b/flyteplugins/go/tasks/pluginmachinery/secret/imagepull_kubernetes_utils.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	imagePullPrefix = "img-pull"
+	envVarPrefix    = "env-var"
 )
 
 const (
@@ -24,11 +25,23 @@ var (
 	ImagePullLabels = map[string]string{
 		secretTypeLabel: "image-pull-secret",
 	}
+
+	EnvVarLabels = map[string]string{
+		secretTypeLabel: "env-var-secret",
+	}
 )
 
 // ToImagePullK8sName generates a Kubernetes secret name based on the provided secret name components.
 // The name includes a consistent hash of the components to ensure uniqueness, be Kubernetes compliant, and avoid collisions.
 func ToImagePullK8sName(components SecretNameComponents) string {
+	return toScopedK8sName(imagePullPrefix, components)
+}
+
+func ToEnvVarK8sName(components SecretNameComponents) string {
+	return toScopedK8sName(envVarPrefix, components)
+}
+
+func toScopedK8sName(prefix string, components SecretNameComponents) string {
 	// Create a deterministic string representation of the components
 	componentStr := fmt.Sprintf("%s:%s:%s:%s",
 		components.Org,
@@ -40,13 +53,23 @@ func ToImagePullK8sName(components SecretNameComponents) string {
 	h := sha256.New()
 	h.Write([]byte(componentStr))
 	hash := fmt.Sprintf("%x", h.Sum(nil))
-	return fmt.Sprintf("%s-%s", imagePullPrefix, hash[:16])
+	return fmt.Sprintf("%s-%s", prefix, hash[:16])
 }
 
 // ToImagePullK8sLabels generates a map of labels that can be used to identify the image pull Kubernetes secret.
 // These labels are intended to supplement the hashed secret name and provide additional metadata.
 func ToImagePullK8sLabels(components SecretNameComponents) map[string]string {
 	return utils.UnionMaps(ImagePullLabels, map[string]string{
+		// TODO Create a function that cleans the values of the labels to be Kubernetes compliant
+		orgLabel:        sanitizeLabelValue(components.Org),
+		projectLabel:    sanitizeLabelValue(components.Project),
+		domainLabel:     sanitizeLabelValue(components.Domain),
+		secretNameLabel: sanitizeLabelValue(components.Name),
+	})
+}
+
+func ToEnvVarK8sLabels(components SecretNameComponents) map[string]string {
+	return utils.UnionMaps(EnvVarLabels, map[string]string{
 		// TODO Create a function that cleans the values of the labels to be Kubernetes compliant
 		orgLabel:        sanitizeLabelValue(components.Org),
 		projectLabel:    sanitizeLabelValue(components.Project),


### PR DESCRIPTION
## Summary
- mirror embedded env-var secret values into generated Kubernetes Secret objects in the target pod namespace
- inject pod env vars with `ValueFrom.SecretKeyRef` instead of putting the raw secret value directly in the pod spec
- reuse the resolved project/domain/org secret scope for generated env-var secret names and labels
- keep existing image-pull secret lookup behavior using the same resolved scope

Fixes #7824.

## Testing
- `GOCACHE=/private/tmp/flyte-secret-go-cache GOMODCACHE=/private/tmp/flyte-secret-go-mod-cache go test ./flyteplugins/go/tasks/pluginmachinery/secret -run 'TestEmbeddedSecretManagerInjector_(Inject|InjectSecretScopedToOrganization|InjectSecretScopedToDomain|InjectSecretScopedToProject|LookUpSecret_StaleOrgCacheDoesNotMaskProjectScope|InjectImagePullSecret)$|Test_ToImagePullK8sName'`
- `GOCACHE=/private/tmp/flyte-secret-go-cache GOMODCACHE=/private/tmp/flyte-secret-go-mod-cache go test ./flyteplugins/go/tasks/pluginmachinery/secret`
- `git diff --check`