### PR TITLE
flytestdlib: add WithCluster context helper

### DIFF
--- a/flytestdlib/contextutils/context.go
+++ b/flytestdlib/contextutils/context.go
@@ -130,6 +130,12 @@ func WithProjectDomain(ctx context.Context, project, domain string) context.Cont
 	return context.WithValue(c, DomainKey, domain)
 }
 
+// WithCluster gets a new context with Organization and ClusterName values set.
+func WithCluster(ctx context.Context, organization, name string) context.Context {
+	c := context.WithValue(ctx, OrganizationKey, organization)
+	return context.WithValue(c, ClusterNameKey, name)
+}
+
 // WithTaskID gets a new context with WorkflowName set.
 func WithTaskID(ctx context.Context, taskID string) context.Context {
 	return context.WithValue(ctx, TaskIDKey, taskID)

--- a/flytestdlib/contextutils/context_test.go
+++ b/flytestdlib/contextutils/context_test.go
@@ -95,6 +95,24 @@ func TestWithProjectDomain(t *testing.T) {
 	assert.Equal(t, "domain", ctx.Value(DomainKey))
 }
 
+func TestWithCluster(t *testing.T) {
+	ctx := context.Background()
+	assert.Nil(t, ctx.Value(OrganizationKey))
+	assert.Nil(t, ctx.Value(ClusterNameKey))
+
+	ctx = WithCluster(ctx, "org1", "cluster1")
+	assert.Equal(t, "org1", ctx.Value(OrganizationKey))
+	assert.Equal(t, "cluster1", ctx.Value(ClusterNameKey))
+
+	ctx = WithCluster(ctx, "org2", "cluster2")
+	assert.Equal(t, "org2", ctx.Value(OrganizationKey))
+	assert.Equal(t, "cluster2", ctx.Value(ClusterNameKey))
+
+	ctx = WithCluster(ctx, "", "")
+	assert.Equal(t, "", ctx.Value(OrganizationKey))
+	assert.Equal(t, "", ctx.Value(ClusterNameKey))
+}
+
 func TestWithTaskID(t *testing.T) {
 	ctx := context.Background()
 	assert.Nil(t, ctx.Value(TaskIDKey))
@@ -113,9 +131,8 @@ func TestGetFields(t *testing.T) {
 	ctx := context.Background()
 	ctx = WithRequestID(WithJobID(WithNamespace(ctx, "ns123"), "job123"), "req123")
 	ctx = WithProjectDomain(ctx, "proj1", "dev")
-	ctx = context.WithValue(ctx, OrganizationKey, "org1")
+	ctx = WithCluster(ctx, "org1", "cluster1")
 	ctx = context.WithValue(ctx, ServiceNameKey, "svc1")
-	ctx = context.WithValue(ctx, ClusterNameKey, "cluster1")
 	m := GetLogFields(ctx)
 	assert.Equal(t, "ns123", m[NamespaceKey.String()])
 	assert.Equal(t, "job123", m[JobIDKey.String()])


### PR DESCRIPTION
## Why are the changes needed?

Callers need a consistent way to add organization and cluster information to a context so Flyte’s context-aware logger can include the `org` and `cluster_id` fields.

## What changes were proposed in this pull request?

- Add `contextutils.WithCluster` to set both values.
- Add tests covering assignment, overwriting, empty values, and structured log fields.

## How was this patch tested?

```shell
go test -race -count=1 ./flytestdlib/contextutils
go vet ./flytestdlib/contextutils
git diff --check
```