### PR TITLE
feat(runs): add settings merge engine

### DIFF
--- a/runs/service/settings_merge.go
+++ b/runs/service/settings_merge.go
@@ -1,0 +1,113 @@
+package service
+
+import (
+	"google.golang.org/protobuf/proto"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings"
+)
+
+// scopeLevelAt maps a position in the level chain to the scope it represents.
+// Callers build the chain broadest first: instance, domain, project.
+func scopeLevelAt(i int) settings.ScopeLevel {
+	switch i {
+	case 0:
+		return settings.ScopeLevel_SCOPE_LEVEL_ORG
+	case 1:
+		return settings.ScopeLevel_SCOPE_LEVEL_DOMAIN
+	default:
+		return settings.ScopeLevel_SCOPE_LEVEL_PROJECT
+	}
+}
+
+// mergeStringSettings resolves one string leaf across the level chain. The last
+// level whose state is not INHERIT wins, so UNSET at a child level blocks a
+// value set higher up. Returns nil when no level had an opinion.
+func mergeStringSettings(levels []*settings.StringSetting) *settings.StringSetting {
+	var winner *settings.StringSetting
+	var level settings.ScopeLevel
+
+	for i, s := range levels {
+		if s.GetState() == settings.SettingState_SETTING_STATE_INHERIT {
+			continue
+		}
+		winner = s
+		level = scopeLevelAt(i)
+	}
+	if winner == nil {
+		return nil
+	}
+
+	out := proto.Clone(winner).(*settings.StringSetting)
+	out.ScopeLevel = level
+
+	return out
+}
+
+// mergeInt64Settings resolves one int64 leaf across the level chain, following the
+// same rule as mergeStringSettings.
+func mergeInt64Settings(levels []*settings.Int64Setting) *settings.Int64Setting {
+	var winner *settings.Int64Setting
+	var level settings.ScopeLevel
+
+	for i, s := range levels {
+		if s.GetState() == settings.SettingState_SETTING_STATE_INHERIT {
+			continue
+		}
+		winner = s
+		level = scopeLevelAt(i)
+	}
+	if winner == nil {
+		return nil
+	}
+
+	out := proto.Clone(winner).(*settings.Int64Setting)
+	out.ScopeLevel = level
+
+	return out
+}
+
+// mergeBoolSettings resolves one bool leaf across the level chain, following the
+// same rule as mergeStringSettings.
+func mergeBoolSettings(levels []*settings.BoolSetting) *settings.BoolSetting {
+	var winner *settings.BoolSetting
+	var level settings.ScopeLevel
+
+	for i, s := range levels {
+		if s.GetState() == settings.SettingState_SETTING_STATE_INHERIT {
+			continue
+		}
+		winner = s
+		level = scopeLevelAt(i)
+	}
+	if winner == nil {
+		return nil
+	}
+
+	out := proto.Clone(winner).(*settings.BoolSetting)
+	out.ScopeLevel = level
+
+	return out
+}
+
+// mergeQuantitySettings resolves one quantity leaf across the level chain, following
+// the same rule as mergeStringSettings.
+func mergeQuantitySettings(levels []*settings.QuantitySetting) *settings.QuantitySetting {
+	var winner *settings.QuantitySetting
+	var level settings.ScopeLevel
+
+	for i, s := range levels {
+		if s.GetState() == settings.SettingState_SETTING_STATE_INHERIT {
+			continue
+		}
+		winner = s
+		level = scopeLevelAt(i)
+	}
+	if winner == nil {
+		return nil
+	}
+
+	out := proto.Clone(winner).(*settings.QuantitySetting)
+	out.ScopeLevel = level
+
+	return out
+}

--- a/runs/service/settings_merge.go
+++ b/runs/service/settings_merge.go
@@ -209,3 +209,125 @@ func mergeTaskResourceSettings(levels []*settings.TaskResourceSettings) *setting
 	}
 	return out
 }
