### PR TITLE
[V2] Fix UI not showing input after HITL signal

### DIFF
--- a/runs/repository/impl/action.go
+++ b/runs/repository/impl/action.go
@@ -518,6 +518,7 @@ func (r *actionRepo) UpdateActionDetailedInfo(ctx context.Context, actionID *com
 	if rowsAffected == 0 {
 		return sql.ErrNoRows
 	}
+	r.notifyActionUpdate(ctx, actionID)
 	return nil
 }
 

--- a/runs/repository/impl/action_test.go
+++ b/runs/repository/impl/action_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -1086,4 +1087,64 @@ func TestUpdateActionPhase_PausedDoesNotResume(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(common.ActionPhase_ACTION_PHASE_PAUSED), action.Phase,
 		"a non-terminal update must not move an action out of PAUSED")
+}
+
+// A condition's signalled value is written to detailed_info outside any phase
+// transition, so that write has to notify watchers on its own.
+func TestUpdateActionDetailedInfo_NotifiesWatchers(t *testing.T) {
+	db := setupActionDB(t)
+	defer func() { db.Exec("DELETE FROM actions") }()
+	repo, err := NewActionRepo(db, testDbConfig)
+	require.NoError(t, err)
+	repoImpl := repo.(*actionRepo)
+
+	actionID := &common.ActionIdentifier{
+		Run: &common.RunIdentifier{
+			Org:     "org1",
+			Project: "proj1",
+			Domain:  "domain1",
+			Name:    "run1",
+		},
+		Name: "action1",
+	}
+
+	ctx := context.Background()
+
+	// Register the watcher before the action exists so the creation
+	// notification is deterministically ours to drain.
+	watchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	updates := make(chan *models.Action, 2)
+	errs := make(chan error, 1)
+	go repo.WatchActionUpdates(watchCtx, actionID, updates, errs)
+
+	require.Eventually(t, func() bool {
+		repoImpl.mu.RLock()
+		defer repoImpl.mu.RUnlock()
+		return len(repoImpl.actionSubscribers) > 0
+	}, 2*time.Second, 10*time.Millisecond, "timed out waiting for watcher registration")
+
+	_, err = repo.CreateAction(ctx, models.NewActionModel(actionID), false)
+	require.NoError(t, err)
+
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for creation notification")
+	}
+
+	detailedInfo, err := proto.Marshal(&workflow.RunInfo{InputsUri: "s3://bucket/inputs.pb"})
+	require.NoError(t, err)
+	require.NoError(t, repo.UpdateActionDetailedInfo(ctx, actionID, detailedInfo))
+
+	select {
+	case action := <-updates:
+		require.Equal(t, actionID.Name, action.Name)
+		assert.Equal(t, detailedInfo, action.DetailedInfo)
+	case err := <-errs:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for detailed_info notification")
+	}
 }

--- a/runs/service/condition_test.go
+++ b/runs/service/condition_test.go
@@ -211,3 +211,44 @@ func TestGetActionDetails_ConditionWithSignalInfo(t *testing.T) {
 	assert.True(t, proto.Equal(testBoolLiteral(true), details.GetSignalInfo().GetOutput()))
 	assert.True(t, proto.Equal(principal, details.GetSignalInfo().GetSignalledBy()))
 }
