### PR TITLE
feat(runs): apply the run base dir and raw data path settings

### DIFF
--- a/dataproxy/service/dataproxy_service.go
+++ b/dataproxy/service/dataproxy_service.go
@@ -275,8 +275,9 @@ func (s *Service) UploadInputs(
 	// When base_dir is set it is a full path used verbatim, bucket and all, so it becomes
 	// the base reference directly (enabling cross-bucket writes); otherwise inputs go
 	// under the configured Upload.StoragePrefix within the operator's base container.
-	// TODO: consult org/project/domain settings (StorageSettings.run_base_dir) here as the
-	// middle tier once settings lookup lands; it must be applied in CreateRun too.
+	// TODO: consult org/project/domain settings (RunSettings.run_base_dir) here as the
+	// middle tier. CreateRun already does, so until this matches, a settings-provided
+	// base applies to run metadata but not to offloaded inputs.
 	var baseRef storage.DataReference
 	var pathComponents []string
 	if base := strings.TrimRight(req.Msg.GetBaseDir(), "/"); base != "" {

--- a/runs/service/run_service.go
+++ b/runs/service/run_service.go
@@ -305,11 +305,12 @@ func (s *RunService) CreateRun(
 	}
 
 	// Compute storage URIs before DB insert so they're persisted in the ActionSpec.
-	// runSpec.RunBaseDir overrides the configured storagePrefix when set; it must
-	// resolve to the same base UploadInputs used (UploadInputsRequest.base_dir) so the
-	// run reads offloaded inputs from where they were written.
-	// TODO: consult org/project/domain settings (StorageSettings.run_base_dir) here as
-	// the middle tier once settings lookup lands; it must be applied in UploadInputs too.
+	// runSpec.RunBaseDir overrides the configured storagePrefix when set, either by the
+	// request or from settings above; it must resolve to the same base UploadInputs used
+	// (UploadInputsRequest.base_dir) so the run reads offloaded inputs from where they
+	// were written.
+	// TODO: UploadInputs does not consult settings, so a base that came from settings
+	// applies to run metadata but not to offloaded inputs.
 	runBase := s.storagePrefix
 	if rb := runSpec.GetRunBaseDir(); rb != "" {
 		runBase = rb

--- a/runs/service/settings_apply.go
+++ b/runs/service/settings_apply.go
@@ -25,4 +25,16 @@ func applyRunSettings(spec *task.RunSpec, resolved *settings.Settings) {
 		concurrency.GetState() == settings.SettingState_SETTING_STATE_VALUE {
 		spec.MaxActionConcurrency = uint32(concurrency.GetIntValue())
 	}
+
+	// Base for run metadata (inputs.pb, outputs.pb), not for user blobs.
+	if baseDir := resolved.GetRun().GetRunBaseDir(); spec.GetRunBaseDir() == "" &&
+		baseDir.GetState() == settings.SettingState_SETTING_STATE_VALUE {
+		spec.RunBaseDir = baseDir.GetStringValue()
+	}
+
+	// RawDataStorage carries only this prefix, so replacing the message loses nothing.
+	if rawDataPath := resolved.GetStorage().GetRawDataPath(); spec.GetRawDataStorage().GetRawDataPrefix() == "" &&
+		rawDataPath.GetState() == settings.SettingState_SETTING_STATE_VALUE {
+		spec.RawDataStorage = &task.RawDataStorage{RawDataPrefix: rawDataPath.GetStringValue()}
+	}
 }

--- a/runs/service/settings_apply_test.go
+++ b/runs/service/settings_apply_test.go
@@ -14,13 +14,23 @@ func runSettings(queue *settings.StringSetting, concurrency *settings.Int64Setti
 	}
 }
 
+func runBaseDirSettings(baseDir *settings.StringSetting) *settings.Settings {
+	return &settings.Settings{Run: &settings.RunSettings{RunBaseDir: baseDir}}
+}
+
+func rawDataSettings(rawDataPath *settings.StringSetting) *settings.Settings {
+	return &settings.Settings{Storage: &settings.StorageSettings{RawDataPath: rawDataPath}}
+}
+
 func TestApplyRunSettings(t *testing.T) {
 	tests := []struct {
-		name            string
-		spec            *task.RunSpec
-		resolved        *settings.Settings
-		wantQueue       string
-		wantConcurrency uint32
+		name              string
+		spec              *task.RunSpec
+		resolved          *settings.Settings
+		wantQueue         string
+		wantConcurrency   uint32
+		wantRunBaseDir    string
+		wantRawDataPrefix string
 	}{
 		{
 			name:      "empty queue takes the settings value",
@@ -68,6 +78,50 @@ func TestApplyRunSettings(t *testing.T) {
 			spec:     nil,
 			resolved: runSettings(&settings.StringSetting{State: stateValue, StringValue: "fast-queue"}, nil),
 		},
+		{
+			name:           "empty run base dir takes the settings value",
+			spec:           &task.RunSpec{},
+			resolved:       runBaseDirSettings(&settings.StringSetting{State: stateValue, StringValue: "s3://settings-base"}),
+			wantRunBaseDir: "s3://settings-base",
+		},
+		{
+			name:           "an explicit run base dir wins over settings",
+			spec:           &task.RunSpec{RunBaseDir: "s3://user-base"},
+			resolved:       runBaseDirSettings(&settings.StringSetting{State: stateValue, StringValue: "s3://settings-base"}),
+			wantRunBaseDir: "s3://user-base",
+		},
+		{
+			name:           "a run base dir in INHERIT contributes nothing",
+			spec:           &task.RunSpec{},
+			resolved:       runBaseDirSettings(&settings.StringSetting{State: stateInherit, StringValue: "s3://settings-base"}),
+			wantRunBaseDir: "",
+		},
+		{
+			name:              "empty raw data prefix takes the settings value",
+			spec:              &task.RunSpec{},
+			resolved:          rawDataSettings(&settings.StringSetting{State: stateValue, StringValue: "s3://settings-raw"}),
+			wantRawDataPrefix: "s3://settings-raw",
+		},
+		{
+			name:              "an explicit raw data prefix wins over settings",
+			spec:              &task.RunSpec{RawDataStorage: &task.RawDataStorage{RawDataPrefix: "s3://user-raw"}},
+			resolved:          rawDataSettings(&settings.StringSetting{State: stateValue, StringValue: "s3://settings-raw"}),
+			wantRawDataPrefix: "s3://user-raw",
+		},
+		{
+			name:              "a raw data path in UNSET contributes nothing",
+			spec:              &task.RunSpec{},
+			resolved:          rawDataSettings(&settings.StringSetting{State: stateUnset, StringValue: "s3://settings-raw"}),
+			wantRawDataPrefix: "",
+		},
+		{
+			// Present but empty still counts as no request value. Guarding on a nil
+			// RawDataStorage instead would skip this row and leave the prefix empty.
+			name:              "a raw data storage message with no prefix takes the settings value",
+			spec:              &task.RunSpec{RawDataStorage: &task.RawDataStorage{}},
+			resolved:          rawDataSettings(&settings.StringSetting{State: stateValue, StringValue: "s3://settings-raw"}),
+			wantRawDataPrefix: "s3://settings-raw",
+		},
 	}
 
 	for _, tt := range tests {
@@ -75,6 +129,8 @@ func TestApplyRunSettings(t *testing.T) {
 			applyRunSettings(tt.spec, tt.resolved)
 			assert.Equal(t, tt.wantQueue, tt.spec.GetQueue())
 			assert.Equal(t, tt.wantConcurrency, tt.spec.GetMaxActionConcurrency())
+			assert.Equal(t, tt.wantRunBaseDir, tt.spec.GetRunBaseDir())
+			assert.Equal(t, tt.wantRawDataPrefix, tt.spec.GetRawDataStorage().GetRawDataPrefix())
 		})
 	}
 }


### PR DESCRIPTION
## Tracking issue

Related to #7775 and #7932. Covers task 3.4 in `CreateRun`: `storage.raw_data_path` in full, `run.run_base_dir` for run metadata. `UploadInputs` does not read settings yet, so offloaded inputs still use the cluster default. That half is a separate PR.

## Why are the changes needed?

`run.run_base_dir` and `storage.raw_data_path` can be stored and resolved, but nothing reads them, so a run's storage paths still come only from the request or the cluster-wide default. An admin cannot point a project's run data at their own bucket.

## What changes were proposed in this pull request?

- `applyRunSettings` fills `RunSpec.run_base_dir` and `RunSpec.raw_data_storage.raw_data_prefix` when the request leaves them unset. An explicit request value always wins, and a setting that is INHERIT or UNSET contributes nothing.
- `CreateRun` needs no logic change. It already reads both fields and falls back to the configured prefix, and `applyRunSettings` runs before that, so the request, then settings, then config precedence holds without any extra code.
- The paired TODOs are corrected. The one in `CreateRun` asked for exactly this and is narrowed to the remaining gap; the one in `UploadInputs` pointed at `StorageSettings.run_base_dir`, which is `reserved` and no longer exists, and claimed `CreateRun` still needed the work.

## How was this patch tested?

- Seven new rows in the `applyRunSettings` table, covering both fields: the setting is applied, an explicit request value wins, and INHERIT and UNSET contribute nothing. One row sends `RawDataStorage` present but with an empty prefix, which must still take the setting.
- Existing `runs/service` and `dataproxy/service` tests pass unchanged.

### Labels

- **added**

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.