+
+// mergeRunSettings resolves the run group across the level chain. Like the other
+// group mergers it holds no rules of its own, only regrouping and delegation.
+// Returns nil when no level set anything under run.
+func mergeRunSettings(levels []*settings.RunSettings) *settings.RunSettings {
+	defaultQueue := make([]*settings.StringSetting, len(levels))
+	maxActionConcurrency := make([]*settings.Int64Setting, len(levels))
+	runBaseDir := make([]*settings.StringSetting, len(levels))
+
+	for i, l := range levels {
+		defaultQueue[i] = l.GetDefaultQueue()
+		maxActionConcurrency[i] = l.GetMaxActionConcurrency()
+		runBaseDir[i] = l.GetRunBaseDir()
+	}
+
+	out := &settings.RunSettings{
+		DefaultQueue:         mergeStringSettings(defaultQueue),
+		MaxActionConcurrency: mergeInt64Settings(maxActionConcurrency),
+		RunBaseDir:           mergeStringSettings(runBaseDir),
+	}
+
+	if out.DefaultQueue == nil && out.MaxActionConcurrency == nil && out.RunBaseDir == nil {
+		return nil
+	}
+	return out
+}
+
+// mergeSecuritySettings resolves the security group across the level chain. Like the
+// other group mergers it holds no rules of its own. Returns nil when nothing resolved.
+func mergeSecuritySettings(levels []*settings.SecuritySettings) *settings.SecuritySettings {
+	serviceAccount := make([]*settings.StringSetting, len(levels))
+
+	for i, l := range levels {
+		serviceAccount[i] = l.GetServiceAccount()
+	}
+
+	out := &settings.SecuritySettings{
+		ServiceAccount: mergeStringSettings(serviceAccount),
+	}
+
+	if out.ServiceAccount == nil {
+		return nil
+	}
+	return out
+}
+
+// mergeStorageSettings resolves the storage group across the level chain. Like the
+// other group mergers it holds no rules of its own. Returns nil when nothing resolved.
+func mergeStorageSettings(levels []*settings.StorageSettings) *settings.StorageSettings {
+	rawDataPath := make([]*settings.StringSetting, len(levels))
+
+	for i, l := range levels {
+		rawDataPath[i] = l.GetRawDataPath()
+	}
+
+	out := &settings.StorageSettings{
+		RawDataPath: mergeStringSettings(rawDataPath),
+	}
+
+	if out.RawDataPath == nil {
+		return nil
+	}
+	return out
+}
+
+// mergeAppSettings resolves the app group across the level chain. Like the other
+// group mergers it holds no rules of its own. Returns nil when nothing resolved.
+func mergeAppSettings(levels []*settings.AppSettings) *settings.AppSettings {
+	disallowAnonymous := make([]*settings.BoolSetting, len(levels))
+
+	for i, l := range levels {
+		disallowAnonymous[i] = l.GetDisallowAnonymous()
+	}
+
+	out := &settings.AppSettings{
+		DisallowAnonymous: mergeBoolSettings(disallowAnonymous),
+	}
+
+	if out.DisallowAnonymous == nil {
+		return nil
+	}
+	return out
+}
+
+// mergeSettings resolves a full settings document across the level chain. Callers
+// pass one entry per level, broadest first, using nil for levels with no stored
+// record.
+func mergeSettings(levels []*settings.Settings) *settings.Settings {
+	run := make([]*settings.RunSettings, len(levels))
+	security := make([]*settings.SecuritySettings, len(levels))
+	storage := make([]*settings.StorageSettings, len(levels))
+	taskResource := make([]*settings.TaskResourceSettings, len(levels))
+	labels := make([]*settings.StringMapSetting, len(levels))
+	annotations := make([]*settings.StringMapSetting, len(levels))
+	envVars := make([]*settings.StringMapSetting, len(levels))
+	app := make([]*settings.AppSettings, len(levels))
+	podTemplateName := make([]*settings.StringSetting, len(levels))
+
+	for i, l := range levels {
+		run[i] = l.GetRun()
+		security[i] = l.GetSecurity()
+		storage[i] = l.GetStorage()
+		taskResource[i] = l.GetTaskResource()
+		labels[i] = l.GetLabels()
+		annotations[i] = l.GetAnnotations()
+		envVars[i] = l.GetEnvironmentVariables()
+		app[i] = l.GetApp()
+		podTemplateName[i] = l.GetPodTemplateName()
+	}
+
+	return &settings.Settings{
+		Run:                  mergeRunSettings(run),
+		Security:             mergeSecuritySettings(security),
+		Storage:              mergeStorageSettings(storage),
+		TaskResource:         mergeTaskResourceSettings(taskResource),
+		Labels:               mergeStringMapSettings(labels),
+		Annotations:          mergeStringMapSettings(annotations),
+		EnvironmentVariables: mergeStringMapSettings(envVars),
+		App:                  mergeAppSettings(app),
+		PodTemplateName:      mergeStringSettings(podTemplateName),
+	}
+}

--- a/runs/service/settings_merge.go
+++ b/runs/service/settings_merge.go
@@ -111,3 +111,45 @@ func mergeQuantitySettings(levels []*settings.QuantitySetting) *settings.Quantit
 
 	return out
 }
