### PR TITLE
feat(runs): prune empty setting messages before storing

### DIFF
--- a/runs/service/settings_prune.go
+++ b/runs/service/settings_prune.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// hasAnyField reports whether m has any populated field. A message with none
+// is exactly one protojson would serialize as {}.
+func hasAnyField(m protoreflect.Message) bool {
+	found := false
+	m.Range(func(protoreflect.FieldDescriptor, protoreflect.Value) bool {
+		found = true
+		return false
+	})
+	return found
+}
+
+// pruneSettings removes message fields that contain no information, so the
+// stored row does not depend on whether a client expressed INHERIT by omitting
+// a field or by sending it present but empty. Both forms read back
+// identically, so pruning only canonicalizes the stored bytes.
+func pruneEmpty(m protoreflect.Message) {
+	m.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		if fd.Kind() != protoreflect.MessageKind || fd.IsMap() || fd.IsList() {
+			return true
+		}
+		child := v.Message()
+		pruneEmpty(child)
+
+		if !hasAnyField(child) {
+			m.Clear(fd)
+		}
+		return true
+	})
+}
+
+// pruneSettings removes settings messages that carry no information, so a
+// stored row does not depend on how the client spelled INHERIT.
+func pruneSettings(s *settings.Settings) {
+	if s == nil {
+		return
+	}
+	pruneEmpty(s.ProtoReflect())
+}

--- a/runs/service/settings_prune_test.go
+++ b/runs/service/settings_prune_test.go
@@ -1,0 +1,1 @@
+package service

--- a/runs/service/settings_prune_test.go
+++ b/runs/service/settings_prune_test.go
@@ -1,1 +1,78 @@
 package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings"
+)
+
+// parseSettings builds a Settings from protojson, failing the test on bad input.
+func parseSettings(t *testing.T, in string) *settings.Settings {
+	t.Helper()
+	s := &settings.Settings{}
+	require.NoError(t, protojson.Unmarshal([]byte(in), s))
+	return s
+}
+
+func TestPruneSettings(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty leaf message is removed",
+			in:   `{"run":{"defaultQueue":{}}}`,
+			want: `{}`,
+		},
+		{
+			name: "empty group is removed",
+			in:   `{"run":{}}`,
+			want: `{}`,
+		},
+		{
+			name: "nested empty messages are removed at every depth",
+			in:   `{"taskResource":{"min":{"cpu":{}},"max":{}}}`,
+			want: `{}`,
+		},
+		{
+			name: "map setting with no entries is removed",
+			in:   `{"environmentVariables":{"mapValue":{"entries":{}}}}`,
+			want: `{}`,
+		},
+		{
+			name: "explicit UNSET is kept",
+			in:   `{"run":{"defaultQueue":{"state":"SETTING_STATE_UNSET"}}}`,
+			want: `{"run":{"defaultQueue":{"state":"SETTING_STATE_UNSET"}}}`,
+		},
+		{
+			name: "value is kept while its empty sibling is removed",
+			in:   `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"fast-queue"},"runBaseDir":{}}}`,
+			want: `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"fast-queue"}}}`,
+		},
+		{
+			name: "settings with no empty messages are unchanged",
+			in:   `{"environmentVariables":{"state":"SETTING_STATE_VALUE","mapValue":{"entries":{"LOG_LEVEL":"debug"}}}}`,
+			want: `{"environmentVariables":{"state":"SETTING_STATE_VALUE","mapValue":{"entries":{"LOG_LEVEL":"debug"}}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSettings(t, tt.in)
+			pruneSettings(got)
+
+			want := parseSettings(t, tt.want)
+			assert.True(t, proto.Equal(want, got), "got %s", protojson.Format(got))
+		})
+	}
+}
+
+func TestPruneSettings_NilDoesNotPanic(t *testing.T) {
+	pruneSettings(nil)
+}

--- a/runs/service/settings_service.go
+++ b/runs/service/settings_service.go
@@ -105,6 +105,7 @@ func (s *SettingsService) CreateSettings(
 		return nil, err
 	}
 
+	pruneSettings(req.Msg.GetSettings())
 	data, err := protojson.Marshal(req.Msg.GetSettings())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
@@ -149,6 +150,7 @@ func (s *SettingsService) UpdateSettings(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("a version is required; use CreateSettings for a new record"))
 	}
 
+	pruneSettings(req.Msg.GetSettings())
 	data, err := protojson.Marshal(req.Msg.GetSettings())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)


### PR DESCRIPTION
## Tracking issue

Related to #7775. This closes task 2.1 (proto to protojson transformers), in a smaller form than the RFC specced. Related to #7932.

## Why are the changes needed?

Task 2.1 asked for two transformers around stored protojson: `Hydrate` on read and `PruneInherited` on write. Most of that job turned out to be built into the serialization layer already:

- `Hydrate` is a no-op. `INHERIT` is the proto3 zero value, and the nil-safe getters return it for absent fields, so a field missing from stored JSON already reads back as `INHERIT`. So there is nothing to implement.
- Prune is mostly free. `protojson.Marshal` already omits zero scalars and nil messages. The one gap: a client can spell `INHERIT` as an empty message (`"defaultQueue": {}`), and that form is stored verbatim and echoed back by `GetSettingsForEdit`.

The empty-message form changes no behavior (both forms read back identically), but it makes stored bytes depend on client phrasing. The Phase 2 exit criteria pins exact response bytes against `settings_customer_flow.md`, which needs one canonical stored form. This PR adds the missing piece and drops the rest of 2.1.

## What changes were proposed in this pull request?

`pruneSettings` in `runs/service/settings_prune.go`, called by `CreateSettings` and `UpdateSettings` right before marshaling:

- Walks the message generically with `protoreflect` and clears every message field with nothing populated inside it. New `Settings` fields are covered automatically.
- Children are pruned before their parent is judged, so a parent emptied by pruning is removed too.
- `UNSET` survives: its state field is populated, so only truly empty messages are removed.
- Side effect worth noting: Create and Update echo the request settings in their responses, so after pruning the echo matches the stored bytes exactly.

## How was this patch tested?

- Table tests in `settings_prune_test.go`: removal at every nesting depth, an empty map wrapper, `UNSET` kept, a value kept next to an empty sibling, clean settings unchanged, and a nil guard.
- Assertions use `proto.Equal`, since protojson output bytes are deliberately unstable.
- Existing settings service tests pass unchanged, so no read path observes the difference.

### Labels

- **changed**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
