### PR TITLE
fix(executor): prevent invalid TaskActions from staying nonterminal

### DIFF
--- a/executor/pkg/controller/taskaction_controller.go
+++ b/executor/pkg/controller/taskaction_controller.go
@@ -374,9 +374,9 @@ func (r *TaskActionReconciler) reconcileTask(
 		setCondition(taskAction, flyteorgv1.ConditionTypeFailed, metav1.ConditionTrue, reason, err.Error())
 		setCondition(taskAction, flyteorgv1.ConditionTypeProgressing, metav1.ConditionFalse, reason, err.Error())
 		start := time.Now()
-		updErr := r.Status().Update(ctx, taskAction) // error intentionally ignored: terminal either way
+		updErr := r.Status().Update(ctx, taskAction)
 		r.metrics.recordK8sOp(ctx, opStatusUpdate, start, updErr)
-		return ctrl.Result{}, nil // terminal — do not requeue
+		return ctrl.Result{}, updErr
 	}
 
 	// Ensure finalizer is present (once validation passes)

--- a/executor/pkg/controller/taskaction_validation_test.go
+++ b/executor/pkg/controller/taskaction_validation_test.go
@@ -2,9 +2,15 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
+
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	flyteorgv1 "github.com/flyteorg/flyte/v2/executor/api/v1"
 	pluginsCore "github.com/flyteorg/flyte/v2/flyteplugins/go/tasks/pluginmachinery/core"
@@ -107,5 +113,40 @@ func TestValidateTaskAction_PluginNotFound(t *testing.T) {
 	}
 	if reason != flyteorgv1.ConditionReasonPluginNotFound {
 		t.Errorf("expected reason %q, got %q", flyteorgv1.ConditionReasonPluginNotFound, reason)
+	}
+}
+
+func TestReconcileTask_ValidationStatusUpdate(t *testing.T) {
+	statusErr := errors.New("status update failed")
+	for _, tc := range []struct {
+		name      string
+		updateErr error
+	}{
+		{name: "success"},
+		{name: "failure", updateErr: statusErr},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			k8sClient := fake.NewClientBuilder().
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourceUpdate: func(context.Context, client.Client, string, client.Object, ...client.SubResourceUpdateOption) error {
+						return tc.updateErr
+					},
+				}).
+				Build()
+			reconciler := &TaskActionReconciler{
+				Client:   k8sClient,
+				Recorder: events.NewFakeRecorder(1),
+			}
+			taskAction := validTaskAction()
+			taskAction.Spec.RunName = ""
+
+			_, err := reconciler.reconcileTask(context.Background(), taskAction, taskAction.DeepCopy())
+			if !errors.Is(err, tc.updateErr) {
+				t.Fatalf("expected %v, got %v", tc.updateErr, err)
+			}
+			if !isTerminal(taskAction) {
+				t.Fatal("expected validation failure to remain terminal")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Tracking issue

None. This bug was found on current `main`.

## Why are the changes needed?

An invalid TaskAction can stay nonterminal when Kubernetes rejects the status write that should mark it failed. The executor discards the write error and reports a successful reconciliation, so controller-runtime removes the request from its work queue until another event happens to enqueue it.

Before this change, one rejected status write can leave the TaskAction stuck. After this change, controller-runtime retries the reconciliation and can persist the terminal failure.

controller-runtime treats these outcomes differently: a non-nil error adds the request back to the rate-limited queue, while a successful empty result forgets it. See [controller-runtime v0.24.1](https://github.com/kubernetes-sigs/controller-runtime/blob/3be3f1bf2b2fcc6b5c9510d55c6a9972294653d0/pkg/internal/controller/controller.go#L478-L512).

## What changes were proposed in this pull request?

Return the status update error from the validation failure path. A successful status write still returns an empty result with no error. The regression test covers both outcomes.

## How was this patch tested?

| Scenario | Result |
| --- | --- |
| Parent source with the regression test | Failed because the status error was swallowed |
| Patched source | Both the successful and failed status-write cases passed |
| Full controller package | Passed |

```bash
git restore --source=500b99b6ca64342f9a221f8c438feeecd1fa9b10 -- executor/pkg/controller/taskaction_controller.go
go test ./executor/pkg/controller -run TestReconcileTask_ValidationStatusUpdate -count=1 -v
git restore --source=689b8a67379292380093d298f211b920cb8821cb -- executor/pkg/controller/taskaction_controller.go
go test ./executor/pkg/controller -run TestReconcileTask_ValidationStatusUpdate -count=1 -v
go test ./executor/pkg/controller -count=1
```

<details><summary>Raw logs</summary>

```text
=== RUN   TestReconcileTask_ValidationStatusUpdate
=== RUN   TestReconcileTask_ValidationStatusUpdate/success
=== RUN   TestReconcileTask_ValidationStatusUpdate/failure
    taskaction_validation_test.go:145: expected status update failed, got <nil>
--- FAIL: TestReconcileTask_ValidationStatusUpdate (0.04s)
    --- PASS: TestReconcileTask_ValidationStatusUpdate/success (0.04s)
    --- FAIL: TestReconcileTask_ValidationStatusUpdate/failure (0.00s)
FAIL
FAIL	github.com/flyteorg/flyte/v2/executor/pkg/controller	0.996s
FAIL

=== RUN   TestReconcileTask_ValidationStatusUpdate
=== RUN   TestReconcileTask_ValidationStatusUpdate/success
=== RUN   TestReconcileTask_ValidationStatusUpdate/failure
--- PASS: TestReconcileTask_ValidationStatusUpdate (0.04s)
    --- PASS: TestReconcileTask_ValidationStatusUpdate/success (0.04s)
    --- PASS: TestReconcileTask_ValidationStatusUpdate/failure (0.00s)
PASS
ok  	github.com/flyteorg/flyte/v2/executor/pkg/controller	1.075s

ok  	github.com/flyteorg/flyte/v2/executor/pkg/controller	10.683s
```

</details>

### Labels

`fixed`

### Setup process

```bash
make -C executor setup-envtest
```

### Screenshots

Not applicable.

## Check all the applicable boxes

- [x] Documentation is not affected.
- [x] All new and existing controller tests passed.
- [x] All commits are signed off.

## Related PRs

None.

## Stack

This PR is not stacked.

## Docs link

Not applicable.
