### PR TITLE
[V2] Enable UI signal human in the loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ empty-config.yaml
 **/flyteidl2.egg-info
 node_modules
 .claude/
+.flyte/

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -8735,7 +8735,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 234f623bb88a11f8007d57f08b191c0d071273e46a56b910dfbba8ae6f43a34c
+        checksum/configuration: 73498ed48a4a737de04a3c1297e3c0e172b0919cdf6d6bfc7dc43bd102f4d1e8
         checksum/configuration-secret: ff95a9986cc42dff0a114449c9b8e9a95c781b7bdd9832b31ca461423ae0b678
       labels:
         app.kubernetes.io/component: flyte-binary

--- a/runs/repository/impl/action.go
+++ b/runs/repository/impl/action.go
@@ -440,6 +440,20 @@ func (r *actionRepo) UpdateActionPhase(
 		int32(common.ActionPhase_ACTION_PHASE_FAILED),
 		int32(common.ActionPhase_ACTION_PHASE_TIMED_OUT),
 	}
+	// A paused action may settle into any terminal phase. This case needs stating
+	// separately because the `phase <= $n` guard below reads the enum's numeric
+	// order as the lifecycle order, and PAUSED breaks that assumption: it was
+	// appended after the terminal phases, so PAUSED (9) sorts above SUCCEEDED (5).
+	// Without this, signalling a condition updates zero rows — silently, since a
+	// no-op update also skips notifyActionUpdate, so the change never reaches the
+	// watch stream either and the console keeps offering the signal input.
+	terminalPhases := []int32{
+		int32(common.ActionPhase_ACTION_PHASE_SUCCEEDED),
+		int32(common.ActionPhase_ACTION_PHASE_FAILED),
+		int32(common.ActionPhase_ACTION_PHASE_ABORTED),
+		int32(common.ActionPhase_ACTION_PHASE_TIMED_OUT),
+		int32(common.ActionPhase_ACTION_PHASE_RECOVERED),
+	}
 
 	var queryBuilder strings.Builder
 	var args []interface{}
@@ -467,9 +481,10 @@ func (r *actionRepo) UpdateActionPhase(
 		argIdx++
 	}
 
-	queryBuilder.WriteString(fmt.Sprintf(" WHERE project = $%d AND domain = $%d AND run_name = $%d AND name = $%d AND (phase <= $%d OR phase = ANY($%d))", //nolint: staticcheck
-		argIdx, argIdx+1, argIdx+2, argIdx+3, argIdx+4, argIdx+5))
-	args = append(args, actionID.Run.Project, actionID.Run.Domain, actionID.Run.Name, actionID.Name, phase, pq.Array(retryablePhases))
+	queryBuilder.WriteString(fmt.Sprintf(" WHERE project = $%d AND domain = $%d AND run_name = $%d AND name = $%d AND (phase <= $%d OR phase = ANY($%d) OR (phase = $%d AND $%d = ANY($%d)))", //nolint: staticcheck
+		argIdx, argIdx+1, argIdx+2, argIdx+3, argIdx+4, argIdx+5, argIdx+6, argIdx+4, argIdx+7))
+	args = append(args, actionID.Run.Project, actionID.Run.Domain, actionID.Run.Name, actionID.Name, phase,
+		pq.Array(retryablePhases), int32(common.ActionPhase_ACTION_PHASE_PAUSED), pq.Array(terminalPhases))
 
 	result, err := r.db.ExecContext(ctx, queryBuilder.String(), args...)
 	if err != nil {

--- a/runs/repository/impl/action.go
+++ b/runs/repository/impl/action.go
@@ -440,13 +440,6 @@ func (r *actionRepo) UpdateActionPhase(
 		int32(common.ActionPhase_ACTION_PHASE_FAILED),
 		int32(common.ActionPhase_ACTION_PHASE_TIMED_OUT),
 	}
-	// A paused action may settle into any terminal phase. This case needs stating
-	// separately because the `phase <= $n` guard below reads the enum's numeric
-	// order as the lifecycle order, and PAUSED breaks that assumption: it was
-	// appended after the terminal phases, so PAUSED (9) sorts above SUCCEEDED (5).
-	// Without this, signalling a condition updates zero rows — silently, since a
-	// no-op update also skips notifyActionUpdate, so the change never reaches the
-	// watch stream either and the console keeps offering the signal input.
 	terminalPhases := []int32{
 		int32(common.ActionPhase_ACTION_PHASE_SUCCEEDED),
 		int32(common.ActionPhase_ACTION_PHASE_FAILED),

--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -1007,3 +1007,83 @@ func TestUpdateActionPhase_AbortedDoesNotInsertEvent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, count, "UpdateActionPhase(ABORTED) must not insert a synthetic action_events row")
 }