+
+// mergeStringMapSettings resolves one string-map leaf across the level chain.
+// Unlike scalars, every level contributes: entries accumulate parent first with
+// child entries overwriting on key conflict, and a level in state UNSET clears
+// everything accumulated above it. ScopeLevel records the most specific level
+// that contributed, since entries may come from several levels.
+func mergeStringMapSettings(levels []*settings.StringMapSetting) *settings.StringMapSetting {
+	entries := map[string]string{}
+	var state settings.SettingState
+	var level settings.ScopeLevel
+
+	for i, s := range levels {
+		switch s.GetState() {
+		case settings.SettingState_SETTING_STATE_INHERIT:
+			continue
+		case settings.SettingState_SETTING_STATE_UNSET:
+			entries = map[string]string{}
+		default:
+			for k, v := range s.GetMapValue().GetEntries() {
+				entries[k] = v
+			}
+		}
+		state = s.GetState()
+		level = scopeLevelAt(i)
+	}
+
+	// state is still its zero value when no level contributed.
+	if state == settings.SettingState_SETTING_STATE_INHERIT {
+		return nil
+	}
+	if state == settings.SettingState_SETTING_STATE_UNSET {
+		return &settings.StringMapSetting{
+			State:      settings.SettingState_SETTING_STATE_UNSET,
+			ScopeLevel: level,
+		}
+	}
+	return &settings.StringMapSetting{
+		State:      settings.SettingState_SETTING_STATE_VALUE,
+		MapValue:   &settings.StringMap{Entries: entries},
+		ScopeLevel: level,
+	}
+}

--- a/runs/service/settings_merge.go
+++ b/runs/service/settings_merge.go
@@ -7,7 +7,7 @@ import (
 )
 
 // scopeLevelAt maps a position in the level chain to the scope it represents.
