### PR TITLE
fix(flyte-devbox): use relative redirect for console root route

### DIFF
--- a/charts/flyte-devbox/templates/proxy/ingress.yaml
+++ b/charts/flyte-devbox/templates/proxy/ingress.yaml
@@ -69,8 +69,13 @@ metadata:
   labels: {{- include "flyte-devbox.labels" . | nindent 4 }}
 spec:
   redirectRegex:
-    regex: "^(https?://[^/]+)/?$"
-    replacement: "${1}{{ $consoleBasePath }}"
+    # Replace the whole URL with just the path, so the browser receives a
+    # relative redirect (Location: /v2) and resolves it against the URL it
+    # actually requested. Echoing back the scheme+host captured from the
+    # request breaks behind proxies that rewrite Host (e.g. GitHub Codespaces
+    # forwarded addresses), where Traefik would see localhost:30080.
+    regex: "^https?://[^/]+/?$"
+    replacement: "{{ $consoleBasePath }}"
     # Temporary, so browsers don't cache the hop if the console ever moves.
     permanent: false
 ---

--- a/docker/devbox-bundled/manifests/complete.yaml
+++ b/docker/devbox-bundled/manifests/complete.yaml
@@ -9743,8 +9743,8 @@ metadata:
 spec:
   redirectRegex:
     permanent: false
-    regex: ^(https?://[^/]+)/?$
-    replacement: ${1}/v2
+    regex: ^https?://[^/]+/?$
+    replacement: /v2
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/docker/devbox-bundled/manifests/dev.yaml
+++ b/docker/devbox-bundled/manifests/dev.yaml
@@ -9140,8 +9140,8 @@ metadata:
 spec:
   redirectRegex:
     permanent: false
-    regex: ^(https?://[^/]+)/?$
-    replacement: ${1}/v2
+    regex: ^https?://[^/]+/?$
+    replacement: /v2
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration


### PR DESCRIPTION
## Problem

The devbox root-to-console redirect (`/` → `/v2`) is implemented with a Traefik `redirectRegex` middleware that echoes back the scheme+host captured from the request URL:

```yaml
regex: "^(https?://[^/]+)/?$"
replacement: "${1}/v2"
```

This breaks behind proxies that rewrite the `Host` header. For example, when the devbox is accessed through a **GitHub Codespaces forwarded address** (`https://<codespace>-30080.app.github.dev/`), Traefik sees the request as `http://localhost:30080/` and the browser gets redirected to `http://localhost:30080/v2` instead of `https://<codespace>-30080.app.github.dev/v2`.

## Fix

Replace the whole matched URL with just the console base path, so Traefik emits a **relative redirect** (`Location: /v2`). The browser resolves it against the URL it actually requested, which works behind Codespaces forwarding, any other proxy, and direct access alike.

```yaml
regex: "^https?://[^/]+/?$"
replacement: "/v2"
```

The redirect stays `permanent: false` (302), so no browser has cached the old hop.

## Changes

- `charts/flyte-devbox/templates/proxy/ingress.yaml` — update the `redirectRegex` middleware
- `docker/devbox-bundled/manifests/{dev,complete}.yaml` — regenerate the affected block in the bundled manifests

## Testing

- Verified with `helm template charts/flyte-devbox --set sandbox.dev=true --set sandbox.console.enabled=true` that the middleware renders as intended.
- Relative `Location` headers are standard (RFC 9110 §10.2.2) and supported by all browsers; the middleware still only matches the bare root path.