### PR TITLE
fix(flyteidl): auth interceptor CondWait deadlock on failed token refresh

### DIFF
--- a/flyteidl/clients/go/admin/auth_interceptor.go
+++ b/flyteidl/clients/go/admin/auth_interceptor.go
@@ -226,6 +226,12 @@ func NewAuthInterceptor(cfg *Config, tokenCache cache.TokenCache, credentialsFut
 							tokenCache.CondWait()
 							return nil
 						}
+						// Wake waiters on every exit path (deferred LIFO: unlock
+						// first, then broadcast). Returning without a broadcast —
+						// e.g. on a MaterializeCredentials failure — would leave
+						// CondWait-ers parked until the next successful refresh,
+						// which may never come.
+						defer tokenCache.CondBroadcast()
 						defer tokenCache.Unlock()
 						_, err := tokenCache.PurgeIfEquals(t)
 						if err != nil && !errors.Is(err, cache.ErrNotFound) {
@@ -239,7 +245,6 @@ func NewAuthInterceptor(cfg *Config, tokenCache cache.TokenCache, credentialsFut
 							return fmt.Errorf("authentication error! Original Error: %w, Auth Error: %w", err, newErr)
 						}
 
-						tokenCache.CondBroadcast()
 						return nil
 					}()
 

--- a/flyteidl/clients/go/admin/auth_interceptor_test.go
+++ b/flyteidl/clients/go/admin/auth_interceptor_test.go
@@ -220,6 +220,9 @@ func Test_newAuthInterceptor(t *testing.T) {
 		assert.Error(t, err)
 		assert.Truef(t, f.IsInitialized(), "PerRPCCredentialFuture should be initialized")
 		assert.False(t, f.Get().RequireTransportSecurity(), "Insecure should be true leading to RequireTLS false")
+		// The refresh failed, but waiters must still be woken — a return without
+		// a broadcast would leave CondWait-ers parked forever.
+		c.AssertCalled(t, "CondBroadcast")
 	})
 
 	t.Run("Already authenticated", func(t *testing.T) {

--- a/flyteidl/clients/go/admin/cache/token_cache_inmemory.go
+++ b/flyteidl/clients/go/admin/cache/token_cache_inmemory.go
@@ -4,15 +4,27 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"golang.org/x/oauth2"
 )
 
+// condWaitTimeout bounds CondWait. Cond-style notification has no memory: a
+// broadcast that fires between a waiter's decision to wait and the wait itself
+// is lost, and a refresher that exits without broadcasting never wakes anyone.
+// The bound turns both cases into a short delay followed by the caller's
+// retry instead of a permanent hang of the calling goroutine.
+// Var, not const, so tests can shorten it.
+var condWaitTimeout = 30 * time.Second
+
 type TokenCacheInMemoryProvider struct {
-	token      atomic.Value
-	mu         *sync.Mutex
-	condLocker *NoopLocker
-	cond       *sync.Cond
+	token atomic.Value
+	mu    *sync.Mutex
+
+	// notify is closed and replaced on every CondBroadcast; waiters select on
+	// the channel they observed, so a broadcast wakes exactly the waiters that
+	// started waiting before it.
+	notify atomic.Pointer[chan struct{}]
 }
 
 func (t *TokenCacheInMemoryProvider) SaveToken(token *oauth2.Token) error {
@@ -45,27 +57,20 @@ func (t *TokenCacheInMemoryProvider) Unlock() {
 	t.mu.Unlock()
 }
 
-// CondWait  adds the current go routine to the condition waitlist and waits for another go routine to notify using CondBroadcast
-// The current usage is that one who was able to acquire the lock using TryLock is the one who gets a valid token and notifies all the waitlist requesters so that they can use the new valid token.
-// It also locks the Locker in the condition variable as the semantics of Wait is that it unlocks the Locker after adding
-// the consumer to the waitlist and before blocking on notification.
-// We use the condLocker which is noOp locker to get added to waitlist for notifications.
-// The underlying notifcationList doesn't need to be guarded as it implementation is atomic and is thread safe
-// Refer https://go.dev/src/runtime/sema.go
-// Following is the function and its comments
-// notifyListAdd adds the caller to a notify list such that it can receive
-// notifications. The caller must eventually call notifyListWait to wait for
-// such a notification, passing the returned ticket number.
-//
-//	func notifyListAdd(l *notifyList) uint32 {
-//		// This may be called concurrently, for example, when called from
-//		// sync.Cond.Wait while holding a RWMutex in read mode.
-//		return l.wait.Add(1) - 1
-//	}
+// CondWait blocks until another goroutine calls CondBroadcast, or until
+// condWaitTimeout elapses — whichever comes first. The current usage is that
+// the goroutine that acquired the lock via TryLock refreshes the token and
+// broadcasts so waiters can retry with the new token. The timeout guarantees a
+// waiter is never parked forever when the broadcast is missed (raced) or never
+// sent (refresh failed); after waking it simply retries and, if the token is
+// still invalid, fails or refreshes on its own.
 func (t *TokenCacheInMemoryProvider) CondWait() {
-	t.condLocker.Lock()
-	t.cond.Wait()
-	t.condLocker.Unlock()
+	ch := *t.notify.Load()
+
+	select {
+	case <-ch:
+	case <-time.After(condWaitTimeout):
+	}
 }
 
 // NoopLocker has empty implementation of Locker interface
@@ -78,17 +83,22 @@ func (*NoopLocker) Lock() {
 func (*NoopLocker) Unlock() {
 }
 
-// CondBroadcast signals the condition.
+// CondBroadcast wakes every goroutine currently blocked in CondWait by closing
+// the notification channel and installing a fresh one for future waiters.
+// Swap guarantees each concurrent broadcaster closes a distinct channel, so a
+// channel is never closed twice.
 func (t *TokenCacheInMemoryProvider) CondBroadcast() {
-	t.cond.Broadcast()
+	newCh := make(chan struct{})
+	old := t.notify.Swap(&newCh)
+	close(*old)
 }
 
 func NewTokenCacheInMemoryProvider() *TokenCacheInMemoryProvider {
-	condLocker := &NoopLocker{}
-	return &TokenCacheInMemoryProvider{
-		mu:         &sync.Mutex{},
-		token:      atomic.Value{},
-		condLocker: condLocker,
-		cond:       sync.NewCond(condLocker),
+	t := &TokenCacheInMemoryProvider{
+		mu:    &sync.Mutex{},
+		token: atomic.Value{},
 	}
+	ch := make(chan struct{})
+	t.notify.Store(&ch)
+	return t
 }

--- a/flyteidl/clients/go/admin/cache/token_cache_inmemory_test.go
+++ b/flyteidl/clients/go/admin/cache/token_cache_inmemory_test.go
@@ -1,0 +1,83 @@
+package cache
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCondBroadcastWakesAllWaiters(t *testing.T) {
+	c := NewTokenCacheInMemoryProvider()
+
+	const waiters = 5
+	var wg sync.WaitGroup
+	wg.Add(waiters)
+	for i := 0; i < waiters; i++ {
+		go func() {
+			defer wg.Done()
+			c.CondWait()
+		}()
+	}
+
+	// Give the waiters a moment to park before broadcasting.
+	time.Sleep(50 * time.Millisecond)
+	c.CondBroadcast()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("waiters were not woken by CondBroadcast")
+	}
+}
+
+func TestCondWaitTimesOutWithoutBroadcast(t *testing.T) {
+	prev := condWaitTimeout
+	condWaitTimeout = 50 * time.Millisecond
+	defer func() { condWaitTimeout = prev }()
+
+	c := NewTokenCacheInMemoryProvider()
+
+	start := time.Now()
+	c.CondWait() // no broadcast ever comes
+	assert.Less(t, time.Since(start), 5*time.Second, "CondWait must return once the timeout elapses")
+}
+
+func TestConcurrentCondBroadcastDoesNotPanic(t *testing.T) {
+	c := NewTokenCacheInMemoryProvider()
+
+	// Concurrent broadcasters must each close a distinct channel (Swap
+	// semantics) — a shared close would panic with "close of closed channel".
+	const broadcasters = 16
+	var wg sync.WaitGroup
+	wg.Add(broadcasters)
+	for i := 0; i < broadcasters; i++ {
+		go func() {
+			defer wg.Done()
+			c.CondBroadcast()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestCondWaitAfterMissedBroadcastTimesOut(t *testing.T) {
+	prev := condWaitTimeout
+	condWaitTimeout = 50 * time.Millisecond
+	defer func() { condWaitTimeout = prev }()
+
+	c := NewTokenCacheInMemoryProvider()
+
+	// The broadcast fires before the waiter starts waiting — the classic lost
+	// wakeup. The waiter must still return via the timeout.
+	c.CondBroadcast()
+
+	start := time.Now()
+	c.CondWait()
+	assert.Less(t, time.Since(start), 5*time.Second, "CondWait must not hang on a missed broadcast")
+}


### PR DESCRIPTION
## Why are the changes needed?

The auth interceptor's token-refresh path can permanently deadlock a caller. In `NewAuthInterceptor`, when a request fails with an authentication error:

```go
if !tokenCache.TryLock() {
    tokenCache.CondWait()   // bare sync.Cond.Wait — no timeout
    return nil
}
defer tokenCache.Unlock()
...
newErr := MaterializeCredentials(...)
if newErr != nil {
    return errors.New(errString)  // returns WITHOUT CondBroadcast
}
tokenCache.CondBroadcast()        // broadcast only on success
```

Two defects combine:

1. The `TryLock` winner broadcasts only on success. If `MaterializeCredentials` (or the cache purge) fails — e.g. the auth server is briefly unreachable — it returns without waking waiters.
2. `TokenCacheInMemoryProvider.CondWait` is a bare `sync.Cond.Wait` over a no-op locker: no timeout, and no check-then-wait mutual exclusion, so a broadcast that fires just before the wait is lost (`sync.Cond` has no memory).

A waiter parked in `CondWait` then sleeps until the *next successful* refresh — which on a low-traffic client may never come. We hit this in production: a goroutine was blocked in `CondWait` for 9+ hours (confirmed by goroutine dump), hanging its caller indefinitely. The RPC deadline cannot help because the wait happens inside the interceptor, outside context control.

## What changes were proposed in this pull request?

- `auth_interceptor.go`: broadcast is now deferred by the `TryLock` winner, so every exit path (including refresh failure) wakes waiters.
- `cache/token_cache_inmemory.go`: `CondWait`/`CondBroadcast` now use a close-and-replace notification channel (`atomic.Pointer` + `Swap`, so concurrent broadcasters never double-close) with a 30s bound on the wait. A missed or raced broadcast degrades to a short delay followed by the caller's normal retry instead of an unbounded hang.

No interface changes; `NoopLocker` is kept (still used by flytectl's keyring token cache).

## How was this patch tested?

- New `token_cache_inmemory_test.go`: broadcast wakes all waiters; wait times out when no broadcast comes; wait after a missed (pre-wait) broadcast returns; concurrent broadcasts don't panic. Passes with `-race`.
- Extended the existing failed-refresh interceptor test to assert `CondBroadcast` is called on the error path.

### Labels

fixed

### Setup process

### Screenshots

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

unionai/flyte#1009 (same fix in Union's fork, where the production incident occurred)

## Docs link
