### PR TITLE
feat(runs): validate settings on create and update

### DIFF
--- a/runs/service/settings_service.go
+++ b/runs/service/settings_service.go
@@ -39,11 +39,8 @@ func (s *SettingsService) GetSettingsForEdit(
 	req *connect.Request[settings.GetSettingsForEditRequest],
 ) (*connect.Response[settings.GetSettingsForEditResponse], error) {
 	key := req.Msg.GetKey()
-	if key == nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("key is required"))
-	}
-	if key.GetProject() != "" && key.GetDomain() == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("a project-scope key requires a domain"))
+	if err := validateSettingsKey(key); err != nil {
+		return nil, err
 	}
 
 	// One partial key per scope level covered by the request, broadest first,
@@ -100,11 +97,14 @@ func (s *SettingsService) CreateSettings(
 	// The buf.validate annotations on these protos are not enforced by the
 	// generated Go code, so required fields and key shape are checked by hand
 	key := req.Msg.GetKey()
-	if key == nil || req.Msg.GetSettings() == nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("key and settings are required"))
+	if err := validateSettingsKey(key); err != nil {
+		return nil, err
 	}
-	if key.GetProject() != "" && key.GetDomain() == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("a project-scope key requires a domain"))
+	if req.Msg.GetSettings() == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("settings is required"))
+	}
+	if err := validateSettings(req.Msg.GetSettings()); err != nil {
+		return nil, err
 	}
 
 	data, err := protojson.Marshal(req.Msg.GetSettings())
@@ -138,11 +138,14 @@ func (s *SettingsService) UpdateSettings(
 	req *connect.Request[settings.UpdateSettingsRequest],
 ) (*connect.Response[settings.UpdateSettingsResponse], error) {
 	key := req.Msg.GetKey()
-	if key == nil || req.Msg.GetSettings() == nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("key and settings are required"))
+	if err := validateSettingsKey(key); err != nil {
+		return nil, err
 	}
-	if key.GetProject() != "" && key.GetDomain() == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("a project-scope key requires a domain"))
+	if req.Msg.GetSettings() == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("settings is required"))
+	}
+	if err := validateSettings(req.Msg.GetSettings()); err != nil {
+		return nil, err
 	}
 	if req.Msg.GetVersion() == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("a version is required; use CreateSettings for a new record"))
@@ -221,6 +224,16 @@ func validateSettings(s *settings.Settings) error {
 		return err
 	}
 	return validateTaskResourceDefaults("task_resource.max", s.GetTaskResource().GetMax())
+}
+
+func validateSettingsKey(key *settings.SettingsKey) error {
+	if key == nil {
+		return connect.NewError(connect.CodeInvalidArgument, errors.New("key is required"))
+	}
+	if key.GetProject() != "" && key.GetDomain() == "" {
+		return connect.NewError(connect.CodeInvalidArgument, errors.New("a project-scope key requires a domain"))
+	}
+	return nil
 }
 
 var _ settingsconnect.SettingsServiceHandler = (*SettingsService)(nil)

--- a/runs/service/settings_service.go
+++ b/runs/service/settings_service.go
@@ -3,10 +3,13 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math"
 
 	"connectrpc.com/connect"
 	"github.com/flyteorg/flyte/v2/runs/repository/models"
 	"google.golang.org/protobuf/encoding/protojson"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings/settingsconnect"
@@ -175,6 +178,49 @@ func (s *SettingsService) UpdateSettings(
 			Version:  model.Version,
 		},
 	}), nil