-// Callers build the chain broadest first: instance, domain, project.
+// Callers build the chain broadest first: org, domain, project.
 func scopeLevelAt(i int) settings.ScopeLevel {
 	switch i {
 	case 0:
@@ -19,97 +19,68 @@ func scopeLevelAt(i int) settings.ScopeLevel {
 	}
 }
 
-// mergeStringSettings resolves one string leaf across the level chain. The last
-// level whose state is not INHERIT wins, so UNSET at a child level blocks a
-// value set higher up. Returns nil when no level had an opinion.
-func mergeStringSettings(levels []*settings.StringSetting) *settings.StringSetting {
-	var winner *settings.StringSetting
-	var level settings.ScopeLevel
+// scalarSetting is the shared shape of the scalar leaf wrappers: a proto message
+// carrying a SettingState.
+type scalarSetting interface {
+	proto.Message
+	GetState() settings.SettingState
+}
+
+// mergeScalar resolves one scalar leaf across the level chain: the last level whose
+// state is not INHERIT wins, so an UNSET child blocks a value set above it, and nil
+// comes back when nothing did. setLevel stamps the winning scope onto the copy,
+// because a generic constraint can require methods but not fields.
+func mergeScalar[T scalarSetting](levels []T, setLevel func(T, settings.ScopeLevel)) T {
+	var out T
+	won := -1
 
 	for i, s := range levels {
 		if s.GetState() == settings.SettingState_SETTING_STATE_INHERIT {
 			continue
 		}
-		winner = s
-		level = scopeLevelAt(i)
-	}
-	if winner == nil {
-		return nil
+		won = i
 	}
 
-	out := proto.Clone(winner).(*settings.StringSetting)
-	out.ScopeLevel = level
+	if won < 0 {
+		return out
+	}
 
+	out = proto.Clone(levels[won]).(T)
+	setLevel(out, scopeLevelAt(won))
 	return out
+}
+
+// mergeStringSettings resolves one string leaf across the level chain. The last
+// level whose state is not INHERIT wins, so UNSET at a child level blocks a
+// value set higher up. Returns nil when no level had an opinion.
+func mergeStringSettings(levels []*settings.StringSetting) *settings.StringSetting {
+	return mergeScalar(levels, func(s *settings.StringSetting, level settings.ScopeLevel) {
+		s.ScopeLevel = level
+	})
 }
 
 // mergeInt64Settings resolves one int64 leaf across the level chain, following the
 // same rule as mergeStringSettings.
 func mergeInt64Settings(levels []*settings.Int64Setting) *settings.Int64Setting {
-	var winner *settings.Int64Setting
-	var level settings.ScopeLevel
-
-	for i, s := range levels {
-		if s.GetState() == settings.SettingState_SETTING_STATE_INHERIT {
-			continue
-		}
-		winner = s
-		level = scopeLevelAt(i)
-	}
-	if winner == nil {
-		return nil
-	}
-
-	out := proto.Clone(winner).(*settings.Int64Setting)
-	out.ScopeLevel = level
-
-	return out
+	return mergeScalar(levels, func(s *settings.Int64Setting, level settings.ScopeLevel) {
+		s.ScopeLevel = level
+	})
 }
 
 // mergeBoolSettings resolves one bool leaf across the level chain, following the
 // same rule as mergeStringSettings.
 func mergeBoolSettings(levels []*settings.BoolSetting) *settings.BoolSetting {
-	var winner *settings.BoolSetting
-	var level settings.ScopeLevel
-
-	for i, s := range levels {
-		if s.GetState() == settings.SettingState_SETTING_STATE_INHERIT {
-			continue
-		}
-		winner = s
-		level = scopeLevelAt(i)
-	}
-	if winner == nil {
-		return nil
-	}
-
-	out := proto.Clone(winner).(*settings.BoolSetting)
-	out.ScopeLevel = level
-
-	return out
+	return mergeScalar(levels, func(s *settings.BoolSetting, level settings.ScopeLevel) {
+		s.ScopeLevel = level
+	})
 }
 
 // mergeQuantitySettings resolves one quantity leaf across the level chain, following
 // the same rule as mergeStringSettings.
 func mergeQuantitySettings(levels []*settings.QuantitySetting) *settings.QuantitySetting {
-	var winner *settings.QuantitySetting
-	var level settings.ScopeLevel
-
-	for i, s := range levels {
-		if s.GetState() == settings.SettingState_SETTING_STATE_INHERIT {
-			continue
-		}
-		winner = s
-		level = scopeLevelAt(i)
-	}
-	if winner == nil {
-		return nil
-	}
-
-	out := proto.Clone(winner).(*settings.QuantitySetting)
-	out.ScopeLevel = level
-
-	return out
+	return mergeScalar(levels, func(s *settings.QuantitySetting, level settings.ScopeLevel) {
+		s.ScopeLevel = level
+	})
 }
 
 // mergeStringMapSettings resolves one string-map leaf across the level chain.

--- a/runs/service/settings_merge.go
+++ b/runs/service/settings_merge.go
@@ -153,3 +153,59 @@ func mergeStringMapSettings(levels []*settings.StringMapSetting) *settings.Strin
 		ScopeLevel: level,
 	}
 }
+
+// mergeTaskResourceDefaults resolves one resource bound (min or max) across the level
+// chain. It holds no merge rules of its own: it regroups the four dimensions by level
+// and delegates each to mergeQuantitySettings. Returns nil when no dimension resolved.
+func mergeTaskResourceDefaults(levels []*settings.TaskResourceDefaults) *settings.TaskResourceDefaults {
+	cpu := make([]*settings.QuantitySetting, len(levels))
+	gpu := make([]*settings.QuantitySetting, len(levels))
+	memory := make([]*settings.QuantitySetting, len(levels))
+	storage := make([]*settings.QuantitySetting, len(levels))
+
+	for i, l := range levels {
+		cpu[i] = l.GetCpu()
+		gpu[i] = l.GetGpu()
+		memory[i] = l.GetMemory()
+		storage[i] = l.GetStorage()
+	}
+
+	out := &settings.TaskResourceDefaults{
+		Cpu:     mergeQuantitySettings(cpu),
+		Gpu:     mergeQuantitySettings(gpu),
+		Memory:  mergeQuantitySettings(memory),
+		Storage: mergeQuantitySettings(storage),
+	}
+
+	if out.Cpu == nil && out.Gpu == nil && out.Memory == nil && out.Storage == nil {
+		return nil
+	}
+	return out
+}
+
+// mergeTaskResourceSettings resolves the task_resource group across the level chain.
+// It holds no merge rules of its own: it regroups min, max, and mirror_limits_request
+// by level and delegates each. Returns nil when no level set anything under
+// task_resource, so the merged output carries no empty group.
+func mergeTaskResourceSettings(levels []*settings.TaskResourceSettings) *settings.TaskResourceSettings {
+	minLevels := make([]*settings.TaskResourceDefaults, len(levels))
+	maxLevels := make([]*settings.TaskResourceDefaults, len(levels))
+	mirror := make([]*settings.BoolSetting, len(levels))
+
+	for i, l := range levels {
+		minLevels[i] = l.GetMin()
+		maxLevels[i] = l.GetMax()
+		mirror[i] = l.GetMirrorLimitsRequest()
+	}
+
+	out := &settings.TaskResourceSettings{
+		Min:                 mergeTaskResourceDefaults(minLevels),
+		Max:                 mergeTaskResourceDefaults(maxLevels),
+		MirrorLimitsRequest: mergeBoolSettings(mirror),
+	}
+
+	if out.Min == nil && out.Max == nil && out.MirrorLimitsRequest == nil {
+		return nil
+	}
+	return out
+}

