### PR TITLE
docs(settings): update the customer flow to match the API and verify it in CI

### DIFF
--- a/flyteidl2/settings/settings_customer_flow.md
+++ b/flyteidl2/settings/settings_customer_flow.md
@@ -3,41 +3,45 @@
 This walkthrough traces a realistic customer flow end-to-end. To keep the examples
 readable, only three settings are used:
 
-| Setting | Type | Description |
-|---|---|---|
-| `run.defaultQueue` | string | Queue that runs are submitted to |
-| `taskResource.defaults.minCpu` | string | Minimum CPU requested for task pods |
-| `environmentVariables` | map(string,string) | Environment variables injected into task pods — **additive** across scopes |
+| Setting                        | Type             | Description |
+|--------------------------------|------------------|---|
+| `run.defaultQueue`             | StringSetting    | Queue that runs are submitted to |
+| `taskResource.min.cpu`         | QuantitySetting  | Minimum CPU requested for task pods |
+| `environmentVariables`         | StringMapSetting | Environment variables injected into task pods — **additive** across scopes |
 
 **Scope hierarchy:** `acme` (org) → `acme/production` (domain) → `acme/production/analytics` (project)
 
+Every request and response below is executed against a running server by
+`runs/test/api/settings_flow_test.go`, so this document is verified by CI rather
+than maintained by hand.
+
 ### API rules in effect
 
-- All settings use a single `SettingValue` message. The oneof field set determines the type and state:
-  - `state: INHERIT` (or empty) — delegate to parent scope
-  - `state: UNSET` — explicitly clear; stops inheritance
-  - `stringValue: "..."` — string value (implies VALUE state)
-  - `intValue: N` — integer value (implies VALUE state)
-  - `listValue: { values: [...] }` — list value (implies VALUE state)
-  - `mapValue: { entries: {...} }` — map value (implies VALUE state)
-- `GetSettings` resolves inheritance top-down and annotates each setting with `scopeLevel`. No descriptions.
-- `GetSettingsForEdit` returns a `levels` array — one entry per scope level covered by the request key, ordered broadest to most specific. Each entry is `{ key, settings, version }` where `key` is a partial key identifying that level. A level with no record has `version: 0`. Descriptions are included; no `scopeLevel`.
-- Map settings (`environmentVariables`) are **additive** on `GetSettings`: parent entries first, child entries merged on top (child wins on key conflict). `scopeLevel` reflects the most specific scope in the resolution chain.
+- Every setting is a typed wrapper message (`StringSetting`, `Int64Setting`, `BoolSetting`, `QuantitySetting`, `StringMapSetting`) carrying an explicit `state`:
+  - `SETTING_STATE_INHERIT` (the default) — take the value from the parent scope
+  - `SETTING_STATE_UNSET` — explicitly clear; stops inheritance
+  - `SETTING_STATE_VALUE` — use this message's value field
+- Omitting a setting and sending it as `{}` both mean INHERIT, and neither is stored.
+- **A value sent without `state: SETTING_STATE_VALUE` is treated as INHERIT and ignored.**
+- `GetSettings` resolves inheritance top-down and returns one merged record wrapped in `settingsRecord`, with each resolved setting annotated by the `scopeLevel` it came from. No descriptions. Merged records carry no `version`, since a merged view corresponds to no single stored row; clients that need a version for an update use `GetSettingsForEdit`.
+- `SCOPE_LEVEL_ORG` is the enum zero value and is omitted from JSON, so an absent `scopeLevel` means the value resolved from the org.
+- `GetSettingsForEdit` returns `requestedKey` plus a `levels` array, one entry per scope level covered by the request key, ordered broadest to most specific. Each entry is `{ key, settings, version }` where `key` is a partial key identifying that level. No descriptions and no `scopeLevel`. A level with no stored record has empty settings and version 0; zero versions are omitted from JSON, so a missing `version` field means "no record yet, use `CreateSettings` for this level".
+- Map settings (`environmentVariables`) are **additive** on `GetSettings`: parent entries first, child entries merged on top (child wins on key conflict), and a level in state `UNSET` clears everything accumulated above it. `scopeLevel` on a merged map is the most specific level that contributed entries.
 
 ---
 
 ## Starting State
 
 Org `acme` has baseline settings from provisioning. The project `analytics` in
-domain `production` was previously configured with a `minCpu` override.
+domain `production` was previously configured with a min CPU override.
 No domain settings exist yet.
 
 **Database**
 
-| id | key                         | data (JSONB)                                                                                                                                                                               | version |
-|----|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| 1  | `acme::`                    | `{"run":{"defaultQueue":{"stringValue":"default"}},"taskResource":{"defaults":{"minCpu":{"stringValue":"500m"}}},"environmentVariables":{"mapValue":{"entries":{"LOG_LEVEL":"info","REGION":"us-east-1"}}}}` | 1       |
-| 2  | `acme:production:analytics` | `{"taskResource":{"defaults":{"minCpu":{"stringValue":"1000m"}}}}`                                                                                                                         | 1       |
+| id | key                            | data (JSONB)                                                                                                                                                                                                                                                | version |
+|----|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| 1  | `v1:acme::`                    | `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"default"}},"taskResource":{"min":{"cpu":{"state":"SETTING_STATE_VALUE","quantityValue":"500m"}}},"environmentVariables":{"state":"SETTING_STATE_VALUE","mapValue":{"entries":{"LOG_LEVEL":"info","REGION":"us-east-1"}}}}` | 1       |
+| 2  | `v1:acme:production:analytics` | `{"taskResource":{"min":{"cpu":{"state":"SETTING_STATE_VALUE","quantityValue":"1000m"}}}}`                                                                                                                                                                  | 1       |
 
 ---
 