+}
+
+func validateMaxActionConcurrency(setting *settings.Int64Setting) error {
+	if setting.GetState() != settings.SettingState_SETTING_STATE_VALUE {
+		return nil
+	}
+	if v := setting.GetIntValue(); v < 0 || v == 1 || v > math.MaxUint32 {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid max_action_concurrency %d: must be 0 (unlimited) or at least 2", v))
+	}
+	return nil
+}
+
+func validateQuantity(name string, setting *settings.QuantitySetting) error {
+	if setting.GetState() != settings.SettingState_SETTING_STATE_VALUE {
+		return nil
+	}
+	if _, err := resource.ParseQuantity(setting.GetQuantityValue()); err != nil {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid %s %q: %w", name, setting.GetQuantityValue(), err))
+	}
+	return nil
+}
+
+func validateTaskResourceDefaults(bound string, d *settings.TaskResourceDefaults) error {
+	if err := validateQuantity(bound+".cpu", d.GetCpu()); err != nil {
+		return err
+	}
+	if err := validateQuantity(bound+".gpu", d.GetGpu()); err != nil {
+		return err
+	}
+	if err := validateQuantity(bound+".memory", d.GetMemory()); err != nil {
+		return err
+	}
+	return validateQuantity(bound+".storage", d.GetStorage())
+}
+
+func validateSettings(s *settings.Settings) error {
+	if err := validateMaxActionConcurrency(s.GetRun().GetMaxActionConcurrency()); err != nil {
+		return err
+	}
+	if err := validateTaskResourceDefaults("task_resource.min", s.GetTaskResource().GetMin()); err != nil {
+		return err
+	}
+	return validateTaskResourceDefaults("task_resource.max", s.GetTaskResource().GetMax())
 }
 
 var _ settingsconnect.SettingsServiceHandler = (*SettingsService)(nil)

--- a/runs/service/settings_service.go
+++ b/runs/service/settings_service.go
@@ -94,8 +94,6 @@ func (s *SettingsService) CreateSettings(
 	ctx context.Context,
 	req *connect.Request[settings.CreateSettingsRequest],
 ) (*connect.Response[settings.CreateSettingsResponse], error) {
-	// The buf.validate annotations on these protos are not enforced by the
-	// generated Go code, so required fields and key shape are checked by hand
 	key := req.Msg.GetKey()
 	if err := validateSettingsKey(key); err != nil {
 		return nil, err
@@ -183,16 +181,34 @@ func (s *SettingsService) UpdateSettings(
 	}), nil
 }
 
+// validateSettingsKey checks the key shape by hand: the buf.validate annotations on
+// these protos are not enforced by the generated Go code, so required fields and scope
+// rules are checked here instead.
+func validateSettingsKey(key *settings.SettingsKey) error {
+	if key == nil {
+		return connect.NewError(connect.CodeInvalidArgument, errors.New("key is required"))
+	}
+	if key.GetProject() != "" && key.GetDomain() == "" {
+		return connect.NewError(connect.CodeInvalidArgument, errors.New("a project-scope key requires a domain"))
+	}
+	return nil
+}
+
+// validateMaxActionConcurrency enforces the bounds on a per-run concurrency cap: 0 means
+// unlimited and 1 is rejected. The ceiling is MaxUint32 because the resolved value is
+// applied to RunSpec.max_action_concurrency, which is a uint32.
 func validateMaxActionConcurrency(setting *settings.Int64Setting) error {
 	if setting.GetState() != settings.SettingState_SETTING_STATE_VALUE {
 		return nil
 	}
 	if v := setting.GetIntValue(); v < 0 || v == 1 || v > math.MaxUint32 {
-		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid max_action_concurrency %d: must be 0 (unlimited) or at least 2", v))
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid max_action_concurrency %d: must be 0 (unlimited) or between 2 and %d", v, math.MaxUint32))
 	}
 	return nil
 }
 
+// validateQuantity checks that a quantity leaf holds a value Kubernetes can parse.
+// name is the dot-path used in the error message, e.g. "task_resource.max.memory".
 func validateQuantity(name string, setting *settings.QuantitySetting) error {
 	if setting.GetState() != settings.SettingState_SETTING_STATE_VALUE {
 		return nil
@@ -224,16 +240,6 @@ func validateSettings(s *settings.Settings) error {
 		return err
 	}
 	return validateTaskResourceDefaults("task_resource.max", s.GetTaskResource().GetMax())
-}
-
-func validateSettingsKey(key *settings.SettingsKey) error {
-	if key == nil {
-		return connect.NewError(connect.CodeInvalidArgument, errors.New("key is required"))
-	}
-	if key.GetProject() != "" && key.GetDomain() == "" {
-		return connect.NewError(connect.CodeInvalidArgument, errors.New("a project-scope key requires a domain"))
-	}
-	return nil
 }
 
 var _ settingsconnect.SettingsServiceHandler = (*SettingsService)(nil)

--- a/runs/service/settings_service_test.go
+++ b/runs/service/settings_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -25,6 +26,20 @@ func envSettings(key, value string) *settings.Settings {
 			MapValue: &settings.StringMap{Entries: map[string]string{key: value}},
 		},
 	}
