### PR TITLE
fix: honor in-band rejection status from UpdateActionStatus

### DIFF
--- a/actions/k8s/client.go
+++ b/actions/k8s/client.go
@@ -803,8 +803,11 @@ func (c *ActionsClient) notifyRunService(ctx context.Context, taskAction *execut
 				Phase: common.ActionPhase_ACTION_PHASE_RUNNING,
 			},
 		}
-		if _, err := c.runClient.UpdateActionStatus(ctx, connect.NewRequest(parentStatusReq)); err != nil {
+		if resp, err := c.runClient.UpdateActionStatus(ctx, connect.NewRequest(parentStatusReq)); err != nil {
 			logger.Warnf(ctx, "Failed to promote parent action %s to RUNNING: %v", update.ParentActionName, err)
+		} else if code := resp.Msg.GetStatus().GetCode(); code != 0 {
+			logger.Warnf(ctx, "Run service rejected promoting parent action %s to RUNNING: code=%d message=%s",
+				update.ParentActionName, code, resp.Msg.GetStatus().GetMessage())
 		}
 	}
 
@@ -837,8 +840,11 @@ func (c *ActionsClient) notifyRunService(ctx context.Context, taskAction *execut
 				}
 			}
 		}
-		if _, err := c.runClient.UpdateActionStatus(ctx, connect.NewRequest(statusReq)); err != nil {
+		if resp, err := c.runClient.UpdateActionStatus(ctx, connect.NewRequest(statusReq)); err != nil {
 			logger.Warnf(ctx, "Failed to update action status in run service for %s: %v", update.ActionID.Name, err)
+		} else if code := resp.Msg.GetStatus().GetCode(); code != 0 {
+			logger.Warnf(ctx, "Run service rejected action status update for %s: code=%d message=%s",
+				update.ActionID.Name, code, resp.Msg.GetStatus().GetMessage())
 		} else if isTerminalPhase(update.Phase) && !update.IsDeleted {
 			// Skip label patching for deleted CRs — the patch would always fail
 			// with "not found" since the object is already gone.

--- a/actions/k8s/client_test.go
+++ b/actions/k8s/client_test.go
@@ -10,11 +10,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	executorv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
 	"github.com/flyteorg/flyte/v2/flytestdlib/fastcheck"
@@ -143,6 +148,67 @@ func TestNotifyRunService_UpdateActionStatusIncludesAttemptsAndCacheStatus(t *te
 	c.notifyRunService(ctx, ta, update, watch.Modified)
 
 	mockClient.AssertNumberOfCalls(t, "UpdateActionStatus", 1)
+}
+
+// TestNotifyRunService_RejectedStatusUpdateSkipsTerminalLabel covers the bug
+// where UpdateActionStatus reports the rejection in-band via resp.Status
+// instead of a transport error. Before the fix, notifyRunService only checked
+// the transport error, so a rejected terminal update was still marked
+// terminal-status-recorded, permanently preventing retries.
+func TestNotifyRunService_RejectedStatusUpdateSkipsTerminalLabel(t *testing.T) {
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, executorv1.AddToScheme(scheme))
+
+	ta := &executorv1.TaskAction{
+		ObjectMeta: metav1.ObjectMeta{Name: "run1-action-5", Namespace: "flyte"},
+		Spec: executorv1.TaskActionSpec{
+			Project:    "proj",
+			Domain:     "dev",
+			RunName:    "run1",
+			ActionName: "action-5",
+		},
+	}
+
+	mockClient := runmocks.NewInternalRunServiceClient(t)
+	c := &ActionsClient{
+		runClient:      mockClient,
+		recordedFilter: testFilter(),
+		subscribers:    make(map[string]map[chan *ActionUpdate]struct{}),
+		k8sClient: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ta.DeepCopy()).
+			Build(),
+	}
+
+	update := &ActionUpdate{
+		ActionID: &common.ActionIdentifier{
+			Run:  &common.RunIdentifier{Project: "proj", Domain: "dev", Name: "run1"},
+			Name: "action-5",
+		},
+		Phase: common.ActionPhase_ACTION_PHASE_SUCCEEDED,
+	}
+
+	// Transport succeeds (err == nil), but the run service rejects the write
+	// in-band — e.g. a DB failure — and reports it via resp.Status.
+	mockClient.On("UpdateActionStatus", mock.Anything, mock.Anything).
+		Return(&connect.Response[workflow.UpdateActionStatusResponse]{
+			Msg: &workflow.UpdateActionStatusResponse{
+				Status: &status.Status{Code: int32(codes.Internal), Message: "db write failed"},
+			},
+		}, nil).Once()
+	mockClient.On("RecordAction", mock.Anything, mock.Anything).
+		Return(&connect.Response[workflow.RecordActionResponse]{}, nil).Maybe()
+
+	c.notifyRunService(ctx, ta, update, watch.Modified)
+
+	mockClient.AssertNumberOfCalls(t, "UpdateActionStatus", 1)
+
+	var got executorv1.TaskAction
+	require.NoError(t, c.k8sClient.Get(ctx, client.ObjectKeyFromObject(ta), &got))
+	assert.NotEqual(t, "true", got.GetLabels()[labelTerminalStatusRecorded],
+		"terminal-status-recorded must not be set when the run service rejects the update")
 }
 
 func TestBuildTaskActionName(t *testing.T) {


### PR DESCRIPTION
UpdateActionStatus never returns a transport error for an in-band rejection (e.g. a DB write failure) — the run service reports it via resp.Status instead. notifyRunService only checked the transport error, so a rejected terminal update was still marked terminal-status-recorded, permanently preventing retries.

Fixes #7884

## Tracking issue

Closes #7884

Related to #7889 — reopened against `main` since `v2` was merged into `main` and is now stale. cc @pingsutw

## Why are the changes needed?

`UpdateActionStatus` never returns a transport error for an in-band rejection (e.g. a DB write failure) — the run service reports it via `resp.Status` instead. `notifyRunService` only checked the transport error, so a rejected terminal status update was still marked `terminal-status-recorded`, permanently preventing further retries and leaving the action stuck in a non-terminal phase with no visible error.

## What changes were proposed in this pull request?

Check `resp.Msg.GetStatus().GetCode()` in addition to the transport error at both `UpdateActionStatus` call sites in `notifyRunService` (parent-promotion and terminal status update). If the run service reports a non-zero status code, log a warning and skip `markTerminalStatusRecorded`, so the update can be retried on the next event.

## How was this patch tested?

Added `TestNotifyRunService_RejectedStatusUpdateSkipsTerminalLabel` in `client_test.go`, which mocks `UpdateActionStatus` returning a non-zero `Status.Code` with a nil transport error, and asserts the TaskAction CR does not receive the `terminal-status-recorded` label.

### Labels

- fixed

### Setup process



### Screenshots



## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

#7889 (superseded by this PR, opened against the stale `v2` branch)

## Stack

<!-- branch-stack -->

## Docs link
