### PR TITLE
fix: append inputs.pb suffix when reading offloaded trigger inputs in dataproxy

### DIFF
--- a/dataproxy/translator.go
+++ b/dataproxy/translator.go
@@ -124,9 +124,10 @@ func (s *TranslatorService) readTriggerLiterals(
 	// reader does the same: the executor re-appends it via ioutils.NewInputFilePaths, and
 	// CreateRun records inputs_uri as inputPrefix + "/inputs.pb". Tolerate a URI that already
 	// names the file so a full path keeps working.
-	inputRef := storage.DataReference(strings.TrimRight(uri, "/") + "/" + ioutils.InputsSuffix)
-	if strings.HasSuffix(uri, "/"+ioutils.InputsSuffix) {
-		inputRef = storage.DataReference(uri)
+	trimmed := strings.TrimRight(uri, "/")
+	inputRef := storage.DataReference(trimmed + "/" + ioutils.InputsSuffix)
+	if strings.HasSuffix(trimmed, "/"+ioutils.InputsSuffix) {
+		inputRef = storage.DataReference(trimmed)
 	}
 
 	var inputs task.Inputs

--- a/dataproxy/translator.go
+++ b/dataproxy/translator.go
@@ -3,10 +3,12 @@ package dataproxy
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"connectrpc.com/connect"
 
 	"github.com/flyteorg/flyte/v2/dataproxy/converter"
+	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/common"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task"
@@ -117,9 +119,19 @@ func (s *TranslatorService) readTriggerLiterals(
 			fmt.Errorf("trigger %s has no offloaded input data", triggerID.GetName().GetName()))
 	}
 
+	// UploadInputs writes the literals to <dir>/inputs.pb but reports the *directory* as
+	// OffloadedInputData.uri, so the suffix has to be appended before reading. Every other
+	// reader does the same: the executor re-appends it via ioutils.NewInputFilePaths, and
+	// CreateRun records inputs_uri as inputPrefix + "/inputs.pb". Tolerate a URI that already
+	// names the file so a full path keeps working.
+	inputRef := storage.DataReference(strings.TrimRight(uri, "/") + "/" + ioutils.InputsSuffix)
+	if strings.HasSuffix(uri, "/"+ioutils.InputsSuffix) {
+		inputRef = storage.DataReference(uri)
+	}
+
 	var inputs task.Inputs
-	if err := s.dataStore.ReadProtobuf(ctx, storage.DataReference(uri), &inputs); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to read trigger literals from %s: %w", uri, err))
+	if err := s.dataStore.ReadProtobuf(ctx, inputRef, &inputs); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to read trigger literals from %s: %w", inputRef, err))
 	}
 	return inputs.GetLiterals(), nil
 }

--- a/dataproxy/translator_test.go
+++ b/dataproxy/translator_test.go
@@ -189,6 +189,49 @@ func TestLiteralsToLaunchFormJson_Trigger(t *testing.T) {
 	assertHelloWorldSchema(t, resp)
 }
 
+// UploadInputs reports the *directory* as OffloadedInputData.uri (it writes the literals
+// to <dir>/inputs.pb), so this is the URI shape real triggers actually carry. Reading the
+// bare directory 404s, which left the trigger launch form falling back to task defaults.
+func TestLiteralsToLaunchFormJson_Trigger_DirectoryURI(t *testing.T) {
+	dirURI := "s3://test-bucket/uploads/proj/dev/offloaded-inputs/abc123"
+	storedInputs := &task.Inputs{Literals: testNamedLiterals()}
+
+	triggerClient := &fakeTriggerClient{
+		resp: &trigger.GetTriggerRevisionDetailsResponse{
+			Trigger: &trigger.TriggerDetails{
+				Id: testTriggerID(),
+				Spec: &trigger.TriggerSpec{
+					InputWrapper: &trigger.TriggerSpec_OffloadedInputData{
+						OffloadedInputData: &common.OffloadedInputData{
+							Uri:        dirURI,
+							InputsHash: "hash",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mockComposedStore := storageMocks.NewComposedProtobufStore(t)
+	// The read must target <dir>/inputs.pb, not the directory itself.
+	mockComposedStore.On("ReadProtobuf", mock.Anything, storage.DataReference(dirURI+"/inputs.pb"), mock.Anything).
+		Run(func(args mock.Arguments) {
+			msg := args.Get(2).(proto.Message)
+			proto.Reset(msg)
+			proto.Merge(msg, storedInputs)
+		}).Return(nil)
+
+	svc := NewTranslatorService(&storage.DataStore{ComposedProtobufStore: mockComposedStore}, nil, triggerClient)
+
+	resp, err := svc.LiteralsToLaunchFormJson(context.Background(), connect.NewRequest(&workflow.LiteralsToLaunchFormJsonRequest{
+		Variables: testVariableMap(),
+		Owner:     &workflow.LiteralsToLaunchFormJsonRequest_TriggerId{TriggerId: testTriggerID()},
+	}))
+
+	require.NoError(t, err)
+	assertHelloWorldSchema(t, resp)
+}
+
 func TestLiteralsToLaunchFormJson_Trigger_NoOffloadedData(t *testing.T) {
 	triggerClient := &fakeTriggerClient{
 		resp: &trigger.GetTriggerRevisionDetailsResponse{


### PR DESCRIPTION
## Why are the changes needed?
  `UploadInputs` writes trigger literals to `<dir>/inputs.pb` but records the
  directory as `OffloadedInputData.uri`. The dataproxy translator read the
  URI as-is, so the read 404'd and the trigger launch form silently fell
  back to task defaults instead of showing the trigger's configured
  inputs.

## What changes were proposed in this pull request?
  - readTriggerLiterals now appends ioutils.InputsSuffix (inputs.pb) to
    the offloaded input URI before reading, matching how the executor
    (ioutils.NewInputFilePaths) and CreateRun (inputPrefix +
    "/inputs.pb") resolve the same URI.
  - Tolerates URIs that already end in /inputs.pb, so a full file path
    keeps working unchanged.
  - Error message now reports the resolved reference that was actually
    read.


## How was this patch tested?
  - Added TestLiteralsToLaunchFormJson_Trigger_DirectoryURI, which feeds
    the translator a directory-shaped URI (the shape real triggers carry)
    and asserts the storage read targets <dir>/inputs.pb and the launch
    form is built from the stored literals.
  - Verify locally with go test ./dataproxy/....
  - Manual check: open the launch form for a trigger with offloaded
    inputs and confirm it shows the trigger's values rather than task
    defaults.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