+
+// The signalled value lives in detailed_info, but only the phase update notifies
+// action watchers — and WatchActionDetails closes its stream as soon as it sees
+// the terminal phase. Persisting RunInfo first is what makes that single
+// notification carry the resolved value, so pin the ordering.
+func TestUpdateActionStatus_PersistsSignalOutputBeforePhase(t *testing.T) {
+	actionRepo, _, svc := newTestServiceWithTaskRepo(t)
+
+	var calls []string
+
+	actionRepo.On("GetAction", mock.Anything, testActionID).Return(&models.Action{
+		Project:    testActionID.Run.Project,
+		Domain:     testActionID.Run.Domain,
+		RunName:    testActionID.Run.Name,
+		Name:       testActionID.Name,
+		ActionType: int32(workflow.ActionType_ACTION_TYPE_CONDITION),
+	}, nil)
+	actionRepo.On("UpdateActionDetailedInfo", mock.Anything, testActionID, mock.Anything).
+		Run(func(args mock.Arguments) {
+			calls = append(calls, "detailedInfo")
+			info := &workflow.RunInfo{}
+			require.NoError(t, proto.Unmarshal(args.Get(2).([]byte), info))
+			assert.True(t, proto.Equal(testBoolLiteral(true), info.GetOutput()))
+		}).
+		Return(nil)
+	actionRepo.On("UpdateActionPhase", mock.Anything, testActionID,
+		common.ActionPhase_ACTION_PHASE_SUCCEEDED, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(mock.Arguments) { calls = append(calls, "phase") }).
+		Return(nil)
+
+	resp, err := svc.UpdateActionStatus(context.Background(), connect.NewRequest(&workflow.UpdateActionStatusRequest{
+		ActionId: testActionID,
+		Status:   &workflow.ActionStatus{Phase: common.ActionPhase_ACTION_PHASE_SUCCEEDED},
+		Output:   testBoolLiteral(true),
+	}))
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, resp.Msg.GetStatus().GetCode())
+
+	assert.Equal(t, []string{"detailedInfo", "phase"}, calls,
+		"RunInfo must be persisted before the phase update that notifies watchers")
+}

--- a/runs/service/internal_run_service.go
+++ b/runs/service/internal_run_service.go
@@ -256,6 +256,16 @@ func (s *RunService) updateSingleActionStatus(ctx context.Context, req *workflow
 		startTime = new(actionStatus.GetStartTime().AsTime())
 	}
 
+	// Persist the inline signal payload (conditions only). The CR is GC'd after
+	// terminal recording, so RunInfo in the DB is the long-term record of the
+	// resolved value and the signalling actor.
+	if req.GetOutput() != nil || req.GetPrincipal() != nil {
+		if err := s.mergeRunInfoOutput(ctx, req); err != nil {
+			logger.Warnf(ctx, "UpdateActionStatus: failed to persist output for %s: %v", req.GetActionId().GetName(), err)
+			return connect.NewError(connect.CodeInternal, err)
+		}
+	}
+
 	if err := s.repo.ActionRepo().UpdateActionPhase(
 		ctx,
 		req.GetActionId(),
@@ -269,15 +279,6 @@ func (s *RunService) updateSingleActionStatus(ctx context.Context, req *workflow
 		return connect.NewError(connect.CodeInternal, err)
 	}
 
-	// Persist the inline signal payload (conditions only). The CR is GC'd after
-	// terminal recording, so RunInfo in the DB is the long-term record of the
-	// resolved value and the signalling actor.
-	if req.GetOutput() != nil || req.GetPrincipal() != nil {
-		if err := s.mergeRunInfoOutput(ctx, req); err != nil {
-			logger.Warnf(ctx, "UpdateActionStatus: failed to persist output for %s: %v", req.GetActionId().GetName(), err)
-			return connect.NewError(connect.CodeInternal, err)
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes #999` to link your PR with the issue.
Example: Closes #999

If your PR is related to an issue or PR, use `Related to #999` to link your PR.
Example: Related to #999

Remove this section if not applicable
-->
Related to #7806 

## Why are the changes needed?

The UI is not rendering input after HITL signal. The main reason is that the backend did not notify the input data after receiving signal. This PR fixed the issue

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

Backend changes
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
The UI will render input after signal

https://github.com/user-attachments/assets/d437e193-98c5-48b1-924c-254c238e7d3a


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
### Labels

Please add one or more of the following labels to categorize your PR:
- **added**: For new features.
- **changed**: For changes in existing functionality.
- **deprecated**: For soon-to-be-removed features.
- **removed**: For features being removed.
- **fixed**: For any bug fixed.
- **security**: In case of vulnerabilities

This is important to improve the readability of release notes.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
