### PR TITLE
feat: restart JobSet tasks on host maintenance without charging the restart budget

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/clustered/build.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/build.go
@@ -110,6 +110,23 @@ func (clusteredResourceHandler) BuildResource(ctx context.Context, taskCtx plugi
 		},
 	}
 
+	if spec.GetFailurePolicy().GetRestartOnHostMaintenance() {
+		// Fail the Job with reason PodFailurePolicy when a pod is terminated by an
+		// involuntary disruption (DisruptionTarget: drain, eviction API, preemption,
+		// taint eviction). The net effect matches backoffLimit=0, but the distinct
+		// failure reason lets the JobSet failurePolicy rule (failure.go) restart the
+		// set without charging maxRestarts. Requires RestartPolicyNever (set above).
+		jobSpec.PodFailurePolicy = &batchv1.PodFailurePolicy{
+			Rules: []batchv1.PodFailurePolicyRule{{
+				Action: batchv1.PodFailurePolicyActionFailJob,
+				OnPodConditions: []batchv1.PodFailurePolicyOnPodConditionsPattern{{
+					Type:   corev1.DisruptionTarget,
+					Status: corev1.ConditionTrue,
+				}},
+			}},
+		}
+	}
+
 	failurePolicy, err := buildFailurePolicy(&spec)
 	if err != nil {
 		return nil, err

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/clustered_test.go
@@ -175,6 +175,8 @@ func TestBuildResource_HappyPath(t *testing.T) {
 	assert.Equal(t, int32(4), *jobSpec.Completions)
 	assert.Equal(t, batchv1.IndexedCompletion, *jobSpec.CompletionMode)
 	assert.Equal(t, int32(0), *jobSpec.BackoffLimit)
+	// Without restart_on_host_maintenance the inner Job carries no podFailurePolicy.
+	assert.Nil(t, jobSpec.PodFailurePolicy)
 
 	// The node-execution labels/annotations must be propagated onto the pod template so
 	// JobSet child pods carry execution-id/node-id; otherwise the node-execution-scoped
@@ -218,6 +220,41 @@ func TestBuildResource_PrimaryContainerPreserved(t *testing.T) {
 
 	// Primary container name must be retrievable from the JobSet at status time.
 	assert.Equal(t, primary.Name, jobSet.Annotations[primaryContainerAnnotation])
+}
+
+func TestBuildResource_HostMaintenance(t *testing.T) {
+	spec := &clusteredpb.ClusteredTaskSpec{
+		Replicas:      2,
+		NprocPerNode:  1,
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 1, RestartOnHostMaintenance: true},
+	}
+	taskTemplate := buildTaskTemplate(spec)
+	taskCtx := dummyTaskCtx(taskTemplate)
+
+	handler := clusteredResourceHandler{}
+	obj, err := handler.BuildResource(context.Background(), taskCtx)
+	assert.NoError(t, err)
+
+	jobSet := obj.(*jobsetv1alpha2.JobSet)
+
+	// JobSet failurePolicy carries the free-restart rule.
+	require.NotNil(t, jobSet.Spec.FailurePolicy)
+	assert.Equal(t, int32(1), jobSet.Spec.FailurePolicy.MaxRestarts)
+	require.Len(t, jobSet.Spec.FailurePolicy.Rules, 1)
+	assert.Equal(t, jobsetv1alpha2.RestartJobSetAndIgnoreMaxRestarts, jobSet.Spec.FailurePolicy.Rules[0].Action)
+
+	// The inner Job fails with reason PodFailurePolicy on DisruptionTarget so the
+	// JobSet rule can distinguish maintenance disruptions from ordinary failures.
+	jobSpec := jobSet.Spec.ReplicatedJobs[0].Template.Spec
+	require.NotNil(t, jobSpec.PodFailurePolicy)
+	require.Len(t, jobSpec.PodFailurePolicy.Rules, 1)
+	rule := jobSpec.PodFailurePolicy.Rules[0]
+	assert.Equal(t, batchv1.PodFailurePolicyActionFailJob, rule.Action)
+	require.Len(t, rule.OnPodConditions, 1)
+	assert.Equal(t, corev1.DisruptionTarget, rule.OnPodConditions[0].Type)
+	assert.Equal(t, corev1.ConditionTrue, rule.OnPodConditions[0].Status)
+	// podFailurePolicy requires restartPolicy Never on the pod template.
+	assert.Equal(t, corev1.RestartPolicyNever, jobSpec.Template.Spec.RestartPolicy)
 }
 
 // --- injectTorchRunEnv tests ---
@@ -309,6 +346,37 @@ func TestBuildFailurePolicy_MaxRestarts(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, fp)
 	assert.Equal(t, int32(3), fp.MaxRestarts)
+	// Without restart_on_host_maintenance no rules are emitted — every restart
+	// counts against the budget.
+	assert.Empty(t, fp.Rules)
+}
+
+func TestBuildFailurePolicy_HostMaintenance(t *testing.T) {
+	spec := &clusteredpb.ClusteredTaskSpec{
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 3, RestartOnHostMaintenance: true},
+	}
+	fp, err := buildFailurePolicy(spec)
+	assert.NoError(t, err)
+	require.NotNil(t, fp)
+	assert.Equal(t, int32(3), fp.MaxRestarts)
+	require.Len(t, fp.Rules, 1)
+	assert.Equal(t, hostMaintenanceRuleName, fp.Rules[0].Name)
+	assert.Equal(t, jobsetv1alpha2.RestartJobSetAndIgnoreMaxRestarts, fp.Rules[0].Action)
+	assert.Equal(t, []string{batchv1.JobReasonPodFailurePolicy}, fp.Rules[0].OnJobFailureReasons)
+}
+
+func TestBuildFailurePolicy_HostMaintenance_ZeroMaxRestarts(t *testing.T) {
+	// max_restarts=0 (the default) must not drop the policy when the flag is set:
+	// ordinary failures fail immediately, maintenance disruptions still restart free.
+	spec := &clusteredpb.ClusteredTaskSpec{
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 0, RestartOnHostMaintenance: true},
+	}
+	fp, err := buildFailurePolicy(spec)
+	assert.NoError(t, err)
+	require.NotNil(t, fp)
+	assert.Equal(t, int32(0), fp.MaxRestarts)
+	require.Len(t, fp.Rules, 1)
+	assert.Equal(t, jobsetv1alpha2.RestartJobSetAndIgnoreMaxRestarts, fp.Rules[0].Action)
 }
 
 func TestBuildFailurePolicy_Zero(t *testing.T) {
@@ -600,6 +668,54 @@ func TestGetTaskPhase_MaintenanceRetry_SystemFailure(t *testing.T) {
 	assert.Equal(t, core.ExecutionError_SYSTEM, phase.Err().GetKind())
 }
 
+func TestGetTaskPhase_FreeRestartsDoNotExhaustBudget(t *testing.T) {
+	// Free host-maintenance restarts bump Status.Restarts but not
+	// Status.RestartsCountTowardsMax. Even with Restarts well past maxRestarts and a
+	// failed rank-0 pod visible, the fast-fail path must not fire while the charged
+	// count is within budget — the JobSet controller is still restarting the set.
+	js := makeJobSet("", "", false)
+	js.Status.Restarts = 3
+	js.Status.RestartsCountTowardsMax = 0
+	js.Status.ReplicatedJobsStatus = []jobsetv1alpha2.ReplicatedJobStatus{
+		{Name: workersReplicatedJobName, Failed: 1, Active: 1},
+	}
+	js.Status.Conditions = []metav1.Condition{
+		{Type: "SomeActiveCondition", Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now())},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rank0PodName(testJobName) + "-abc12",
+			Namespace: testNS,
+		},
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodFailed,
+			Reason: "Error",
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "primary",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"},
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(k8sscheme.Scheme).WithObjects(pod).Build()
+
+	spec := &clusteredpb.ClusteredTaskSpec{
+		Replicas:      2,
+		NprocPerNode:  1,
+		FailurePolicy: &clusteredpb.ClusterFailurePolicy{MaxRestarts: 1, RestartOnHostMaintenance: true},
+	}
+	pCtx := dummyPluginCtx(buildTaskTemplate(spec), fakeClient)
+
+	handler := clusteredResourceHandler{}
+	phase, err := handler.GetTaskPhase(context.Background(), pCtx, js)
+	assert.NoError(t, err)
+	assert.Equal(t, pluginsCore.PhaseRunning, phase.Phase())
+}
+
 func TestFindRank0Pod_SuffixedAndDeterministic(t *testing.T) {
 	oldFailed := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -639,6 +755,7 @@ func TestGetTaskPhase_FastFail_FailedWithBudgetRemainingReturnsRunning(t *testin
 	js := makeJobSet("", "", false)
 	js.Spec.FailurePolicy = &jobsetv1alpha2.FailurePolicy{MaxRestarts: 2}
 	js.Status.Restarts = 1
+	js.Status.RestartsCountTowardsMax = 1
 	js.Status.ReplicatedJobsStatus = []jobsetv1alpha2.ReplicatedJobStatus{
 		{Name: workersReplicatedJobName, Failed: 1, Active: 1},
 	}
@@ -674,6 +791,8 @@ func TestGetTaskPhase_FastFail_FailedWithBudgetExhaustedReturnsRetryableFailure(
 	js := makeJobSet("", "", false)
 	js.Spec.FailurePolicy = &jobsetv1alpha2.FailurePolicy{MaxRestarts: 1}
 	js.Status.Restarts = 1
+	// Ordinary (non-maintenance) restarts are charged: the controller bumps both counters.
+	js.Status.RestartsCountTowardsMax = 1
 	js.Status.ReplicatedJobsStatus = []jobsetv1alpha2.ReplicatedJobStatus{
 		{Name: workersReplicatedJobName, Failed: 1, Active: 1},
 	}
@@ -792,7 +911,7 @@ func TestGetTaskPhase_RestartingCondition_ReportsRunningWithAttempt(t *testing.T
 		{Name: workersReplicatedJobName, Failed: 1},
 	}
 	js.Status.Conditions = []metav1.Condition{
-		{Type: jobSetRestartingConditionType, Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now())},
+		{Type: string(jobsetv1alpha2.JobSetRestarting), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now())},
 	}
 
 	pod := &corev1.Pod{

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/failure.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/failure.go
@@ -1,24 +1,40 @@
 package clustered
 
 import (
+	batchv1 "k8s.io/api/batch/v1"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	flyteerr "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/errors"
 	clusteredpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/plugins"
 )
 
+// hostMaintenanceRuleName must match the JobSet rule-name regex
+// ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$ — hyphens are rejected by the webhook.
+const hostMaintenanceRuleName = "restartOnHostMaintenance"
+
 // buildFailurePolicy returns the JobSet failurePolicy from the SDK spec.
-// restart_on_host_maintenance (eviction free-restart via RestartJobSetAndIgnoreMaxRestarts) is deferred to PR 4.
+// With restart_on_host_maintenance, a disruption-evicted pod fails its Job with
+// reason PodFailurePolicy (see the inner Job's podFailurePolicy in build.go) and
+// the rule below restarts the whole set without charging maxRestarts. Any other
+// failure takes the default RestartJobSet action, which counts toward the budget.
 func buildFailurePolicy(spec *clusteredpb.ClusteredTaskSpec) (*jobsetv1alpha2.FailurePolicy, error) {
 	fp := spec.GetFailurePolicy()
-	if fp == nil || fp.GetMaxRestarts() == 0 {
+	if fp == nil || (fp.GetMaxRestarts() == 0 && !fp.GetRestartOnHostMaintenance()) {
 		return nil, nil
 	}
 	maxRestarts := fp.GetMaxRestarts()
 	if maxRestarts < 0 {
 		return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "failure_policy.max_restarts must be >= 0, got %d", maxRestarts)
 	}
-	return &jobsetv1alpha2.FailurePolicy{
+	policy := &jobsetv1alpha2.FailurePolicy{
 		MaxRestarts: maxRestarts,
-	}, nil
+	}
+	if fp.GetRestartOnHostMaintenance() {
+		policy.Rules = []jobsetv1alpha2.FailurePolicyRule{{
+			Name:                hostMaintenanceRuleName,
+			Action:              jobsetv1alpha2.RestartJobSetAndIgnoreMaxRestarts,
+			OnJobFailureReasons: []string{batchv1.JobReasonPodFailurePolicy},
+		}}
+	}
+	return policy, nil
 }

--- a/flyteplugins/go/tasks/plugins/k8s/clustered/phase.go
+++ b/flyteplugins/go/tasks/plugins/k8s/clustered/phase.go
@@ -20,12 +20,6 @@ import (
 	clusteredpb "github.com/flyteorg/flyte/v2/gen/go/flyteidl2/plugins"
 )
 
-const (
-	// jobSetRestartingConditionType is emitted by newer JobSet controllers, but the pinned v0.5.2 API package
-	// predates this constant. Keep this string check until we can bump the dependency.
-	jobSetRestartingConditionType = "RestartingJobSet"
-)
-
 func (clusteredResourceHandler) GetTaskPhase(ctx context.Context, pluginContext k8s.PluginContext, resource client.Object) (pluginsCore.PhaseInfo, error) {
 	jobSet, ok := resource.(*jobsetv1alpha2.JobSet)
 	if !ok {
@@ -82,7 +76,7 @@ func (clusteredResourceHandler) GetTaskPhase(ctx context.Context, pluginContext 
 		}
 		return pluginsCore.PhaseInfoRetryableFailure(condition.Reason, condition.Message, &taskInfo), nil
 
-	case jobsetv1alpha2.JobSetConditionType(jobSetRestartingConditionType):
+	case jobsetv1alpha2.JobSetRestarting:
 		if phase, ok := maybeFastFailWorker0(ctx, pluginContext, jobSet, &taskInfo, maxRestarts, false); ok {
 			return phase, nil
 		}
@@ -142,7 +136,11 @@ func workersHaveFailures(jobSet *jobsetv1alpha2.JobSet) bool {
 }
 
 func isRestartBudgetExhausted(jobSet *jobsetv1alpha2.JobSet, maxRestarts int32) bool {
-	return jobSet.Status.Restarts >= maxRestarts
+	// Status.Restarts counts every whole-set restart, including free host-maintenance
+	// restarts (RestartJobSetAndIgnoreMaxRestarts). Only RestartsCountTowardsMax is
+	// charged against maxRestarts, so compare that — otherwise free restarts would
+	// falsely trip the fast-fail path while the JobSet controller is still restarting.
+	return jobSet.Status.RestartsCountTowardsMax >= maxRestarts
 }
 
 func readPluginState(ctx context.Context, pluginContext k8s.PluginContext) (k8s.PluginState, bool) {


### PR DESCRIPTION
## Why are the changes needed?

 Pods terminated by involuntary disruptions (node drain, eviction API, preemption, taint eviction) are outside the user's control, but today those failures consume the JobSet's max_restarts budget like any other failure. This wires up `failure_policy.restart_on_host_maintenance` so disruption-caused failures restart the set for free.

## What changes were proposed in this pull request?

  - build.go: when restart_on_host_maintenance is set, add a podFailurePolicy to the inner Job that fails it with reason PodFailurePolicy whenever a pod carries a true DisruptionTarget condition.
  - failure.go: emit a JobSet failurePolicy rule (restartOnHostMaintenance) with actionRestartJobSetAndIgnoreMaxRestarts matching that failure reason; all other failures fall through to the default RestartJobSet action and count toward the budget. A policy is now also built when max_restarts is 0 but the flag is set.
  - phase.go: compare Status.RestartsCountTowardsMax (not Status.Restarts) against max_restarts, so free restarts don't falsely trigger the fast-fail path; use the upstream JobSetRestarting constant instead of the local string.


## How was this patch tested?
  - Unit tests: TestBuildResource_HostMaintenance, TestBuildFailurePolicy_HostMaintenance, TestBuildFailurePolicy_HostMaintenance_ZeroMaxRestarts, TestGetTaskPhase_FreeRestartsDoNotExhaustBudget; go
    test ./go/tasks/plugins/k8s/clustered/... passes.
  - Verified end-to-end on dogfood-1 (run u48c8qx64gfwfffmffdb, flytesnacks/development) using flyte-sdk/examples/clustered/eviction_restart.py (max_restarts=1, restart_on_host_maintenance=True, 2
    replicas):
    - Created JobSet carried the inner-Job podFailurePolicy (FailJob on DisruptionTarget) and the restartOnHostMaintenance failure-policy rule.
    - Evicted one worker pod via the Eviction API mid-run; Job events show the DisruptionTarget condition
      matching the rule, and the JobSet applied RestartJobSetAndIgnoreMaxRestarts.
    - After the restart: status.restarts=1, status.restartsCountTowardsMax=0 — budget uncharged;
      with maxRestarts=1 the old phase logic would have fast-failed here.
    - Run completed SUCCEEDED on restart attempt 1.


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
