### PR TITLE
fix(flytectl): print execution details holding a NaN

### DIFF
--- a/flytectl/cmd/get/node_execution.go
+++ b/flytectl/cmd/get/node_execution.go
@@ -3,6 +3,7 @@ package get
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyte/flytestdlib/utils"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var nodeExecutionColumns = []printer.Column{
@@ -259,7 +261,55 @@ func extractLiteralMap(literalMap *core.LiteralMap) (map[string]interface{}, err
 		if err != nil {
 			return nil, err
 		}
-		m[key] = extractedLiteralVal
+		m[key] = jsonSafe(extractedLiteralVal)
 	}
 	return m, nil
+}
+
+// jsonSafe replaces the non-finite floats an extracted literal can hold with
+// nil. A task may legitimately output one (a metric that came out NaN, say),
+// and encoding/json refuses them, so without this the whole detailed view -
+// every node of the execution, in every output format - fails to print.
+func jsonSafe(value interface{}) interface{} {
+	switch typedValue := value.(type) {
+	case float64:
+		if math.IsNaN(typedValue) || math.IsInf(typedValue, 0) {
+			return nil
+		}
+	case float32:
+		if math.IsNaN(float64(typedValue)) || math.IsInf(float64(typedValue), 0) {
+			return nil
+		}
+	case map[string]interface{}:
+		for key, item := range typedValue {
+			typedValue[key] = jsonSafe(item)
+		}
+	case []interface{}:
+		for index, item := range typedValue {
+			typedValue[index] = jsonSafe(item)
+		}
+	case *structpb.Struct:
+		for _, field := range typedValue.GetFields() {
+			jsonSafeStructValue(field)
+		}
+	}
+	return value
+}
+
+// jsonSafeStructValue nulls out the same floats inside a generic literal.
+func jsonSafeStructValue(value *structpb.Value) {
+	switch kind := value.GetKind().(type) {
+	case *structpb.Value_NumberValue:
+		if math.IsNaN(kind.NumberValue) || math.IsInf(kind.NumberValue, 0) {
+			value.Kind = &structpb.Value_NullValue{}
+		}
+	case *structpb.Value_StructValue:
+		for _, field := range kind.StructValue.GetFields() {
+			jsonSafeStructValue(field)
+		}
+	case *structpb.Value_ListValue:
+		for _, item := range kind.ListValue.GetValues() {
+			jsonSafeStructValue(item)
+		}
+	}
 }

--- a/flytectl/cmd/get/node_execution_test.go
+++ b/flytectl/cmd/get/node_execution_test.go
@@ -1,7 +1,9 @@
 package get
 
 import (
+	"encoding/json"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -323,4 +326,61 @@ func TestExtractLiteralMapError(t *testing.T) {
 	literalMap, err = extractLiteralMap(&core.LiteralMap{})
 	assert.Nil(t, err)
 	assert.Equal(t, len(literalMap), 0)
+}
+
+func floatLiteral(value float64) *core.Literal {
+	return &core.Literal{Value: &core.Literal_Scalar{Scalar: &core.Scalar{
+		Value: &core.Scalar_Primitive{Primitive: &core.Primitive{
+			Value: &core.Primitive_FloatValue{FloatValue: value},
+		}},
+	}}}
+}
+
+func TestExtractLiteralMapNonFiniteFloats(t *testing.T) {
+	t.Run("primitive", func(t *testing.T) {
+		literalMap, err := extractLiteralMap(&core.LiteralMap{Literals: map[string]*core.Literal{
+			"nan":      floatLiteral(math.NaN()),
+			"inf":      floatLiteral(math.Inf(1)),
+			"negInf":   floatLiteral(math.Inf(-1)),
+			"accuracy": floatLiteral(0.5),
+		}})
+		assert.Nil(t, err)
+		assert.Equal(t, map[string]interface{}{
+			"nan": nil, "inf": nil, "negInf": nil, "accuracy": 0.5,
+		}, literalMap)
+
+		_, err = json.Marshal(literalMap)
+		assert.Nil(t, err)
+	})
+
+	t.Run("inside a map literal", func(t *testing.T) {
+		literalMap, err := extractLiteralMap(&core.LiteralMap{Literals: map[string]*core.Literal{
+			"o0": {Value: &core.Literal_Map{Map: &core.LiteralMap{
+				Literals: map[string]*core.Literal{"Average Bytes": floatLiteral(math.NaN())},
+			}}},
+		}})
+		assert.Nil(t, err)
+		assert.Equal(t, map[string]interface{}{
+			"o0": map[string]interface{}{"Average Bytes": nil},
+		}, literalMap)
+
+		_, err = json.Marshal(literalMap)
+		assert.Nil(t, err)
+	})
+
+	t.Run("inside a generic literal", func(t *testing.T) {
+		generic, err := structpb.NewStruct(map[string]interface{}{"scores": []interface{}{0.5}})
+		assert.Nil(t, err)
+		generic.Fields["scores"].GetListValue().Values[0] = structpb.NewNumberValue(math.NaN())
+
+		literalMap, err := extractLiteralMap(&core.LiteralMap{Literals: map[string]*core.Literal{
+			"o0": {Value: &core.Literal_Scalar{Scalar: &core.Scalar{
+				Value: &core.Scalar_Generic{Generic: generic},
+			}}},
+		}})
+		assert.Nil(t, err)
+
+		_, err = json.Marshal(literalMap)
+		assert.Nil(t, err)
+	})
 }


### PR DESCRIPTION
## Why are the changes needed?

`flytectl get execution --details` cannot print an execution whose node inputs or outputs hold a non-finite float:

```
$ flytectl get execution -p my-project -d production my-exec -o json --details
Error: json: unsupported value: NaN
```

The marshal happens before the output-format switch, so `-o json` and `-o yaml` fail alike and nothing at all is printed: one task output that came out NaN loses the whole detailed view of every node in the execution.

## What changes were proposed in this pull request?

Extracted non-finite floats become `nil`, so they print as `null` and the rest of the view survives.

## How was this patch tested?

`TestExtractLiteralMapNonFiniteFloats` covers a float primitive (NaN, +Inf, -Inf, alongside a finite value that must survive), a map literal holding a NaN, and a generic literal holding one, asserting both the extracted value and that `json.Marshal` then succeeds. It fails without the fix, `float64 NaN` vs `<nil>` plus the two marshal errors.

`go test ./cmd/get/...` passes.

Checked against the real command as well, on an execution that reproduces the failure. Before, on `flytectl` v0.9.8 and on `master`:

```
$ flytectl get execution -p fl-default -d production my-failing-execution -o json --details
Error: json: unsupported value: NaN
```

After, with a binary built from this branch, the full details view prints, 33 node executions, with the three NaN eval metrics as `null`:

```
$ flytectl-patched get execution -p fl-default -d production my-failing-execution -o json --details
# details, no error
```

### Labels

fixed

## Check all the applicable boxes

- [x] I updated the documentation accordingly. (no user-facing behaviour to document beyond the changelog label)
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
