### PR TITLE
refactor(runs): make settings resolution callable outside the handlers

### DIFF
--- a/runs/service/settings_resolve.go
+++ b/runs/service/settings_resolve.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings"
+	"github.com/flyteorg/flyte/v2/runs/repository/interfaces"
+	"github.com/flyteorg/flyte/v2/runs/repository/models"
+)
+
+// fetchLevels returns the scope levels covered by key, broadest first, together with
+// the stored row for each. The two slices align by position, and a nil row means no
+// record exists at that level. Order comes from the key ladder; the repo returns rows
+// unordered.
+func fetchLevels(ctx context.Context, repo interfaces.SettingsRepo, key *settings.SettingsKey) ([]*settings.SettingsKey, []*models.Settings, error) {
+	levelKeys := []*settings.SettingsKey{{Org: key.GetOrg()}}
+	if key.GetDomain() != "" {
+		levelKeys = append(levelKeys, &settings.SettingsKey{Org: key.GetOrg(), Domain: key.GetDomain()})
+	}
+	if key.GetProject() != "" {
+		levelKeys = append(levelKeys, &settings.SettingsKey{Org: key.GetOrg(), Domain: key.GetDomain(), Project: key.GetProject()})
+	}
+
+	storageKeys := make([]string, 0, len(levelKeys))
+	for _, lk := range levelKeys {
+		storageKeys = append(storageKeys, models.EncodeSettingsKey(lk.GetOrg(), lk.GetDomain(), lk.GetProject()))
+	}
+
+	rows, err := repo.GetSettingsByKeys(ctx, storageKeys)
+	if err != nil {
+		return nil, nil, err
+	}
+	rowsByKey := make(map[string]*models.Settings, len(rows))
+	for _, row := range rows {
+		rowsByKey[row.Key] = row
+	}
+
+	aligned := make([]*models.Settings, len(levelKeys))
+	for i := range levelKeys {
+		aligned[i] = rowsByKey[storageKeys[i]]
+	}
+	return levelKeys, aligned, nil
+}
+
+// decodeStored unmarshals one stored row into a Settings message. Unknown fields are
+// discarded so a row written by a newer server still loads on an older one.
+func decodeStored(row *models.Settings) (*settings.Settings, error) {
+	stored := &settings.Settings{}
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(row.Data, stored); err != nil {
+		return nil, err
+	}
+	return stored, nil
+}
+
+// resolveSettings returns the effective settings at the scope named by key, merging
+// every level of the chain. Callers inside this package use this directly; GetSettings
+// only wraps it in a response.
+func resolveSettings(ctx context.Context, repo interfaces.SettingsRepo, key *settings.SettingsKey) (*settings.Settings, error) {
+	_, rows, err := fetchLevels(ctx, repo, key)
+	if err != nil {
+		return nil, err
+	}
+
+	levels := make([]*settings.Settings, len(rows))
+	for i, row := range rows {
+		if row == nil {
+			continue
+		}
+		stored, err := decodeStored(row)
+		if err != nil {
+			return nil, err
+		}
+		levels[i] = stored
+	}
+	return mergeSettings(levels), nil
+}

--- a/runs/service/settings_resolve_test.go
+++ b/runs/service/settings_resolve_test.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/flyteorg/flyte/v2/gen/go/flyteidl2/settings"
+	"github.com/flyteorg/flyte/v2/runs/repository/impl"
+)
+
+// TestResolveSettings resolves a chain without going through a connect handler,
+// which is what run creation will do in phase 3.
+func TestResolveSettings(t *testing.T) {
+	ctx := context.Background()
+	t.Cleanup(func() { testDB.Exec("DELETE FROM settings") })
+
+	repo := impl.NewSettingsRepo(testDB)
+	svc := NewSettingsService(repo)
+
+	_, err := svc.CreateSettings(ctx, connect.NewRequest(&settings.CreateSettingsRequest{
+		Key:      &settings.SettingsKey{Org: "acme"},
+		Settings: envSettings("LOG_LEVEL", "info"),
+	}))
+	require.NoError(t, err)
+
+	_, err = svc.CreateSettings(ctx, connect.NewRequest(&settings.CreateSettingsRequest{
+		Key:      &settings.SettingsKey{Org: "acme", Domain: "production", Project: "analytics"},
+		Settings: envSettings("LOG_LEVEL", "debug"),
+	}))
+	require.NoError(t, err)
+
+	resolved, err := resolveSettings(ctx, repo, &settings.SettingsKey{
+		Org: "acme", Domain: "production", Project: "analytics",
+	})
+	require.NoError(t, err)
+
+	want := &settings.StringMapSetting{
+		State:      stateValue,
+		MapValue:   &settings.StringMap{Entries: map[string]string{"LOG_LEVEL": "debug"}},
+		ScopeLevel: settings.ScopeLevel_SCOPE_LEVEL_PROJECT,
+	}
+
+	require.True(t, proto.Equal(want, resolved.GetEnvironmentVariables()),
+		"got %s", protojson.Format(resolved.GetEnvironmentVariables()))
+}