+
+// PAUSED sorts above every terminal phase in the enum, so the monotonic
+// `phase <= $n` guard would reject a signalled condition's transition to
+// SUCCEEDED and update zero rows. A no-op update also skips notifyActionUpdate,
+// so the console would never learn the condition resolved and would keep
+// offering the signal input.
+func TestUpdateActionPhase_PausedSettlesIntoTerminal(t *testing.T) {
+	db := setupActionDB(t)
+	defer func() { db.Exec("DELETE FROM actions") }()
+	actionRepo, err := NewActionRepo(db, testDbConfig)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name     string
+		terminal common.ActionPhase
+	}{
+		{"signalled", common.ActionPhase_ACTION_PHASE_SUCCEEDED},
+		{"timed out", common.ActionPhase_ACTION_PHASE_TIMED_OUT},
+		{"aborted", common.ActionPhase_ACTION_PHASE_ABORTED},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actionID := &common.ActionIdentifier{
+				Run: &common.RunIdentifier{
+					Org: "org1", Project: "proj1", Domain: "domain1", Name: "run1",
+				},
+				Name: "cond-" + tc.name,
+			}
+			_, err := actionRepo.CreateAction(ctx, models.NewActionModel(actionID), false)
+			require.NoError(t, err)
+
+			require.NoError(t, actionRepo.UpdateActionPhase(ctx, actionID,
+				common.ActionPhase_ACTION_PHASE_PAUSED, 1, core.CatalogCacheStatus_CACHE_DISABLED, nil, nil))
+			paused, err := actionRepo.GetAction(ctx, actionID)
+			require.NoError(t, err)
+			require.Equal(t, int32(common.ActionPhase_ACTION_PHASE_PAUSED), paused.Phase)
+
+			endTime := time.Now()
+			require.NoError(t, actionRepo.UpdateActionPhase(ctx, actionID,
+				tc.terminal, 1, core.CatalogCacheStatus_CACHE_DISABLED, &endTime, nil))
+
+			action, err := actionRepo.GetAction(ctx, actionID)
+			require.NoError(t, err)
+			assert.Equal(t, int32(tc.terminal), action.Phase,
+				"a paused action must be able to settle into %s", tc.terminal)
+			assert.True(t, action.EndedAt.Valid)
+		})
+	}
+}
+
+// The paused exception is deliberately one-way: it lets a paused action settle,
+// not resume. A stale RUNNING event arriving after the pause must still be
+// rejected, exactly as the monotonic guard rejects it today.
+func TestUpdateActionPhase_PausedDoesNotResume(t *testing.T) {
+	db := setupActionDB(t)
+	defer func() { db.Exec("DELETE FROM actions") }()
+	actionRepo, err := NewActionRepo(db, testDbConfig)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	actionID := &common.ActionIdentifier{
+		Run: &common.RunIdentifier{
+			Org: "org1", Project: "proj1", Domain: "domain1", Name: "run1",
+		},
+		Name: "paused-action",
+	}
+	_, err = actionRepo.CreateAction(ctx, models.NewActionModel(actionID), false)
+	require.NoError(t, err)
+
+	require.NoError(t, actionRepo.UpdateActionPhase(ctx, actionID,
+		common.ActionPhase_ACTION_PHASE_PAUSED, 1, core.CatalogCacheStatus_CACHE_DISABLED, nil, nil))
+
+	require.NoError(t, actionRepo.UpdateActionPhase(ctx, actionID,
+		common.ActionPhase_ACTION_PHASE_RUNNING, 1, core.CatalogCacheStatus_CACHE_DISABLED, nil, nil))
+
+	action, err := actionRepo.GetAction(ctx, actionID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(common.ActionPhase_ACTION_PHASE_PAUSED), action.Phase,
+		"a non-terminal update must not move an action out of PAUSED")
+}

