### PR TITLE
fix(runs): ignore org in the settings storage key

### DIFF
--- a/flyteidl2/settings/settings_customer_flow.md
+++ b/flyteidl2/settings/settings_customer_flow.md
@@ -26,6 +26,7 @@ than maintained by hand.
 - `GetSettings` resolves inheritance top-down and returns one merged record wrapped in `settingsRecord`, with each resolved setting annotated by the `scopeLevel` it came from. No descriptions. Merged records carry no `version`, since a merged view corresponds to no single stored row; clients that need a version for an update use `GetSettingsForEdit`.
 - `SCOPE_LEVEL_ORG` is the enum zero value and is omitted from JSON, so an absent `scopeLevel` means the value resolved from the org.
 - `GetSettingsForEdit` returns `requestedKey` plus a `levels` array, one entry per scope level covered by the request key, ordered broadest to most specific. Each entry is `{ key, settings, version }` where `key` is a partial key identifying that level. No descriptions and no `scopeLevel`. A level with no stored record has empty settings and version 0; zero versions are omitted from JSON, so a missing `version` field means "no record yet, use `CreateSettings` for this level".
+- The storage key ignores `org`: OSS Flyte has no organization concept, so a record is stored under `v1::{domain}:{project}` whatever org the client sends. A request key's `org` is still echoed back in responses.
 - Map settings (`environmentVariables`) are **additive** on `GetSettings`: parent entries first, child entries merged on top (child wins on key conflict), and a level in state `UNSET` clears everything accumulated above it. `scopeLevel` on a merged map is the most specific level that contributed entries.
 
 ---
@@ -40,8 +41,8 @@ No domain settings exist yet.
 
 | id | key                            | data (JSONB)                                                                                                                                                                                                                                                | version |
 |----|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| 1  | `v1:acme::`                    | `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"default"}},"taskResource":{"min":{"cpu":{"state":"SETTING_STATE_VALUE","quantityValue":"500m"}}},"environmentVariables":{"state":"SETTING_STATE_VALUE","mapValue":{"entries":{"LOG_LEVEL":"info","REGION":"us-east-1"}}}}` | 1       |
-| 2  | `v1:acme:production:analytics` | `{"taskResource":{"min":{"cpu":{"state":"SETTING_STATE_VALUE","quantityValue":"1000m"}}}}`                                                                                                                                                                  | 1       |
+| 1  | `v1:::`                        | `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"default"}},"taskResource":{"min":{"cpu":{"state":"SETTING_STATE_VALUE","quantityValue":"500m"}}},"environmentVariables":{"state":"SETTING_STATE_VALUE","mapValue":{"entries":{"LOG_LEVEL":"info","REGION":"us-east-1"}}}}` | 1       |
+| 2  | `v1::production:analytics`     | `{"taskResource":{"min":{"cpu":{"state":"SETTING_STATE_VALUE","quantityValue":"1000m"}}}}`                                                                                                                                                                  | 1       |
 
 ---
 
@@ -215,8 +216,8 @@ results. `version` is now `2`.
 
 | id | key                            | data (JSONB)                                                                                                                                                                                                                | version |
 |----|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| 1  | `v1:acme::`                    | `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"default"}},...}` (unchanged)                                                                                                                            | 1       |
-| 2  | `v1:acme:production:analytics` | `{"taskResource":{"min":{"cpu":{"state":"SETTING_STATE_VALUE","quantityValue":"2000m"}}},"environmentVariables":{"state":"SETTING_STATE_VALUE","mapValue":{"entries":{"LOG_LEVEL":"debug"}}}}` | 2       |
+| 1  | `v1:::`                        | `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"default"}},...}` (unchanged)                                                                                                                            | 1       |
+| 2  | `v1::production:analytics`     | `{"taskResource":{"min":{"cpu":{"state":"SETTING_STATE_VALUE","quantityValue":"2000m"}}},"environmentVariables":{"state":"SETTING_STATE_VALUE","mapValue":{"entries":{"LOG_LEVEL":"debug"}}}}` | 2       |
 
 `run.defaultQueue` is absent from the project row: INHERIT is never written to
 the database, whether the client omitted the field or sent it empty.
