### PR TITLE
fix(flyteplugins): fail tasks whose container exits non-zero instead of relaunching forever

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -40,6 +40,16 @@ const SIGKILL = 137
 // unsignedSIGKILL = 256 - 9
 const unsignedSIGKILL = 247
 
+// ContainerFailed is reported when the task's container exited with a non-zero status of its own
+// accord and the container runtime gave no more specific reason.
+const ContainerFailed = "ContainerFailed"
+
+// maxUserExitCode is the highest exit status attributable to the application itself. A process
+// killed by signal N is reported as 128+N, so the band above 127 means something terminated the
+// process rather than the process choosing to fail. Graceful eviction, drain and preemption all
+// send SIGTERM first, which surfaces as 143.
+const maxUserExitCode = 127
+
 const defaultContainerTemplateName = "default"
 const defaultInitContainerTemplateName = "default-init"
 const primaryContainerTemplateName = "primary"
@@ -1600,6 +1610,21 @@ func DemystifyFailure(ctx context.Context, status v1.PodStatus, info pluginsCore
 					containerState.Terminated.ExitCode,
 					containerState.Terminated.Reason,
 					containerState.Terminated.Message)
+			}
+		}
+	}
+
+	// A container that exited non-zero on its own is the application reporting failure, not the
+	// missing kubelet record the fallback below assumes. Only main containers are considered: the
+	// co-pilot runs as init containers. When a pod has exactly one main container, that
+	// container's exit status is taken as the task's result.
+	if code == "UnknownError" && len(status.ContainerStatuses) == 1 {
+		if t := status.ContainerStatuses[0].State.Terminated; t != nil &&
+			t.ExitCode > 0 && t.ExitCode <= maxUserExitCode {
+			if t.Reason != "" {
+				code = t.Reason
+			} else {
+				code = ContainerFailed
 			}
 		}
 	}

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -3156,6 +3156,107 @@ func TestDemystifyFailure(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("non-zero exit with no reason is a user error", func(t *testing.T) {
+		phaseInfo, err := DemystifyFailure(ctx, v1.PodStatus{
+			Phase: v1.PodFailed,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name: "abc123-n0-0",
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							ExitCode: 2,
+						},
+					},
+				},
+			},
+		}, pluginsCore.TaskInfo{}, "")
+		assert.Nil(t, err)
+		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
+		assert.Equal(t, ContainerFailed, phaseInfo.Err().Code)
+		assert.Equal(t, core.ExecutionError_USER, phaseInfo.Err().Kind)
+	})
+
+	t.Run("exit 127 is still a user error", func(t *testing.T) {
+		// 127 is the inclusive upper bound: a missing binary or bad entrypoint is
+		// the user's failure, not the platform's.
+		phaseInfo, err := DemystifyFailure(ctx, v1.PodStatus{
+			Phase: v1.PodFailed,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name: "abc123-n0-0",
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Reason:   "Error",
+							ExitCode: 127,
+						},
+					},
+				},
+			},
+		}, pluginsCore.TaskInfo{}, "")
+		assert.Nil(t, err)
+		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
+		assert.Equal(t, "Error", phaseInfo.Err().Code)
+		assert.Equal(t, core.ExecutionError_USER, phaseInfo.Err().Kind)
+	})
+
+	t.Run("non-zero exit alongside a co-pilot init container", func(t *testing.T) {
+		// The co-pilot runs as init containers, so it must not count towards the
+		// single main container guard.
+		phaseInfo, err := DemystifyFailure(ctx, v1.PodStatus{
+			Phase: v1.PodFailed,
+			InitContainerStatuses: []v1.ContainerStatus{
+				{
+					Name: "flyte-copilot-uploader",
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Reason:   "Completed",
+							ExitCode: 0,
+						},
+					},
+				},
+			},
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name: "abc123-n0-0",
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Reason:   "Error",
+							ExitCode: 5,
+						},
+					},
+				},
+			},
+		}, pluginsCore.TaskInfo{}, "")
+		assert.Nil(t, err)
+		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
+		assert.Equal(t, "Error", phaseInfo.Err().Code)
+		assert.Equal(t, core.ExecutionError_USER, phaseInfo.Err().Kind)
+	})
+
+	t.Run("exit above 127 stays a system error", func(t *testing.T) {
+		// Anything above maxUserExitCode is 128+N, so something killed the process
+		// rather than the process choosing to fail. Eviction, drain and preemption
+		// send SIGTERM first (143), and those must not burn user retries.
+		phaseInfo, err := DemystifyFailure(ctx, v1.PodStatus{
+			Phase: v1.PodFailed,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name: "abc123-n0-0",
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Reason:   "Error",
+							ExitCode: 128,
+						},
+					},
+				},
+			},
+		}, pluginsCore.TaskInfo{}, "")
+		assert.Nil(t, err)
+		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
+		assert.Equal(t, Interrupted, phaseInfo.Err().Code)
+		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().Kind)
+	})
 }
 
 func TestDemystifyPending_testcases(t *testing.T) {


### PR DESCRIPTION
## Tracking issue

Closes #7874

## Why are the changes needed?

A raw `ContainerTask` whose command exits non-zero never fails. The executor keeps deleting and recreating the pod under the same name forever, and `retries` has no effect.

When a pod fails, `DemystifyFailure` decides whether the failure is the user's fault (consumes a retry) or the system's fault (relaunch the pod, no retry consumed). It makes that call from the pod-level `status.Reason` field, but the kubelet leaves that field empty for an ordinary container failure. Finding nothing, the code assumes the node died before anything was recorded and classifies the failure as SYSTEM. The system path relaunches the pod without consuming retries, so the same failure repeats forever. The actual answer, the container's own exit code, was available the whole time but never consulted.

## What changes were proposed in this pull request?

Before falling back to SYSTEM: if the pod has exactly one main container and it exited with a code between 1 and 127, classify the failure as USER, using the container's recorded reason (`ContainerFailed` when the runtime left it empty).

This matches `DeterminePrimaryContainerPhase` in the same file, which already treats a non-zero exit as a user error. Two guards keep the change narrow:

- Exit codes above 127 mean the process was killed by a signal (a node drain or spot eviction sends SIGTERM, which surfaces as 143). Those stay SYSTEM so infrastructure churn never burns user retries.
- Only the pod's main containers are considered. Flyte's co-pilot runs as init containers, so it can never be blamed on the user.

The new code only runs when `code` is still `UnknownError`, so it can only affect cases that previously fell into the fallback.

## How was this patch tested?

Four new unit tests in `pod_helper_test.go`; three fail without the fix (non-zero exit with no reason, exit 127, exit 5 alongside a co-pilot init container), and one pins exit codes above 127 as SYSTEM.

Also verified end to end the same way the issue was reported: the repro script from #7874 unchanged, submitted with the `flyte` CLI (Python SDK) via `flyte run repro.py ...` against a local devbox running the backend built from this branch, with the pods watched through `kubectl`:

| run | before (#7874) | after |
|---|---|---|
| `exit_zero` | succeeded | succeeded, output intact |
| `exit_nonzero`, `retries=0` | looped forever, 11 pod uids | failed in ~5s, USER error with the exit code |
| same, `retries=2` | retries had no effect | pods `-0`, `-1`, `-2`, then failed, 3 attempts used |

The recorded error also correctly separates the sidecar from the task:

    [flyte-copilot-uploader] terminated with ExitCode 0.
    [rcqzcwfvs5kx84p7chdb-a0-0] terminated with exit code (5). Reason [Error].

### Setup process

    make devbox-build FLYTE_ARCHES=arm64
    make devbox-run
    flyte create config --endpoint localhost:30080 --project flytesnacks --domain development --builder local --insecure
    flyte run repro.py exit_nonzero   # repro.py verbatim from #7874

### Screenshots
<img width="1600" height="900" alt="image-1787352527483" src="https://github.com/user-attachments/assets/d4695f31-2a82-44d6-8a5a-eec105f52183" />
<img width="1600" height="900" alt="image-1787352533409" src="https://github.com/user-attachments/assets/52b1e053-b478-4128-862a-cf255959140d" />

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.