### PR TITLE
fix(copilot): write the error document to the name the output reader reads

### DIFF
--- a/flytecopilot/cmd/download.go
+++ b/flytecopilot/cmd/download.go
@@ -129,7 +129,7 @@ func NewDownloadCommand(opts *RootOptions) *cobra.Command {
 	}
 
 	downloadCmd.Flags().StringVarP(&downloadOpts.remoteInputsPath, "from-remote", "f", "", "The remote path/key for inputs in stow store.")
-	downloadCmd.Flags().StringVarP(&downloadOpts.remoteOutputsPrefix, "to-output-prefix", "", "", "The remote path/key prefix for outputs in stow store. this is mostly used to write error.pb.")
+	downloadCmd.Flags().StringVarP(&downloadOpts.remoteOutputsPrefix, "to-output-prefix", "", "", "The remote path/key prefix for outputs in stow store. This is mostly used to write error.pb.")
 	downloadCmd.Flags().StringVarP(&downloadOpts.localDirectoryPath, "to-local-dir", "o", "", "The local directory on disk where data should be downloaded.")
 	downloadCmd.Flags().StringVarP(&downloadOpts.metadataFormat, "format", "m", core.DataLoadingConfig_JSON.String(), fmt.Sprintf("What should be the output format for the primitive and structured types. Options [%v]", GetFormatVals()))
 	downloadCmd.Flags().StringVarP(&downloadOpts.downloadMode, "download-mode", "d", core.IOStrategy_DOWNLOAD_EAGER.String(), fmt.Sprintf("Download mode to use. Options [%v]", GetDownloadModeVals()))

--- a/flytecopilot/cmd/download.go
+++ b/flytecopilot/cmd/download.go
@@ -129,7 +129,7 @@ func NewDownloadCommand(opts *RootOptions) *cobra.Command {
 	}
 
 	downloadCmd.Flags().StringVarP(&downloadOpts.remoteInputsPath, "from-remote", "f", "", "The remote path/key for inputs in stow store.")
-	downloadCmd.Flags().StringVarP(&downloadOpts.remoteOutputsPrefix, "to-output-prefix", "", "", "The remote path/key prefix for outputs in stow store. this is mostly used to write errors.pb.")
+	downloadCmd.Flags().StringVarP(&downloadOpts.remoteOutputsPrefix, "to-output-prefix", "", "", "The remote path/key prefix for outputs in stow store. this is mostly used to write error.pb.")
 	downloadCmd.Flags().StringVarP(&downloadOpts.localDirectoryPath, "to-local-dir", "o", "", "The local directory on disk where data should be downloaded.")
 	downloadCmd.Flags().StringVarP(&downloadOpts.metadataFormat, "format", "m", core.DataLoadingConfig_JSON.String(), fmt.Sprintf("What should be the output format for the primitive and structured types. Options [%v]", GetFormatVals()))
 	downloadCmd.Flags().StringVarP(&downloadOpts.downloadMode, "download-mode", "d", core.IOStrategy_DOWNLOAD_EAGER.String(), fmt.Sprintf("Download mode to use. Options [%v]", GetDownloadModeVals()))