+}
+
+const (
+	stateValue   = settings.SettingState_SETTING_STATE_VALUE
+	stateInherit = settings.SettingState_SETTING_STATE_INHERIT
+	stateUnset   = settings.SettingState_SETTING_STATE_UNSET
+)
+
+func quantity(state settings.SettingState, value string) *settings.QuantitySetting {
+	return &settings.QuantitySetting{State: state, QuantityValue: value}
+}
+
+func concurrency(state settings.SettingState, value int64) *settings.Int64Setting {
+	return &settings.Int64Setting{State: state, IntValue: value}
 }
 
 func TestSettingsCRUD(t *testing.T) {
@@ -171,6 +186,15 @@ func TestCreateSettings_Validation(t *testing.T) {
 				Settings: envSettings("LOG_LEVEL", "debug"),
 			},
 		},
+		{
+			name: "invalid quantity",
+			req: &settings.CreateSettingsRequest{
+				Key: &settings.SettingsKey{Org: "acme", Domain: "development"},
+				Settings: &settings.Settings{TaskResource: &settings.TaskResourceSettings{
+					Max: &settings.TaskResourceDefaults{Cpu: quantity(stateValue, "apple")},
+				}},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -218,6 +242,16 @@ func TestUpdateSettings_Validation(t *testing.T) {
 			req: &settings.UpdateSettingsRequest{
 				Key:      &settings.SettingsKey{Org: "acme", Domain: "development"},
 				Settings: envSettings("LOG_LEVEL", "debug"),
+			},
+		},
+		{
+			name: "invalid quantity",
+			req: &settings.UpdateSettingsRequest{
+				Key: &settings.SettingsKey{Org: "acme", Domain: "development"},
+				Settings: &settings.Settings{TaskResource: &settings.TaskResourceSettings{
+					Max: &settings.TaskResourceDefaults{Cpu: quantity(stateValue, "apple")},
+				}},
+				Version: 1,
 			},
 		},
 	}
@@ -386,6 +420,158 @@ func TestGetSettingsForEdit_LevelsFollowKeyDepth(t *testing.T) {
 			}))
 			require.NoError(t, err)
 			assert.Len(t, resp.Msg.GetLevels(), tt.wantLevels)
