### PR TITLE
fix(copilot): let a raw container declare a permanent failure

### DIFF
--- a/flytecopilot/cmd/root.go
+++ b/flytecopilot/cmd/root.go
@@ -48,19 +48,25 @@ func (r RootOptions) UploadError(ctx context.Context, code string, recvErr error
 	if recvErr == nil {
 		recvErr = fmt.Errorf("unknown error")
 	}
+	return r.UploadErrorDocument(ctx, &core.ErrorDocument{
+		Error: &core.ContainerError{
+			Code:    code,
+			Message: recvErr.Error(),
+			Kind:    core.ContainerError_RECOVERABLE,
+		},
+	}, prefix)
+}
+
+// UploadErrorDocument writes document where the plugin's output reader looks
+// for a task's error, leaving its kind and origin as the caller set them.
+func (r RootOptions) UploadErrorDocument(ctx context.Context, document *core.ErrorDocument, prefix storage.DataReference) error {
 	errorPath, err := r.Store.ConstructReference(ctx, prefix, r.errorOutputName)
 	if err != nil {
 		logger.Errorf(ctx, "failed to create error file path err: %s", err)
 		return err
 	}
 	logger.Infof(ctx, "Uploading Error file to path [%s], errFile: %s", errorPath, r.errorOutputName)
-	return r.Store.WriteProtobuf(ctx, errorPath, storage.Options{}, &core.ErrorDocument{
-		Error: &core.ContainerError{
-			Code:    code,
-			Message: recvErr.Error(),
-			Kind:    core.ContainerError_RECOVERABLE,
-		},
-	})
+	return r.Store.WriteProtobuf(ctx, errorPath, storage.Options{}, document)
 }
 
 // NewDataCommand returns a new instance of the co-pilot root command

