### PR TITLE
feat(runs): implement GetSettings

### DIFF
--- a/runs/service/settings_service.go
+++ b/runs/service/settings_service.go
@@ -105,29 +105,9 @@ func (s *SettingsService) GetSettingsForEdit(
 		return nil, err
 	}
 
-	// One partial key per scope level covered by the request, broadest first,
-	// as GetSettingsForEditResponse requires. Order comes from this list; the
-	// repo returns rows unordered.
-	levelKeys := []*settings.SettingsKey{{Org: key.GetOrg()}}
-	if key.GetDomain() != "" {
-		levelKeys = append(levelKeys, &settings.SettingsKey{Org: key.GetOrg(), Domain: key.GetDomain()})
-	}
-	if key.GetProject() != "" {
-		levelKeys = append(levelKeys, &settings.SettingsKey{Org: key.GetOrg(), Domain: key.GetDomain(), Project: key.GetProject()})
-	}
-
-	storageKeys := make([]string, 0, len(levelKeys))
-	for _, lk := range levelKeys {
-		storageKeys = append(storageKeys, models.EncodeSettingsKey(lk.GetOrg(), lk.GetDomain(), lk.GetProject()))
-	}
-
-	rows, err := s.settingsRepo.GetSettingsByKeys(ctx, storageKeys)
+	levelKeys, rows, err := s.fetchLevels(ctx, key)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	rowsByKey := make(map[string]*models.Settings, len(rows))
-	for _, row := range rows {
-		rowsByKey[row.Key] = row
 	}
 
 	levels := make([]*settings.SettingsRecord, 0, len(levelKeys))