@@ -56,23 +60,29 @@ inherit from, so every setting either has a value or is absent from the response
 **Response**
 ```json
 {
-  "key": { "org": "acme" },
-  "settings": {
-    "run": {
-      "defaultQueue": { "stringValue": "default", "scopeLevel": "ORG" }
-    },
-    "taskResource": {
-      "defaults": {
-        "minCpu": { "stringValue": "500m", "scopeLevel": "ORG" }
+  "settingsRecord": {
+    "key": { "org": "acme" },
+    "settings": {
+      "run": {
+        "defaultQueue": { "state": "SETTING_STATE_VALUE", "stringValue": "default" }
+      },
+      "taskResource": {
+        "min": {
+          "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "500m" }
+        }
+      },
+      "environmentVariables": {
+        "state": "SETTING_STATE_VALUE",
+        "mapValue": { "entries": { "LOG_LEVEL": "info", "REGION": "us-east-1" } }
       }
-    },
-    "environmentVariables": {
-      "mapValue": { "entries": { "LOG_LEVEL": "info", "REGION": "us-east-1" } },
-      "scopeLevel": "ORG"
     }
   }
 }
 ```
+
+All three values resolved from the org, and `SCOPE_LEVEL_ORG` is the enum zero
+value, so no `scopeLevel` appears in the JSON. There is no `version` either:
+merged records never carry one.
 
 **Database:** unchanged.
 
@@ -82,8 +92,8 @@ inherit from, so every setting either has a value or is absent from the response
 
 ### 2a — GetSettingsForEdit at project scope
 
