### PR TITLE
fix(executor): honor task-level interruptible when the run-level flag is unset

### DIFF
--- a/executor/pkg/plugin/task_exec_metadata.go
+++ b/executor/pkg/plugin/task_exec_metadata.go
@@ -140,6 +140,11 @@ func NewTaskExecutionMetadata(ta *flyteorgv1.TaskAction) (pluginsCore.TaskExecut
 	injectLabels[AttemptLabel] = strconv.FormatUint(uint64(retryAttempt)+1, 10)
 	setSanitizedLabel(injectLabels, TaskNameLabel, taskID.GetName())
 
+	interruptible := ta.Spec.Interruptible
+	if interruptible == nil {
+		interruptible = interruptibleFromTaskTemplate(ta.Spec.TaskTemplate)
+	}
+
 	return &taskExecutionMetadata{
 		ownerID: types.NamespacedName{
 			Name:      ta.Name,
@@ -173,7 +178,7 @@ func NewTaskExecutionMetadata(ta *flyteorgv1.TaskAction) (pluginsCore.TaskExecut
 		maxAttempts:     maxAttempts,
 		overrides:       overrides,
 		envVars:         envVars,
-		interruptible:   ta.Spec.Interruptible != nil && *ta.Spec.Interruptible,
+		interruptible:   interruptible != nil && *interruptible,
 		securityContext: securityContext,
 		serviceAccount:  resolveServiceAccount(securityContext, executorconfig.GetConfig().DefaultK8sServiceAccount),
 	}, nil
@@ -197,6 +202,26 @@ func attemptToRetry(attempt uint32) uint32 {
 		return 0
 	}
 	return attempt - 1
+}
+
+// interruptibleFromTaskTemplate gives the task template's interruptible flag, or nil when the
+// template does not declare one.
+func interruptibleFromTaskTemplate(data []byte) *bool {
+	if len(data) == 0 {
+		return nil
+	}
+
+	tmpl := &core.TaskTemplate{}
+	if err := proto.Unmarshal(data, tmpl); err != nil {
+		return nil
+	}
+
+	md := tmpl.GetMetadata()
+	if md == nil || md.GetInterruptibleValue() == nil {
+		return nil
+	}
+
+	return ptr.To(md.GetInterruptible())
 }
 
 // maxAttemptsFromTaskTemplate give the max attempts (retries + 1) from the task template.

--- a/executor/pkg/plugin/task_exec_metadata_test.go
+++ b/executor/pkg/plugin/task_exec_metadata_test.go
@@ -51,6 +51,55 @@ func TestNewTaskExecutionMetadata_UsesProjectedRunContext(t *testing.T) {
 	require.True(t, meta.IsInterruptible())
 }
 
+func TestNewTaskExecutionMetadata_Interruptible(t *testing.T) {
+	marshalTemplate := func(t *testing.T, tmpl *core.TaskTemplate) []byte {
+		data, err := proto.Marshal(tmpl)
+		require.NoError(t, err)
+		return data
+	}
+	templateWith := func(t *testing.T, interruptible bool) []byte {
+		return marshalTemplate(t, &core.TaskTemplate{
+			Metadata: &core.TaskMetadata{
+				InterruptibleValue: &core.TaskMetadata_Interruptible{Interruptible: interruptible},
+			},
+		})
+	}
+	newMeta := func(t *testing.T, runLevel *bool, taskTemplate []byte) pluginsCore.TaskExecutionMetadata {
+		meta, err := NewTaskExecutionMetadata(&flyteorgv1.TaskAction{
+			Spec: flyteorgv1.TaskActionSpec{
+				Project:       "project",
+				Domain:        "development",
+				RunName:       "run-name",
+				ActionName:    "action-name",
+				RunOutputBase: "s3://bucket/run",
+				Interruptible: runLevel,
+				TaskTemplate:  taskTemplate,
+			},
+		})
+		require.NoError(t, err)
+		return meta
+	}
+
+	t.Run("defaults to false", func(t *testing.T) {
+		require.False(t, newMeta(t, nil, nil).IsInterruptible())
+	})
+
+	t.Run("template metadata applies when run level is unset", func(t *testing.T) {
+		require.True(t, newMeta(t, nil, templateWith(t, true)).IsInterruptible())
+		require.False(t, newMeta(t, nil, templateWith(t, false)).IsInterruptible())
+	})
+
+	t.Run("template without the flag leaves the default", func(t *testing.T) {
+		require.False(t, newMeta(t, nil, marshalTemplate(t, &core.TaskTemplate{Metadata: &core.TaskMetadata{}})).IsInterruptible())
+	})
+
+	t.Run("run level wins over template metadata", func(t *testing.T) {
+		runTrue, runFalse := true, false
+		require.True(t, newMeta(t, &runTrue, templateWith(t, false)).IsInterruptible())
+		require.False(t, newMeta(t, &runFalse, templateWith(t, true)).IsInterruptible())
+	})
+}
+
 func TestNewTaskExecutionMetadata_UserEnvVarsCannotClobberInternal(t *testing.T) {
 	taskAction := &flyteorgv1.TaskAction{
 		Spec: flyteorgv1.TaskActionSpec{


### PR DESCRIPTION
## Why are the changes needed?

`interruptible` set at the `TaskEnvironment` or `@env.task` level has no effect on pod scheduling; only the run-level flag (`flyte.with_runcontext(interruptible=True)`, or a `Trigger`'s `interruptible`) is honoured. The [Interruptible tasks docs](https://www.union.ai/docs/v2/flyte/user-guide/tasks/task-configuration/interruptible-tasks-and-queues/) state that `interruptible` can be set at the `TaskEnvironment`, `@env.task`, and `task.override()` levels.

The SDK serialises env/task-level `interruptible` into `TaskTemplate.metadata.interruptible`, and the template is embedded verbatim in the TaskAction CR. However, the executor builds `TaskExecutionMetadata` from `TaskAction.Spec.Interruptible` only, which is populated from the run-level `RunSpec` (root action, inherited by child actions) — the embedded template's metadata is never consulted, so `flytek8s` never applies the `plugins.k8s` interruptible node affinity/tolerations for env/task-level flags.

Reproduced on EKS (self-hosted `flyte-binary-v2`, chart `v2.0.42`) with `plugins.k8s.interruptible-node-selector-requirement` / `non-interruptible-node-selector-requirement` / `interruptible-tolerations` configured against Karpenter `karpenter.sh/capacity-type` labels. No run-level flag was set for the env/task-level cases:

| Flag level | Pod affinity stamped |
|---|---|
| `TaskEnvironment(interruptible=True)` | `capacity-type In [on-demand]` (non-interruptible) ❌ |
| `@env.task(interruptible=True)` | `capacity-type In [on-demand]` (non-interruptible) ❌ |
| `with_runcontext(interruptible=True)` (control) | `capacity-type In [spot]` + interruptible toleration ✅ |

## What changes were proposed in this pull request?

In `NewTaskExecutionMetadata`, when `TaskAction.Spec.Interruptible` is unset, interruptibility now falls back to the embedded task template's `metadata.interruptible` (a new `interruptibleFromTaskTemplate` helper, mirroring the existing `maxAttemptsFromTaskTemplate`). An explicit run-level value still wins. The template's `interruptible_value` oneof distinguishes "declared false" from "not declared", and both leave the task non-interruptible when the run-level flag is unset.

## How was this patch tested?

Added `TestNewTaskExecutionMetadata_Interruptible` covering: default false with no flags; template-level true/false applying when the run level is unset; a template without the oneof leaving the default; and the run-level flag winning over template metadata in both directions. `go test ./executor/pkg/plugin/` and `go vet ./executor/...` pass (the `executor/test/integration` envtest suite was not run locally — no kubebuilder test binaries on this machine).

### Labels

- **fixed**: For any bug fixed.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly. (No docs change needed — this makes behaviour match the existing docs.)
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