@@ -135,7 +115,7 @@ func (s *SettingsService) GetSettingsForEdit(
 		// Absent level: empty settings, version 0 — the client's signal to use
 		// CreateSettings there (see SettingsRecord in the proto).
 		record := &settings.SettingsRecord{Key: lk, Settings: &settings.Settings{}}
-		if row := rowsByKey[storageKeys[i]]; row != nil {
+		if row := rows[i]; row != nil {
 			stored := &settings.Settings{}
 			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(row.Data, stored); err != nil {
 				return nil, connect.NewError(connect.CodeInternal, err)

--- a/runs/service/settings_service.go
+++ b/runs/service/settings_service.go
@@ -26,12 +26,74 @@ func NewSettingsService(settingsRepo interfaces.SettingsRepo) *SettingsService {
 	return &SettingsService{settingsRepo: settingsRepo}
 }
 
+// fetchLevels returns the scope levels covered by key, broadest first, together with
+// the stored row for each. The two slices align by position, and a nil row means no
+// record exists at that level. Order comes from the key ladder; the repo returns rows
+// unordered.
+func (s *SettingsService) fetchLevels(ctx context.Context, key *settings.SettingsKey) ([]*settings.SettingsKey, []*models.Settings, error) {
+	levelKeys := []*settings.SettingsKey{{Org: key.GetOrg()}}
+	if key.GetDomain() != "" {
+		levelKeys = append(levelKeys, &settings.SettingsKey{Org: key.GetOrg(), Domain: key.GetDomain()})
+	}
+	if key.GetProject() != "" {
+		levelKeys = append(levelKeys, &settings.SettingsKey{Org: key.GetOrg(), Domain: key.GetDomain(), Project: key.GetProject()})
+	}
+
+	storageKeys := make([]string, 0, len(levelKeys))
+	for _, lk := range levelKeys {
+		storageKeys = append(storageKeys, models.EncodeSettingsKey(lk.GetOrg(), lk.GetDomain(), lk.GetProject()))
+	}
+
+	rows, err := s.settingsRepo.GetSettingsByKeys(ctx, storageKeys)
+	if err != nil {
+		return nil, nil, err
+	}
+	rowsByKey := make(map[string]*models.Settings, len(rows))
+	for _, row := range rows {
+		rowsByKey[row.Key] = row
+	}
+
+	aligned := make([]*models.Settings, len(levelKeys))
+	for i := range levelKeys {
+		aligned[i] = rowsByKey[storageKeys[i]]
+	}
+	return levelKeys, aligned, nil
+}
+
 // GetSettings returns resolved, merged settings.
 func (s *SettingsService) GetSettings(
 	ctx context.Context,
 	req *connect.Request[settings.GetSettingsRequest],
 ) (*connect.Response[settings.GetSettingsResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("settings resolution engine not implemented yet"))
+	key := req.Msg.GetKey()
+	if err := validateSettingsKey(key); err != nil {
+		return nil, err
+	}
+
+	_, rows, err := s.fetchLevels(ctx, key)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	levels := make([]*settings.Settings, len(rows))
+	for i, row := range rows {
+		if row == nil {
+			continue
+		}
+		stored := &settings.Settings{}
+		if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(row.Data, stored); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		levels[i] = stored
+	}
+	// Merged settings do not correspond to a stored row, so the record carries no
+	// version. Clients that need one for an update use GetSettingsForEdit.
+	return connect.NewResponse(&settings.GetSettingsResponse{
+		SettingsRecord: &settings.SettingsRecord{
+			Key:      key,
+			Settings: mergeSettings(levels),
+		},
+	}), nil
 }
 
 func (s *SettingsService) GetSettingsForEdit(

--- a/runs/service/settings_service_test.go
+++ b/runs/service/settings_service_test.go
@@ -332,7 +332,7 @@ func TestGetSettingsForEdit_AllLevels(t *testing.T) {
 	require.Len(t, levels, 3)
 
 	// Each level carries only what it stores. Nothing is merged, which is the job
-	// of GetSettings, which is not implemented yet.
+	// of GetSettings.
 	assert.True(t, proto.Equal(orgKey, levels[0].GetKey()))
 	assert.True(t, proto.Equal(envSettings("LOG_LEVEL", "org"), levels[0].GetSettings()))
 	assert.Equal(t, uint64(1), levels[0].GetVersion())
@@ -574,4 +574,57 @@ func TestValidateSettings(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.wantPath)
 		})
 	}
+}
+
+func TestGetSettings_MergesAcrossLevels(t *testing.T) {
+	ctx := context.Background()
+	svc := setupSettingsService(t)
+
+	orgKey := &settings.SettingsKey{Org: "acme"}
+	projectKey := &settings.SettingsKey{Org: "acme", Domain: "development", Project: "recsys"}
+
+	_, err := svc.CreateSettings(ctx, connect.NewRequest(&settings.CreateSettingsRequest{
+		Key:      orgKey,
+		Settings: envSettings("LOG_LEVEL", "info"),
+	}))
+	require.NoError(t, err)
+
+	_, err = svc.CreateSettings(ctx, connect.NewRequest(&settings.CreateSettingsRequest{
+		Key:      projectKey,
+		Settings: envSettings("TEAM", "ml"),
+	}))
+	require.NoError(t, err)
+
+	resp, err := svc.GetSettings(ctx, connect.NewRequest(&settings.GetSettingsRequest{
+		Key: projectKey,
+	}))
+	require.NoError(t, err)
+
+	record := resp.Msg.GetSettingsRecord()
+	assert.True(t, proto.Equal(projectKey, record.GetKey()))
+
+	// Entries from both levels, with no domain row in between.
+	assert.Equal(t, map[string]string{"LOG_LEVEL": "info", "TEAM": "ml"},
+		record.GetSettings().GetEnvironmentVariables().GetMapValue().GetEntries())
+	assert.Equal(t, levelProject, record.GetSettings().GetEnvironmentVariables().GetScopeLevel())
+
+	// Merged settings are not a stored row, so no version comes back even though
+	// both stored rows are at version 1.
+	assert.Equal(t, uint64(0), record.GetVersion())
+}
+
+func TestGetSettings_NothingStored(t *testing.T) {
+	ctx := context.Background()
+	svc := setupSettingsService(t)
+
+	resp, err := svc.GetSettings(ctx, connect.NewRequest(&settings.GetSettingsRequest{
+		Key: &settings.SettingsKey{Org: "acme", Domain: "development", Project: "recsys"},
+	}))
+	require.NoError(t, err)
+
+	record := resp.Msg.GetSettingsRecord()
+	require.NotNil(t, record)
+	require.NotNil(t, record.GetSettings())
+	assert.Nil(t, record.GetSettings().GetEnvironmentVariables())
+	assert.Equal(t, uint64(0), record.GetVersion())
 }


### PR DESCRIPTION
## Tracking issue

Related to #7775. This is the `GetSettings` half of task 2.5.

## Why are the changes needed?

`GetSettings` is the RPC that answers "what settings apply to this project?", and it has returned `Unimplemented` since the service was added. It is also what every Phase 3 applier will call to resolve settings once per run.

## What changes were proposed in this pull request?

`GetSettings` now fetches the rows for every scope level the request key covers, decodes them, and hands them to the merge engine from #7925. The response carries one record with the merged document.

The merged record has no version. It does not correspond to a stored row, so there is nothing to write back to, and returning a real version would let a client save the merged document into one scope and silently stop it inheriting. Clients that want to edit use `GetSettingsForEdit`, which returns a real version per level.

The level fetch is extracted into `fetchLevels`, since `GetSettingsForEdit` did the same work: build the key ladder broadest first, fetch in one query, and align the rows back to level order. Alignment matters because the merge decides scope from position while the repo returns rows unordered. `GetSettingsForEdit` now uses it and is otherwise unchanged.

Reads keep `DiscardUnknown` so a row written by a newer build stays readable after a rollback, matching the existing read path.

## How was this patch tested?

Two service tests against the embedded Postgres harness:

- a merged read where an org row and a project row contribute and no domain row exists. Asserts the merged entries, the resolved `scope_level`, and that the version is 0 despite both stored rows being at version 1.
- a read of a scope with nothing stored. Asserts an empty document rather than an error.

### Labels

- **added**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

Follows #7841, #7859, #7881 and #7900. Stacked on #7925.