--- a/flytecopilot/cmd/sidecar.go
+++ b/flytecopilot/cmd/sidecar.go
@@ -116,6 +116,17 @@ func (u *UploadOptions) Sidecar(ctx context.Context) error {
 
 	if err := u.uploader(ctx); err != nil {
 		logger.Errorf(ctx, "Uploading failed, err %s", err)
+		// A container that declared its own failure has already said whether it
+		// can be retried and whose fault it is; only the upload's own failures
+		// are ours to classify, and those are worth another attempt.
+		var containerErr data.ContainerError
+		if errors.As(err, &containerErr) {
+			if err := u.UploadErrorDocument(ctx, containerErr.Document, storage.DataReference(u.remoteOutputsPrefix)); err != nil {
+				logger.Errorf(ctx, "Failed to write error document, err :%s", err)
+				return err
+			}
+			return nil
+		}
 		if err := u.UploadError(ctx, "OutputUploadFailed", err, storage.DataReference(u.remoteOutputsPrefix)); err != nil {
 			logger.Errorf(ctx, "Failed to write error document, err :%s", err)
 			return err

--- a/flytecopilot/cmd/sidecar.go
+++ b/flytecopilot/cmd/sidecar.go
@@ -116,12 +116,11 @@ func (u *UploadOptions) Sidecar(ctx context.Context) error {
 
 	if err := u.uploader(ctx); err != nil {
 		logger.Errorf(ctx, "Uploading failed, err %s", err)
-		// A container that declared its own failure has already said whether it
-		// can be retried and whose fault it is; only the upload's own failures
-		// are ours to classify, and those are worth another attempt.
-		var containerErr data.ContainerError
-		if errors.As(err, &containerErr) {
-			if err := u.UploadErrorDocument(ctx, containerErr.Document, storage.DataReference(u.remoteOutputsPrefix)); err != nil {
+		var rawContainerErr data.RawContainerError
+		if errors.As(err, &rawContainerErr) {
+			// When it is a flyte error with error code and message, we should upload the the error directly
+			// The executor will decide whether this is a retryable error
+			if err := u.UploadErrorDocument(ctx, rawContainerErr.Document, storage.DataReference(u.remoteOutputsPrefix)); err != nil {
 				logger.Errorf(ctx, "Failed to write error document, err :%s", err)
 				return err
 			}

--- a/flytecopilot/cmd/sidecar_test.go
+++ b/flytecopilot/cmd/sidecar_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/flyteorg/flyte/v2/flytecopilot/cmd/containerwatcher"
 	"github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/ioutils"
@@ -94,4 +96,73 @@ func TestUploadOptions_Upload(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, v.Exists())
 	})
+}
+
+// The failure a container declares is the one flyte must act on: writing a
+// NON_RECOVERABLE user error to the error file is the only way a raw container
+// can say "do not retry me", and until the document reaches the output reader
+// intact the container is retried against the cluster's system-failure budget.
+func TestSidecarForwardsTheContainersErrorDocument(t *testing.T) {
+	ctx := context.TODO()
+	tmpDir, err := os.MkdirTemp("", "upload_test")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	document, err := proto.Marshal(&core.ErrorDocument{
+		Error: &core.ContainerError{
+			Code:    "BenchmarkFailed",
+			Message: "the model rejected the prompt",
+			Kind:    core.ContainerError_NON_RECOVERABLE,
+			Origin:  core.ExecutionError_USER,
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path.Join(tmpDir, ErrorFile), document, os.ModePerm)) // #nosec G306
+
+	iface, err := proto.Marshal(&core.TypedInterface{
+		Outputs: &core.VariableMap{
+			Variables: []*core.VariableEntry{{
+				Key: "x",
+				Value: &core.Variable{
+					Type: &core.LiteralType{Type: &core.LiteralType_Blob{Blob: &core.BlobType{Dimensionality: core.BlobType_SINGLE}}},
+				},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	s := promutils.NewTestScope()
+	store, err := storage.NewDataStore(&storage.Config{Type: storage.TypeMemory}, s.NewSubScope("storage"))
+	require.NoError(t, err)
+	prefix := storage.DataReference("output")
+	uopts := UploadOptions{
+		RootOptions: &RootOptions{
+			Scope:           s,
+			Store:           store,
+			errorOutputName: ioutils.ErrorsSuffix,
+		},
+		remoteOutputsPrefix: string(prefix),
+		metadataFormat:      core.DataLoadingConfig_JSON.String(),
+		uploadMode:          core.IOStrategy_UPLOAD_ON_EXIT.String(),
+		startWatcherType:    containerwatcher.WatcherTypeNoop,
+		exitWatcherType:     containerwatcher.WatcherTypeNoop,
+		typedInterface:      iface,
+		localDirectoryPath:  tmpDir,
+	}
+
+	require.NoError(t, uopts.Sidecar(ctx))
+
+	reader := ioutils.NewRemoteFileOutputReader(ctx, store, ioutils.NewReadOnlyOutputFilePaths(ctx, store, prefix), 1024*1024)
+	isErr, err := reader.IsError(ctx)
+	require.NoError(t, err)
+	require.True(t, isErr, "reader should see the error document the container wrote")
+
+	ee, err := reader.ReadError(ctx)
+	require.NoError(t, err)
+	assert.False(t, ee.IsRecoverable, "the container declared a permanent failure")
+	assert.Equal(t, core.ExecutionError_USER, ee.ExecutionError.GetKind())
+	assert.Equal(t, "BenchmarkFailed", ee.ExecutionError.GetCode())
+	assert.Equal(t, "the model rejected the prompt", ee.ExecutionError.GetMessage())
 }

--- a/flytecopilot/data/upload.go
+++ b/flytecopilot/data/upload.go
@@ -32,27 +32,18 @@ type Uploader struct {
 	errorFileName           string
 }
 
-// ContainerError is the failure a container declared by writing a
-// core.ErrorDocument to its error file, as opposed to a failure of the upload
-// itself. The document travels to the blob store untouched, so the kind and
-// origin the container chose are the ones flyte acts on.
-type ContainerError struct {
+// RawContainerError is the failure raised by the raw container
+type RawContainerError struct {
 	Document *core.ErrorDocument
 }
 
-func (e ContainerError) Error() string {
+func (e RawContainerError) Error() string {
 	return e.Document.GetError().GetMessage()
 }
 
-// errorDocument reads an error file as a core.ErrorDocument, reporting whether
-// it is one. A document is recognised by its structure and not by re-encoding
-// to the same bytes: the wire format is not canonical, so field order, varint
-// width and a field a newer idl added all differ legitimately between
-// encoders, and rejecting those would discard the kind and origin the
-// container chose. proto.Unmarshal does accept some plain text by chance, but
-// such a parse leaves the error's own fields empty, and a document with
-// neither a code nor a message says nothing the plain-text path cannot.
-func errorDocument(raw []byte) (*core.ErrorDocument, bool) {
+// readErrorDocument unmarshall the error file into flyte error document
+// The unmarshall will fail if it is not a flyte error
+func readErrorDocument(raw []byte) (*core.ErrorDocument, bool) {
 	document := &core.ErrorDocument{}
 	if err := proto.Unmarshal(raw, document); err != nil {
 		return nil, false
@@ -154,6 +145,7 @@ func (u Uploader) RecursiveUpload(ctx context.Context, vars *core.VariableMap, f
 	defer cancel()
 
 	errFile := path.Join(fromPath, u.errorFileName)
+	// TODO(alex): The error like info.Size() > 1024*1024 should be non-retriable too
 	if info, err := os.Stat(errFile); err != nil {
 		if !os.IsNotExist(err) {
 			return err
@@ -167,8 +159,8 @@ func (u Uploader) RecursiveUpload(ctx context.Context, vars *core.VariableMap, f
 		if err != nil {
 			return err
 		}
-		if document, ok := errorDocument(b); ok {
-			return ContainerError{Document: document}
+		if document, ok := readErrorDocument(b); ok {
+			return RawContainerError{Document: document}
 		}
 		return errors.Errorf("User Error: %s", string(b))
 	}

--- a/flytecopilot/data/upload.go
+++ b/flytecopilot/data/upload.go
@@ -32,6 +32,37 @@ type Uploader struct {
 	errorFileName           string
 }
 
+// ContainerError is the failure a container declared by writing a
+// core.ErrorDocument to its error file, as opposed to a failure of the upload
+// itself. The document travels to the blob store untouched, so the kind and
+// origin the container chose are the ones flyte acts on.
+type ContainerError struct {
+	Document *core.ErrorDocument
+}
+
+func (e ContainerError) Error() string {
+	return e.Document.GetError().GetMessage()
+}
+
+// errorDocument reads an error file as a core.ErrorDocument, reporting whether
+// it is one. A document is recognised by its structure and not by re-encoding
+// to the same bytes: the wire format is not canonical, so field order, varint
+// width and a field a newer idl added all differ legitimately between
+// encoders, and rejecting those would discard the kind and origin the
+// container chose. proto.Unmarshal does accept some plain text by chance, but
+// such a parse leaves the error's own fields empty, and a document with
+// neither a code nor a message says nothing the plain-text path cannot.
+func errorDocument(raw []byte) (*core.ErrorDocument, bool) {
+	document := &core.ErrorDocument{}
+	if err := proto.Unmarshal(raw, document); err != nil {
+		return nil, false
+	}
+	if document.GetError().GetCode() == "" && document.GetError().GetMessage() == "" {
+		return nil, false
+	}
+	return document, true
+}
+
 type dirFile struct {
 	path string
 	info os.FileInfo
@@ -135,6 +166,9 @@ func (u Uploader) RecursiveUpload(ctx context.Context, vars *core.VariableMap, f
 		b, err := os.ReadFile(errFile)
 		if err != nil {
 			return err
+		}
+		if document, ok := errorDocument(b); ok {
+			return ContainerError{Document: document}
 		}
 		return errors.Errorf("User Error: %s", string(b))
 	}

--- a/flytecopilot/data/upload_test.go
+++ b/flytecopilot/data/upload_test.go
@@ -162,7 +162,7 @@ func TestUploader_RecursiveUpload_ContainerErrorDocument(t *testing.T) {
 
 	err = u.RecursiveUpload(context.TODO(), &core.VariableMap{}, tmpDir, "output", "raw")
 
-	var containerErr ContainerError
+	var containerErr RawContainerError
 	if assert.ErrorAs(t, err, &containerErr) {
 		assert.True(t, proto.Equal(document, containerErr.Document))
 	}
@@ -195,7 +195,7 @@ func TestUploader_RecursiveUpload_ContainerErrorDocumentFromAnotherEncoder(t *te
 
 	err = u.RecursiveUpload(context.TODO(), &core.VariableMap{}, tmpDir, "output", "raw")
 
-	var containerErr ContainerError
+	var containerErr RawContainerError
 	if assert.ErrorAs(t, err, &containerErr) {
 		assert.Equal(t, "BenchmarkFailed", containerErr.Document.GetError().GetCode())
 		assert.Equal(t, "the model rejected the prompt", containerErr.Document.GetError().GetMessage())
@@ -220,7 +220,7 @@ func TestUploader_RecursiveUpload_ContainerErrorMessage(t *testing.T) {
 
 	err = u.RecursiveUpload(context.TODO(), &core.VariableMap{}, tmpDir, "output", "raw")
 
-	var containerErr ContainerError
+	var containerErr RawContainerError
 	assert.NotErrorAs(t, err, &containerErr)
 	assert.EqualError(t, err, "User Error: failed")
 }

--- a/flytecopilot/data/upload_test.go
+++ b/flytecopilot/data/upload_test.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/golang/protobuf/proto" //nolint: staticcheck
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/encoding/protowire"
 
 	"github.com/flyteorg/flyte/v2/flytestdlib/promutils"
 	"github.com/flyteorg/flyte/v2/flytestdlib/storage"
@@ -129,4 +131,96 @@ func TestUploader_RecursiveUpload(t *testing.T) {
 			assert.Equal(t, body, string(b), "content mismatch for %s", rel)
 		}
 	})
+}
+
+// A container reports its own failure by writing the error file. Writing a
+// core.ErrorDocument there is how it declares a permanent failure: the
+// document has to survive the trip untouched, or the kind and origin it chose
+// are lost and the failure comes back retryable.
+func TestUploader_RecursiveUpload_ContainerErrorDocument(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "upload_test")
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	document := &core.ErrorDocument{
+		Error: &core.ContainerError{
+			Code:    "BenchmarkFailed",
+			Message: "the model rejected the prompt",
+			Kind:    core.ContainerError_NON_RECOVERABLE,
+			Origin:  core.ExecutionError_USER,
+		},
+	}
+	raw, err := proto.Marshal(document)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(path.Join(tmpDir, "error"), raw, os.ModePerm)) // #nosec G306
+
+	store, err := storage.NewDataStore(&storage.Config{Type: storage.TypeMemory}, promutils.NewTestScope())
+	assert.NoError(t, err)
+	u := NewUploader(context.TODO(), store, core.DataLoadingConfig_JSON, core.IOStrategy_UPLOAD_ON_EXIT, "error")
+
+	err = u.RecursiveUpload(context.TODO(), &core.VariableMap{}, tmpDir, "output", "raw")
+
+	var containerErr ContainerError
+	if assert.ErrorAs(t, err, &containerErr) {
+		assert.True(t, proto.Equal(document, containerErr.Document))
+	}
+}
+
+// A document another encoder wrote, with the fields out of order and carrying
+// a field this binary does not know, is still a document.
+func TestUploader_RecursiveUpload_ContainerErrorDocumentFromAnotherEncoder(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "upload_test")
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	containerError := protowire.AppendTag(nil, 4, protowire.VarintType)
+	containerError = protowire.AppendVarint(containerError, uint64(core.ExecutionError_USER))
+	containerError = protowire.AppendTag(containerError, 2, protowire.BytesType)
+	containerError = protowire.AppendString(containerError, "the model rejected the prompt")
+	containerError = protowire.AppendTag(containerError, 1, protowire.BytesType)
+	containerError = protowire.AppendString(containerError, "BenchmarkFailed")
+	containerError = protowire.AppendTag(containerError, 99, protowire.VarintType)
+	containerError = protowire.AppendVarint(containerError, 1)
+	raw := protowire.AppendTag(nil, 1, protowire.BytesType)
+	raw = protowire.AppendBytes(raw, containerError)
+	assert.NoError(t, os.WriteFile(path.Join(tmpDir, "error"), raw, os.ModePerm)) // #nosec G306
+
+	store, err := storage.NewDataStore(&storage.Config{Type: storage.TypeMemory}, promutils.NewTestScope())
+	assert.NoError(t, err)
+	u := NewUploader(context.TODO(), store, core.DataLoadingConfig_JSON, core.IOStrategy_UPLOAD_ON_EXIT, "error")
+
+	err = u.RecursiveUpload(context.TODO(), &core.VariableMap{}, tmpDir, "output", "raw")
+
+	var containerErr ContainerError
+	if assert.ErrorAs(t, err, &containerErr) {
+		assert.Equal(t, "BenchmarkFailed", containerErr.Document.GetError().GetCode())
+		assert.Equal(t, "the model rejected the prompt", containerErr.Document.GetError().GetMessage())
+		assert.Equal(t, core.ExecutionError_USER, containerErr.Document.GetError().GetOrigin())
+	}
+}
+
+// An error file that is not a document still reaches flyte as the message the
+// container wrote.
+func TestUploader_RecursiveUpload_ContainerErrorMessage(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "upload_test")
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	assert.NoError(t, os.WriteFile(path.Join(tmpDir, "error"), []byte("failed"), os.ModePerm)) // #nosec G306
+
+	store, err := storage.NewDataStore(&storage.Config{Type: storage.TypeMemory}, promutils.NewTestScope())
+	assert.NoError(t, err)
+	u := NewUploader(context.TODO(), store, core.DataLoadingConfig_JSON, core.IOStrategy_UPLOAD_ON_EXIT, "error")
+
+	err = u.RecursiveUpload(context.TODO(), &core.VariableMap{}, tmpDir, "output", "raw")
+
+	var containerErr ContainerError
+	assert.NotErrorAs(t, err, &containerErr)
+	assert.EqualError(t, err, "User Error: failed")
 }


### PR DESCRIPTION
## Tracking issue

No upstream issue. Related to #7922, which reconnected the error document to the reader
and listed this as deliberately out of scope:

> `Sidecar` writes every uploader failure as `RECOVERABLE` with `Origin` unset, so a
> container's own `_ERROR` file comes back retryable rather than a permanent USER error.
> Pre-existing, but this PR is what makes it observable.

This is a follow-up adding the permanent USER error.

## Why are the changes needed?

A raw container has two ways to report failure and neither can express a permanent user
error.

Exiting non-zero is classified as a *system* failure: the task's `retries` is never
consulted and the node is retried up to `max-node-retries-system-failures` instead.

Writing the error file is the documented alternative, and `RecursiveUpload` picks it up —
but `Sidecar` then discards what the container said about it, rewriting every uploader
failure as `OutputUploadFailed` / `RECOVERABLE` / `Origin` unset. A container that knows
its failure is deterministic has no way to say so, and `retries` cannot express it either:
the whole point of `retries=0` is defeated by a system-failure budget the task does not
control.

Today the only workaround for us is the container speaking flyte's blob protocol itself:
build an `ErrorDocument`, construct an S3 PUT and write `error.pb` into the output
prefix.

## What changes were proposed in this pull request?

Let the container write a serialized `core.ErrorDocument` to its error file and forward it
untouched, so the `Kind` and `Origin` it chose are what flyte acts on.

1. `flytecopilot/data/upload.go` — when the error file's bytes are an `ErrorDocument`,
   `RecursiveUpload` returns the new `ContainerError` carrying it. A document is
   recognised by structure, a parse that yields a code or a message, rather than by
   re-encoding to the same bytes: the wire format is not canonical, so field order,
   varint width and a field a newer idl added all differ legitimately between encoders.
   `proto.Unmarshal` does accept some plain text by chance, but such a parse leaves the
   error's own fields empty, and a document with neither a code nor a message says
   nothing the plain-text path cannot.
2. `flytecopilot/cmd/root.go` — `UploadErrorDocument` writes a caller-built document;
   `UploadError` keeps its signature and its recoverable classification, delegating.
3. `flytecopilot/cmd/sidecar.go` — `Sidecar` forwards a `ContainerError`'s document and
   classifies everything else exactly as before.

Backwards compatible by construction: an error file that is not a document still becomes
`User Error: <contents>` under `OutputUploadFailed` / `RECOVERABLE`.

Two adjacent things left alone deliberately:

- A plain-text error file arguably should not be recoverable either (a container that
  wrote its error and exited is done deciding), and its `Origin` is arguably `USER` rather
  than unset. Both change existing behaviour for anyone relying on the retry, so they are
  not in here.
- The `_ERROR` protocol is not documented for raw-container authors as far as I can find.
  If there is a page for it, I'll document the document form there.

## How was this patch tested?

New tests, each watched fail before the fix and pass after:

- `TestUploader_RecursiveUpload_ContainerErrorDocument` — a document in the error file
  comes back as `ContainerError` with the document intact. Before the fix it fails showing
  exactly today's behaviour, the serialized proto stringified into a message:
  `in chain: "User Error: \n2\n\x0fBenchmarkFailed\x12\x1dthe model rejected the prompt \x01"`.
- `TestUploader_RecursiveUpload_ContainerErrorDocumentFromAnotherEncoder` — the same
  document hand-encoded with the fields out of order and carrying a field this binary
  does not know is still read as a document, with the container's code, message and
  `Origin` intact.
- `TestUploader_RecursiveUpload_ContainerErrorMessage` — a plain-text error file still
  produces `User Error: failed` and no `ContainerError`. Guards the compatibility claim;
  passes before and after.
- `TestSidecarForwardsTheContainersErrorDocument` — end to end across the two components:
  `Sidecar` runs against a memory store, then `NewRemoteFileOutputReader` over the same
  prefix must report `IsError()`, `IsRecoverable == false`, `Kind == USER` and the
  container's own code and message. Before the fix: `expected BenchmarkFailed, actual
  OutputUploadFailed`.

```
go build ./flytecopilot/...
go test ./flytecopilot/... ./flyteplugins/go/tasks/pluginmachinery/ioutils/...
```

All pass, `gofmt` and `go vet` clean.

### Labels

**fixed**

## Check all the applicable boxes

- [x] I updated the documentation accordingly. (code comments; see the note above about
      raw-container docs)
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
