### PR TITLE
fix(actions): retry rejected action records

### DIFF
--- a/actions/k8s/client.go
+++ b/actions/k8s/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -782,8 +783,17 @@ func (c *ActionsClient) notifyRunService(ctx context.Context, taskAction *execut
 				Task: ta,
 			}
 		}
-		if _, err := c.runClient.RecordAction(ctx, connect.NewRequest(recordReq)); err != nil {
+		// RecordAction reports rejections in the response body, not as a transport
+		// error, so the body status has to be checked before memoizing the key —
+		// otherwise a rejected action is never recorded and never retried.
+		resp, err := c.runClient.RecordAction(ctx, connect.NewRequest(recordReq))
+		if err != nil {
 			logger.Warnf(ctx, "Failed to record action in run service for %s: %v", update.ActionID.Name, err)
+		} else if resp == nil || resp.Msg == nil || resp.Msg.GetStatus() == nil {
+			logger.Warnf(ctx, "Run service returned no RecordAction status for %s", update.ActionID.Name)
+		} else if status := resp.Msg.GetStatus(); status.GetCode() != int32(code.Code_OK) {
+			logger.Warnf(ctx, "Run service rejected RecordAction for %s with code %d: %s",
+				update.ActionID.Name, status.GetCode(), status.GetMessage())
 		} else {
 			c.recordedFilter.Add(ctx, actionKey)
 		}

--- a/actions/k8s/client.go
+++ b/actions/k8s/client.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"google.golang.org/genproto/googleapis/rpc/code"
+	rpccode "google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -783,15 +783,16 @@ func (c *ActionsClient) notifyRunService(ctx context.Context, taskAction *execut
 				Task: ta,
 			}
 		}