--- a/runs/service/settings_service.go
+++ b/runs/service/settings_service.go
@@ -26,40 +26,6 @@ func NewSettingsService(settingsRepo interfaces.SettingsRepo) *SettingsService {
 	return &SettingsService{settingsRepo: settingsRepo}
 }
 
-// fetchLevels returns the scope levels covered by key, broadest first, together with
-// the stored row for each. The two slices align by position, and a nil row means no
-// record exists at that level. Order comes from the key ladder; the repo returns rows
-// unordered.
-func (s *SettingsService) fetchLevels(ctx context.Context, key *settings.SettingsKey) ([]*settings.SettingsKey, []*models.Settings, error) {
-	levelKeys := []*settings.SettingsKey{{Org: key.GetOrg()}}
-	if key.GetDomain() != "" {
-		levelKeys = append(levelKeys, &settings.SettingsKey{Org: key.GetOrg(), Domain: key.GetDomain()})
-	}
-	if key.GetProject() != "" {
-		levelKeys = append(levelKeys, &settings.SettingsKey{Org: key.GetOrg(), Domain: key.GetDomain(), Project: key.GetProject()})
-	}
-
-	storageKeys := make([]string, 0, len(levelKeys))
-	for _, lk := range levelKeys {
-		storageKeys = append(storageKeys, models.EncodeSettingsKey(lk.GetOrg(), lk.GetDomain(), lk.GetProject()))
-	}
-
-	rows, err := s.settingsRepo.GetSettingsByKeys(ctx, storageKeys)
-	if err != nil {
-		return nil, nil, err
-	}
-	rowsByKey := make(map[string]*models.Settings, len(rows))
-	for _, row := range rows {
-		rowsByKey[row.Key] = row
-	}
-
-	aligned := make([]*models.Settings, len(levelKeys))
-	for i := range levelKeys {
-		aligned[i] = rowsByKey[storageKeys[i]]
-	}
-	return levelKeys, aligned, nil
-}
-
 // GetSettings returns resolved, merged settings.
 func (s *SettingsService) GetSettings(
 	ctx context.Context,
@@ -70,28 +36,17 @@ func (s *SettingsService) GetSettings(
 		return nil, err
 	}
 
-	_, rows, err := s.fetchLevels(ctx, key)
+	resolved, err := resolveSettings(ctx, s.settingsRepo, key)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	levels := make([]*settings.Settings, len(rows))
-	for i, row := range rows {
-		if row == nil {
-			continue
-		}
-		stored := &settings.Settings{}
-		if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(row.Data, stored); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		levels[i] = stored
-	}
 	// Merged settings do not correspond to a stored row, so the record carries no
 	// version. Clients that need one for an update use GetSettingsForEdit.
 	return connect.NewResponse(&settings.GetSettingsResponse{
 		SettingsRecord: &settings.SettingsRecord{
 			Key:      key,
-			Settings: mergeSettings(levels),
+			Settings: resolved,
 		},
 	}), nil
 }
@@ -105,7 +60,7 @@ func (s *SettingsService) GetSettingsForEdit(
 		return nil, err
 	}
 
-	levelKeys, rows, err := s.fetchLevels(ctx, key)
+	levelKeys, rows, err := fetchLevels(ctx, s.settingsRepo, key)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -116,8 +71,8 @@ func (s *SettingsService) GetSettingsForEdit(
 		// CreateSettings there (see SettingsRecord in the proto).
 		record := &settings.SettingsRecord{Key: lk, Settings: &settings.Settings{}}
 		if row := rows[i]; row != nil {
-			stored := &settings.Settings{}
-			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(row.Data, stored); err != nil {
+			stored, err := decodeStored(row)
+			if err != nil {
 				return nil, connect.NewError(connect.CodeInternal, err)
 			}
 			record.Settings = stored


### PR DESCRIPTION
## Tracking issue

Related to #7775. Preparation for task 3.1. Related to #7932.

## Why are the changes needed?

Task 3.1 needs to resolve settings inside `RunService.CreateRun`, but the only way to resolve them today is `GetSettings`, a Connect handler. Calling it from another service means building a request envelope for a call that never leaves the process. The work it does is not reachable on its own either, since `fetchLevels` is a method on `SettingsService` and the fetch, decode and merge steps are inlined in the handler.

## What changes were proposed in this pull request?

- New `runs/service/settings_resolve.go`: `fetchLevels` (moved, now takes the repo as a parameter), `decodeStored` (new, one place for the row decode both read paths duplicated), and `resolveSettings` (fetch, decode, merge, returning a plain error).
- `GetSettings` is now validate, resolve, wrap. `GetSettingsForEdit` uses the moved `fetchLevels` and the shared decode.

No behavior change: same responses, same errors, same queries.

## How was this patch tested?

- The existing settings service tests pass unchanged.
- New `TestResolveSettings` resolves an org and project chain with no handler involved, asserting the merged value and its `scopeLevel`. The key names a domain with no record, so the gap case is covered.
- The `runs/test/api` suite passes, so `GetSettings` is unchanged over real HTTP.

### Labels

- **changed**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

Builds on #7841, #7859, #7900, #7925, #7927 and #7937. The follow-up wires this into `RunService` and applies the first setting.