--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -1956,13 +1956,9 @@ func (s *RunService) convertNodeUpdateToEnrichedProto(
 		metadata.EnvironmentName = action.EnvironmentName.String
 
 	case workflow.ActionType_ACTION_TYPE_CONDITION:
-		// Mirrors actionMetadataFromModel. The console decides an action is a
-		// condition from metadata.spec alone, so leaving this unset renders a
-		// paused condition as an ordinary action with no way to signal it.
 		condMeta := &workflow.ConditionActionMetadata{
 			Name: action.FunctionName,
 		}
-		// Clients type-check the payload against metadata.condition.type before signaling, pull it from the stored spec.
 		if spec := extractActionSpec(action.ActionSpec); spec != nil {
 			if cond := spec.GetCondition(); cond != nil {
 				condMeta.Type = cond.GetType()

--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -1956,7 +1956,22 @@ func (s *RunService) convertNodeUpdateToEnrichedProto(
 		metadata.EnvironmentName = action.EnvironmentName.String
 
 	case workflow.ActionType_ACTION_TYPE_CONDITION:
-		// Unhandled for now
+		// Mirrors actionMetadataFromModel. The console decides an action is a
+		// condition from metadata.spec alone, so leaving this unset renders a
+		// paused condition as an ordinary action with no way to signal it.
+		condMeta := &workflow.ConditionActionMetadata{
+			Name: action.FunctionName,
+		}
+		// Clients type-check the payload against metadata.condition.type before signaling, pull it from the stored spec.
+		if spec := extractActionSpec(action.ActionSpec); spec != nil {
+			if cond := spec.GetCondition(); cond != nil {
+				condMeta.Type = cond.GetType()
+				if condMeta.Name == "" {
+					condMeta.Name = cond.GetName()
+				}
+			}
+		}
+		metadata.Spec = &workflow.ActionMetadata_Condition{Condition: condMeta}
 	case workflow.ActionType_ACTION_TYPE_UNSPECIFIED:
 		// No-op, this should never happen.
 	}

--- a/runs/service/run_service_test.go
+++ b/runs/service/run_service_test.go
@@ -1867,3 +1867,50 @@ func TestGetActionLogContext(t *testing.T) {
 		assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
 	})
 }
+
+// The console decides an action is a signalable condition from metadata.spec
+// alone. The watch stream builds its own metadata rather than reusing
+// actionMetadataFromModel, so the condition arm has to be kept in step: without
+// it a paused condition streams as an ordinary action and the UI renders no way
+// to signal it.
+func TestConvertNodeUpdateToEnrichedProto_ConditionMetadata(t *testing.T) {
+	svc := &RunService{}
+	runID := &common.RunIdentifier{Project: "p", Domain: "d", Name: "r1"}
+
+	condType := &core.LiteralType{
+		Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRING},
+	}
+	specBytes, err := proto.Marshal(&workflow.ActionSpec{
+		Spec: &workflow.ActionSpec_Condition{
+			Condition: &workflow.ConditionAction{
+				Name: "approve-item",
+				Type: condType,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	enriched := svc.convertNodeUpdateToEnrichedProto(runID, &nodeUpdate{
+		Node: &node{
+			Action: &models.Action{
+				Project:      "p",
+				Domain:       "d",
+				RunName:      "r1",
+				Name:         "cond1",
+				Phase:        int32(common.ActionPhase_ACTION_PHASE_PAUSED),
+				ActionType:   int32(workflow.ActionType_ACTION_TYPE_CONDITION),
+				FunctionName: "approve-item",
+				ActionSpec:   specBytes,
+			},
+		},
+		MeetsFilter: true,
+	})
+
+	require.NotNil(t, enriched)
+	condMeta := enriched.GetAction().GetMetadata().GetCondition()
+	require.NotNil(t, condMeta, "condition metadata must be set, otherwise the console cannot classify the action")
+	assert.Equal(t, "approve-item", condMeta.GetName())
+	// The declared type drives which input the console renders, and the payload
+	// type check before signaling.
+	assert.Equal(t, core.SimpleType_STRING, condMeta.GetType().GetSimple())
+}


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->
Closes #7806 

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
The human in the loop signal message bar is not showing in the UI because the backend DB lacks action metadata info. This PR fixed the issue


## What changes were proposed in this pull request?

Backend changes

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

Test with the script
```python
"""Minimal HITL condition, for exercising the pause/signal round trip on the devbox.

Run it, note the run name it prints, then resolve the condition from another shell:

    flyte get condition <run-name>
    flyte signal condition <run-name> <action-name> yes

The task blocks in `cond.wait()` until then. A 30 minute timeout keeps a forgotten
run from pausing forever.
"""

import asyncio
import logging
from datetime import timedelta

import flyte

image = (
    flyte.Image.from_debian_base()
    .with_pip_packages("cryptography==44.0.3", "pyOpenSSL==25.1.0")
)

env = flyte.TaskEnvironment(
    name="hitl_demo",
    resources=flyte.Resources(cpu=1, memory="1Gi"),
    image=image,
)


@env.task
async def ask_human(item: str) -> str:
    cond = await flyte.new_condition.aio(
        "approve-item",
        prompt=f"Approve {item}? (yes/no)",
        data_type=str,
        description="Demo condition for exercising the signal path on the devbox.",
        timeout=timedelta(minutes=30),
    )
    print(f"waiting for a signal on '{item}' — action: {flyte.ctx().action}")
    answer = await cond.wait.aio()
    print(f"got: {answer!r}")
    return answer


@env.task(entrypoint=True)
async def main(item: str = "widget-42") -> str:
    answer = await ask_human(item=item)
    return f"{item} -> {answer}"


if __name__ == "__main__":
    flyte.init_from_config()
    run = flyte.with_runcontext(log_level=logging.INFO).run(main, item="widget-42")
    print(f"run name: {run.name}")
    print(f"resolve with: flyte signal condition {run.name} <action-name> yes")

```
We can see the message bar now
<img width="1843" height="657" alt="Screenshot 2026-08-19 at 11 48 59 AM" src="https://github.com/user-attachments/assets/0b8e7ae4-7317-4400-9daf-548f3e30eb1a" />


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
