### PR TITLE
Increase resources, k8s setting to handle overwhelming request

### DIFF
--- a/charts/flyte-devbox/values.yaml
+++ b/charts/flyte-devbox/values.yaml
@@ -126,6 +126,10 @@ flyte-binary:
         path: /readyz
         port: http
       periodSeconds: 1
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2Gi
     waitForDB:
       image:
         repository: bitnami/postgresql
@@ -149,6 +153,13 @@ flyte-binary:
 rustfs:
   enabled: true
   fullnameOverride: rustfs
+  config:
+    rustfs:
+      log_level: "error"
+  resources:
+    requests:
+      cpu: 1
+      memory: 2Gi
   mode:
     standalone:
       enabled: true

--- a/charts/flyte-devbox/values.yaml
+++ b/charts/flyte-devbox/values.yaml
@@ -126,10 +126,6 @@ flyte-binary:
         path: /readyz
         port: http
       periodSeconds: 1
-    resources:
-      requests:
-        cpu: "1"
-        memory: 2Gi
     waitForDB:
       image:
         repository: bitnami/postgresql
@@ -153,13 +149,6 @@ flyte-binary:
 rustfs:
   enabled: true
   fullnameOverride: rustfs
-  config:
-    rustfs:
-      log_level: "error"
-  resources:
-    requests:
-      cpu: 1
-      memory: 2Gi
   mode:
     standalone:
       enabled: true

--- a/docker/devbox-bundled/Dockerfile
+++ b/docker/devbox-bundled/Dockerfile
@@ -100,4 +100,11 @@ VOLUME /var/lib/flyte/storage
 ENV SSL_CERT_DIR /var/lib/flyte/config/ca-certificates
 
 ENTRYPOINT [ "/bin/k3d-entrypoint.sh" ]
-CMD [ "server", "--disable=servicelb", "--disable=metrics-server" ]
+CMD [ "server", "--cluster-init", "--disable=servicelb", "--disable=metrics-server", \
+      #"--kubelet-arg=system-reserved=cpu=1500m,memory=3Gi", \
+      #"--kubelet-arg=kube-reserved=cpu=500m,memory=1Gi", \
+      "--kube-apiserver-arg=max-requests-inflight=3000", \
+      "--kube-apiserver-arg=max-mutating-requests-inflight=3000", \
+      "--kube-controller-manager-arg=kube-api-burst=3000", \
+      "--kube-controller-manager-arg=kube-api-qps=3000" \
+    ]


### PR DESCRIPTION
## Tracking issue
Close  #7939 

## Why are the changes needed?
[flyte-benchmark](https://github.com/flyteorg/flyte-benchmarks/tree/main) triggers overloading problem of k8s API server, OOM of rustfs and flute-binary.

## What changes were proposed in this pull request?
Set default reserved resources for flyte and rustfs.

## How was this patch tested?
Running experiment with parameters with -k 10 -n 2000 to trigger the issue.
I recommended that environment 20core and 28G to run the benchmark with parameters  `-k 25 -n 2000 ` in devbox.
```bash
# git clone flyte-benchmark
uv run scripts/v2/swarm.py    --k 10 --n 2000 #  9core 26G
uv run scripts/v2/swarm.py    --k 25 --n 2000 #  24core 64G
```

### Labels
- **fixed**: For any bug fixed.

### Setup process
My environments includes 9 core, 26G memory and 100G disk. (Colima instance)

1. Setting resources in  _common.py in benchmark.
```python
def task_env(name):
    """Parent environment for one benchmark shape."""
    return flyte.TaskEnvironment(
        name=name,
        image=image,
        resources=flyte.Resources(cpu=("50m", "80m"), memory=("300Mi", "512Mi")),
        depends_on=[sleep_env],
    )
```
2. Setting up devbox.
```bash
# git clone flyte
make devbox-build
make devbox-run
```

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
Related   #7757 

## Stack

If you do use [`git town`](https://www.git-town.com/introduction) to manage PR Stacks, the stack relevant to this PR
will show below. Otherwise, you can ignore this section.

<!-- branch-stack -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