@@ -314,9 +315,9 @@ queue.
 
 | id | key                            | data (JSONB)                                                                                                                                                                                       | version |
 |----|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| 1  | `v1:acme::`                    | `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"default"}},...}` (unchanged)                                                                                                     | 1       |
-| 3  | `v1:acme:production:`          | `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"fast-queue"}}}`                                                                                                                  | 1       |
-| 2  | `v1:acme:production:analytics` | `{"taskResource":{"min":{"cpu":{"state":"SETTING_STATE_VALUE","quantityValue":"2000m"}}},...}` (unchanged)                                                                                             | 2       |
+| 1  | `v1:::`                        | `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"default"}},...}` (unchanged)                                                                                                     | 1       |
+| 3  | `v1::production:`              | `{"run":{"defaultQueue":{"state":"SETTING_STATE_VALUE","stringValue":"fast-queue"}}}`                                                                                                                  | 1       |
+| 2  | `v1::production:analytics`     | `{"taskResource":{"min":{"cpu":{"state":"SETTING_STATE_VALUE","quantityValue":"2000m"}}},...}` (unchanged)                                                                                             | 2       |
 
 Only `defaultQueue` reaches the domain row: the empty CPU and env-var objects
 were pruned before storing.

--- a/runs/repository/impl/settings_test.go
+++ b/runs/repository/impl/settings_test.go
@@ -20,7 +20,7 @@ func TestCreateAndGetSettings_RoundTrip(t *testing.T) {
 	repo := setupSettingTest(t)
 	ctx := context.Background()
 
-	key := models.EncodeSettingsKey("", "development", "")
+	key := models.EncodeSettingsKey("development", "")
 	created := &models.Settings{
 		Key:  key,
 		Data: []byte(`{"environmentVariables":{"state":"VALUE", "values":{"LOG_LEVEL": "debug"}}}`),
@@ -40,7 +40,7 @@ func TestCreateSettings_AlreadyExists(t *testing.T) {
 	repo := setupSettingTest(t)
 	ctx := context.Background()
 
-	key := models.EncodeSettingsKey("", "development", "recsys")
+	key := models.EncodeSettingsKey("development", "recsys")
 	first := &models.Settings{Key: key, Data: []byte(`{}`)}
 	require.NoError(t, repo.CreateSettings(ctx, first))
 
@@ -57,7 +57,7 @@ func TestGetSettings_NotFound(t *testing.T) {
 	repo := setupSettingTest(t)
 	ctx := context.Background()
 
-	got, err := repo.GetSettings(ctx, models.EncodeSettingsKey("", "nowhere", ""))
+	got, err := repo.GetSettings(ctx, models.EncodeSettingsKey("nowhere", ""))
 	require.ErrorIs(t, err, interfaces.ErrSettingsNotFound)
 	require.Nil(t, got)
 }
@@ -66,9 +66,9 @@ func TestGetSettingsByKeys_MissingRowsAreNotErrors(t *testing.T) {
 	repo := setupSettingTest(t)
 	ctx := context.Background()
 
-	instanceKey := models.EncodeSettingsKey("", "", "")
-	domainKey := models.EncodeSettingsKey("", "development", "")
-	projectKey := models.EncodeSettingsKey("", "development", "recsys")
+	instanceKey := models.EncodeSettingsKey("", "")
+	domainKey := models.EncodeSettingsKey("development", "")
+	projectKey := models.EncodeSettingsKey("development", "recsys")
 
 	require.NoError(t, repo.CreateSettings(ctx, &models.Settings{Key: instanceKey, Data: []byte(`{}`)}))
 	require.NoError(t, repo.CreateSettings(ctx, &models.Settings{Key: domainKey, Data: []byte(`{}`)}))
@@ -91,7 +91,7 @@ func TestUpdateSettings_VersionConflict(t *testing.T) {
 	repo := setupSettingTest(t)
 	ctx := context.Background()
 
-	key := models.EncodeSettingsKey("", "development", "recsys")
+	key := models.EncodeSettingsKey("development", "recsys")
 
 	// The row is born at version 1.
 	writer := &models.Settings{Key: key, Data: []byte(`{"run":{"defaultQueue":{"state":"VALUE","stringValue":"cpu-pool"}}}`)}
@@ -126,7 +126,7 @@ func TestUpdateSettings_NotFound(t *testing.T) {
 	ctx := context.Background()
 
 	stale := &models.Settings{
-		Key:     models.EncodeSettingsKey("", "nowhere", ""),
+		Key:     models.EncodeSettingsKey("nowhere", ""),
 		Data:    []byte(`{}`),
 		Version: 1,
 	}

--- a/runs/repository/models/settings.go
+++ b/runs/repository/models/settings.go
@@ -15,21 +15,11 @@ type Settings struct {
 	UpdatedAt time.Time `db:"updated_at"`
 }
 
-// DefaultOrg mirrors secret.DefaultOrganization; duplicated so runs/ doesn't
-// take a flyteplugins import for one constant.
-const DefaultOrg = "flyte"
-
-// NormalizeOrg returns DefaultOrg for an empty org, otherwise org unchanged.
-func NormalizeOrg(org string) string {
-	if org == "" {
-		return DefaultOrg
-	}
-	return org
-}
-
-// EncodeSettingsKey encodes a settings scope as "v1:{org}:{domain}:{project}".
-// Empty org is normalized to DefaultOrg; empty domain/project segments are
-// kept, so an instance-level key looks like "v1:flyte::".
-func EncodeSettingsKey(org, domain, project string) string {
-	return fmt.Sprintf("v1:%s:%s:%s", NormalizeOrg(org), domain, project)
+// EncodeSettingsKey encodes a settings scope as "v1::{domain}:{project}".
+// The org segment is always empty: OSS Flyte has no organization concept, so
+// settings are stored and looked up under the same key whatever org a client
+// sends. Empty domain/project segments are kept, so an instance-level key
+// looks like "v1:::".
+func EncodeSettingsKey(domain, project string) string {
+	return fmt.Sprintf("v1::%s:%s", domain, project)
 }

--- a/runs/repository/models/settings_test.go
+++ b/runs/repository/models/settings_test.go
@@ -9,21 +9,18 @@ import (
 func TestEncodeSettingsKey(t *testing.T) {
 	cases := []struct {
 		name    string
-		org     string
 		domain  string
 		project string
 		want    string
 	}{
-		{name: "all segments set", org: "acme", domain: "dev", project: "recsys", want: "v1:acme:dev:recsys"},
-		{name: "domain level, empty org normalized", org: "", domain: "dev", project: "", want: "v1:flyte:dev:"},
-		{name: "instance level, all empty", org: "", domain: "", project: "", want: "v1:flyte::"},
-		{name: "empty org with domain and project", org: "", domain: "dev", project: "recsys", want: "v1:flyte:dev:recsys"},
-		{name: "org flyte passes through unchanged", org: "flyte", domain: "dev", project: "", want: "v1:flyte:dev:"},
+		{name: "project level", domain: "dev", project: "recsys", want: "v1::dev:recsys"},
+		{name: "domain level", domain: "dev", project: "", want: "v1::dev:"},
+		{name: "instance level", domain: "", project: "", want: "v1:::"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, EncodeSettingsKey(tc.org, tc.domain, tc.project))
+			require.Equal(t, tc.want, EncodeSettingsKey(tc.domain, tc.project))
 		})
 	}
 }

--- a/runs/service/settings_resolve.go
+++ b/runs/service/settings_resolve.go
@@ -25,7 +25,7 @@ func fetchLevels(ctx context.Context, repo interfaces.SettingsRepo, key *setting
 
 	storageKeys := make([]string, 0, len(levelKeys))
 	for _, lk := range levelKeys {
-		storageKeys = append(storageKeys, models.EncodeSettingsKey(lk.GetOrg(), lk.GetDomain(), lk.GetProject()))
+		storageKeys = append(storageKeys, models.EncodeSettingsKey(lk.GetDomain(), lk.GetProject()))
 	}
 
 	rows, err := repo.GetSettingsByKeys(ctx, storageKeys)

--- a/runs/service/settings_resolve_test.go
+++ b/runs/service/settings_resolve_test.go
@@ -48,3 +48,47 @@ func TestResolveSettings(t *testing.T) {
 	require.True(t, proto.Equal(want, resolved.GetEnvironmentVariables()),
 		"got %s", protojson.Format(resolved.GetEnvironmentVariables()))
 }
+
+// TestResolveSettings_IgnoresOrg writes a setting under one org and reads it back
+// under a different one. Clients disagree about the org: the SDK guesses it from
+// the server hostname, while the scheduler sends none. Both must reach the same
+// stored record.
+func TestResolveSettings_IgnoresOrg(t *testing.T) {
+	ctx := context.Background()
+	t.Cleanup(func() { testDB.Exec("DELETE FROM settings") })
+
+	repo := impl.NewSettingsRepo(testDB)
+	svc := NewSettingsService(repo)
+
+	// Written the way the CLI writes it, under an org derived from the endpoint.
+	_, err := svc.CreateSettings(ctx,
+		connect.NewRequest(&settings.CreateSettingsRequest{
+			Key:      &settings.SettingsKey{Org: "acme"},
+			Settings: envSettings("LOG_LEVEL", "info"),
+		}))
+	require.NoError(t, err)
+
+	// An instance-level resolve reports SCOPE_LEVEL_ORG, the enum zero value.
+	want := &settings.StringMapSetting{
+		State:    stateValue,
+		MapValue: &settings.StringMap{Entries: map[string]string{"LOG_LEVEL": "info"}},
+	}
+
+	cases := []struct {
+		name string
+		org  string
+	}{
+		{name: "same org as the write", org: "acme"},
+		{name: "no org, as a scheduled run sends", org: ""},
+		{name: "a different org", org: "other"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolved, err := resolveSettings(ctx, repo, &settings.SettingsKey{Org: tc.org})
+			require.NoError(t, err)
+			require.True(t, proto.Equal(want, resolved.GetEnvironmentVariables()),
+				"got %s", protojson.Format(resolved.GetEnvironmentVariables()))
+		})
+	}
+}

--- a/runs/service/settings_service.go
+++ b/runs/service/settings_service.go
@@ -109,7 +109,7 @@ func (s *SettingsService) CreateSettings(
 	}
 
 	model := &models.Settings{
-		Key:  models.EncodeSettingsKey(key.GetOrg(), key.GetDomain(), key.GetProject()),
+		Key:  models.EncodeSettingsKey(key.GetDomain(), key.GetProject()),
 		Data: data,
 	}
 
@@ -154,7 +154,7 @@ func (s *SettingsService) UpdateSettings(
 	}
 
 	model := &models.Settings{
-		Key:     models.EncodeSettingsKey(key.GetOrg(), key.GetDomain(), key.GetProject()),
+		Key:     models.EncodeSettingsKey(key.GetDomain(), key.GetProject()),
 		Data:    data,
 		Version: req.Msg.GetVersion(),
 	}


### PR DESCRIPTION
## Tracking issue

Related to #7775 and #7932. Addresses a review comment on #7961.

## Why are the changes needed?

The settings storage key is built from the org in the request, which nothing else in OSS Flyte reads. #7157 removed org from every runs table and service and left the proto fields in place, unread.

The SDK derives an org from the endpoint hostname, so settings written through the CLI are stored under it. Runs created without a name and runs created by the scheduler carry no org and look under the default, so they find nothing. Whether a stored setting applies depends on how the run was started, and neither path reports an error.

## What changes were proposed in this pull request?

- `EncodeSettingsKey` no longer takes an org, so keys go from `v1:{org}:{domain}:{project}` to `v1::{domain}:{project}`. Removing the parameter rather than ignoring it keeps the mismatch from coming back. `NormalizeOrg` and `DefaultOrg` go with it.
- The wire API is unchanged. Clients still send org, validation is untouched, and `GetSettingsForEdit` still echoes the requested org back in each level key.
- One behavior change: two clients sending different orgs for the same domain and project now collapse onto one key, so the second `CreateSettings` returns `AlreadyExists`.

## How was this patch tested?

- Added a regression test that writes under one org and resolves under another, expecting the same record. Nothing covered that before, so the bug had no test.
- The encoder table test now pins one key per scope level.
- `go test ./runs/...` passes, including the `runs/test/api` customer flow replay.

### Labels

- **fixed**

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

#7961 is the first PR that reads these settings and applies them to a run. Builds on #7841, #7859, #7900, #7925, #7927, #7937 and #7956.