--- a/flytecopilot/cmd/download_test.go
+++ b/flytecopilot/cmd/download_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/v2/flyteidl2/clients/go/coreutils"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
@@ -151,7 +152,7 @@ func TestDownloadOptions_Download(t *testing.T) {
 		dopts.RootOptions = &RootOptions{
 			Scope:           s,
 			Store:           store,
-			errorOutputName: "errors.pb",
+			errorOutputName: ioutils.ErrorsSuffix,
 		}
 
 		assert.NoError(t, store.WriteProtobuf(ctx, storage.DataReference(inputPath), storage.Options{}, &core.LiteralMap{
@@ -177,7 +178,7 @@ func TestDownloadOptions_Download(t *testing.T) {
 		}))
 		err = dopts.Download(ctx)
 		assert.NoError(t, err, "Download Operation failed")
-		errFile, err := store.ConstructReference(ctx, storage.DataReference(outputPath), "errors.pb")
+		errFile, err := store.ConstructReference(ctx, storage.DataReference(outputPath), ioutils.ErrorsSuffix)
 		assert.NoError(t, err)
 		errProto := &core.ErrorDocument{}
 		err = store.ReadProtobuf(ctx, errFile, errProto)

--- a/flytecopilot/cmd/root.go
+++ b/flytecopilot/cmd/root.go
@@ -32,7 +32,7 @@ type RootOptions struct {
 	Store          *storage.DataStore
 	configAccessor config.Accessor
 	cfgFile        string
-	// The actual key name that should be created under the remote prefix where the error document is written of the form errors.pb
+	// The actual key name that should be created under the remote prefix where the error document is written of the form error.pb
 	errorOutputName string
 }
 
@@ -101,7 +101,7 @@ func NewDataCommand() *cobra.Command {
 
 	command.PersistentFlags().StringVar(&rootOpts.cfgFile, "config", "", "config file (default is $HOME/config.yaml)")
 	command.PersistentFlags().BoolVarP(&rootOpts.showSource, "show-source", "s", false, "Show line number for errors")
-	command.PersistentFlags().StringVar(&rootOpts.errorOutputName, "err-output-name", "errors.pb", "Actual key name under the prefix where the error protobuf should be written to")
+	command.PersistentFlags().StringVar(&rootOpts.errorOutputName, "err-output-name", "error.pb", "Actual key name under the prefix where the error protobuf should be written to")
 
 	rootOpts.configAccessor = viper.NewAccessor(config.Options{StrictMode: true})
 	// Here you will define your flags and configuration settings. Cobra supports persistent flags, which, if defined

--- a/flytecopilot/cmd/root_test.go
+++ b/flytecopilot/cmd/root_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/ioutils"
+	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
+	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
+)
+
+// The error document co-pilot writes on an upload/download failure is only honoured if the
+// plugin's output reader finds it. The reader resolves the error path through
+// ioutils.ErrorsSuffix, so the flag default has to match it -- otherwise a RECOVERABLE
+// failure is written to a file nobody reads and gets mis-classified as a system error.
+func TestErrOutputNameDefaultMatchesReader(t *testing.T) {
+	cmd := NewDataCommand()
+	f := cmd.PersistentFlags().Lookup("err-output-name")
+	if assert.NotNil(t, f, "err-output-name flag should be registered") {
+		assert.Equal(t, ioutils.ErrorsSuffix, f.DefValue)
+	}
+}
+
+// End to end across the two components that disagreed: co-pilot writes the error document
+// with its default name, and the plugin-side reader must pick it up as a recoverable task
+// error carrying the real cause -- not fall through to a missing outputs.pb.
+func TestUploadErrorIsReadBackAsRecoverable(t *testing.T) {
+	ctx := context.TODO()
+	scope := promutils.NewTestScope()
+	store, err := storage.NewDataStore(&storage.Config{Type: storage.TypeMemory}, scope.NewSubScope("storage"))
+	require.NoError(t, err)
+
+	cmd := NewDataCommand()
+	errOutputName := cmd.PersistentFlags().Lookup("err-output-name")
+	require.NotNil(t, errOutputName)
+
+	prefix := storage.DataReference("/output")
+	opts := RootOptions{Store: store, Scope: scope, errorOutputName: errOutputName.DefValue}
+	require.NoError(t, opts.UploadError(ctx, "OutputUploadFailed", fmt.Errorf("connection reset by peer"), prefix))
+
+	reader := ioutils.NewRemoteFileOutputReader(ctx, store, ioutils.NewReadOnlyOutputFilePaths(ctx, store, prefix), 1024*1024)
+
+	isErr, err := reader.IsError(ctx)
+	require.NoError(t, err)
+	assert.True(t, isErr, "reader should see the error document co-pilot wrote")
+
+	ee, err := reader.ReadError(ctx)
+	require.NoError(t, err)
+	assert.True(t, ee.IsRecoverable, "an upload failure is retryable against the task's retry budget")
+	assert.Equal(t, "OutputUploadFailed", ee.ExecutionError.GetCode())
+	assert.Contains(t, ee.ExecutionError.GetMessage(), "connection reset by peer")
+}

--- a/flytecopilot/cmd/sidecar_test.go
+++ b/flytecopilot/cmd/sidecar_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyte/v2/flytecopilot/cmd/containerwatcher"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
@@ -77,7 +78,7 @@ func TestUploadOptions_Upload(t *testing.T) {
 			RootOptions: &RootOptions{
 				Scope:           s,
 				Store:           store,
-				errorOutputName: "errors.pb",
+				errorOutputName: ioutils.ErrorsSuffix,
 			},
 			remoteOutputsPrefix: outputPath,
 			metadataFormat:      core.DataLoadingConfig_JSON.String(),
@@ -89,7 +90,7 @@ func TestUploadOptions_Upload(t *testing.T) {
 		}
 
 		assert.NoError(t, uopts.Sidecar(ctx))
-		v, err := store.Head(ctx, "/output/errors.pb")
+		v, err := store.Head(ctx, storage.DataReference("/output/"+ioutils.ErrorsSuffix))
 		assert.NoError(t, err)
 		assert.True(t, v.Exists())
 	})

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -16,6 +16,7 @@ import (
 	core2 "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/io"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyte/v2/flytestdlib/logger"
 	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/core"
@@ -131,6 +132,11 @@ func SidecarCommandArgs(fromLocalPath string, outputPrefix, rawOutputPath storag
 		outputPrefix.String(),
 		"--from-local-dir",
 		fromLocalPath,
+		// Pin the error document's name to the one the output reader looks for, so an
+		// upload failure is read back as the RECOVERABLE task error co-pilot recorded
+		// instead of surfacing as a missing outputs.pb system error.
+		"--err-output-name",
+		ioutils.ErrorsSuffix,
 		"--interface",
 		base64.StdEncoding.EncodeToString(b),
 	}, nil
@@ -156,6 +162,10 @@ func DownloadCommandArgs(fromInputsPath, outputPrefix storage.DataReference, toL
 		format.String(),
 		"--file-input-layout",
 		layout.String(),
+		// See SidecarCommandArgs: the downloader writes its error document to the same
+		// prefix, and it has to carry the name the output reader reads.
+		"--err-output-name",
+		ioutils.ErrorsSuffix,
 		"--input-interface",
 		base64.StdEncoding.EncodeToString(b),
 	}, nil

--- a/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
+++ b/flyteplugins/go/tasks/pluginmachinery/flytek8s/copilot_test.go
@@ -19,6 +19,7 @@ import (
 	pluginsCoreMock "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core/mocks"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
 	pluginsIOMock "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/io/mocks"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	config2 "github.com/flyteorg/flyte/v2/flytestdlib/config"
 	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
 	"github.com/flyteorg/flyte/v2/flytestdlib/utils"
@@ -268,7 +269,7 @@ func TestDownloadCommandArgs(t *testing.T) {
 	}
 	d, err := DownloadCommandArgs("s3://from", "s3://output-meta", "/to", core.DataLoadingConfig_JSON, core.DataLoadingConfig_NAMED_DIR, iFace)
 	assert.NoError(t, err)
-	expected := []string{"download", "--from-remote", "s3://from", "--to-output-prefix", "s3://output-meta", "--to-local-dir", "/to", "--format", "JSON", "--file-input-layout", "NAMED_DIR", "--input-interface", "<interface>"}
+	expected := []string{"download", "--from-remote", "s3://from", "--to-output-prefix", "s3://output-meta", "--to-local-dir", "/to", "--format", "JSON", "--file-input-layout", "NAMED_DIR", "--err-output-name", ioutils.ErrorsSuffix, "--input-interface", "<interface>"}
 	if assert.Len(t, d, len(expected)) {
 		for i := 0; i < len(expected)-1; i++ {
 			assert.Equal(t, expected[i], d[i])
@@ -303,7 +304,7 @@ func TestSidecarCommandArgs(t *testing.T) {
 	}
 	d, err := SidecarCommandArgs("/from", "s3://output-meta", "s3://raw-output", time.Hour*1, iFace)
 	assert.NoError(t, err)
-	expected := []string{"sidecar", "--timeout", "1h0m0s", "--to-raw-output", "s3://raw-output", "--to-output-prefix", "s3://output-meta", "--from-local-dir", "/from", "--interface", "<interface>"}
+	expected := []string{"sidecar", "--timeout", "1h0m0s", "--to-raw-output", "s3://raw-output", "--to-output-prefix", "s3://output-meta", "--from-local-dir", "/from", "--err-output-name", ioutils.ErrorsSuffix, "--interface", "<interface>"}
 	if assert.Len(t, d, len(expected)) {
 		for i := 0; i < len(expected)-1; i++ {
 			assert.Equal(t, expected[i], d[i])


### PR DESCRIPTION
## Tracking issue

No upstream issue — found in our own self-hosted deployment (v2.0.37, k3s + GCS; still
present on `main`). Related to #7566, which made a `RECOVERABLE` `error.pb` honoured for
Ray tasks — the same machinery this PR reconnects for raw-container tasks.

## Why are the changes needed?

Two components disagree on one filename. `flytecopilot` writes its `ErrorDocument` to
**`errors.pb`** (the `--err-output-name` default in `flytecopilot/cmd/root.go`);
`RemoteFileOutputReader.IsError()` looks for **`error.pb`** (`ioutils.ErrorsSuffix`).
`SidecarCommandArgs` never passes the flag, so copilot's default always wins and nothing
reads the file it wrote.

`IsError()` returns `false`, `Read()` falls through to a non-existent `outputs.pb`, and
that Go error reaches `recordSystemError`. A transient blob-store error during output
upload is therefore counted as a *system* failure: the task's `retries` budget is never
consulted, and the action dies after `MaxSystemFailures` (default 3) naming the wrong file:

```
[MaxSystemFailuresExceeded] plugin "pod" failed with system error 4 times:
failed to read data from dataDir [gs://.../1/outputs.pb]. Error: ... object doesn't exist
```

…while `errors.pb` in that same prefix holds the real cause — `OutputUploadFailed`, a
`connection reset by peer` on a 5,950-byte upload. One TCP reset permanently fails the
action and discards every completed minute of that attempt; ours run 40 minutes to
16 hours, and we hit this 3 times in 14 days. The retry machinery already exists and is
already wired — one wrong default string disables it.

## What changes were proposed in this pull request?

Both halves, so the two sides cannot drift apart again:

1. `flytecopilot/cmd/root.go` — `--err-output-name` now defaults to `error.pb`. The flag is
   kept for overrides.
2. `flyteplugins/.../flytek8s/copilot.go` — `SidecarCommandArgs` and `DownloadCommandArgs`
   pass `--err-output-name` + `ioutils.ErrorsSuffix` explicitly, making the plugin side the
   single source of truth. This also fixes an older copilot image under a newer propeller.
3. Comment/help-text touch-ups where `errors.pb` was named, plus the tests that hard-coded it.

`OutputUploadFailed` now becomes a retryable *task* error carrying the real upload message,
spending the user's `retries` rather than the cluster-wide `maxSystemFailures`.

Deliberately out of scope, each wanting its own change:

- `UploadFileToStorage` has no retry/backoff, so one reset still aborts the whole output
  set — with the filename fixed the attempt is retried, but a backoff would avoid re-running
  the task at all.
- `Sidecar` writes every uploader failure as `RECOVERABLE` with `Origin` unset, so a
  container's own `_ERROR` file comes back retryable rather than a permanent USER error.
  Pre-existing, but this PR is what makes it observable.
- `DownloadOptions.Download` returns `nil` after writing the error document and pods only
  consult the output reader on `PhaseSuccess`, so `InputDownloadFailed` still isn't read
  back. On that side this PR only keeps the two names aligned.

## How was this patch tested?

New tests, each watched fail before the fix and pass after:

- `TestErrOutputNameDefaultMatchesReader` — the flag default equals `ioutils.ErrorsSuffix`.
  Fails on `main`: `expected: error.pb, actual: errors.pb`.
- `TestUploadErrorIsReadBackAsRecoverable` — end to end across the two components:
  `UploadError` writes with the default name, then `NewRemoteFileOutputReader` over the same
  prefix must see `IsError() == true` and a recoverable `OutputUploadFailed` carrying the
  original message. On `main` it fails as production did.
- `TestSidecarCommandArgs` / `TestDownloadCommandArgs` now expect `--err-output-name` in the
  argv; reverting `copilot.go` fails both.

```
go build ./flytecopilot/... ./flyteplugins/...
go test ./flytecopilot/... ./flyteplugins/go/tasks/pluginmachinery/...
```

Affected packages pass, `gofmt` clean. The one failure in `pluginmachinery/tasklog`
(`TestAzureTemplateLogPlugin`) is pre-existing and reproduces on stock `main`.

### Labels

**fixed**

## Check all the applicable boxes

- [x] I updated the documentation accordingly. (flag help text / code comments)
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