-		// RecordAction reports rejections in the response body, not as a transport
-		// error, so the body status has to be checked before memoizing the key —
-		// otherwise a rejected action is never recorded and never retried.
+		// RecordAction reports rejections in the response body rather than as a
+		// transport error, so the body status has to be checked before memoizing
+		// the key. Otherwise a rejected action is memoized as recorded and is
+		// never retried.
 		resp, err := c.runClient.RecordAction(ctx, connect.NewRequest(recordReq))
 		if err != nil {
 			logger.Warnf(ctx, "Failed to record action in run service for %s: %v", update.ActionID.Name, err)
 		} else if resp == nil || resp.Msg == nil || resp.Msg.GetStatus() == nil {
 			logger.Warnf(ctx, "Run service returned no RecordAction status for %s", update.ActionID.Name)
-		} else if status := resp.Msg.GetStatus(); status.GetCode() != int32(code.Code_OK) {
+		} else if status := resp.Msg.GetStatus(); status.GetCode() != int32(rpccode.Code_OK) {
 			logger.Warnf(ctx, "Run service rejected RecordAction for %s with code %d: %s",
 				update.ActionID.Name, status.GetCode(), status.GetMessage())
 		} else {

--- a/actions/k8s/client_test.go
+++ b/actions/k8s/client_test.go
@@ -58,6 +58,10 @@ func newTestActionUpdate(actionName string) (*executorv1.TaskAction, *ActionUpda
 
 func acceptedRecordActionResponse() *connect.Response[workflow.RecordActionResponse] {
 	return connect.NewResponse(&workflow.RecordActionResponse{
+		ActionId: &common.ActionIdentifier{
+			Run:  &common.RunIdentifier{Org: "org", Project: "proj", Domain: "dev", Name: "run"},
+			Name: "action",
+		},
 		Status: &status.Status{Code: int32(code.Code_OK)},
 	})
 }

--- a/actions/k8s/client_test.go
+++ b/actions/k8s/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
@@ -55,6 +56,12 @@ func newTestActionUpdate(actionName string) (*executorv1.TaskAction, *ActionUpda
 	return ta, update
 }
 
+func acceptedRecordActionResponse() *connect.Response[workflow.RecordActionResponse] {
+	return connect.NewResponse(&workflow.RecordActionResponse{
+		Status: &status.Status{Code: int32(code.Code_OK)},
+	})
+}
+
 func TestNotifyRunService_DeduplicateRecordAction(t *testing.T) {
 	ctx := context.Background()
 
@@ -73,7 +80,7 @@ func TestNotifyRunService_DeduplicateRecordAction(t *testing.T) {
 
 	// Expect RecordAction called exactly once
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Once()
+		Return(acceptedRecordActionResponse(), nil).Once()
 
 	// First Added event — should call RecordAction
 	c.notifyRunService(ctx, ta, update, watch.Added)
@@ -105,7 +112,7 @@ func TestNotifyRunService_FailedRecordAllowsRetry(t *testing.T) {
 		Return((*connect.Response[workflow.RecordActionResponse])(nil), fmt.Errorf("transient error")).Once()
 	// Second call succeeds
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Once()
+		Return(acceptedRecordActionResponse(), nil).Once()
 
 	// First event — RecordAction fails, should NOT add to filter
 	c.notifyRunService(ctx, ta, update, watch.Added)
@@ -118,6 +125,115 @@ func TestNotifyRunService_FailedRecordAllowsRetry(t *testing.T) {
 	// Third event — now it's in the filter, should be skipped
 	c.notifyRunService(ctx, ta, update, watch.Added)
 	mockClient.AssertNumberOfCalls(t, "RecordAction", 2)
+}
+
+func TestNotifyRunService_MissingResponseAllowsRetry(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		response *connect.Response[workflow.RecordActionResponse]
+	}{
+		{name: "nil response"},
+		{name: "nil message", response: &connect.Response[workflow.RecordActionResponse]{}},
+		{name: "nil status", response: connect.NewResponse(&workflow.RecordActionResponse{})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			mockClient := runmocks.NewInternalRunServiceClient(t)
+			filter, err := fastcheck.NewOppoBloomFilter(128, promutils.NewTestScope())
+			assert.NoError(t, err)
+			c := &ActionsClient{
+				runClient:      mockClient,
+				recordedFilter: filter,
+				subscribers:    make(map[string]map[chan *ActionUpdate]struct{}),
+			}
+			ta, update := newTestActionUpdate("action-missing-response")
+			mockClient.On("RecordAction", mock.Anything, mock.Anything).
+				Return(tc.response, nil).Twice()
+
+			c.notifyRunService(ctx, ta, update, watch.Added)
+			c.notifyRunService(ctx, ta, update, watch.Added)
+
+			mockClient.AssertNumberOfCalls(t, "RecordAction", 2)
+		})
+	}
+}
+
+func TestNotifyRunService_RejectedRecordAllowsRetry(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := runmocks.NewInternalRunServiceClient(t)
+
+	filter, err := fastcheck.NewOppoBloomFilter(128, promutils.NewTestScope())
+	assert.NoError(t, err)
+
+	c := &ActionsClient{
+		runClient:      mockClient,
+		recordedFilter: filter,
+		subscribers:    make(map[string]map[chan *ActionUpdate]struct{}),
+	}
+
+	ta, update := newTestActionUpdate("action-rejected")
+
+	// The run service reports rejections in the response body with a nil
+	// transport error, so the first two calls look like successes to connect.
+	rejected := connect.NewResponse(&workflow.RecordActionResponse{
+		ActionId: update.ActionID,
+		Status: &status.Status{
+			Code:    int32(code.Code_INVALID_ARGUMENT),
+			Message: "unsupported action spec type: <nil>",
+		},
+	})
+	mockClient.On("RecordAction", mock.Anything, mock.Anything).
+		Return(rejected, nil).Twice()
+	mockClient.On("RecordAction", mock.Anything, mock.Anything).
+		Return(connect.NewResponse(&workflow.RecordActionResponse{
+			ActionId: update.ActionID,
+			Status:   &status.Status{Code: int32(code.Code_OK)},
+		}), nil).Once()
+
+	// First event — rejected, so the action must stay retryable.
+	c.notifyRunService(ctx, ta, update, watch.Added)
+	mockClient.AssertNumberOfCalls(t, "RecordAction", 1)
+
+	// Second event — still not recorded, so it is sent again.
+	c.notifyRunService(ctx, ta, update, watch.Added)
+	mockClient.AssertNumberOfCalls(t, "RecordAction", 2)
+
+	// Third event — accepted this time.
+	c.notifyRunService(ctx, ta, update, watch.Added)
+	mockClient.AssertNumberOfCalls(t, "RecordAction", 3)
+
+	// Fourth event — now recorded, so it is deduplicated.
+	c.notifyRunService(ctx, ta, update, watch.Added)
+	mockClient.AssertNumberOfCalls(t, "RecordAction", 3)
+}
+
+func TestNotifyRunService_AcceptedRecordDeduplicates(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := runmocks.NewInternalRunServiceClient(t)
+
+	filter, err := fastcheck.NewOppoBloomFilter(128, promutils.NewTestScope())
+	assert.NoError(t, err)
+
+	c := &ActionsClient{
+		runClient:      mockClient,
+		recordedFilter: filter,
+		subscribers:    make(map[string]map[chan *ActionUpdate]struct{}),
+	}
+
+	ta, update := newTestActionUpdate("action-accepted")
+
+	mockClient.On("RecordAction", mock.Anything, mock.Anything).
+		Return(connect.NewResponse(&workflow.RecordActionResponse{
+			ActionId: update.ActionID,
+			Status:   &status.Status{Code: int32(code.Code_OK)},
+		}), nil).Once()
+
+	c.notifyRunService(ctx, ta, update, watch.Added)
+	c.notifyRunService(ctx, ta, update, watch.Added)
+
+	mockClient.AssertNumberOfCalls(t, "RecordAction", 1)
 }
 
 func TestNotifyRunService_UpdateActionStatusIncludesAttemptsAndCacheStatus(t *testing.T) {
@@ -143,7 +259,7 @@ func TestNotifyRunService_UpdateActionStatusIncludesAttemptsAndCacheStatus(t *te
 	})).Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil).Once()
 	// First-sight MODIFIED now also records (deduped via the mandatory filter).
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Maybe()
+		Return(acceptedRecordActionResponse(), nil).Maybe()
 
 	c.notifyRunService(ctx, ta, update, watch.Modified)
 
@@ -476,7 +592,7 @@ func TestNotifyRunService_ChildAddedPromotesParentToRunning(t *testing.T) {
 
 	// Expect RecordAction for the child
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Once()
+		Return(acceptedRecordActionResponse(), nil).Once()
 
 	// Expect UpdateActionStatus for the PARENT with RUNNING phase
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.MatchedBy(func(req *connect.Request[workflow.UpdateActionStatusRequest]) bool {
@@ -527,7 +643,7 @@ func TestNotifyRunService_SkipsTerminalAddedEventsOnlyWhenInBloomFilter(t *testi
 
 	// First ADDED event (cold start, not in bloom filter): should process normally
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Once()
+		Return(acceptedRecordActionResponse(), nil).Once()
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.Anything).
 		Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil)
 	c.notifyRunService(ctx, ta, update, watch.Added)
@@ -583,7 +699,7 @@ func TestNotifyRunService_ProcessesNonTerminalAddedEvents(t *testing.T) {
 
 	// Non-terminal ADDED events should be processed normally
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Once()
+		Return(acceptedRecordActionResponse(), nil).Once()
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.Anything).
 		Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil).Once()
 
@@ -611,7 +727,7 @@ func TestNotifyRunService_DuplicateAddedSkipsRecordAction(t *testing.T) {
 
 	// First call — should process normally
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Once()
+		Return(acceptedRecordActionResponse(), nil).Once()
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.Anything).
 		Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil)
 	c.notifyRunService(ctx, ta, update, watch.Added)
@@ -641,7 +757,7 @@ func TestNotifyRunService_TerminalDuplicateRepairsTimestamps(t *testing.T) {
 
 	// First call — should process normally (RecordAction + UpdateActionStatus)
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Once()
+		Return(acceptedRecordActionResponse(), nil).Once()
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.Anything).
 		Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil).Times(2)
 	c.notifyRunService(ctx, ta, update, watch.Added)
@@ -668,7 +784,7 @@ func TestNotifyRunService_RootActionAddedDoesNotPromoteParent(t *testing.T) {
 	ta, update := newTestActionUpdate("action-root")
 
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Once()
+		Return(acceptedRecordActionResponse(), nil).Once()
 
 	c.notifyRunService(ctx, ta, update, watch.Added)
 
@@ -782,7 +898,7 @@ func TestHandleWatchEvent_CoalescedReadsLatestPhase(t *testing.T) {
 	}
 
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Once()
+		Return(acceptedRecordActionResponse(), nil).Once()
 	// Accept exactly one status update, and ONLY if it is SUCCEEDED. A RUNNING update
 	// would be an unexpected call and fail the test.
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.MatchedBy(func(req *connect.Request[workflow.UpdateActionStatusRequest]) bool {
@@ -827,7 +943,7 @@ func TestHandleWatchEvent_CreateThenDeleteStillRecords(t *testing.T) {
 
 	// Step 2: the DELETE tombstone (still carries Spec) must create the row, then abort it.
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Once()
+		Return(acceptedRecordActionResponse(), nil).Once()
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.MatchedBy(func(req *connect.Request[workflow.UpdateActionStatusRequest]) bool {
 		return req.Msg.GetStatus().GetPhase() == common.ActionPhase_ACTION_PHASE_ABORTED
 	})).Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil).Once()

--- a/actions/k8s/client_test.go
+++ b/actions/k8s/client_test.go
@@ -56,11 +56,15 @@ func newTestActionUpdate(actionName string) (*executorv1.TaskAction, *ActionUpda
 	return ta, update
 }
 
-func acceptedRecordActionResponse() *connect.Response[workflow.RecordActionResponse] {
+func acceptedRecordActionResponse(taskAction *executorv1.TaskAction) *connect.Response[workflow.RecordActionResponse] {
 	return connect.NewResponse(&workflow.RecordActionResponse{
 		ActionId: &common.ActionIdentifier{
-			Run:  &common.RunIdentifier{Org: "org", Project: "proj", Domain: "dev", Name: "run"},
-			Name: "action",
+			Run: &common.RunIdentifier{
+				Project: taskAction.Spec.Project,
+				Domain:  taskAction.Spec.Domain,
+				Name:    taskAction.Spec.RunName,
+			},
+			Name: taskAction.Spec.ActionName,
 		},
 		Status: &status.Status{Code: int32(code.Code_OK)},
 	})
@@ -84,7 +88,7 @@ func TestNotifyRunService_DeduplicateRecordAction(t *testing.T) {
 
 	// Expect RecordAction called exactly once
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(acceptedRecordActionResponse(), nil).Once()
+		Return(acceptedRecordActionResponse(ta), nil).Once()
 
 	// First Added event — should call RecordAction
 	c.notifyRunService(ctx, ta, update, watch.Added)
@@ -116,7 +120,7 @@ func TestNotifyRunService_FailedRecordAllowsRetry(t *testing.T) {
 		Return((*connect.Response[workflow.RecordActionResponse])(nil), fmt.Errorf("transient error")).Once()
 	// Second call succeeds
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(acceptedRecordActionResponse(), nil).Once()
+		Return(acceptedRecordActionResponse(ta), nil).Once()
 
 	// First event — RecordAction fails, should NOT add to filter
 	c.notifyRunService(ctx, ta, update, watch.Added)
@@ -263,7 +267,7 @@ func TestNotifyRunService_UpdateActionStatusIncludesAttemptsAndCacheStatus(t *te
 	})).Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil).Once()
 	// First-sight MODIFIED now also records (deduped via the mandatory filter).
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(acceptedRecordActionResponse(), nil).Maybe()
+		Return(acceptedRecordActionResponse(ta), nil).Maybe()
 
 	c.notifyRunService(ctx, ta, update, watch.Modified)
 
@@ -596,7 +600,7 @@ func TestNotifyRunService_ChildAddedPromotesParentToRunning(t *testing.T) {
 
 	// Expect RecordAction for the child
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(acceptedRecordActionResponse(), nil).Once()
+		Return(acceptedRecordActionResponse(ta), nil).Once()
 
 	// Expect UpdateActionStatus for the PARENT with RUNNING phase
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.MatchedBy(func(req *connect.Request[workflow.UpdateActionStatusRequest]) bool {
@@ -647,7 +651,7 @@ func TestNotifyRunService_SkipsTerminalAddedEventsOnlyWhenInBloomFilter(t *testi
 
 	// First ADDED event (cold start, not in bloom filter): should process normally
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(acceptedRecordActionResponse(), nil).Once()
+		Return(acceptedRecordActionResponse(ta), nil).Once()
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.Anything).
 		Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil)
 	c.notifyRunService(ctx, ta, update, watch.Added)
@@ -703,7 +707,7 @@ func TestNotifyRunService_ProcessesNonTerminalAddedEvents(t *testing.T) {
 
 	// Non-terminal ADDED events should be processed normally
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(acceptedRecordActionResponse(), nil).Once()
+		Return(acceptedRecordActionResponse(ta), nil).Once()
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.Anything).
 		Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil).Once()
 
@@ -731,7 +735,7 @@ func TestNotifyRunService_DuplicateAddedSkipsRecordAction(t *testing.T) {
 
 	// First call — should process normally
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(acceptedRecordActionResponse(), nil).Once()
+		Return(acceptedRecordActionResponse(ta), nil).Once()
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.Anything).
 		Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil)
 	c.notifyRunService(ctx, ta, update, watch.Added)
@@ -761,7 +765,7 @@ func TestNotifyRunService_TerminalDuplicateRepairsTimestamps(t *testing.T) {
 
 	// First call — should process normally (RecordAction + UpdateActionStatus)
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(acceptedRecordActionResponse(), nil).Once()
+		Return(acceptedRecordActionResponse(ta), nil).Once()
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.Anything).
 		Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil).Times(2)
 	c.notifyRunService(ctx, ta, update, watch.Added)
@@ -788,7 +792,7 @@ func TestNotifyRunService_RootActionAddedDoesNotPromoteParent(t *testing.T) {
 	ta, update := newTestActionUpdate("action-root")
 
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(acceptedRecordActionResponse(), nil).Once()
+		Return(acceptedRecordActionResponse(ta), nil).Once()
 
 	c.notifyRunService(ctx, ta, update, watch.Added)
 
@@ -902,7 +906,7 @@ func TestHandleWatchEvent_CoalescedReadsLatestPhase(t *testing.T) {
 	}
 
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(acceptedRecordActionResponse(), nil).Once()
+		Return(acceptedRecordActionResponse(succeededTaskAction("a3")), nil).Once()
 	// Accept exactly one status update, and ONLY if it is SUCCEEDED. A RUNNING update
 	// would be an unexpected call and fail the test.
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.MatchedBy(func(req *connect.Request[workflow.UpdateActionStatusRequest]) bool {
@@ -947,7 +951,7 @@ func TestHandleWatchEvent_CreateThenDeleteStillRecords(t *testing.T) {
 
 	// Step 2: the DELETE tombstone (still carries Spec) must create the row, then abort it.
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(acceptedRecordActionResponse(), nil).Once()
+		Return(acceptedRecordActionResponse(runningTaskAction("d1")), nil).Once()
 	mockClient.On("UpdateActionStatus", mock.Anything, mock.MatchedBy(func(req *connect.Request[workflow.UpdateActionStatusRequest]) bool {
 		return req.Msg.GetStatus().GetPhase() == common.ActionPhase_ACTION_PHASE_ABORTED
 	})).Return(&connect.Response[workflow.UpdateActionStatusResponse]{}, nil).Once()

--- a/actions/k8s/client_test.go
+++ b/actions/k8s/client_test.go
@@ -166,7 +166,7 @@ func TestNotifyRunService_MissingResponseAllowsRetry(t *testing.T) {
 	}
 }
 
-func TestNotifyRunService_RejectedRecordAllowsRetry(t *testing.T) {
+func TestNotifyRunService_InternalFailureAllowsRetry(t *testing.T) {
 	ctx := context.Background()
 
 	mockClient := runmocks.NewInternalRunServiceClient(t)
@@ -180,26 +180,26 @@ func TestNotifyRunService_RejectedRecordAllowsRetry(t *testing.T) {
 		subscribers:    make(map[string]map[chan *ActionUpdate]struct{}),
 	}
 
-	ta, update := newTestActionUpdate("action-rejected")
+	ta, update := newTestActionUpdate("action-internal-failure")
 
-	// The run service reports rejections in the response body with a nil
+	// The run service reports repository failures in the response body with a nil
 	// transport error, so the first two calls look like successes to connect.
-	rejected := connect.NewResponse(&workflow.RecordActionResponse{
+	failed := connect.NewResponse(&workflow.RecordActionResponse{
 		ActionId: update.ActionID,
 		Status: &status.Status{
-			Code:    int32(code.Code_INVALID_ARGUMENT),
-			Message: "unsupported action spec type: <nil>",
+			Code:    int32(code.Code_INTERNAL),
+			Message: "failed to create action: transient database error",
 		},
 	})
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
-		Return(rejected, nil).Twice()
+		Return(failed, nil).Twice()
 	mockClient.On("RecordAction", mock.Anything, mock.Anything).
 		Return(connect.NewResponse(&workflow.RecordActionResponse{
 			ActionId: update.ActionID,
 			Status:   &status.Status{Code: int32(code.Code_OK)},
 		}), nil).Once()
 
-	// First event — rejected, so the action must stay retryable.
+	// First event fails, so the action must stay retryable.
 	c.notifyRunService(ctx, ta, update, watch.Added)
 	mockClient.AssertNumberOfCalls(t, "RecordAction", 1)
 

--- a/runs/test/api/record_action_status_test.go
+++ b/runs/test/api/record_action_status_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/code"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow/workflowconnect"
+)
+
+func TestRecordActionReturnsRepositoryFailureInBody(t *testing.T) {
+	t.Cleanup(func() { cleanupTestDB(t) })
+
+	ctx := context.Background()
+	require.NoError(t, testDB.PingContext(ctx))
+	require.NoError(t, renameActionsTable(ctx, "actions", "actions_unavailable"))
+	t.Cleanup(func() {
+		require.NoError(t, renameActionsTable(context.Background(), "actions_unavailable", "actions"))
+	})
+
+	client := workflowconnect.NewInternalRunServiceClient(newClient(), endpoint)
+	response, err := client.RecordAction(ctx, connect.NewRequest(&workflow.RecordActionRequest{
+		ActionId: &common.ActionIdentifier{
+			Run: &common.RunIdentifier{
+				Org:     testOrg,
+				Project: testProject,
+				Domain:  testDomain,
+				Name:    "r" + uniqueString(),
+			},
+			Name: "record-action-db-failure",
+		},
+		Spec: &workflow.RecordActionRequest_Task{
+			Task: &workflow.TaskAction{
+				Spec: &task.TaskSpec{TaskTemplate: &core.TaskTemplate{Type: "python"}},
+			},
+		},
+	}))
+
+	require.NoError(t, err)
+	require.Equal(t, int32(code.Code_INTERNAL), response.Msg.GetStatus().GetCode())
+	t.Logf(
+		"DB-FAILURE transportErr=%v status.code=%d status.message=%q",
+		err,
+		response.Msg.GetStatus().GetCode(),
+		response.Msg.GetStatus().GetMessage(),
+	)
+}
+
+func renameActionsTable(ctx context.Context, from string, to string) error {
+	_, err := testDB.ExecContext(ctx, "ALTER TABLE "+from+" RENAME TO "+to)
+	return err
+}

--- a/runs/test/api/record_action_status_test.go
+++ b/runs/test/api/record_action_status_test.go
@@ -54,6 +54,8 @@ func TestRecordActionReturnsRepositoryFailureInBody(t *testing.T) {
 }
 
 func renameActionsTable(ctx context.Context, from string, to string) error {
+	// Table identifiers cannot be bind parameters, so the names are concatenated.
+	// Both callers pass string literals, so nothing here comes from user input.
 	_, err := testDB.ExecContext(ctx, "ALTER TABLE "+from+" RENAME TO "+to)
 	return err
 }


### PR DESCRIPTION
## Tracking issue

N/A

## Why are the changes needed?

An action can disappear from Flyte's run history after a repository failure. `RecordAction` puts application failures in `resp.Msg.Status` while returning `err == nil`. The old client adds the failed action to `recordedFilter`, so it is never retried.

It surfaced while checking whether https://github.com/flyteorg/flyte/pull/7852 applied to v2. V2 handles duplicates idempotently; its failure path was broken instead.

## What changes were proposed in this pull request?

Only memoize an action after a non-nil response reports `Status.Code == OK`. Keep every other result retryable and log rejected statuses.

## How was this patch tested?

A real `RunService`, Connect handler, migrations, and embedded PostgreSQL returned `Status=INTERNAL` with no Connect error. The merge-base client stopped after one RPC; the PR retried until OK.

<details><summary>Commands and raw output</summary>

```console
$ go test ./runs/test/api -run '^TestRecordActionReturnsRepositoryFailureInBody$' -count=1 -v
DB-FAILURE transportErr=<nil> status.code=13 status.message="failed to create action: ERROR: relation \"actions\" does not exist (SQLSTATE 42P01)"
--- PASS: TestRecordActionReturnsRepositoryFailureInBody (0.01s)

$ BASE=$(git merge-base HEAD upstream/main)
$ git restore --source="$BASE" -- actions/k8s/client.go
$ go test ./actions/k8s/... -run TestNotifyRunService_InternalFailureAllowsRetry -count=1 -v
    Expected number of calls (3) of method RecordAction does not match the actual number of calls (1).
--- FAIL: TestNotifyRunService_InternalFailureAllowsRetry (0.00s)

$ git restore --source=HEAD -- actions/k8s/client.go
$ go test ./actions/k8s/... -run TestNotifyRunService_InternalFailureAllowsRetry -count=1 -v
--- PASS: TestNotifyRunService_InternalFailureAllowsRetry (0.00s)
```

</details>

### Labels

fixed

### Setup process

N/A

### Screenshots

N/A

## Check all the applicable boxes

- [ ] I updated the documentation accordingly. Not applicable: no documented behavior changed.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flyte/pull/7852

## Stack

<!-- branch-stack -->

## Docs link

N/A
