### PR TITLE
fix(plugins/ray): retry KubeRay status-loss failures

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -930,24 +930,22 @@ func (plugin rayJobResourceHandler) GetTaskPhase(ctx context.Context, pluginCont
 		return pluginsCore.PhaseInfoQueuedWithTaskInfo(time.Now(), pluginsCore.DefaultPhaseVersion, "cluster is suspended", info), nil
 	case rayv1.JobDeploymentStatusFailed:
 		failInfo := fmt.Sprintf("Failed to run Ray job %s with error: [%s] %s", rayJob.Name, rayJob.Status.Reason, rayJob.Status.Message)
-		if rayJob.Status.Reason == rayv1.JobDeploymentStatusTransitionGracePeriodExceeded {
-			// KubeRay never observed the RayJob's final status, so the job's outcome is unknown and the
-			// task's code may never have run. Retry on a fresh cluster instead of blaming the task.
-			return pluginsCore.PhaseInfoSystemRetryableFailureWithCleanup(flyteerr.TaskFailedWithError, failInfo, info), nil
-		}
-		// Honor a RECOVERABLE error.pb (written by sdk) so the task's retries fire. A failed RayJob surfaces here as a
-		// terminal phase, so -- unlike the success path -- the k8s plugin manager never reads the
-		// error file on our behalf. Key off the proto-level recoverability so only a genuine
-		// RECOVERABLE container error retries: an absent, unreadable, or malformed error file is
-		// reported by the reader as a SYSTEM error and stays terminal, preserving previous behavior.
 		phaseInfo, err = pluginsCore.PhaseInfoFailure(flyteerr.TaskFailedWithError, failInfo, info), nil
+		taskErrorAbsent := false
+		// A task error is authoritative; use KubeRay's fallback only when no error file exists.
 		if ow := pluginContext.OutputWriter(); ow != nil {
 			reader := ioutils.NewRemoteFileOutputReader(ctx, pluginContext.DataStore(), ow, 0)
-			if hasErr, readerErr := reader.IsError(ctx); readerErr == nil && hasErr {
-				if execErr, readerErr := reader.ReadError(ctx); readerErr == nil && execErr.GetRecoverability() == core.ContainerError_RECOVERABLE {
-					phaseInfo = pluginsCore.PhaseInfoRetryableFailure(flyteerr.TaskFailedWithError, failInfo, info)
+			if hasErr, readerErr := reader.IsError(ctx); readerErr == nil {
+				taskErrorAbsent = !hasErr
+				if hasErr {
+					if execErr, readerErr := reader.ReadError(ctx); readerErr == nil && execErr.GetRecoverability() == core.ContainerError_RECOVERABLE {
+						phaseInfo = pluginsCore.PhaseInfoRetryableFailure(flyteerr.TaskFailedWithError, failInfo, info)
+					}
 				}
 			}
+		}
+		if taskErrorAbsent && rayJob.Status.Reason == rayv1.JobDeploymentStatusTransitionGracePeriodExceeded {
+			phaseInfo = pluginsCore.PhaseInfoSystemRetryableFailureWithCleanup(flyteerr.TaskFailedWithError, failInfo, info)
 		}
 	default:
 		// We already handle all known deployment status, so this should never happen unless a future version of ray

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -930,6 +930,11 @@ func (plugin rayJobResourceHandler) GetTaskPhase(ctx context.Context, pluginCont
 		return pluginsCore.PhaseInfoQueuedWithTaskInfo(time.Now(), pluginsCore.DefaultPhaseVersion, "cluster is suspended", info), nil
 	case rayv1.JobDeploymentStatusFailed:
 		failInfo := fmt.Sprintf("Failed to run Ray job %s with error: [%s] %s", rayJob.Name, rayJob.Status.Reason, rayJob.Status.Message)
+		if rayJob.Status.Reason == rayv1.JobDeploymentStatusTransitionGracePeriodExceeded {
+			// KubeRay never observed the RayJob's final status, so the job's outcome is unknown and the
+			// task's code may never have run. Retry on a fresh cluster instead of blaming the task.
+			return pluginsCore.PhaseInfoSystemRetryableFailureWithCleanup(flyteerr.TaskFailedWithError, failInfo, info), nil
+		}
 		// Honor a RECOVERABLE error.pb (written by sdk) so the task's retries fire. A failed RayJob surfaces here as a
 		// terminal phase, so -- unlike the success path -- the k8s plugin manager never reads the
 		// error file on our behalf. Key off the proto-level recoverability so only a genuine

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -1716,6 +1716,76 @@ func TestGetTaskPhase_RecoverableErrorFile(t *testing.T) {
 	}
 }
 
+// TestGetTaskPhase_DeploymentStatusTransitionGracePeriodExceeded verifies that a RayJob failed by
+// KubeRay's status-transition grace period is mapped to a *system* retryable failure with cleanup,
+// while a genuine application failure stays a terminal user failure.
+func TestGetTaskPhase_DeploymentStatusTransitionGracePeriodExceeded(t *testing.T) {
+	ctx := context.Background()
+	handler := rayJobResourceHandler{}
+
+	newFailedRayJob := func(reason rayv1.JobFailedReason, message string) *rayv1.RayJob {
+		startTime := metav1.NewTime(time.Now())
+		return &rayv1.RayJob{
+			Spec: rayv1.RayJobSpec{
+				RayClusterSpec: &rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "ray-head", Image: "rayproject/ray:latest"},
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: rayv1.RayJobStatus{
+				JobDeploymentStatus: rayv1.JobDeploymentStatusFailed,
+				RayClusterName:      "ray-clust",
+				Reason:              reason,
+				Message:             message,
+				StartTime:           &startTime,
+			},
+		}
+	}
+
+	for _, tc := range []struct {
+		name            string
+		reason          rayv1.JobFailedReason
+		message         string
+		expectedPhase   pluginsCore.Phase
+		expectedKind    core.ExecutionError_ErrorKind
+		expectedCleanup bool
+	}{
+		{
+			name:            "status transition grace period exceeded is a retryable system failure",
+			reason:          rayv1.JobDeploymentStatusTransitionGracePeriodExceeded,
+			message:         "The JobDeploymentStatus transition from Running to Complete exceeded the grace period",
+			expectedPhase:   pluginsCore.PhaseRetryableFailure,
+			expectedKind:    core.ExecutionError_SYSTEM,
+			expectedCleanup: true,
+		},
+		{
+			name:            "app failure stays a terminal user failure",
+			reason:          rayv1.AppFailed,
+			message:         "Job entrypoint command failed with exit code 1",
+			expectedPhase:   pluginsCore.PhasePermanentFailure,
+			expectedKind:    core.ExecutionError_USER,
+			expectedCleanup: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pluginCtx := rayPluginContext(k8s.PluginState{})
+			phaseInfo, err := handler.GetTaskPhase(ctx, pluginCtx, newFailedRayJob(tc.reason, tc.message))
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedPhase.String(), phaseInfo.Phase().String())
+			assert.Equal(t, tc.expectedKind, phaseInfo.Err().GetKind())
+			assert.Equal(t, tc.expectedCleanup, phaseInfo.CleanupOnFailure())
+			assert.Contains(t, phaseInfo.Err().GetMessage(), tc.message)
+		})
+	}
+}
+
 func TestGetTaskPhaseIncreasePhaseVersion(t *testing.T) {
 	rayJobResourceHandler := rayJobResourceHandler{}
 

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -1716,12 +1716,20 @@ func TestGetTaskPhase_RecoverableErrorFile(t *testing.T) {
 	}
 }
 
-// TestGetTaskPhase_DeploymentStatusTransitionGracePeriodExceeded verifies that a RayJob failed by
-// KubeRay's status-transition grace period is mapped to a *system* retryable failure with cleanup,
-// while a genuine application failure stays a terminal user failure.
+// TestGetTaskPhase_DeploymentStatusTransitionGracePeriodExceeded verifies that task errors take
+// precedence over KubeRay's status-transition fallback.
 func TestGetTaskPhase_DeploymentStatusTransitionGracePeriodExceeded(t *testing.T) {
 	ctx := context.Background()
 	handler := rayJobResourceHandler{}
+
+	newErrorDoc := func(kind core.ContainerError_Kind) *core.ErrorDocument {
+		return &core.ErrorDocument{Error: &core.ContainerError{
+			Code:    "USER:Unknown",
+			Message: "boom",
+			Kind:    kind,
+			Origin:  core.ExecutionError_USER,
+		}}
+	}
 
 	newFailedRayJob := func(reason rayv1.JobFailedReason, message string) *rayv1.RayJob {
 		startTime := metav1.NewTime(time.Now())
@@ -1753,6 +1761,7 @@ func TestGetTaskPhase_DeploymentStatusTransitionGracePeriodExceeded(t *testing.T
 		name            string
 		reason          rayv1.JobFailedReason
 		message         string
+		errorDoc        *core.ErrorDocument
 		expectedPhase   pluginsCore.Phase
 		expectedKind    core.ExecutionError_ErrorKind
 		expectedCleanup bool
@@ -1766,6 +1775,24 @@ func TestGetTaskPhase_DeploymentStatusTransitionGracePeriodExceeded(t *testing.T
 			expectedCleanup: true,
 		},
 		{
+			name:            "non-recoverable task error stays a terminal user failure",
+			reason:          rayv1.JobDeploymentStatusTransitionGracePeriodExceeded,
+			message:         "The JobDeploymentStatus transition from Running to Failed exceeded the grace period",
+			errorDoc:        newErrorDoc(core.ContainerError_NON_RECOVERABLE),
+			expectedPhase:   pluginsCore.PhasePermanentFailure,
+			expectedKind:    core.ExecutionError_USER,
+			expectedCleanup: false,
+		},
+		{
+			name:            "recoverable task error stays a retryable user failure",
+			reason:          rayv1.JobDeploymentStatusTransitionGracePeriodExceeded,
+			message:         "The JobDeploymentStatus transition from Running to Failed exceeded the grace period",
+			errorDoc:        newErrorDoc(core.ContainerError_RECOVERABLE),
+			expectedPhase:   pluginsCore.PhaseRetryableFailure,
+			expectedKind:    core.ExecutionError_USER,
+			expectedCleanup: false,
+		},
+		{
 			name:            "app failure stays a terminal user failure",
 			reason:          rayv1.AppFailed,
 			message:         "Job entrypoint command failed with exit code 1",
@@ -1775,7 +1802,7 @@ func TestGetTaskPhase_DeploymentStatusTransitionGracePeriodExceeded(t *testing.T
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			pluginCtx := rayPluginContext(k8s.PluginState{})
+			pluginCtx := rayPluginContextWithErrorDoc(k8s.PluginState{}, tc.errorDoc)
 			phaseInfo, err := handler.GetTaskPhase(ctx, pluginCtx, newFailedRayJob(tc.reason, tc.message))
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedPhase.String(), phaseInfo.Phase().String())


### PR DESCRIPTION
## Tracking issue

Related to https://github.com/flyteorg/flyte/pull/7153

## Why are the changes needed?

KubeRay can mark a job failed when its deployment status never reaches a terminal
state within the grace period. Flyte currently attributes that bookkeeping failure to
user code.

Before this change, a task can fail permanently without using a retry even when its
code never ran. After this change, Flyte retries that status-loss case on a fresh Ray
cluster, but an existing task error still decides whether the failure is recoverable.

## What changes were proposed in this pull request?

Use a retryable system failure with cleanup only when KubeRay reports the grace-period
reason and no task error file exists. Recoverable and non-recoverable task errors keep
their existing classification.

## How was this patch tested?

The phase test covers the status-loss case, both task-error kinds, and a normal
application failure. A live KubeRay timeout has not been forced.

```console
$ git checkout upstream/main -- flyteplugins/go/tasks/plugins/k8s/ray/ray.go
$ cd flyteplugins && go test ./go/tasks/plugins/k8s/ray/... -run TestGetTaskPhase_DeploymentStatusTransitionGracePeriodExceeded -v
--- FAIL: status_transition_grace_period_exceeded_is_a_retryable_system_failure
    expected: PhaseRetryableFailure
    actual: PhasePermanentFailure

$ git checkout origin/1fanwang-fix-ray-infra-failure-retry -- go/tasks/plugins/k8s/ray/ray.go
$ go test ./go/tasks/plugins/k8s/ray/... -run TestGetTaskPhase_DeploymentStatusTransitionGracePeriodExceeded -v
--- PASS: status_transition_grace_period_exceeded_is_a_retryable_system_failure
--- PASS: non-recoverable_task_error_stays_a_terminal_user_failure
--- PASS: recoverable_task_error_stays_a_retryable_user_failure
--- PASS: app_failure_stays_a_terminal_user_failure
```

### Labels

fixed

### Setup process

The test uses RayJob objects and the plugin's in-memory task error store.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly. Not applicable: no documented behavior changed.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

- https://github.com/flyteorg/flyte/pull/7153
- https://github.com/flyteorg/flyte/pull/7566

## Stack

<!-- branch-stack -->