--- a/runs/service/settings_merge_test.go
+++ b/runs/service/settings_merge_test.go
@@ -37,10 +37,6 @@ func wantMap(level settings.ScopeLevel, entries map[string]string) *settings.Str
 	}
 }
 
-func boolSetting(state settings.SettingState, value bool) *settings.BoolSetting {
-	return &settings.BoolSetting{State: state, BoolValue: value}
-}
-
 func TestMergeStringSettings(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -181,36 +177,6 @@ func TestMergeStringMapSettings(t *testing.T) {
 			assert.Truef(t, proto.Equal(tt.want, got), "want %v, got %v", tt.want, got)
 		})
 	}
-}
-
-// TestMergeScalarCopies smoke-tests the int64, bool and quantity mergers. They are
-// copies of mergeStringSettings with the leaf type swapped, so each case only needs
-// to resolve a winner: that exercises the type assertion, which is the one line where
-// a bad copy compiles but panics at runtime.
-func TestMergeScalarCopies(t *testing.T) {
-	t.Run("int64", func(t *testing.T) {
-		got := mergeInt64Settings([]*settings.Int64Setting{
-			concurrency(stateValue, 8), nil, concurrency(stateValue, 64),
-		})
-		want := &settings.Int64Setting{State: stateValue, IntValue: 64, ScopeLevel: levelProject}
-		assert.Truef(t, proto.Equal(want, got), "want %v, got %v", want, got)
-	})
-
-	t.Run("bool", func(t *testing.T) {
-		got := mergeBoolSettings([]*settings.BoolSetting{
-			boolSetting(stateValue, false), nil, boolSetting(stateValue, true),
-		})
-		want := &settings.BoolSetting{State: stateValue, BoolValue: true, ScopeLevel: levelProject}
-		assert.Truef(t, proto.Equal(want, got), "want %v, got %v", want, got)
-	})
-
-	t.Run("quantity", func(t *testing.T) {
-		got := mergeQuantitySettings([]*settings.QuantitySetting{
-			quantity(stateValue, "16"), nil, quantity(stateValue, "32"),
-		})
-		want := &settings.QuantitySetting{State: stateValue, QuantityValue: "32", ScopeLevel: levelProject}
-		assert.Truef(t, proto.Equal(want, got), "want %v, got %v", want, got)
-	})
 }
 
 func TestMergeSettings(t *testing.T) {

--- a/runs/service/settings_merge_test.go
+++ b/runs/service/settings_merge_test.go
@@ -1,0 +1,287 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings"
+)
+
+const (
+	levelOrg     = settings.ScopeLevel_SCOPE_LEVEL_ORG
+	levelDomain  = settings.ScopeLevel_SCOPE_LEVEL_DOMAIN
+	levelProject = settings.ScopeLevel_SCOPE_LEVEL_PROJECT
+)
+
+func str(state settings.SettingState, value string) *settings.StringSetting {
+	return &settings.StringSetting{State: state, StringValue: value}
+}
+
+func strMap(state settings.SettingState, entries map[string]string) *settings.StringMapSetting {
+	m := &settings.StringMapSetting{State: state}
+	if entries != nil {
+		m.MapValue = &settings.StringMap{Entries: entries}
+	}
+	return m
+}
+
+// wantMap builds an expected merged map leaf: state VALUE plus a scope level.
+func wantMap(level settings.ScopeLevel, entries map[string]string) *settings.StringMapSetting {
+	return &settings.StringMapSetting{
+		State:      stateValue,
+		MapValue:   &settings.StringMap{Entries: entries},
+		ScopeLevel: level,
+	}
+}
+
+func boolSetting(state settings.SettingState, value bool) *settings.BoolSetting {
+	return &settings.BoolSetting{State: state, BoolValue: value}
+}
+
+func TestMergeStringSettings(t *testing.T) {
+	tests := []struct {
+		name   string
+		levels []*settings.StringSetting
+		want   *settings.StringSetting
+	}{
+		{
+			name:   "nothing set anywhere",
+			levels: []*settings.StringSetting{nil, nil, nil},
+			want:   nil,
+		},
+		{
+			name:   "all inherit",
+			levels: []*settings.StringSetting{str(stateInherit, ""), str(stateInherit, ""), str(stateInherit, "")},
+			want:   nil,
+		},
+		{
+			name:   "only org sets it",
+			levels: []*settings.StringSetting{str(stateValue, "default"), nil, nil},
+			want:   &settings.StringSetting{State: stateValue, StringValue: "default", ScopeLevel: levelOrg},
+		},
+		{
+			name:   "project overrides org",
+			levels: []*settings.StringSetting{str(stateValue, "default"), nil, str(stateValue, "gpu-pool")},
+			want:   &settings.StringSetting{State: stateValue, StringValue: "gpu-pool", ScopeLevel: levelProject},
+		},
+		{
+			name:   "domain wins when project inherits",
+			levels: []*settings.StringSetting{str(stateValue, "default"), str(stateValue, "fast"), str(stateInherit, "")},
+			want:   &settings.StringSetting{State: stateValue, StringValue: "fast", ScopeLevel: levelDomain},
+		},
+		{
+			name:   "unset at project blocks the org value",
+			levels: []*settings.StringSetting{str(stateValue, "default-runner"), nil, str(stateUnset, "")},
+			want:   &settings.StringSetting{State: stateUnset, ScopeLevel: levelProject},
+		},
+		{
+			name:   "unset at domain survives an inheriting project",
+			levels: []*settings.StringSetting{str(stateValue, "default-runner"), str(stateUnset, ""), str(stateInherit, "")},
+			want:   &settings.StringSetting{State: stateUnset, ScopeLevel: levelDomain},
+		},
+		{
+			name:   "project overrides an unset domain",
+			levels: []*settings.StringSetting{str(stateValue, "default"), str(stateUnset, ""), str(stateValue, "mine")},
+			want:   &settings.StringSetting{State: stateValue, StringValue: "mine", ScopeLevel: levelProject},
+		},
+		{
+			name:   "shorter chain for an org-scoped request",
+			levels: []*settings.StringSetting{str(stateValue, "default")},
+			want:   &settings.StringSetting{State: stateValue, StringValue: "default", ScopeLevel: levelOrg},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeStringSettings(tt.levels)
+			assert.Truef(t, proto.Equal(tt.want, got), "want %v, got %v", tt.want, got)
+		})
+	}
+}
+
+func TestMergeStringMapSettings(t *testing.T) {
+	tests := []struct {
+		name   string
+		levels []*settings.StringMapSetting
+		want   *settings.StringMapSetting
+	}{
+		{
+			name:   "nothing set anywhere",
+			levels: []*settings.StringMapSetting{nil, nil, nil},
+			want:   nil,
+		},
+		{
+			name:   "only org contributes",
+			levels: []*settings.StringMapSetting{strMap(stateValue, map[string]string{"A": "1"}), nil, nil},
+			want:   wantMap(levelOrg, map[string]string{"A": "1"}),
+		},
+		{
+			name: "levels accumulate when keys do not clash",
+			levels: []*settings.StringMapSetting{
+				strMap(stateValue, map[string]string{"A": "1"}),
+				strMap(stateValue, map[string]string{"B": "2"}),
+				nil,
+			},
+			want: wantMap(levelDomain, map[string]string{"A": "1", "B": "2"}),
+		},
+		{
+			name: "child overrides parent on key conflict",
+			levels: []*settings.StringMapSetting{
+				strMap(stateValue, map[string]string{"LOG_LEVEL": "info", "REGION": "us-east-1"}),
+				strMap(stateValue, map[string]string{"LOG_LEVEL": "debug"}),
+				nil,
+			},
+			want: wantMap(levelDomain, map[string]string{"LOG_LEVEL": "debug", "REGION": "us-east-1"}),
+		},
+		{
+			name: "unset clears everything accumulated above it",
+			levels: []*settings.StringMapSetting{
+				strMap(stateValue, map[string]string{"A": "1", "B": "2"}),
+				strMap(stateUnset, nil),
+				nil,
+			},
+			want: &settings.StringMapSetting{State: stateUnset, ScopeLevel: levelDomain},
+		},
+		{
+			name: "a level below unset refills an empty bucket",
+			levels: []*settings.StringMapSetting{
+				strMap(stateValue, map[string]string{"A": "1", "B": "2"}),
+				strMap(stateUnset, nil),
+				strMap(stateValue, map[string]string{"C": "3"}),
+			},
+			want: wantMap(levelProject, map[string]string{"C": "3"}),
+		},
+		{
+			name: "value with no entries contributes nothing but claims the level",
+			levels: []*settings.StringMapSetting{
+				strMap(stateValue, map[string]string{"A": "1"}),
+				strMap(stateValue, nil),
+				nil,
+			},
+			want: wantMap(levelDomain, map[string]string{"A": "1"}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeStringMapSettings(tt.levels)
+			assert.Truef(t, proto.Equal(tt.want, got), "want %v, got %v", tt.want, got)
+		})
+	}
+}
+
+// TestMergeScalarCopies smoke-tests the int64, bool and quantity mergers. They are
+// copies of mergeStringSettings with the leaf type swapped, so each case only needs
+// to resolve a winner: that exercises the type assertion, which is the one line where
+// a bad copy compiles but panics at runtime.
+func TestMergeScalarCopies(t *testing.T) {
+	t.Run("int64", func(t *testing.T) {
+		got := mergeInt64Settings([]*settings.Int64Setting{
+			concurrency(stateValue, 8), nil, concurrency(stateValue, 64),
+		})
+		want := &settings.Int64Setting{State: stateValue, IntValue: 64, ScopeLevel: levelProject}
+		assert.Truef(t, proto.Equal(want, got), "want %v, got %v", want, got)
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		got := mergeBoolSettings([]*settings.BoolSetting{
+			boolSetting(stateValue, false), nil, boolSetting(stateValue, true),
+		})
+		want := &settings.BoolSetting{State: stateValue, BoolValue: true, ScopeLevel: levelProject}
+		assert.Truef(t, proto.Equal(want, got), "want %v, got %v", want, got)
+	})
+
+	t.Run("quantity", func(t *testing.T) {
+		got := mergeQuantitySettings([]*settings.QuantitySetting{
+			quantity(stateValue, "16"), nil, quantity(stateValue, "32"),
+		})
+		want := &settings.QuantitySetting{State: stateValue, QuantityValue: "32", ScopeLevel: levelProject}
+		assert.Truef(t, proto.Equal(want, got), "want %v, got %v", want, got)
+	})
+}
+
+func TestMergeSettings(t *testing.T) {
+	org := &settings.Settings{
+		Run:                  &settings.RunSettings{DefaultQueue: str(stateValue, "default")},
+		EnvironmentVariables: strMap(stateValue, map[string]string{"LOG_LEVEL": "info"}),
+		TaskResource: &settings.TaskResourceSettings{
+			Max: &settings.TaskResourceDefaults{Cpu: quantity(stateValue, "16")},
+		},
+	}
+	domain := &settings.Settings{
+		Run:      &settings.RunSettings{DefaultQueue: str(stateValue, "fast-queue")},
+		Security: &settings.SecuritySettings{ServiceAccount: str(stateValue, "runner")},
+	}
+	project := &settings.Settings{
+		EnvironmentVariables: strMap(stateValue, map[string]string{"TEAM": "ml"}),
+		TaskResource: &settings.TaskResourceSettings{
+			Max: &settings.TaskResourceDefaults{Cpu: quantity(stateValue, "32")},
+		},
+		PodTemplateName: str(stateValue, "gpu-template"),
+	}
+
+	got := mergeSettings([]*settings.Settings{org, domain, project})
+
+	t.Run("scalars resolve from the most specific level that set them", func(t *testing.T) {
+		assert.Equal(t, "fast-queue", got.GetRun().GetDefaultQueue().GetStringValue())
+		assert.Equal(t, levelDomain, got.GetRun().GetDefaultQueue().GetScopeLevel())
+		assert.Equal(t, "runner", got.GetSecurity().GetServiceAccount().GetStringValue())
+		assert.Equal(t, "gpu-template", got.GetPodTemplateName().GetStringValue())
+	})
+
+	t.Run("nested quantities resolve independently", func(t *testing.T) {
+		assert.Equal(t, "32", got.GetTaskResource().GetMax().GetCpu().GetQuantityValue())
+		assert.Equal(t, levelProject, got.GetTaskResource().GetMax().GetCpu().GetScopeLevel())
+		assert.Nil(t, got.GetTaskResource().GetMax().GetMemory())
+		assert.Nil(t, got.GetTaskResource().GetMin())
+	})
+
+	t.Run("maps accumulate across levels", func(t *testing.T) {
+		assert.Equal(t, map[string]string{"LOG_LEVEL": "info", "TEAM": "ml"},
+			got.GetEnvironmentVariables().GetMapValue().GetEntries())
+	})
+
+	t.Run("groups nobody configured are absent, not empty", func(t *testing.T) {
+		assert.Nil(t, got.GetStorage())
+		assert.Nil(t, got.GetApp())
+		assert.Nil(t, got.GetLabels())
+		assert.Nil(t, got.GetAnnotations())
+		assert.Nil(t, got.GetRun().GetMaxActionConcurrency())
+	})
+}
+
+func TestMergeSettings_NothingStored(t *testing.T) {
+	got := mergeSettings([]*settings.Settings{nil, nil, nil})
+
+	require.NotNil(t, got)
+	assert.Nil(t, got.GetRun())
+	assert.Nil(t, got.GetTaskResource())
+	assert.Nil(t, got.GetEnvironmentVariables())
+}
+
+// TestMergeSettingsHandlesEveryField fails when a field is added to the Settings
+// proto without being handled in mergeSettings. Adding a field there is easy to
+// forget, and a forgotten field silently never resolves.
+func TestMergeSettingsHandlesEveryField(t *testing.T) {
+	handled := map[string]bool{
+		"run":                   true,
+		"security":              true,
+		"storage":               true,
+		"task_resource":         true,
+		"labels":                true,
+		"annotations":           true,
+		"environment_variables": true,
+		"app":                   true,
+		"pod_template_name":     true,
+	}
+
+	fields := (&settings.Settings{}).ProtoReflect().Descriptor().Fields()
+	for i := 0; i < fields.Len(); i++ {
+		name := string(fields.Get(i).Name())
+		assert.Truef(t, handled[name],
+			"Settings field %q is not handled by mergeSettings; add it there, then add it to this list", name)
+	}
+}

