### PR TITLE
ci: publish npm package via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing vX.Y.Z tag to publish"
+        description: "Existing vX.Y.Z tag to publish (tag name only; resolved under refs/tags/)"
         required: true
         type: string
 
@@ -31,7 +31,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          # Dispatch inputs are pinned into the tag namespace so a branch name
+          # or SHA cannot be published: checkout fails fast unless
+          # refs/tags/<input> exists. Tag-push runs use the pushed ref.
+          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: "24.x"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -48,12 +48,17 @@ jobs:
         # the lockfile, which still carries the 0.0.0-develop placeholder.
         run: npm ci
       - name: Set version in npm package
+        # The dispatch input reaches the shell through env, never by expression
+        # interpolation into the script, so quotes/newlines in it cannot inject
+        # shell. Empty on tag-push runs, where the pushed ref carries the tag.
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
         run: |
-          REF="${{ inputs.tag || github.ref }}"
+          REF="${TAG_INPUT:-$GITHUB_REF}"
           # v1.2.3 get 1.2.3
           VERSION="${REF#refs/tags/}"
           VERSION="${VERSION#v}"
-          VERSION=$VERSION make update_npmversion
+          VERSION="$VERSION" make update_npmversion
         shell: bash
       - name: Publish
         # No NODE_AUTH_TOKEN on purpose: with a trusted publisher configured,

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,41 +4,54 @@ on:
   push:
     tags:
       - 'v*'
+  # Re-publish an existing tag whose tag-push run failed (e.g. before npm
+  # trusted publishing was configured). The workflow definition is taken from
+  # the ref the dispatch runs on; the package content comes from the tag.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing vX.Y.Z tag to publish"
+        required: true
+        type: string
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/flyteorg/flyte/ci:v2
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    # npm trusted publishing: the job authenticates to registry.npmjs.org with
+    # a GitHub OIDC token instead of a long-lived NPM_TOKEN secret. Requires
+    # the @flyteorg/flyteidl2 package on npmjs.com to list this repository and
+    # workflow file as a trusted publisher.
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: ./gen/ts/
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Debug Info
-        run: |
-          pwd
-          ls -la
-      - uses: actions/setup-node@v1
         with:
-          node-version: "20.x"
+          ref: ${{ inputs.tag || github.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
+      - name: Update npm
+        # Trusted publishing needs npm >= 11.5.1; make sure we are past it
+        # regardless of what the setup-node runtime bundles.
+        run: npm install -g npm@latest && npm --version
       - name: Set version in npm package
         run: |
+          REF="${{ inputs.tag || github.ref }}"
           # v1.2.3 get 1.2.3
-          VERSION=$(echo "${GITHUB_REF#refs/tags/v}")
+          VERSION="${REF#refs/tags/}"
+          VERSION="${VERSION#v}"
           VERSION=$VERSION make update_npmversion
         shell: bash
-
       - name: Install dependencies
         run: npm install
       - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          NPM_REGISTRY_URL="https://registry.npmjs.org/"
-          npm publish --access=public --registry $NPM_REGISTRY_URL
+        # No NODE_AUTH_TOKEN on purpose: with a trusted publisher configured,
+        # npm exchanges the workflow's OIDC token for publish credentials and
+        # attaches provenance automatically.
+        run: npm publish --access=public

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -31,10 +31,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # Dispatch inputs are pinned into the tag namespace so a branch name
-          # or SHA cannot be published: checkout fails fast unless
-          # refs/tags/<input> exists. Tag-push runs use the pushed ref.
-          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          # Dispatch runs always resolve under the tag namespace, keyed on the
+          # event (not input truthiness) so an empty input yields "refs/tags/"
+          # and fails the checkout rather than falling back to the branch ref.
+          # A branch name or SHA cannot be published either: checkout fails
+          # fast unless refs/tags/<input> exists. Tag-push runs use the
+          # pushed ref.
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: "24.x"
@@ -54,7 +57,14 @@ jobs:
         env:
           TAG_INPUT: ${{ inputs.tag }}
         run: |
-          REF="${TAG_INPUT:-$GITHUB_REF}"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            # Keyed on the event, matching the checkout above: an empty input
+            # must fail here, never fall back to the branch ref.
+            [ -n "$TAG_INPUT" ] || { echo "inputs.tag must be a vX.Y.Z tag"; exit 1; }
+            REF="$TAG_INPUT"
+          else
+            REF="$GITHUB_REF"
+          fi
           # v1.2.3 get 1.2.3
           VERSION="${REF#refs/tags/}"
           VERSION="${VERSION#v}"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -37,9 +37,13 @@ jobs:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
       - name: Update npm
-        # Trusted publishing needs npm >= 11.5.1; make sure we are past it
-        # regardless of what the setup-node runtime bundles.
-        run: npm install -g npm@latest && npm --version
+        # Trusted publishing needs npm >= 11.5.1; stay within major 11 so the
+        # publish behavior does not shift under us.
+        run: npm install -g npm@11 && npm --version
+      - name: Install dependencies
+        # Before the version stamp below: npm ci verifies package.json against
+        # the lockfile, which still carries the 0.0.0-develop placeholder.
+        run: npm ci
       - name: Set version in npm package
         run: |
           REF="${{ inputs.tag || github.ref }}"
@@ -48,8 +52,6 @@ jobs:
           VERSION="${VERSION#v}"
           VERSION=$VERSION make update_npmversion
         shell: bash
-      - name: Install dependencies
-        run: npm install
       - name: Publish
         # No NODE_AUTH_TOKEN on purpose: with a trusted publisher configured,
         # npm exchanges the workflow's OIDC token for publish credentials and


### PR DESCRIPTION
## Why

The TypeScript publish workflow has failed for **every** release since v2.0.17 (`@flyteorg/flyteidl2` on npm is stuck at 2.0.16). The `NPM_TOKEN` secret can no longer publish — npm masks the authorization failure as `E404 '@flyteorg/flyteidl2@x.y.z' is not in this registry` — and npm is deprecating long-lived 2FA-bypass tokens outright: as of early August 2026 they cannot perform package-management operations, and around January 2027 they lose direct publishing entirely ([changelog](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/)). Rotating the token is a dead end; the recommended path is trusted publishing.

## What

- Grant the job `id-token: write` and drop `NODE_AUTH_TOKEN`: npm exchanges the workflow's OIDC identity for publish credentials, with provenance attached automatically.
- `actions/setup-node@v1` → `@v4`, node 24, plus `npm install -g npm@latest` (trusted publishing needs npm ≥ 11.5.1).
- Add a `workflow_dispatch` input taking an existing tag, so releases whose tag-push run already failed (v2.0.17…v2.0.46) can be re-published — the dispatch checks out the tag while running this fixed workflow definition.

## One-time setup required before merge takes effect

An `@flyteorg` npm org owner must add a trusted publisher on npmjs.com: **@flyteorg/flyteidl2 → Settings → Publishing access → Trusted publisher → GitHub Actions**, with repository `flyteorg/flyte` and workflow filename `publish-npm.yml` (no environment). After that, the `NPM_TOKEN` repo secret can be deleted.

## Verification plan

After merge + npm-side setup: run the workflow via dispatch with tag `v2.0.46`, then `npm view @flyteorg/flyteidl2@2.0.46`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzRDrkwWaxeTpqB4WS165m