### PR TITLE
Prevent exponential compile time for reconverging workflows

### DIFF
--- a/flytepropeller/pkg/compiler/utils.go
+++ b/flytepropeller/pkg/compiler/utils.go
@@ -48,7 +48,9 @@ func detectCycle(startNode string, neighbors func(nodeId string) sets.String) (c
 		if visiting.Has(nodeId) {
 			return []common.NodeID{}, true
 		}
-
+		if visited.Has(nodeId) {
+			return []common.NodeID{}, false
+		}
 		visiting.Insert(nodeId)
 		visited.Insert(nodeId)
 

--- a/flytepropeller/pkg/compiler/utils_test.go
+++ b/flytepropeller/pkg/compiler/utils_test.go
@@ -6,6 +6,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/flyteorg/flyte/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common"
+	"github.com/flyteorg/flyte/flytepropeller/pkg/compiler/common/mocks"
 )
 
 func neighbors(adjList map[string][]string) func(nodeId string) sets.String {
@@ -40,6 +44,29 @@ func assertCycle(t *testing.T, startNode string, adjList map[string][]string) {
 	assert.True(t, detected)
 	assert.NotEqual(t, 0, len(cycle))
 	t.Logf("Cycle: %v", strings.Join(cycle, ","))
+}
+
+func TestToInterfaceProviderMap(t *testing.T) {
+	provider := mocks.NewInterfaceProvider(t)
+	id := &core.Identifier{Name: "task"}
+	provider.EXPECT().GetID().Return(id)
+
+	providers := toInterfaceProviderMap([]common.InterfaceProvider{provider})
+
+	assert.Len(t, providers, 1)
+	assert.Same(t, provider, providers[id.String()])
+}
+
+func TestToCompiledWorkflows(t *testing.T) {
+	workflows := []*core.WorkflowTemplate{
+		{Id: &core.Identifier{Name: "workflow-1"}},
+		{Id: &core.Identifier{Name: "workflow-2"}},
+	}
+
+	assert.Equal(t, []*core.CompiledWorkflow{
+		{Template: workflows[0]},
+		{Template: workflows[1]},
+	}, toCompiledWorkflows(workflows...))
 }
 
 func TestDetectCycle(t *testing.T) {

--- a/flytepropeller/pkg/compiler/utils_test.go
+++ b/flytepropeller/pkg/compiler/utils_test.go
@@ -62,4 +62,32 @@ func TestDetectCycle(t *testing.T) {
 
 		assertCycle(t, "1", cyclic)
 	})
+
+	t.Run("Reconverging", func(t *testing.T) {
+		reconverging := map[string][]string{
+			"root":     {"left", "right"},
+			"left":     {"shared-a", "shared-b"},
+			"right":    {"shared-a", "shared-b"},
+			"shared-a": {"leaf"},
+			"shared-b": {"leaf"},
+		}
+		visits := make(map[string]int)
+
+		cycle, visited, detected := detectCycle("root", func(nodeID string) sets.String {
+			visits[nodeID]++
+			return neighbors(reconverging)(nodeID)
+		})
+
+		assert.False(t, detected)
+		assert.Empty(t, cycle)
+		assert.Equal(t, uniqueNodesCount(reconverging), len(visited))
+		assert.Equal(t, map[string]int{
+			"root":     1,
+			"left":     1,
+			"right":    1,
+			"shared-a": 1,
+			"shared-b": 1,
+			"leaf":     1,
+		}, visits)
+	})
 }


### PR DESCRIPTION
## Why are the changes needed?

Reconverging acyclic workflows can take exponentially longer to compile because cycle detection revisits checked descendants.

Before, each reconvergence multiplied the remaining traversal. After, each node is expanded once.

## What changes were proposed in this pull request?

The traversal checks the active stack first, then skips completed nodes. Back edges still report cycles. A regression test counts expansions.

## How was this patch tested?

The regression fails against the exact parent and passes at this PR's head.

```console
$ git worktree add /tmp/flyte-pre-fix d8b6a3b49ec3ecdb7c2f3d6b9c2fa8da5635b850
$ git show 689b446:flytepropeller/pkg/compiler/utils_test.go > /tmp/flyte-pre-fix/flytepropeller/pkg/compiler/utils_test.go
$ (cd /tmp/flyte-pre-fix/flytepropeller && go test ./pkg/compiler -run '^TestDetectCycle/Reconverging$' -count=1)
$ git worktree remove /tmp/flyte-pre-fix
$ cd flytepropeller
$ go test ./pkg/compiler -run '^TestDetectCycle/Reconverging$' -count=1
$ go test ./pkg/compiler -count=1
$ go test ./pkg/compiler -race -coverprofile=/tmp/flyte-compiler-race-cover.out -covermode=atomic -count=1
```

<details>
<summary>Raw logs</summary>

Parent implementation with the regression test applied:

```text
--- FAIL: TestDetectCycle (0.00s)
    --- FAIL: TestDetectCycle/Reconverging (0.00s)
        expected: map[string]int{"leaf":1, "left":1, "right":1, "root":1, "shared-a":1, "shared-b":1}
        actual  : map[string]int{"leaf":4, "left":1, "right":1, "root":1, "shared-a":2, "shared-b":2}
FAIL
FAIL	github.com/flyteorg/flyte/flytepropeller/pkg/compiler	0.882s
FAIL
```

This patch:

```text
ok  	github.com/flyteorg/flyte/flytepropeller/pkg/compiler	1.175s
ok  	github.com/flyteorg/flyte/flytepropeller/pkg/compiler	1.068s
ok  	github.com/flyteorg/flyte/flytepropeller/pkg/compiler	4.919s	coverage: 82.0% of statements
```

</details>

At `69e00fb`, the race run reports 82.0% compiler package coverage and 100% coverage for `utils.go`. `codecov/project` and `codecov/patch` both pass.

The unrelated sandbox job failed during `go mod download` from `proxy.golang.org` (`stream ID 433; INTERNAL_ERROR; received from peer`).

### Labels

- **fixed**

### Setup process

N/A.

### Screenshots

N/A.

## Check all the applicable boxes

- [x] Documentation is not applicable because no public API or configuration changes.
- [x] All new and existing compiler tests passed.
- [x] All commits are signed-off.