--- a/runs/service/settings_merge_test.go
+++ b/runs/service/settings_merge_test.go
@@ -92,6 +92,16 @@ func TestMergeStringSettings(t *testing.T) {
 			levels: []*settings.StringSetting{str(stateValue, "default")},
 			want:   &settings.StringSetting{State: stateValue, StringValue: "default", ScopeLevel: levelOrg},
 		},
+		{
+			name:   "unset at org with nothing below",
+			levels: []*settings.StringSetting{str(stateUnset, ""), nil, nil},
+			want:   &settings.StringSetting{State: stateUnset, ScopeLevel: levelOrg},
+		},
+		{
+			name:   "domain is the only level that sets it",
+			levels: []*settings.StringSetting{nil, str(stateValue, "fast"), nil},
+			want:   &settings.StringSetting{State: stateValue, StringValue: "fast", ScopeLevel: levelDomain},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Tracking issue

Related to #7775. This is task 2.2 (merge engine).

## Why are the changes needed?

Settings are stored one row per scope, so answering "what applies to this project?" means resolving up to three rows into one document. Nothing does that yet, which is why `GetSettings` still returns `Unimplemented` and why no Phase 3 applier can start.

## What changes were proposed in this pull request?

Pure resolution functions in `runs/service/settings_merge.go`, following the rules in the RFC:

- scalars: walk org, domain, project; the last level whose state is not `INHERIT` wins, so `UNSET` at a child level blocks a value set above it
- string maps: entries accumulate parent first, child entries overwrite on key conflict, and a level in state `UNSET` clears everything accumulated above it
- task resources: the scalar rule applied per dimension across the min and max bounds
- every resolved leaf is annotated with the `scope_level` it came from

`mergeSettings` is the only entry point. The rest are either leaf mergers, which hold the rules, or group mergers, which only regroup fields by level and delegate. Groups that no level configured resolve to nil, so the merged document carries no empty objects.

Nothing calls this yet. The `GetSettings` handler is the other half of task 2.5 and comes in a follow-up.

One point the RFC leaves open: it says to annotate the winner with its scope level, which is unambiguous for a scalar but not for a map assembled from several levels. Here a merged map records the most specific level that contributed. Per-entry origins remain available from `GetSettingsForEdit`.

## How was this patch tested?

Table tests with no database, since the functions are pure. Every `SettingState` appears at every position in the chain, and the map table covers accumulation, child override, `UNSET` clearing, and a level below `UNSET` refilling the map. There is also a test that fails if a field is added to the `Settings` proto without being handled in `mergeSettings`.

### Labels

- **added**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

Follows #7841, #7859 and #7881. Stacked on #7900.
