### PR TITLE
fix(executor): stop retrying Kubernetes HTTP 400 responses

### DIFF
--- a/executor/pkg/plugin/k8s/plugin_manager.go
+++ b/executor/pkg/plugin/k8s/plugin_manager.go
@@ -126,6 +126,12 @@ func (pm *PluginManager) launchResource(ctx context.Context, tCtx pluginsCore.Ta
 		if k8serrors.IsInvalid(err) {
 			return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("InvalidResource", err.Error(), nil)), nil
 		}
+		// Same for HTTP 400, which is what a validating admission webhook returns when it
+		// rejects the spec outright. Distinct code from InvalidResource because a webhook
+		// rejection and a field the apiserver itself found invalid are different diagnoses.
+		if k8serrors.IsBadRequest(err) {
+			return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("BadRequest", err.Error(), nil)), nil
+		}
 		reason := k8serrors.ReasonForError(err)
 		logger.Errorf(ctx, "Failed to launch job, system error. err: %v", err)
 		return pluginsCore.UnknownTransition, errors.Wrapf(stdErrors.ErrorCode(reason), err, "failed to create resource")

--- a/executor/pkg/plugin/k8s/plugin_manager_test.go
+++ b/executor/pkg/plugin/k8s/plugin_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -166,6 +167,94 @@ func TestLaunchResource_InvalidCreateFastFails(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, pluginsCore.PhasePermanentFailure, transition.Info().Phase())
 	assert.Equal(t, "InvalidResource", transition.Info().Err().GetCode())
+}
+
+// A validating admission webhook rejecting the pod spec surfaces as HTTP 400, which is neither
+// Forbidden nor Invalid: without its own branch it reaches the catch-all and the executor keeps
+// retrying a request that can never succeed.
+func TestLaunchResourceErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		createErr error
+		wantPhase pluginsCore.Phase
+		wantCode  string
+		wantErr   bool
+	}{
+		{
+			name:      "webhook 400 fails",
+			createErr: k8serrors.NewBadRequest(`admission webhook "validate.example.com" denied the request: spec.containers[0].image is required`),
+			wantPhase: pluginsCore.PhasePermanentFailure,
+			wantCode:  "BadRequest",
+		},
+		{
+			// A rejection can also arrive with no reason set and a bare 400; IsBadRequest
+			// falls back to the status code for that shape.
+			name: "bare 400 fails",
+			createErr: &k8serrors.StatusError{ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    http.StatusBadRequest,
+				Message: "the server rejected our request",
+			}},
+			wantPhase: pluginsCore.PhasePermanentFailure,
+			wantCode:  "BadRequest",
+		},
+		{
+			name: "invalid fails",
+			createErr: k8serrors.NewInvalid(
+				schema.GroupKind{Kind: "Pod"}, "name",
+				field.ErrorList{field.Invalid(field.NewPath("metadata", "name"), "x", "must be no more than 63 characters")},
+			),
+			wantPhase: pluginsCore.PhasePermanentFailure,
+			wantCode:  "InvalidResource",
+		},
+		{
+			name:      "forbidden retries",
+			createErr: k8serrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "name", fmt.Errorf("exceeded quota")),
+			wantPhase: pluginsCore.PhaseRetryableFailure,
+			wantCode:  "RuntimeFailure",
+		},
+		{
+			name:      "unknown retries",
+			createErr: k8serrors.NewInternalError(fmt.Errorf("etcd unavailable")),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(k8sscheme.Scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(context.Context, client.WithWatch, client.Object, ...client.CreateOption) error {
+						return tt.createErr
+					},
+				}).
+				Build()
+
+			kubeClient := &pluginsCoreMock.KubeClient{}
+			kubeClient.EXPECT().GetClient().Return(fakeClient)
+
+			plugin := &k8sMocks.Plugin{}
+			plugin.EXPECT().GetProperties().Return(k8s.PluginProperties{})
+			plugin.EXPECT().BuildResource(mock.Anything, mock.Anything).Return(&v1.Pod{}, nil)
+
+			tCtx := &pluginsCoreMock.TaskExecutionContext{}
+			tCtx.EXPECT().TaskExecutionMetadata().Return(metadataMock("name"))
+
+			pm := NewPluginManager("test", plugin, kubeClient)
+
+			transition, err := pm.launchResource(context.Background(), tCtx)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, pluginsCore.UnknownTransition, transition)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantPhase, transition.Info().Phase())
+			assert.Equal(t, tt.wantCode, transition.Info().Err().GetCode())
+			assert.Equal(t, core.ExecutionError_USER, transition.Info().Err().GetKind())
+		})
+	}
 }
 
 func TestHandle_CorruptedPluginStateFailsPermanently(t *testing.T) {


### PR DESCRIPTION
## Tracking issue

Related to https://github.com/flyteorg/flyte/pull/7366

## Why are the changes needed?

A validating admission webhook can reject a Kubernetes resource with HTTP 400. The
executor currently treats that response as a transient system error.

Before this change, Flyte retries the same rejected resource until the task times out.
After this change, the task fails once as a user error and shows the API server's
message.

## What changes were proposed in this pull request?

Classify Kubernetes bad-request responses as terminal failures with reason
`BadRequest`. Existing handling for forbidden, invalid, and unknown errors is
unchanged.

## How was this patch tested?

The real create-error classification path is exercised with webhook and bare HTTP 400
responses at the Kubernetes client boundary. No live admission webhook was used.

```console
$ git checkout upstream/main -- executor/pkg/plugin/k8s/plugin_manager.go
$ go test ./executor/pkg/plugin/k8s/... -run TestLaunchResourceErrors -v
--- FAIL: TestLaunchResourceErrors/webhook_400_fails
--- FAIL: TestLaunchResourceErrors/bare_400_fails

$ git checkout origin/1fanwang-k8s-badrequest-terminal-failure -- executor/pkg/plugin/k8s/plugin_manager.go
$ go test ./executor/pkg/plugin/k8s/... -run TestLaunchResourceErrors -v
--- PASS: TestLaunchResourceErrors/webhook_400_fails
--- PASS: TestLaunchResourceErrors/bare_400_fails
--- PASS: TestLaunchResourceErrors/invalid_fails
--- PASS: TestLaunchResourceErrors/forbidden_retries
--- PASS: TestLaunchResourceErrors/unknown_retries
```

### Labels

fixed

### Setup process

The controller-runtime fake client returns real Kubernetes status errors from Create.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly. Not applicable: no documented behavior changed.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

- https://github.com/flyteorg/flyte/pull/7366

## Stack

<!-- branch-stack -->