+		})
+	}
+}
+
+func TestValidateMaxActionConcurrency(t *testing.T) {
+	tests := []struct {
+		name    string
+		setting *settings.Int64Setting
+		wantErr bool
+	}{
+		{"nil leaf", nil, false},
+		{"inherit ignores its value", concurrency(stateInherit, 1), false},
+		{"unset ignores its value", concurrency(stateUnset, 1), false},
+		{"zero means unlimited", concurrency(stateValue, 0), false},
+		{"one is rejected", concurrency(stateValue, 1), true},
+		{"two is allowed", concurrency(stateValue, 2), false},
+		{"negative is rejected", concurrency(stateValue, -1), true},
+		{"max uint32 is allowed", concurrency(stateValue, math.MaxUint32), false},
+		{"above max uint32 is rejected", concurrency(stateValue, math.MaxUint32+1), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMaxActionConcurrency(tt.setting)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateQuantity(t *testing.T) {
+	tests := []struct {
+		name    string
+		setting *settings.QuantitySetting
+		wantErr bool
+	}{
+		{"nil leaf", nil, false},
+		{"inherit ignores its value", quantity(stateInherit, "apple"), false},
+		{"unset ignores its value", quantity(stateUnset, "apple"), false},
+		{"millicore", quantity(stateValue, "500m"), false},
+		{"whole cpus", quantity(stateValue, "16"), false},
+		{"binary memory", quantity(stateValue, "64Gi"), false},
+		{"garbage value is rejected", quantity(stateValue, "apple"), true},
+		{"empty value is rejected", quantity(stateValue, ""), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateQuantity("task_resource.max.cpu", tt.setting)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateTaskResourceDefaults(t *testing.T) {
+	t.Run("nil defaults has nothing to check", func(t *testing.T) {
+		assert.NoError(t, validateTaskResourceDefaults("task_resource.max", nil))
+	})
+
+	t.Run("all four valid pass", func(t *testing.T) {
+		assert.NoError(t, validateTaskResourceDefaults("task_resource.max",
+			&settings.TaskResourceDefaults{
+				Cpu:     quantity(stateValue, "16"),
+				Gpu:     quantity(stateValue, "1"),
+				Memory:  quantity(stateValue, "64Gi"),
+				Storage: quantity(stateValue, "10Gi"),
+			}))
+	})
+
+	tests := []struct {
+		name     string
+		defaults *settings.TaskResourceDefaults
+		wantPath string
+	}{
+		{"cpu", &settings.TaskResourceDefaults{Cpu: quantity(stateValue, "apple")}, "task_resource.max.cpu"},
+		{"gpu", &settings.TaskResourceDefaults{Gpu: quantity(stateValue, "apple")}, "task_resource.max.gpu"},
+		{"memory", &settings.TaskResourceDefaults{Memory: quantity(stateValue, "apple")}, "task_resource.max.memory"},
+		{"storage", &settings.TaskResourceDefaults{Storage: quantity(stateValue, "apple")}, "task_resource.max.storage"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTaskResourceDefaults("task_resource.max", tt.defaults)
+			require.Error(t, err)
+			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+			assert.Contains(t, err.Error(), tt.wantPath)
+		})
+	}
+}
+
+func TestValidateSettings(t *testing.T) {
+	t.Run("nil settings has nothing to check", func(t *testing.T) {
+		assert.NoError(t, validateSettings(nil))
+	})
+
+	t.Run("empty settings has nothing to check", func(t *testing.T) {
+		assert.NoError(t, validateSettings(&settings.Settings{}))
+	})
+
+	t.Run("valid settings pass", func(t *testing.T) {
+		assert.NoError(t, validateSettings(&settings.Settings{
+			Run: &settings.RunSettings{MaxActionConcurrency: concurrency(stateValue, 64)},
+			TaskResource: &settings.TaskResourceSettings{
+				Min: &settings.TaskResourceDefaults{Cpu: quantity(stateValue, "500m")},
+				Max: &settings.TaskResourceDefaults{Cpu: quantity(stateValue, "16")},
+			},
+		}))
+	})
+
+	tests := []struct {
+		name     string
+		input    *settings.Settings
+		wantPath string
+	}{
+		{
+			name: "bad min quantity names the min path",
+			input: &settings.Settings{TaskResource: &settings.TaskResourceSettings{
+				Min: &settings.TaskResourceDefaults{Cpu: quantity(stateValue, "apple")},
+			}},
+			wantPath: "task_resource.min.cpu",
+		},
+		{
+			name: "bad max quantity names the max path",
+			input: &settings.Settings{TaskResource: &settings.TaskResourceSettings{
+				Max: &settings.TaskResourceDefaults{Memory: quantity(stateValue, "apple")},
+			}},
+			wantPath: "task_resource.max.memory",
+		},
+		{
+			name: "bad concurrency is reported",
+			input: &settings.Settings{Run: &settings.RunSettings{
+				MaxActionConcurrency: concurrency(stateValue, 1),
+			}},
+			wantPath: "max_action_concurrency",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSettings(tt.input)
+			require.Error(t, err)
+			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+			assert.Contains(t, err.Error(), tt.wantPath)
 		})
 	}
 }


### PR DESCRIPTION
## Tracking issue

Related to #7775. This is task 2.3 (validators).

## Why are the changes needed?

The `buf.validate` annotations on the settings protos are not enforced by the generated Go code, so the service currently accepts any value. `task_resource.max.memory` can be stored as `"apple"`. Nothing reads these values yet, but once the appliers land a bad value would fail deep inside a run instead of at the point someone saved it.

## What changes were proposed in this pull request?

Validators wired into `CreateSettings` and `UpdateSettings`:

- quantities must parse with `resource.ParseQuantity`, across all eight `task_resource.{min,max}.{cpu,gpu,memory,storage}` leaves; the error names the dot-path
- `max_action_concurrency` must be `0` or between `2` and `MaxUint32`. The ceiling matches `RunSpec.max_action_concurrency`, which is a `uint32`
- key-shape checks, previously duplicated in three handlers, extracted into `validateSettingsKey`

Leaves whose state is not `VALUE` are skipped, so sparse documents stay valid.

## How was this patch tested?

Table tests per validator, plus rows added to the existing `TestCreateSettings_Validation` and `TestUpdateSettings_Validation` tables to cover the handler wiring.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

Follows #7841, #7859 and #7881.