-Before editing, fetch the current stored state at all levels. This returns every
-setting field at every scope — inheritance is not applied — with descriptions.
+Before editing, fetch the current stored state at all levels. This returns each
+level's stored settings as-is: inheritance is not applied.
 
 **Request — `GetSettingsForEdit`**
 ```json
@@ -95,39 +105,37 @@ setting field at every scope — inheritance is not applied — with description
 **Response**
 ```json
 {
-  "key": { "org": "acme", "domain": "production", "project": "analytics" },
+  "requestedKey": { "org": "acme", "domain": "production", "project": "analytics" },
   "levels": [
     {
       "key": { "org": "acme" },
       "settings": {
         "run": {
-          "defaultQueue": { "stringValue": "default", "description": "Queue that runs are submitted to" }
+          "defaultQueue": { "state": "SETTING_STATE_VALUE", "stringValue": "default" }
         },
         "taskResource": {
-          "defaults": {
-            "minCpu": { "stringValue": "500m", "description": "Minimum CPU requested for task pods" }
+          "min": {
+            "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "500m" }
           }
         },
         "environmentVariables": {
-          "mapValue": { "entries": { "LOG_LEVEL": "info", "REGION": "us-east-1" } },
-          "description": "Environment variables injected into task pods — additive across scopes"
+          "state": "SETTING_STATE_VALUE",
+          "mapValue": { "entries": { "LOG_LEVEL": "info", "REGION": "us-east-1" } }
         }
       },
       "version": "1"
     },
     {
+      "key": { "org": "acme", "domain": "production" },
+      "settings": {}
+    },
+    {
       "key": { "org": "acme", "domain": "production", "project": "analytics" },
       "settings": {
-        "run": {
-          "defaultQueue": { "description": "Queue that runs are submitted to" }
-        },
         "taskResource": {
-          "defaults": {
-            "minCpu": { "stringValue": "1000m", "description": "Minimum CPU requested for task pods" }
+          "min": {
+            "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "1000m" }
           }
-        },
-        "environmentVariables": {
-          "description": "Environment variables injected into task pods — additive across scopes"
         }
       },
       "version": "1"
@@ -136,11 +144,13 @@ setting field at every scope — inheritance is not applied — with description
 }
 ```
 
-The `levels` array runs from broadest to most specific. Org shows its full values.
-Domain is not present no record exists yet,
-so `CreateSettings` would be used to write to it rather than `UpdateSettings`.
-Project shows the existing `minCpu: 1000m`; `defaultQueue` and `environmentVariables` are empty
-(INHERIT). Use `version: 1` from the project entry for the update.
+The `levels` array runs from broadest to most specific and always contains one
+record per level covered by the request key. The domain has no stored record
+yet, so its entry has empty settings and no `version` field (version 0 is
+omitted from JSON). That missing version is the client's signal to use
+`CreateSettings` for the domain rather than `UpdateSettings`. The project shows
+only what is stored there: the `1000m` CPU override. Use `version: 1` from the
+project entry for the update.
 
 **Database:** unchanged.
 
@@ -148,8 +158,10 @@ Project shows the existing `minCpu: 1000m`; `defaultQueue` and `environmentVaria
 
 ### 2b — UpdateSettings at project scope
 
-Increase `minCpu` for this compute-heavy project and add a project-specific env var.
-`defaultQueue` is left as INHERIT. Supply `version: 1` from `project` above.
+Increase the CPU minimum for this compute-heavy project and add a
+project-specific env var. `defaultQueue` is sent as an empty object, one of the
+two equivalent spellings of INHERIT. Supply `version: 1` from the project entry
+above.
 
 **Request — `UpdateSettings`**
 ```json
@@ -160,11 +172,14 @@ Increase `minCpu` for this compute-heavy project and add a project-specific env 
       "defaultQueue": {}
     },
     "taskResource": {
-      "defaults": {
-        "minCpu": { "stringValue": "2000m" }
+      "min": {
+        "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "2000m" }
       }
     },
-    "environmentVariables": { "mapValue": { "entries": { "LOG_LEVEL": "debug" } } }
+    "environmentVariables": {
+      "state": "SETTING_STATE_VALUE",
+      "mapValue": { "entries": { "LOG_LEVEL": "debug" } }
+    }
   },
   "version": "1"
 }
@@ -173,34 +188,38 @@ Increase `minCpu` for this compute-heavy project and add a project-specific env 
 **Response**
 ```json
 {
-  "key": { "org": "acme", "domain": "production", "project": "analytics" },
-  "settings": {
-    "run": {
-      "defaultQueue": {}
-    },
-    "taskResource": {
-      "defaults": {
-        "minCpu": { "stringValue": "2000m" }
+  "settingsRecord": {
+    "key": { "org": "acme", "domain": "production", "project": "analytics" },
+    "settings": {
+      "taskResource": {
+        "min": {
+          "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "2000m" }
+        }
+      },
+      "environmentVariables": {
+        "state": "SETTING_STATE_VALUE",
+        "mapValue": { "entries": { "LOG_LEVEL": "debug" } }
       }
     },
-    "environmentVariables": { "mapValue": { "entries": { "LOG_LEVEL": "debug" } } }
-  },
-  "version": "2"
+    "version": "2"
+  }
 }
 ```
 
-The response echoes back exactly what was stored — no inheritance, no descriptions.
-`version` is now `2`.
+The response echoes exactly what was stored. The empty `defaultQueue` object
+was pruned before storing, so it appears in neither the stored row nor the
+echo: sending a setting as `{}` and omitting it entirely produce identical
+results. `version` is now `2`.
 
 **Database**
 
-| id | key                         | data (JSONB)                                                                                                                            | version |
-|----|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|
-| 1  | `acme::`                    | `{"run":{"defaultQueue":{"stringValue":"default"}},...}` (unchanged)                                                                    | 1       |
-| 2  | `acme:production:analytics` | `{"taskResource":{"defaults":{"minCpu":{"stringValue":"2000m"}}},"environmentVariables":{"mapValue":{"entries":{"LOG_LEVEL":"debug"}}}}` | 2       |
+| id | key                            | data (JSONB)                                                                                                                                                                                                                | version |
+|----|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| 1  | `v1:acme::`                    | `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"default"}},...}` (unchanged)                                                                                                                            | 1       |
+| 2  | `v1:acme:production:analytics` | `{"taskResource":{"min":{"cpu":{"state":"SETTING_STATE_VALUE","quantityValue":"2000m"}}},"environmentVariables":{"state":"SETTING_STATE_VALUE","mapValue":{"entries":{"LOG_LEVEL":"debug"}}}}` | 2       |
 
-`run.defaultQueue` is absent from the project row — INHERIT is the zero value and
-is never written to the database.
+`run.defaultQueue` is absent from the project row: INHERIT is never written to
+the database, whether the client omitted the field or sent it empty.
 
 ---
 
@@ -219,27 +238,34 @@ values resolve through two levels: org → project.
 **Response**
 ```json
 {
-  "key": { "org": "acme", "domain": "production", "project": "analytics" },
-  "settings": {
-    "run": {
-      "defaultQueue": { "stringValue": "default", "scopeLevel": "ORG" }
-    },
-    "taskResource": {
-      "defaults": {
-        "minCpu": { "stringValue": "2000m", "scopeLevel": "PROJECT" }
+  "settingsRecord": {
+    "key": { "org": "acme", "domain": "production", "project": "analytics" },
+    "settings": {
+      "run": {
+        "defaultQueue": { "state": "SETTING_STATE_VALUE", "stringValue": "default" }
+      },
+      "taskResource": {
+        "min": {
+          "cpu": {
+            "state": "SETTING_STATE_VALUE",
+            "quantityValue": "2000m",
+            "scopeLevel": "SCOPE_LEVEL_PROJECT"
+          }
+        }
+      },
+      "environmentVariables": {
+        "state": "SETTING_STATE_VALUE",
+        "mapValue": { "entries": { "LOG_LEVEL": "debug", "REGION": "us-east-1" } },
+        "scopeLevel": "SCOPE_LEVEL_PROJECT"
       }
-    },
-    "environmentVariables": {
-      "mapValue": { "entries": { "LOG_LEVEL": "debug", "REGION": "us-east-1" } },
-      "scopeLevel": "PROJECT"
     }
   }
 }
 ```
 
-- `defaultQueue` — no override in the chain; resolved from org.
-- `minCpu` — project override from step 2b; `scopeLevel` is PROJECT.
-- `environmentVariables` — additive merge: org contributes `LOG_LEVEL=info` and `REGION=us-east-1`, project contributes `LOG_LEVEL=debug` which overrides the org value. `scopeLevel` is PROJECT, the most specific scope in the resolution chain.
+- `defaultQueue`: no override in the chain, resolved from the org. Its `scopeLevel` is `SCOPE_LEVEL_ORG`, the zero value, so the field is absent.
+- `taskResource.min.cpu`: the project override from step 2b, annotated `SCOPE_LEVEL_PROJECT`.
+- `environmentVariables`: additive merge. The org contributes `LOG_LEVEL=info` and `REGION=us-east-1`; the project contributes `LOG_LEVEL=debug`, which wins the key conflict. `scopeLevel` is `SCOPE_LEVEL_PROJECT`, the most specific level that contributed entries.
 
 **Database:** unchanged.
 
@@ -247,8 +273,9 @@ values resolve through two levels: org → project.
 
 ## Step 4 — CreateSettings at domain scope
 
-The `production` domain has no settings record yet (absent from step 2a).
-Create one to route all production runs to a dedicated queue.
+The `production` domain has no settings record yet (its level came back with no
+version in step 2a). Create one to route all production runs to a dedicated
+queue.
 
 **Request — `CreateSettings`**
 ```json
@@ -256,11 +283,11 @@ Create one to route all production runs to a dedicated queue.
   "key": { "org": "acme", "domain": "production" },
   "settings": {
     "run": {
-      "defaultQueue": { "stringValue": "fast-queue" }
+      "defaultQueue": { "state": "SETTING_STATE_VALUE", "stringValue": "fast-queue" }
     },
     "taskResource": {
-      "defaults": {
-        "minCpu": {}
+      "min": {
+        "cpu": {}
       }
     },
     "environmentVariables": {}
@@ -271,31 +298,28 @@ Create one to route all production runs to a dedicated queue.
 **Response**
 ```json
 {
-  "key": { "org": "acme", "domain": "production" },
-  "settings": {
-    "run": {
-      "defaultQueue": { "stringValue": "fast-queue" }
-    },
-    "taskResource": {
-      "defaults": {
-        "minCpu": {}
+  "settingsRecord": {
+    "key": { "org": "acme", "domain": "production" },
+    "settings": {
+      "run": {
+        "defaultQueue": { "state": "SETTING_STATE_VALUE", "stringValue": "fast-queue" }
       }
     },
-    "environmentVariables": {}
-  },
-  "version": "1"
+    "version": "1"
+  }
 }
 ```
 
 **Database**
 
-| id | key                         | data (JSONB)                                                                                                                            | version |
-|----|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|
-| 1  | `acme::`                    | `{"run":{"defaultQueue":{"stringValue":"default"}},...}` (unchanged)                                                                    | 1       |
-| 3  | `acme:production:`          | `{"run":{"defaultQueue":{"stringValue":"fast-queue"}}}`                                                                                 | 1       |
-| 2  | `acme:production:analytics` | `{"taskResource":{"defaults":{"minCpu":{"stringValue":"2000m"}}},"environmentVariables":{"mapValue":{"entries":{"LOG_LEVEL":"debug"}}}}` (unchanged) | 2       |
+| id | key                            | data (JSONB)                                                                                                                                                                                       | version |
+|----|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| 1  | `v1:acme::`                    | `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"default"}},...}` (unchanged)                                                                                                     | 1       |
+| 3  | `v1:acme:production:`          | `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"fast-queue"}}}`                                                                                                                  | 1       |
+| 2  | `v1:acme:production:analytics` | `{"taskResource":{"min":{"cpu":{"state":"SETTING_STATE_VALUE","quantityValue":"2000m"}}},...}` (unchanged)                                                                                             | 2       |
 
-Only `defaultQueue` is written to the domain row — INHERIT fields are not stored.
+Only `defaultQueue` reaches the domain row: the empty CPU and env-var objects
+were pruned before storing.
 
 ---
 
@@ -314,27 +338,38 @@ resolution chain is org → domain → project.
 **Response**
 ```json
 {
-  "key": { "org": "acme", "domain": "production", "project": "analytics" },
-  "settings": {
-    "run": {
-      "defaultQueue": { "stringValue": "fast-queue", "scopeLevel": "DOMAIN" }
-    },
-    "taskResource": {
-      "defaults": {
-        "minCpu": { "stringValue": "2000m", "scopeLevel": "PROJECT" }
+  "settingsRecord": {
+    "key": { "org": "acme", "domain": "production", "project": "analytics" },
+    "settings": {
+      "run": {
+        "defaultQueue": {
+          "state": "SETTING_STATE_VALUE",
+          "stringValue": "fast-queue",
+          "scopeLevel": "SCOPE_LEVEL_DOMAIN"
+        }
+      },
+      "taskResource": {
+        "min": {
+          "cpu": {
+            "state": "SETTING_STATE_VALUE",
+            "quantityValue": "2000m",
+            "scopeLevel": "SCOPE_LEVEL_PROJECT"
+          }
+        }
+      },
+      "environmentVariables": {
+        "state": "SETTING_STATE_VALUE",
+        "mapValue": { "entries": { "LOG_LEVEL": "debug", "REGION": "us-east-1" } },
+        "scopeLevel": "SCOPE_LEVEL_PROJECT"
       }
-    },
-    "environmentVariables": {
-      "mapValue": { "entries": { "LOG_LEVEL": "debug", "REGION": "us-east-1" } },
-      "scopeLevel": "PROJECT"
     }
   }
 }
 ```
 
-- `defaultQueue` — now resolves to `fast-queue` from the domain, overriding org's `default`. Nothing in the project record changed; the domain insert was enough.
-- `minCpu` — still `2000m` from the project. The domain did not override it.
-- `environmentVariables` — still the additive merge of org (`LOG_LEVEL=info`, `REGION=us-east-1`) + project (`LOG_LEVEL=debug`). The domain contributed no env vars, so the result is unchanged and `scopeLevel` remains PROJECT.
+- `defaultQueue` now resolves to `fast-queue` from the domain, overriding the org's `default`, and for the first time a `scopeLevel` appears on it: `SCOPE_LEVEL_DOMAIN` is nonzero, so it serializes. Nothing in the project record changed; the domain insert was enough.
+- `taskResource.min.cpu`: still `2000m` from the project. The domain did not override it.
+- `environmentVariables`: still the additive merge of org and project. The domain contributed no entries, so the result and its `scopeLevel` are unchanged.
 
 **Database:** unchanged.
 
@@ -344,12 +379,12 @@ resolution chain is org → domain → project.
 
 | Step | Scope touched | What changed |
 |------|--------------|--------------|
-| 1 | — | Read org settings |
-| 2a | project (read) | GetSettingsForEdit: two levels returned — org with full values, project with existing `minCpu: 1000m`; domain has no record and is omitted |
-| 2b | project (write) | Updated `minCpu` 1000m→2000m, added `environmentVariables={LOG_LEVEL:debug}`; version 1→2 |
-| 3 | — | Read project: org+project merge, no domain yet; `LOG_LEVEL` overridden by project |
-| 4 | domain (create) | Set `defaultQueue=fast-queue` at domain; `version: 0` → 1 |
-| 5 | — | Read project: domain now intercepts `defaultQueue`; env vars and minCpu unchanged |
+| 1 | — | Read org settings; all annotations implicit (org is the zero scope level) |
+| 2a | project (read) | GetSettingsForEdit: three levels returned, org and project with values and versions, the domain as a gap record with empty settings and no version |
+| 2b | project (write) | Updated min CPU 1000m→2000m, added `environmentVariables={LOG_LEVEL:debug}`; the empty `defaultQueue` was pruned; version 1→2 |
+| 3 | — | Read project: org+project merge, no domain yet; `LOG_LEVEL` overridden by the project |
+| 4 | domain (create) | Set `defaultQueue=fast-queue` at the domain; empty settings pruned; version 1 |
+| 5 | — | Read project: the domain now intercepts `defaultQueue`; env vars and CPU unchanged |
 
 The key insight: changes at one scope are immediately visible to all child scopes
 on the next `GetSettings` call. No project-level record needs to be touched when

--- a/runs/service/settings_prune.go
+++ b/runs/service/settings_prune.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// hasAnyField reports whether m has any populated field. A message with none
+// is exactly one protojson would serialize as {}.
+func hasAnyField(m protoreflect.Message) bool {
+	found := false
+	m.Range(func(protoreflect.FieldDescriptor, protoreflect.Value) bool {
+		found = true
+		return false
+	})
+	return found
+}
+
+// pruneSettings removes message fields that contain no information, so the
+// stored row does not depend on whether a client expressed INHERIT by omitting
+// a field or by sending it present but empty. Both forms read back
+// identically, so pruning only canonicalizes the stored bytes.
+func pruneEmpty(m protoreflect.Message) {
+	m.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		if fd.Kind() != protoreflect.MessageKind || fd.IsMap() || fd.IsList() {
+			return true
+		}
+		child := v.Message()
+		pruneEmpty(child)
+
+		if !hasAnyField(child) {
+			m.Clear(fd)
+		}
+		return true
+	})
+}
+
+// pruneSettings removes settings messages that carry no information, so a
+// stored row does not depend on how the client spelled INHERIT.
+func pruneSettings(s *settings.Settings) {
+	if s == nil {
+		return
+	}
+	pruneEmpty(s.ProtoReflect())
+}

--- a/runs/service/settings_prune_test.go
+++ b/runs/service/settings_prune_test.go
@@ -1,0 +1,1 @@
+package service

--- a/runs/service/settings_prune_test.go
+++ b/runs/service/settings_prune_test.go
@@ -1,1 +1,78 @@
 package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings"
+)
+
+// parseSettings builds a Settings from protojson, failing the test on bad input.
+func parseSettings(t *testing.T, in string) *settings.Settings {
+	t.Helper()
+	s := &settings.Settings{}
+	require.NoError(t, protojson.Unmarshal([]byte(in), s))
+	return s
+}
+
+func TestPruneSettings(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty leaf message is removed",
+			in:   `{"run":{"defaultQueue":{}}}`,
+			want: `{}`,
+		},
+		{
+			name: "empty group is removed",
+			in:   `{"run":{}}`,
+			want: `{}`,
+		},
+		{
+			name: "nested empty messages are removed at every depth",
+			in:   `{"taskResource":{"min":{"cpu":{}},"max":{}}}`,
+			want: `{}`,
+		},
+		{
+			name: "map setting with no entries is removed",
+			in:   `{"environmentVariables":{"mapValue":{"entries":{}}}}`,
+			want: `{}`,
+		},
+		{
+			name: "explicit UNSET is kept",
+			in:   `{"run":{"defaultQueue":{"state":"SETTING_STATE_UNSET"}}}`,
+			want: `{"run":{"defaultQueue":{"state":"SETTING_STATE_UNSET"}}}`,
+		},
+		{
+			name: "value is kept while its empty sibling is removed",
+			in:   `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"fast-queue"},"runBaseDir":{}}}`,
+			want: `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"fast-queue"}}}`,
+		},
+		{
+			name: "settings with no empty messages are unchanged",
+			in:   `{"environmentVariables":{"state":"SETTING_STATE_VALUE","mapValue":{"entries":{"LOG_LEVEL":"debug"}}}}`,
+			want: `{"environmentVariables":{"state":"SETTING_STATE_VALUE","mapValue":{"entries":{"LOG_LEVEL":"debug"}}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSettings(t, tt.in)
+			pruneSettings(got)
+
+			want := parseSettings(t, tt.want)
+			assert.True(t, proto.Equal(want, got), "got %s", protojson.Format(got))
+		})
+	}
+}
+
+func TestPruneSettings_NilDoesNotPanic(t *testing.T) {
+	pruneSettings(nil)
+}

--- a/runs/service/settings_service.go
+++ b/runs/service/settings_service.go
@@ -147,6 +147,7 @@ func (s *SettingsService) CreateSettings(
 		return nil, err
 	}
 
+	pruneSettings(req.Msg.GetSettings())
 	data, err := protojson.Marshal(req.Msg.GetSettings())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
@@ -191,6 +192,7 @@ func (s *SettingsService) UpdateSettings(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("a version is required; use CreateSettings for a new record"))
 	}
 
+	pruneSettings(req.Msg.GetSettings())
 	data, err := protojson.Marshal(req.Msg.GetSettings())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)

--- a/runs/test/api/settings_flow_test.go
+++ b/runs/test/api/settings_flow_test.go
@@ -1,0 +1,205 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings/settingsconnect"
+)
+
+// mustJSON unmarshals a protojson literal from settings_customer_flow.md into
+// msg, failing the test on bad input
+func mustJSON(t *testing.T, in string, msg proto.Message) {
+	t.Helper()
+	require.NoError(t, protojson.Unmarshal([]byte(in), msg))
+}
+
+// expectEqual asserts actual matches the doc's expected JSON, printing both on failure.
+func expectEqual(t *testing.T, step string, expected, actual proto.Message) {
+	t.Helper()
+	if !proto.Equal(expected, actual) {
+		t.Errorf("%s mismatch\nexpected: %s\nactual:   %s",
+			step, protojson.Format(expected), protojson.Format(actual))
+	}
+}
+
+// TestSettingsCustomerFlow replays flyteidl2/settings/settings_customer_flow.md
+// against the running test server. Every JSON literal below is copied from that
+// document, so a failure here means the two have drifted apart.
+func TestSettingsCustomerFlow(t *testing.T) {
+	ctx := context.Background()
+	cleanupTestDB(t)
+
+	client := settingsconnect.NewSettingsServiceClient(newClient(), endpoint)
+
+	// --- Starting state: seed the two rows from the doc's Database table ---
+	seedOrg := &settings.CreateSettingsRequest{}
+	mustJSON(t, `{
+	  "key": { "org": "acme" },
+	  "settings": {
+	    "run": { "defaultQueue": { "state": "SETTING_STATE_VALUE", "stringValue": "default" } },
+	    "taskResource": { "min": { "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "500m" } } },
+	    "environmentVariables": { "state": "SETTING_STATE_VALUE", "mapValue": { "entries": { "LOG_LEVEL": "info", "REGION": "us-east-1" } } }
+	  }
+	}`, seedOrg)
+	_, err := client.CreateSettings(ctx, connect.NewRequest(seedOrg))
+	require.NoError(t, err)
+
+	seedProject := &settings.CreateSettingsRequest{}
+	mustJSON(t, `{
+	  "key": { "org": "acme", "domain": "production", "project": "analytics" },
+	  "settings": {
+	    "taskResource": { "min": { "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "1000m" } } }
+	  }
+	}`, seedProject)
+	_, err = client.CreateSettings(ctx, connect.NewRequest(seedProject))
+	require.NoError(t, err)
+
+	// --- Step 1: GetSettings at org scope ---
+	step1Req := &settings.GetSettingsRequest{}
+	mustJSON(t, `{ "key": { "org": "acme" } }`, step1Req)
+	step1, err := client.GetSettings(ctx,
+		connect.NewRequest(step1Req))
+	require.NoError(t, err)
+
+	step1Want := &settings.GetSettingsResponse{}
+	mustJSON(t, `{
+	  "settingsRecord": {
+	    "key": { "org": "acme" },
+	    "settings": {
+	      "run": { "defaultQueue": { "state": "SETTING_STATE_VALUE", "stringValue": "default" } },
+	      "taskResource": { "min": { "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "500m" } } },
+	      "environmentVariables": { "state": "SETTING_STATE_VALUE", "mapValue": { "entries": { "LOG_LEVEL": "info", "REGION": "us-east-1" } } }
+	    }
+	  }
+	}`, step1Want)
+	expectEqual(t, "step 1", step1Want, step1.Msg)
+
+	// --- Step 2a: GetSettingsForEdit at project scope ---
+	step2aReq := &settings.GetSettingsForEditRequest{}
+	mustJSON(t, `{ "key": { "org": "acme", "domain": "production", "project": "analytics" } }`, step2aReq)
+	step2a, err := client.GetSettingsForEdit(ctx, connect.NewRequest(step2aReq))
+	require.NoError(t, err)
+
+	step2aWant := &settings.GetSettingsForEditResponse{}
+	mustJSON(t, `{
+	  "requestedKey": { "org": "acme", "domain": "production", "project": "analytics" },
+	  "levels": [
+	    {
+	      "key": { "org": "acme" },
+	      "settings": {
+	        "run": { "defaultQueue": { "state": "SETTING_STATE_VALUE", "stringValue": "default" } },
+	        "taskResource": { "min": { "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "500m" } } },
+	        "environmentVariables": { "state": "SETTING_STATE_VALUE", "mapValue": { "entries": { "LOG_LEVEL": "info", "REGION": "us-east-1" } } }
+	      },
+	      "version": "1"
+	    },
+	    {
+	      "key": { "org": "acme", "domain": "production" },
+	      "settings": {}
+	    },
+	    {
+	      "key": { "org": "acme", "domain": "production", "project": "analytics" },
+	      "settings": {
+	        "taskResource": { "min": { "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "1000m" } } }
+	      },
+	      "version": "1"
+	    }
+	  ]
+	}`, step2aWant)
+	expectEqual(t, "step 2a", step2aWant, step2a.Msg)
+
+	// --- Step 2b: UpdateSettings at project scope ---
+	step2bReq := &settings.UpdateSettingsRequest{}
+	mustJSON(t, `{
+	  "key": { "org": "acme", "domain": "production", "project": "analytics" },
+	  "settings": {
+	    "run": { "defaultQueue": {} },
+	    "taskResource": { "min": { "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "2000m" } } },
+	    "environmentVariables": { "state": "SETTING_STATE_VALUE", "mapValue": { "entries": { "LOG_LEVEL": "debug" } } }
+	  },
+	  "version": "1"
+	}`, step2bReq)
+	step2b, err := client.UpdateSettings(ctx, connect.NewRequest(step2bReq))
+	require.NoError(t, err)
+
+	step2bWant := &settings.UpdateSettingsResponse{}
+	mustJSON(t, `{
+	  "settingsRecord": {
+	    "key": { "org": "acme", "domain": "production", "project": "analytics" },
+	    "settings": {
+	      "taskResource": { "min": { "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "2000m" } } },
+	      "environmentVariables": { "state": "SETTING_STATE_VALUE", "mapValue": { "entries": { "LOG_LEVEL": "debug" } } }
+	    },
+	    "version": "2"
+	  }
+	}`, step2bWant)
+	expectEqual(t, "step 2b", step2bWant, step2b.Msg)
+
+	// --- Step 3: GetSettings at project scope ---
+	step3Req := &settings.GetSettingsRequest{}
+	mustJSON(t, `{ "key": { "org": "acme", "domain": "production", "project": "analytics" } }`, step3Req)
+	step3, err := client.GetSettings(ctx, connect.NewRequest(step3Req))
+	require.NoError(t, err)
+
+	step3Want := &settings.GetSettingsResponse{}
+	mustJSON(t, `{
+	  "settingsRecord": {
+	    "key": { "org": "acme", "domain": "production", "project": "analytics" },
+	    "settings": {
+	      "run": { "defaultQueue": { "state": "SETTING_STATE_VALUE", "stringValue": "default" } },
+	      "taskResource": { "min": { "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "2000m", "scopeLevel": "SCOPE_LEVEL_PROJECT" } } },
+	      "environmentVariables": { "state": "SETTING_STATE_VALUE", "mapValue": { "entries": { "LOG_LEVEL": "debug", "REGION": "us-east-1" } }, "scopeLevel": "SCOPE_LEVEL_PROJECT" }
+	    }
+	  }
+	}`, step3Want)
+	expectEqual(t, "step 3", step3Want, step3.Msg)
+
+	// --- Step 4: CreateSettings at domain scope ---
+	step4Req := &settings.CreateSettingsRequest{}
+	mustJSON(t, `{
+	  "key": { "org": "acme", "domain": "production" },
+	  "settings": {
+	    "run": { "defaultQueue": { "state": "SETTING_STATE_VALUE", "stringValue": "fast-queue" } },
+	    "taskResource": { "min": { "cpu": {} } },
+	    "environmentVariables": {}
+	  }
+	}`, step4Req)
+	step4, err := client.CreateSettings(ctx, connect.NewRequest(step4Req))
+	require.NoError(t, err)
+
+	step4Want := &settings.CreateSettingsResponse{}
+	mustJSON(t, `{
+	  "settingsRecord": {
+	    "key": { "org": "acme", "domain": "production" },
+	    "settings": {
+	      "run": { "defaultQueue": { "state": "SETTING_STATE_VALUE", "stringValue": "fast-queue" } }
+	    },
+	    "version": "1"
+	  }
+	}`, step4Want)
+	expectEqual(t, "step 4", step4Want, step4.Msg)
+
+	// --- Step 5: GetSettings at project scope, after the domain exists ---
+	step5, err := client.GetSettings(ctx, connect.NewRequest(step3Req))
+	require.NoError(t, err)
+
+	step5Want := &settings.GetSettingsResponse{}
+	mustJSON(t, `{
+	  "settingsRecord": {
+	    "key": { "org": "acme", "domain": "production", "project": "analytics" },
+	    "settings": {
+	      "run": { "defaultQueue": { "state": "SETTING_STATE_VALUE", "stringValue": "fast-queue", "scopeLevel": "SCOPE_LEVEL_DOMAIN" } },
+	      "taskResource": { "min": { "cpu": { "state": "SETTING_STATE_VALUE", "quantityValue": "2000m", "scopeLevel": "SCOPE_LEVEL_PROJECT" } } },
+	      "environmentVariables": { "state": "SETTING_STATE_VALUE", "mapValue": { "entries": { "LOG_LEVEL": "debug", "REGION": "us-east-1" } }, "scopeLevel": "SCOPE_LEVEL_PROJECT" }
+	    }
+	  }
+	}`, step5Want)
+	expectEqual(t, "step 5", step5Want, step5.Msg)
+}

--- a/runs/test/api/settings_flow_test.go
+++ b/runs/test/api/settings_flow_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // mustJSON unmarshals a protojson literal from settings_customer_flow.md into
-// msg, failing the test on bad input
+// msg, failing the test on bad input.
 func mustJSON(t *testing.T, in string, msg proto.Message) {
 	t.Helper()
 	require.NoError(t, protojson.Unmarshal([]byte(in), msg))

--- a/runs/test/api/setup_test.go
+++ b/runs/test/api/setup_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/actions/actionsconnect"
 	projectpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/project"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/project/projectconnect"
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings/settingsconnect"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/task/taskconnect"
 	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/workflow/workflowconnect"
 	"github.com/flyteorg/flyte/v2/runs/config"
@@ -138,6 +139,10 @@ func TestMain(m *testing.M) {
 	internalRunPath, internalRunHandler := workflowconnect.NewInternalRunServiceHandler(runSvc)
 	mux.Handle(internalRunPath, internalRunHandler)
 
+	settingsSvc := service.NewSettingsService(impl.NewSettingsRepo(testDB))
+	settingsPath, settingsHandler := settingsconnect.NewSettingsServiceHandler(settingsSvc)
+	mux.Handle(settingsPath, settingsHandler)
+
 	// Add health check
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -232,7 +237,7 @@ func cleanupTestDB(t *testing.T) {
 	// Truncate known tables. The projects table is excluded so the shared fixture
 	// project created in TestMain survives across tests.
 	tables := []string{
-		"action_events", "actions", "runs", "tasks",
+		"action_events", "actions", "runs", "tasks", "settings",
 	}
 	for _, table := range tables {
 		if _, err := testDB.Exec(fmt.Sprintf("DELETE FROM %s", table)); err != nil {

--- a/runs/test/api/utils.go
+++ b/runs/test/api/utils.go
@@ -10,7 +10,7 @@ func uniqueString() string { //nolint: unused
 	return fmt.Sprintf("%d", time.Now().UnixNano())
 }
 
-func newClient() *http.Client { //nolint: unused
+func newClient() *http.Client {
 	return &http.Client{
 		Timeout: 30 * time.Second,
 	}


### PR DESCRIPTION
## Tracking issue

Related to #7775. This closes the Phase 2 exit criteria: every request and response in `settings_customer_flow.md` now reproduces against a running server. Related to #7932.

## Why are the changes needed?

`flyteidl2/settings/settings_customer_flow.md` appears to predate the current settings IDL: it describes a single `SettingValue` message carrying every setting, where the protos use typed wrapper messages.

So the examples need updating to match the implementation. The most consequential gap is the `state` field: a value only takes effect when `state` is `SETTING_STATE_VALUE`, and the examples were written before that, so copying one today sends a request the server reads as INHERIT. Field paths (`taskResource.defaults.minCpu`), response shapes (the `settingsRecord` wrapper), and the stored key format have moved on as well, and step 2a is missing the domain level that `GetSettingsForEdit` returns for scopes with no record.

The RFC designates this document as the Phase 2 acceptance criteria, so this PR also adds a test that executes it, which keeps the document and the server in step from here on.

## What changes were proposed in this pull request?

- Rewrote the document against the current protos: typed wrapper messages with an explicit `state`, `taskResource.min.cpu`, `settingsRecord` and `requestedKey` response shapes, `v1:`-prefixed storage keys, and no per-field descriptions (those live in proto field options now).
- Documented the protojson conventions the examples depend on, since the document is a byte-level spec: `SCOPE_LEVEL_ORG` is the enum zero value so an absent `scopeLevel` means the org, an absent `version` means no stored record, and merged reads carry no version at all.
- Fixed step 2a, which omitted the domain level. It now shows all three levels, with the domain as a gap record the client uses to decide between `CreateSettings` and `UpdateSettings`.
- Added `runs/test/api/settings_flow_test.go`, which replays all five steps against the test server. Every JSON literal in it is copied from the document, so the two cannot drift apart without a test failure.
- Mounted the settings service in the `runs/test/api` harness and added `settings` to `cleanupTestDB`, so the flow test is re-runnable.

## How was this patch tested?

- `runs/test/api/settings_flow_test.go` is the test. It seeds the starting state through the API, then asserts each of the five steps with `proto.Equal` against the document's JSON. Comparison is by message rather than by marshaled string, since protojson output bytes are deliberately unstable.
- No CI change is needed: `.github/workflows/go-tests.yml` already runs `./runs/test/api/...` in the `runs-api-integration` job on every pull request.
- Verified locally alone, with the full package, twice in a row (`-count=2`), and under `-race`, which is what CI runs.
- The database tables in the document were checked against a dump of the real `settings` rows after the flow, matching on keys, versions, and stored JSON.

### Labels

- **changed**

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

Stacked on #7937 (task 2.1, pruning). Builds on #7841, #7859, #7900, #7925, and #7927, which implement the API this document describes.
